### PR TITLE
Add Manim visualizations for table similarity metrics

### DIFF
--- a/dev/experimental/manim-visualizations/README.md
+++ b/dev/experimental/manim-visualizations/README.md
@@ -1,0 +1,31 @@
+# Table Metric Visualizations
+
+Manim Community Edition animations explaining table similarity metrics: TEDS, GriTS, and TableRecordMatch (from ParseBench).
+
+## Videos
+
+- **`teds_vs_grits.py`** — TEDS vs GriTS comparison. Covers tree vs grid representations, edit operations, formulas, and the row-column asymmetry problem.
+- **`table_metrics.py`** — All three metrics. Adds TableRecordMatch and GTRM, showing how column reordering and header errors are handled differently.
+
+## Reproduce
+
+```bash
+# Install ManimCE (requires Python 3.9+, ffmpeg, cairo, pango)
+pip install manim
+
+# Render high quality (1080p60)
+manim -qh teds_vs_grits.py TEDSvsGRITS
+manim -qh table_metrics.py TableMetrics
+
+# Render low quality for quick preview
+manim -ql teds_vs_grits.py TEDSvsGRITS
+manim -ql table_metrics.py TableMetrics
+```
+
+Output appears in `media/videos/`.
+
+## System dependencies (macOS)
+
+```bash
+brew install cairo pango ffmpeg
+```

--- a/dev/experimental/manim-visualizations/table_metrics.py
+++ b/dev/experimental/manim-visualizations/table_metrics.py
@@ -1,0 +1,752 @@
+from manim import *
+import numpy as np
+
+# ── Color Palette ──────────────────────────────────────────────
+BG = "#1a1a2e"
+TEDS_COL = "#4ade80"       # green
+GRITS_COL = "#22d3ee"      # cyan
+TRM_COL = "#c084fc"        # purple
+GTRM_COL = "#f472b6"       # pink
+HIGHLIGHT = "#facc15"      # yellow
+ERR = "#f87171"            # red
+GOOD = "#4ade80"           # green
+CELL_FILL = "#334155"
+CELL_STROKE = "#94a3b8"
+HEADER_FILL = "#1e3a5f"
+HEADER_FILL_2 = "#3b1f5e"
+
+
+class TableMetrics(Scene):
+    """TEDS vs GriTS vs TableRecordMatch — full explainer."""
+
+    def setup(self):
+        self.camera.background_color = BG
+
+    def construct(self):
+        self.intro()
+        self.recap_teds_grits()
+        self.problem_reordering()
+        self.problem_headers()
+        self.introduce_trm()
+        self.trm_handles_both()
+        self.gtrm_combined()
+        self.summary()
+        self.outro()
+
+    # ── helpers ─────────────────────────────────────────────────
+    def make_table(self, data, cw=1.0, ch=0.42, font_size=16,
+                   header=True, header_color=HEADER_FILL,
+                   highlight_cells=None, dim_cells=None):
+        rows, cols = len(data), len(data[0])
+        rects = VGroup()
+        texts = VGroup()
+        for i in range(rows):
+            for j in range(cols):
+                fill = header_color if (header and i == 0) else CELL_FILL
+                opacity = 0.7 if (header and i == 0) else 0.4
+                sc = CELL_STROKE
+                sw = 1.5
+                if highlight_cells and (i, j) in highlight_cells:
+                    sc = ERR
+                    sw = 3
+                    fill = ERR
+                    opacity = 0.25
+                if dim_cells and (i, j) in dim_cells:
+                    opacity = 0.1
+                rect = Rectangle(width=cw, height=ch,
+                                 fill_color=fill, fill_opacity=opacity,
+                                 stroke_color=sc, stroke_width=sw)
+                rect.move_to(np.array([j * cw, -i * ch, 0]))
+                t = Text(str(data[i][j]), font_size=font_size, color=WHITE)
+                t.move_to(rect.get_center())
+                rects.add(rect)
+                texts.add(t)
+        table = VGroup(rects, texts)
+        table.move_to(ORIGIN)
+        return table, rects, texts
+
+    def section_title(self, text, color=WHITE, size=44):
+        t = Text(text, font_size=size, weight=BOLD, color=color)
+        t.to_edge(UP, buff=0.45)
+        return t
+
+    def badge(self, label, color, width=2.8):
+        box = RoundedRectangle(width=width, height=0.55, corner_radius=0.1,
+                               color=color, fill_opacity=0.2, stroke_width=2)
+        t = Text(label, font_size=18, weight=BOLD, color=color)
+        t.move_to(box.get_center())
+        return VGroup(box, t)
+
+    def penalty_indicator(self, level, position):
+        """level: 'high', 'low', 'none'."""
+        colors = {"high": ERR, "low": HIGHLIGHT, "none": GOOD}
+        labels = {"high": "Heavy penalty", "low": "Mild penalty",
+                  "none": "No penalty"}
+        col = colors[level]
+        t = Text(labels[level], font_size=16, weight=BOLD, color=col)
+        t.move_to(position)
+        return t
+
+    # ── Scene 1 : Intro ───────────────────────────────────────
+    def intro(self):
+        title = Text("Measuring Table Similarity", font_size=52, weight=BOLD)
+        sub = Text("TEDS  ·  GriTS  ·  TableRecordMatch",
+                    font_size=26, color=GREY_B)
+        sub2 = Text("ParseBench (Zhang et al., 2025)", font_size=20,
+                     color=GREY_C)
+        g = VGroup(title, sub, sub2).arrange(DOWN, buff=0.4)
+        self.play(Write(title), run_time=1.2)
+        self.play(FadeIn(sub, shift=UP * 0.3))
+        self.play(FadeIn(sub2, shift=UP * 0.2))
+        self.wait(2)
+        self.play(FadeOut(g))
+
+    # ── Scene 2 : Quick recap ─────────────────────────────────
+    def recap_teds_grits(self):
+        title = self.section_title("Quick Recap")
+        self.play(Write(title), run_time=0.6)
+
+        # TEDS card
+        teds_card = RoundedRectangle(width=5.2, height=2.8, corner_radius=0.15,
+                                     color=TEDS_COL, fill_opacity=0.08,
+                                     stroke_width=2)
+        teds_name = Text("TEDS", font_size=32, weight=BOLD, color=TEDS_COL)
+        teds_items = VGroup(
+            Text("HTML tree representation", font_size=16, color=GREY_A),
+            Text("Tree edit distance", font_size=16, color=GREY_A),
+            Text("Rows ≠ columns (asymmetric)", font_size=16, color=ERR),
+        ).arrange(DOWN, buff=0.18, aligned_edge=LEFT)
+        teds_content = VGroup(teds_name, teds_items).arrange(DOWN, buff=0.3)
+        teds_content.move_to(teds_card)
+
+        # GriTS card
+        grits_card = RoundedRectangle(width=5.2, height=2.8, corner_radius=0.15,
+                                      color=GRITS_COL, fill_opacity=0.08,
+                                      stroke_width=2)
+        grits_name = Text("GriTS", font_size=32, weight=BOLD, color=GRITS_COL)
+        grits_items = VGroup(
+            Text("2D grid / matrix representation", font_size=16, color=GREY_A),
+            Text("Optimal substructure matching", font_size=16, color=GREY_A),
+            Text("Rows = columns (symmetric)", font_size=16, color=GOOD),
+        ).arrange(DOWN, buff=0.18, aligned_edge=LEFT)
+        grits_content = VGroup(grits_name, grits_items).arrange(DOWN, buff=0.3)
+        grits_content.move_to(grits_card)
+
+        cards = VGroup(
+            VGroup(teds_card, teds_content),
+            VGroup(grits_card, grits_content),
+        ).arrange(RIGHT, buff=0.6).next_to(title, DOWN, buff=0.5)
+
+        self.play(
+            FadeIn(teds_card), FadeIn(teds_content),
+            FadeIn(grits_card), FadeIn(grits_content),
+            run_time=1.2,
+        )
+        self.wait(1.5)
+
+        # Shared problem
+        problem = Text(
+            "Both focus on structural similarity...\n"
+            "but what about semantic correctness?",
+            font_size=22, color=HIGHLIGHT, line_spacing=1.3,
+        )
+        problem.to_edge(DOWN, buff=0.5)
+        self.play(Write(problem), run_time=1.2)
+        self.wait(2)
+
+        self.play(FadeOut(VGroup(
+            title, teds_card, teds_content, grits_card, grits_content, problem
+        )))
+
+    # ── Scene 3 : Problem — Column Reordering ─────────────────
+    def problem_reordering(self):
+        title = self.section_title("Problem 1: Column Reordering", color=ERR)
+        self.play(Write(title), run_time=0.8)
+
+        # Ground truth
+        gt_data = [["Name", "Age", "City"],
+                   ["Alice", "30",  "NYC"],
+                   ["Bob",   "25",  "LA"]]
+        gt, _, _ = self.make_table(gt_data, cw=1.1)
+        gt_lab = Text("Ground Truth", font_size=20, color=WHITE, weight=BOLD)
+        gt.shift(LEFT * 3.5 + UP * 0.3)
+        gt_lab.next_to(gt, UP, buff=0.2)
+
+        # Prediction: columns reordered
+        pred_data = [["City", "Name", "Age"],
+                     ["NYC",  "Alice", "30"],
+                     ["LA",   "Bob",   "25"]]
+        pred, _, _ = self.make_table(pred_data, cw=1.1)
+        pred_lab = Text("Prediction (cols swapped)", font_size=20,
+                        color=HIGHLIGHT, weight=BOLD)
+        pred.shift(RIGHT * 3.5 + UP * 0.3)
+        pred_lab.next_to(pred, UP, buff=0.2)
+
+        self.play(FadeIn(gt), Write(gt_lab))
+        self.play(FadeIn(pred), Write(pred_lab))
+        self.wait(0.5)
+
+        # Semantically identical note
+        sem = Text("Semantically identical — same data, different column order",
+                    font_size=18, color=GREY_B)
+        sem.next_to(VGroup(gt, pred), DOWN, buff=0.4)
+        self.play(Write(sem))
+        self.wait(1)
+
+        # But TEDS/GriTS penalize it
+        penalty_box = RoundedRectangle(width=11, height=1.6, corner_radius=0.12,
+                                       color=ERR, fill_opacity=0.08,
+                                       stroke_width=2)
+        penalty_box.to_edge(DOWN, buff=0.4)
+
+        teds_p = VGroup(
+            Text("TEDS:", font_size=18, weight=BOLD, color=TEDS_COL),
+            Text("Heavy penalty", font_size=18, weight=BOLD, color=ERR),
+            Text("(cells at wrong tree positions)", font_size=14, color=GREY_B),
+        ).arrange(RIGHT, buff=0.15)
+
+        grits_p = VGroup(
+            Text("GriTS:", font_size=18, weight=BOLD, color=GRITS_COL),
+            Text("Heavy penalty", font_size=18, weight=BOLD, color=ERR),
+            Text("(column order changes grid alignment)", font_size=14,
+                 color=GREY_B),
+        ).arrange(RIGHT, buff=0.15)
+
+        penalties = VGroup(teds_p, grits_p).arrange(DOWN, buff=0.2)
+        penalties.move_to(penalty_box)
+
+        self.play(FadeIn(penalty_box))
+        self.play(Write(teds_p), run_time=0.8)
+        self.play(Write(grits_p), run_time=0.8)
+        self.wait(2)
+
+        self.play(FadeOut(VGroup(
+            title, gt, gt_lab, pred, pred_lab, sem, penalty_box, penalties
+        )))
+
+    # ── Scene 4 : Problem — Header Dropping ───────────────────
+    def problem_headers(self):
+        title = self.section_title("Problem 2: Header Errors", color=ERR)
+        self.play(Write(title), run_time=0.8)
+
+        # Ground truth
+        gt_data = [["Name", "Age", "City"],
+                   ["Alice", "30",  "NYC"],
+                   ["Bob",   "25",  "LA"]]
+        gt, _, _ = self.make_table(gt_data, cw=1.1)
+        gt_lab = Text("Ground Truth", font_size=20, color=WHITE, weight=BOLD)
+
+        # Prediction: headers transposed
+        pred_data = [["Age", "Name", "City"],
+                     ["Alice", "30",  "NYC"],
+                     ["Bob",   "25",  "LA"]]
+        pred, pred_r, _ = self.make_table(
+            pred_data, cw=1.1,
+            highlight_cells={(0, 0), (0, 1)},
+        )
+        pred_lab = Text("Prediction (headers swapped)", font_size=20,
+                        color=ERR, weight=BOLD)
+
+        gt.shift(LEFT * 3.5 + UP * 0.3)
+        pred.shift(RIGHT * 3.5 + UP * 0.3)
+        gt_lab.next_to(gt, UP, buff=0.2)
+        pred_lab.next_to(pred, UP, buff=0.2)
+
+        self.play(FadeIn(gt), Write(gt_lab))
+        self.play(FadeIn(pred), Write(pred_lab))
+        self.wait(0.5)
+
+        # This is catastrophic
+        cat = Text(
+            'Catastrophic — "Alice" is now keyed as "Age",  "30" as "Name"',
+            font_size=17, color=ERR,
+        )
+        cat.next_to(VGroup(gt, pred), DOWN, buff=0.35)
+        self.play(Write(cat))
+        self.wait(1)
+
+        # But TEDS/GriTS treat it as mild
+        penalty_box = RoundedRectangle(width=11, height=1.6, corner_radius=0.12,
+                                       color=HIGHLIGHT, fill_opacity=0.08,
+                                       stroke_width=2)
+        penalty_box.to_edge(DOWN, buff=0.4)
+
+        teds_p = VGroup(
+            Text("TEDS:", font_size=18, weight=BOLD, color=TEDS_COL),
+            Text("Mild penalty", font_size=18, weight=BOLD, color=HIGHLIGHT),
+            Text("(only 2 header cells differ)", font_size=14, color=GREY_B),
+        ).arrange(RIGHT, buff=0.15)
+
+        grits_p = VGroup(
+            Text("GriTS:", font_size=18, weight=BOLD, color=GRITS_COL),
+            Text("Mild penalty", font_size=18, weight=BOLD, color=HIGHLIGHT),
+            Text("(structure is mostly correct)", font_size=14, color=GREY_B),
+        ).arrange(RIGHT, buff=0.15)
+
+        penalties = VGroup(teds_p, grits_p).arrange(DOWN, buff=0.2)
+        penalties.move_to(penalty_box)
+
+        self.play(FadeIn(penalty_box))
+        self.play(Write(teds_p), run_time=0.8)
+        self.play(Write(grits_p), run_time=0.8)
+        self.wait(1.5)
+
+        # The core issue
+        issue = Text(
+            "Structure-focused metrics miss semantic correctness!",
+            font_size=20, weight=BOLD, color=ERR,
+        )
+        issue.next_to(penalty_box, UP, buff=0.15)
+        self.play(Write(issue))
+        self.wait(2)
+
+        self.play(FadeOut(VGroup(
+            title, gt, gt_lab, pred, pred_lab, cat,
+            penalty_box, penalties, issue,
+        )))
+
+    # ── Scene 5 : Introduce TableRecordMatch ──────────────────
+    def introduce_trm(self):
+        title = self.section_title("TableRecordMatch", color=TRM_COL)
+        sub = Text("from ParseBench (Zhang et al., 2025)",
+                    font_size=20, color=GREY_B)
+        sub.next_to(title, DOWN, buff=0.12)
+        self.play(Write(title), FadeIn(sub, shift=UP * 0.2))
+
+        # Core idea
+        idea = Text("Treat a table as a bag of records",
+                     font_size=26, color=HIGHLIGHT, weight=BOLD)
+        idea.next_to(sub, DOWN, buff=0.5)
+        self.play(Write(idea))
+        self.wait(1)
+
+        # Show a table transforming into records
+        gt_data = [["Name", "Age", "City"],
+                   ["Alice", "30",  "NYC"],
+                   ["Bob",   "25",  "LA"]]
+        tbl, _, _ = self.make_table(gt_data, cw=1.1, header_color=HEADER_FILL_2)
+        tbl.shift(LEFT * 4.0 + DOWN * 1.0)
+
+        self.play(FadeIn(tbl))
+        self.wait(0.5)
+
+        # Arrow
+        arr = Arrow(tbl.get_right() + RIGHT * 0.2,
+                    RIGHT * 0.2 + DOWN * 0.5,
+                    color=TRM_COL, stroke_width=2.5, buff=0.1)
+        self.play(GrowArrow(arr), run_time=0.5)
+
+        # Records as key-value cards
+        def record_card(pairs, idx):
+            items = VGroup()
+            for k, v in pairs:
+                key_t = Text(f"{k}:", font_size=14, weight=BOLD, color=TRM_COL)
+                val_t = Text(f" {v}", font_size=14, color=WHITE)
+                row = VGroup(key_t, val_t).arrange(RIGHT, buff=0.05)
+                items.add(row)
+            items.arrange(DOWN, buff=0.1, aligned_edge=LEFT)
+            box = RoundedRectangle(
+                width=items.get_width() + 0.4,
+                height=items.get_height() + 0.3,
+                corner_radius=0.1, color=TRM_COL,
+                fill_opacity=0.12, stroke_width=1.5,
+            )
+            label = Text(f"Record {idx}", font_size=12, color=GREY_B)
+            label.next_to(box, UP, buff=0.08)
+            items.move_to(box)
+            return VGroup(box, items, label)
+
+        r1 = record_card([("Name", "Alice"), ("Age", "30"),
+                          ("City", "NYC")], 1)
+        r2 = record_card([("Name", "Bob"), ("Age", "25"),
+                          ("City", "LA")], 2)
+        records = VGroup(r1, r2).arrange(DOWN, buff=0.35)
+        records.shift(RIGHT * 2.5 + DOWN * 1.0)
+
+        self.play(FadeIn(r1, shift=RIGHT * 0.3))
+        self.play(FadeIn(r2, shift=RIGHT * 0.3))
+        self.wait(1.5)
+
+        # Key insight callouts
+        insight1 = Text("Each row → record keyed by column headers",
+                        font_size=17, color=GREY_A)
+        insight2 = Text("Order doesn't matter — it's a bag!",
+                        font_size=17, color=TRM_COL)
+        insights = VGroup(insight1, insight2).arrange(DOWN, buff=0.15)
+        insights.to_edge(DOWN, buff=0.4)
+        self.play(Write(insight1))
+        self.play(Write(insight2))
+        self.wait(2)
+
+        self.play(FadeOut(VGroup(tbl, arr, records, idea, insights)))
+
+        # ── Formulas ──
+        step2 = Text("Match & score records", font_size=24, color=HIGHLIGHT)
+        step2.next_to(sub, DOWN, buff=0.4)
+        self.play(Write(step2))
+
+        # Equation 1
+        eq1_label = Text("Overall score:", font_size=18, color=GREY_B)
+        eq1 = MathTex(
+            r"\text{TRM}(G, P) = "
+            r"\frac{\displaystyle\sum_{(g,p) \in M}"
+            r"\text{RecordSim}(g, p)}{\max(|G|,\;|P|)}",
+            font_size=30,
+        )
+        eq1[0][:3].set_color(TRM_COL)
+
+        # Equation 2
+        eq2_label = Text("Per-record similarity:", font_size=18, color=GREY_B)
+        eq2 = MathTex(
+            r"\text{RecordSim}(g, p) = "
+            r"\frac{\displaystyle\sum_{k \in K(g) \cap K(p)}"
+            r"\mathbf{1}[g[k] = p[k]]}{|K(g) \cup K(p)|}",
+            font_size=28,
+        )
+
+        formulas = VGroup(
+            VGroup(eq1_label, eq1).arrange(DOWN, buff=0.15),
+            VGroup(eq2_label, eq2).arrange(DOWN, buff=0.15),
+        ).arrange(DOWN, buff=0.5)
+        formulas.next_to(step2, DOWN, buff=0.4)
+
+        self.play(Write(eq1_label), Write(eq1), run_time=1.5)
+        self.wait(1)
+        self.play(Write(eq2_label), Write(eq2), run_time=1.5)
+        self.wait(1)
+
+        # Annotation
+        ann = VGroup(
+            Text("M = optimal matching between records", font_size=15,
+                 color=GREY_B),
+            Text("K(r) = set of column keys for record r", font_size=15,
+                 color=GREY_B),
+            Text("𝟏[·] = 1 if values match, 0 otherwise", font_size=15,
+                 color=GREY_B),
+        ).arrange(DOWN, buff=0.1, aligned_edge=LEFT)
+        ann.to_edge(DOWN, buff=0.35)
+        self.play(FadeIn(ann))
+        self.wait(3)
+
+        self.play(FadeOut(VGroup(title, sub, step2, formulas, ann)))
+
+    # ── Scene 6 : TRM handles both problems ───────────────────
+    def trm_handles_both(self):
+        title = self.section_title("TRM Fixes Both Problems", color=TRM_COL)
+        self.play(Write(title), run_time=0.7)
+
+        # ── Problem 1 fix: column reordering ──
+        p1_label = Text("Column Reordering", font_size=24, weight=BOLD,
+                        color=HIGHLIGHT)
+        p1_label.next_to(title, DOWN, buff=0.4)
+        self.play(Write(p1_label))
+
+        # Show two tables side by side, small
+        gt_data = [["Name", "Age", "City"],
+                   ["Alice", "30",  "NYC"]]
+        pred_data = [["City", "Name", "Age"],
+                     ["NYC",  "Alice", "30"]]
+
+        gt, _, _ = self.make_table(gt_data, cw=0.9, ch=0.38, font_size=14,
+                                    header_color=HEADER_FILL_2)
+        pred, _, _ = self.make_table(pred_data, cw=0.9, ch=0.38, font_size=14,
+                                      header_color=HEADER_FILL_2)
+        gt.shift(LEFT * 4.0 + UP * 0.1)
+        pred.shift(LEFT * 0.5 + UP * 0.1)
+        gl = Text("GT", font_size=14, color=GREY_B)
+        pl = Text("Pred", font_size=14, color=GREY_B)
+        gl.next_to(gt, UP, buff=0.1)
+        pl.next_to(pred, UP, buff=0.1)
+
+        self.play(FadeIn(gt), FadeIn(pred), FadeIn(gl), FadeIn(pl))
+
+        # Show records are the same
+        rec_text = Text(
+            'Both → {Name: "Alice", Age: "30", City: "NYC"}',
+            font_size=16, color=TRM_COL,
+        )
+        rec_text.shift(UP * 0.1 + RIGHT * 3.2)
+
+        eq_sign = Text("Same bag of records!", font_size=18, weight=BOLD,
+                        color=GOOD)
+        eq_sign.next_to(rec_text, DOWN, buff=0.2)
+
+        trm_score = Text("TRM = 1.0  (perfect)", font_size=20, weight=BOLD,
+                          color=TRM_COL)
+        trm_score.next_to(eq_sign, DOWN, buff=0.2)
+
+        self.play(Write(rec_text))
+        self.play(Write(eq_sign))
+        self.play(Write(trm_score))
+        self.wait(2)
+
+        self.play(FadeOut(VGroup(
+            gt, pred, gl, pl, rec_text, eq_sign, trm_score, p1_label
+        )))
+
+        # ── Problem 2 fix: header transposition ──
+        p2_label = Text("Header Transposition", font_size=24, weight=BOLD,
+                        color=ERR)
+        p2_label.next_to(title, DOWN, buff=0.4)
+        self.play(Write(p2_label))
+
+        gt_data2 = [["Name", "Age"],
+                    ["Alice", "30"],
+                    ["Bob",   "25"]]
+        pred_data2 = [["Age", "Name"],
+                      ["Alice", "30"],
+                      ["Bob",   "25"]]
+
+        gt2, _, _ = self.make_table(gt_data2, cw=1.0, ch=0.38, font_size=14,
+                                     header_color=HEADER_FILL_2)
+        pred2, _, _ = self.make_table(
+            pred_data2, cw=1.0, ch=0.38, font_size=14,
+            header_color=HEADER_FILL_2,
+            highlight_cells={(0, 0), (0, 1)},
+        )
+        gt2.shift(LEFT * 4.5 + UP * 0.0)
+        pred2.shift(LEFT * 1.5 + UP * 0.0)
+        gl2 = Text("GT", font_size=14, color=GREY_B)
+        pl2 = Text("Pred", font_size=14, color=GREY_B)
+        gl2.next_to(gt2, UP, buff=0.1)
+        pl2.next_to(pred2, UP, buff=0.1)
+
+        self.play(FadeIn(gt2), FadeIn(pred2), FadeIn(gl2), FadeIn(pl2))
+
+        # Show the records
+        gt_rec = VGroup(
+            Text('GT record:', font_size=15, weight=BOLD, color=GREY_A),
+            Text('{Name: "Alice", Age: "30"}', font_size=14, color=GOOD),
+        ).arrange(DOWN, buff=0.1, aligned_edge=LEFT)
+
+        pred_rec = VGroup(
+            Text('Pred record:', font_size=15, weight=BOLD, color=GREY_A),
+            Text('{Age: "Alice", Name: "30"}', font_size=14, color=ERR),
+        ).arrange(DOWN, buff=0.1, aligned_edge=LEFT)
+
+        recs = VGroup(gt_rec, pred_rec).arrange(DOWN, buff=0.3,
+                                                  aligned_edge=LEFT)
+        recs.shift(RIGHT * 2.5 + UP * 0.1)
+
+        self.play(FadeIn(gt_rec))
+        self.play(FadeIn(pred_rec))
+        self.wait(0.5)
+
+        # Show the comparison
+        comp = VGroup(
+            Text('Name: "Alice" vs "30"  →  ✗', font_size=15, color=ERR),
+            Text('Age:  "30" vs "Alice"  →  ✗', font_size=15, color=ERR),
+        ).arrange(DOWN, buff=0.12, aligned_edge=LEFT)
+        comp.next_to(recs, DOWN, buff=0.35)
+
+        self.play(Write(comp[0]))
+        self.play(Write(comp[1]))
+
+        trm_bad = Text("RecordSim = 0 / 2 = 0.0", font_size=20,
+                        weight=BOLD, color=ERR)
+        trm_bad.next_to(comp, DOWN, buff=0.25)
+        self.play(Write(trm_bad))
+
+        trm_verdict = Text("TRM ≈ 0.0  — correctly catastrophic!",
+                            font_size=20, weight=BOLD, color=TRM_COL)
+        trm_verdict.to_edge(DOWN, buff=0.4)
+        self.play(Write(trm_verdict))
+        self.wait(3)
+
+        self.play(FadeOut(VGroup(
+            title, p2_label, gt2, pred2, gl2, pl2,
+            recs, comp, trm_bad, trm_verdict,
+        )))
+
+    # ── Scene 7 : GTRM combined metric ───────────────────────
+    def gtrm_combined(self):
+        title = self.section_title("GTRM: Best of Both Worlds", color=GTRM_COL)
+        self.play(Write(title), run_time=0.8)
+
+        # Motivation
+        motiv = Text(
+            "GriTS captures structure.  TRM captures semantics.\nCombine them.",
+            font_size=22, color=GREY_A, line_spacing=1.3,
+        )
+        motiv.next_to(title, DOWN, buff=0.5)
+        self.play(Write(motiv))
+        self.wait(1.5)
+
+        # Formula
+        eq = MathTex(
+            r"\text{GTRM}", r"=", r"\frac{\text{GriTS} + \text{TRM}}{2}",
+            font_size=44,
+        )
+        eq[0].set_color(GTRM_COL)
+        eq[2][0:5].set_color(GRITS_COL)
+        eq[2][6:9].set_color(TRM_COL)
+        eq.next_to(motiv, DOWN, buff=0.6)
+        self.play(Write(eq), run_time=1.5)
+        self.wait(1)
+
+        # Two components visualized
+        grits_box = RoundedRectangle(width=4.5, height=2.2, corner_radius=0.15,
+                                     color=GRITS_COL, fill_opacity=0.1,
+                                     stroke_width=2)
+        grits_label = Text("GriTS", font_size=26, weight=BOLD, color=GRITS_COL)
+        grits_desc = VGroup(
+            Text("Grid structure matching", font_size=15, color=GREY_A),
+            Text("Row/column symmetry", font_size=15, color=GREY_A),
+            Text("Spatial accuracy (IoU)", font_size=15, color=GREY_A),
+        ).arrange(DOWN, buff=0.12, aligned_edge=LEFT)
+        grits_inner = VGroup(grits_label, grits_desc).arrange(DOWN, buff=0.2)
+        grits_inner.move_to(grits_box)
+
+        trm_box = RoundedRectangle(width=4.5, height=2.2, corner_radius=0.15,
+                                   color=TRM_COL, fill_opacity=0.1,
+                                   stroke_width=2)
+        trm_label = Text("TRM", font_size=26, weight=BOLD, color=TRM_COL)
+        trm_desc = VGroup(
+            Text("Bag-of-records matching", font_size=15, color=GREY_A),
+            Text("Order insensitive", font_size=15, color=GREY_A),
+            Text("Header-aware (key-value)", font_size=15, color=GREY_A),
+        ).arrange(DOWN, buff=0.12, aligned_edge=LEFT)
+        trm_inner = VGroup(trm_label, trm_desc).arrange(DOWN, buff=0.2)
+        trm_inner.move_to(trm_box)
+
+        boxes = VGroup(
+            VGroup(grits_box, grits_inner),
+            VGroup(trm_box, trm_inner),
+        ).arrange(RIGHT, buff=0.5)
+        boxes.to_edge(DOWN, buff=0.5)
+
+        plus = Text("+", font_size=36, color=WHITE)
+        plus.move_to(boxes.get_center())
+
+        self.play(
+            FadeIn(grits_box), FadeIn(grits_inner),
+            FadeIn(trm_box), FadeIn(trm_inner),
+            Write(plus),
+            run_time=1.2,
+        )
+        self.wait(3)
+
+        self.play(FadeOut(VGroup(title, motiv, eq, boxes, plus)))
+
+    # ── Scene 8 : Summary ─────────────────────────────────────
+    def summary(self):
+        title = self.section_title("Comparison")
+        self.play(Write(title), run_time=0.6)
+
+        # Build a comparison matrix
+        # Headers
+        metrics = ["TEDS", "GriTS", "TRM"]
+        metric_colors = [TEDS_COL, GRITS_COL, TRM_COL]
+        properties = [
+            "Representation",
+            "Row/col symmetry",
+            "Column reorder",
+            "Header errors",
+            "Provides P & R",
+        ]
+        values = [
+            ["HTML tree",     "2D grid",    "Bag of records"],
+            ["No",            "Yes",        "N/A (orderless)"],
+            ["Heavy penalty", "Heavy penalty", "No penalty"],
+            ["Mild penalty",  "Mild penalty",  "Heavy penalty"],
+            ["No",            "Yes",        "Yes"],
+        ]
+        value_colors = [
+            [GREY_A, GREY_A, GREY_A],
+            [ERR,    GOOD,   GOOD],
+            [ERR,    ERR,    GOOD],
+            [ERR,    ERR,    GOOD],
+            [ERR,    GOOD,   GOOD],
+        ]
+
+        # Build the table manually
+        cw_prop = 2.6
+        cw_val = 2.8
+        ch = 0.5
+        start_y = 1.8
+        start_x = -5.5
+
+        all_cells = VGroup()
+
+        # Metric headers
+        for j, (m, mc) in enumerate(zip(metrics, metric_colors)):
+            t = Text(m, font_size=20, weight=BOLD, color=mc)
+            t.move_to(np.array([start_x + cw_prop + j * cw_val + cw_val / 2,
+                                start_y + ch / 2, 0]))
+            all_cells.add(t)
+
+        # Property column header
+        prop_h = Text("Property", font_size=18, weight=BOLD, color=GREY_B)
+        prop_h.move_to(np.array([start_x + cw_prop / 2,
+                                  start_y + ch / 2, 0]))
+        all_cells.add(prop_h)
+
+        # Separator line
+        sep = Line(
+            np.array([start_x, start_y, 0]),
+            np.array([start_x + cw_prop + 3 * cw_val, start_y, 0]),
+            color=GREY_D, stroke_width=1.5,
+        )
+        all_cells.add(sep)
+
+        # Rows
+        rows_group = VGroup()
+        for i, (prop, vals, cols) in enumerate(
+                zip(properties, values, value_colors)):
+            y = start_y - (i + 1) * ch
+            pt = Text(prop, font_size=16, color=GREY_A)
+            pt.move_to(np.array([start_x + cw_prop / 2, y, 0]))
+            row_items = VGroup(pt)
+            for j, (v, c) in enumerate(zip(vals, cols)):
+                vt = Text(v, font_size=15, color=c)
+                vt.move_to(np.array([start_x + cw_prop + j * cw_val
+                                      + cw_val / 2, y, 0]))
+                row_items.add(vt)
+            rows_group.add(row_items)
+
+        # Animate
+        self.play(FadeIn(all_cells), run_time=0.8)
+        self.play(
+            LaggedStart(*[FadeIn(r, shift=RIGHT * 0.2) for r in rows_group],
+                         lag_ratio=0.15),
+            run_time=2.5,
+        )
+        self.wait(2)
+
+        # Final takeaway
+        takeaway_box = RoundedRectangle(
+            width=10, height=1.2, corner_radius=0.12,
+            color=GTRM_COL, fill_opacity=0.12, stroke_width=2,
+        )
+        takeaway_box.to_edge(DOWN, buff=0.35)
+
+        takeaway = VGroup(
+            Text("GTRM = (GriTS + TRM) / 2", font_size=22,
+                 weight=BOLD, color=GTRM_COL),
+            Text("Structural correctness + Semantic correctness",
+                 font_size=18, color=GREY_A),
+        ).arrange(DOWN, buff=0.12)
+        takeaway.move_to(takeaway_box)
+
+        self.play(FadeIn(takeaway_box), Write(takeaway))
+        self.wait(3)
+
+        self.play(FadeOut(VGroup(title, all_cells, rows_group,
+                                  takeaway_box, takeaway)))
+
+    # ── Outro ──────────────────────────────────────────────────
+    def outro(self):
+        t1 = Text("TEDS", font_size=36, weight=BOLD, color=TEDS_COL)
+        dot1 = Text("·", font_size=36, color=GREY_B)
+        t2 = Text("GriTS", font_size=36, weight=BOLD, color=GRITS_COL)
+        dot2 = Text("·", font_size=36, color=GREY_B)
+        t3 = Text("TRM", font_size=36, weight=BOLD, color=TRM_COL)
+        row = VGroup(t1, dot1, t2, dot2, t3).arrange(RIGHT, buff=0.3)
+
+        sub = Text("ParseBench — Zhang et al., 2025",
+                    font_size=20, color=GREY_B)
+        g = VGroup(row, sub).arrange(DOWN, buff=0.4)
+        self.play(Write(row), run_time=1.2)
+        self.play(FadeIn(sub))
+        self.wait(2.5)
+        self.play(FadeOut(g))

--- a/dev/experimental/manim-visualizations/teds_vs_grits.py
+++ b/dev/experimental/manim-visualizations/teds_vs_grits.py
@@ -1,0 +1,569 @@
+from manim import *
+import numpy as np
+
+# ── Color Palette ──────────────────────────────────────────────
+BG = "#1a1a2e"
+TEDS_COLOR = "#4ade80"     # green
+GRITS_COLOR = "#22d3ee"    # cyan/teal
+HIGHLIGHT = "#facc15"      # yellow
+ERR = "#f87171"            # red
+ACCENT = "#fbbf24"         # gold
+CELL_FILL = "#334155"
+CELL_STROKE = "#94a3b8"
+HEADER_FILL = "#1e3a5f"
+
+
+class TEDSvsGRITS(Scene):
+    """Full explainer: TEDS vs GriTS for table similarity."""
+
+    def setup(self):
+        self.camera.background_color = BG
+
+    def construct(self):
+        self.intro()
+        self.problem_setup()
+        self.teds_section()
+        self.grits_section()
+        self.asymmetry_demo()
+        self.summary()
+
+    # ── helpers ─────────────────────────────────────────────────
+    def make_table(self, data, cw=1.0, ch=0.45, font_size=18,
+                   header=True, highlight_cells=None):
+        """Return (table_vgroup, cell_rects_flat, cell_texts_flat)."""
+        rows, cols = len(data), len(data[0])
+        rects = VGroup()
+        texts = VGroup()
+        for i in range(rows):
+            for j in range(cols):
+                fill = HEADER_FILL if (header and i == 0) else CELL_FILL
+                opacity = 0.7 if (header and i == 0) else 0.45
+                rect = Rectangle(
+                    width=cw, height=ch,
+                    fill_color=fill, fill_opacity=opacity,
+                    stroke_color=CELL_STROKE, stroke_width=1.5,
+                )
+                rect.move_to(np.array([j * cw, -i * ch, 0]))
+                if highlight_cells and (i, j) in highlight_cells:
+                    rect.set_stroke(ERR, width=3)
+                    rect.set_fill(ERR, opacity=0.25)
+                t = Text(str(data[i][j]), font_size=font_size, color=WHITE)
+                t.move_to(rect.get_center())
+                rects.add(rect)
+                texts.add(t)
+        table = VGroup(rects, texts)
+        table.move_to(ORIGIN)
+        return table, rects, texts
+
+    def section_title(self, text, color=WHITE):
+        t = Text(text, font_size=44, weight=BOLD, color=color)
+        t.to_edge(UP, buff=0.45)
+        return t
+
+    def tree_node(self, label, color, radius=0.28, font_size=13):
+        c = Circle(radius=radius, color=color, fill_opacity=0.55,
+                   stroke_width=2)
+        t = Text(label, font_size=font_size, color=WHITE)
+        t.move_to(c.get_center())
+        return VGroup(c, t)
+
+    # ── Scene 1 : Intro ───────────────────────────────────────
+    def intro(self):
+        title = Text("TEDS  vs  GriTS", font_size=60, weight=BOLD)
+        title[0:4].set_color(TEDS_COLOR)
+        title[8:13].set_color(GRITS_COLOR)
+        sub = Text("Two Ways to Measure Table Similarity",
+                    font_size=28, color=GREY_B)
+        g = VGroup(title, sub).arrange(DOWN, buff=0.5)
+        self.play(Write(title), run_time=1.2)
+        self.play(FadeIn(sub, shift=UP * 0.3))
+        self.wait(2)
+        self.play(FadeOut(g))
+
+    # ── Scene 2 : Problem Setup ───────────────────────────────
+    def problem_setup(self):
+        header = self.section_title("The Problem")
+        self.play(Write(header), run_time=0.7)
+
+        gt_data = [["Name", "Age", "City"],
+                   ["Alice", "30",  "NYC"],
+                   ["Bob",   "25",  "LA"]]
+        pred_data = [["Name", "Age City", ""],
+                     ["Alice", "30",      "NYC"],
+                     ["Bob",   "25",      "LA"]]
+
+        gt, _, _ = self.make_table(gt_data, cw=1.15)
+        pr, _, _ = self.make_table(pred_data, cw=1.15)
+
+        gt_lab = Text("Ground Truth", font_size=22, color=TEDS_COLOR)
+        pr_lab = Text("Prediction", font_size=22, color=ERR)
+
+        gt.shift(LEFT * 3.2 + DOWN * 0.4)
+        pr.shift(RIGHT * 3.2 + DOWN * 0.4)
+        gt_lab.next_to(gt, UP, buff=0.25)
+        pr_lab.next_to(pr, UP, buff=0.25)
+
+        self.play(FadeIn(gt), Write(gt_lab))
+        self.play(FadeIn(pr), Write(pr_lab))
+
+        arrow = Arrow(gt.get_right() + RIGHT * 0.15,
+                      pr.get_left() + LEFT * 0.15,
+                      color=HIGHLIGHT, stroke_width=2.5, buff=0.1)
+        q = Text("How similar?", font_size=30, color=HIGHLIGHT, weight=BOLD)
+        q.next_to(arrow, UP, buff=0.2)
+
+        self.play(GrowArrow(arrow), Write(q))
+        self.wait(2)
+        self.play(FadeOut(VGroup(gt, pr, gt_lab, pr_lab, arrow, q, header)))
+
+    # ── Scene 3 : TEDS ────────────────────────────────────────
+    def teds_section(self):
+        title = self.section_title("TEDS", color=TEDS_COLOR)
+        sub = Text("Tree Edit Distance-based Similarity",
+                    font_size=24, color=GREY_B)
+        sub.next_to(title, DOWN, buff=0.15)
+        self.play(Write(title), FadeIn(sub, shift=UP * 0.2))
+
+        # ─ step 1: table → tree ─
+        step = Text("Represent table as an HTML tree",
+                     font_size=22, color=HIGHLIGHT)
+        step.next_to(sub, DOWN, buff=0.35)
+        self.play(Write(step))
+
+        data = [["A", "B", "C"], ["D", "E", "F"]]
+        tbl, _, _ = self.make_table(data, cw=0.75, ch=0.4, font_size=16)
+        tbl.shift(LEFT * 4.2 + DOWN * 1.0)
+        self.play(FadeIn(tbl))
+
+        # build tree
+        root = self.tree_node("<table>", BLUE_C)
+        tr1 = self.tree_node("<tr>", TEAL_C)
+        tr2 = self.tree_node("<tr>", TEAL_C)
+        tds_labels = ["A", "B", "C", "D", "E", "F"]
+        tds = [self.tree_node(f"{l}", GREEN_C, radius=0.24, font_size=14)
+               for l in tds_labels]
+
+        # positions
+        tc = RIGHT * 1.8 + DOWN * 0.2
+        root.move_to(tc + UP * 1.8)
+        tr1.move_to(tc + UP * 0.4 + LEFT * 1.6)
+        tr2.move_to(tc + UP * 0.4 + RIGHT * 1.6)
+        for k, td in enumerate(tds[:3]):
+            td.move_to(tc + DOWN * 1.1 + LEFT * (2.4 - k * 1.2))
+        for k, td in enumerate(tds[3:]):
+            td.move_to(tc + DOWN * 1.1 + RIGHT * (0.0 + k * 1.2))
+
+        edges = VGroup(
+            Line(root[0].get_bottom(), tr1[0].get_top(), stroke_width=2, color=GREY_B),
+            Line(root[0].get_bottom(), tr2[0].get_top(), stroke_width=2, color=GREY_B),
+            *[Line(tr1[0].get_bottom(), tds[i][0].get_top(), stroke_width=2, color=GREY_B)
+              for i in range(3)],
+            *[Line(tr2[0].get_bottom(), tds[i][0].get_top(), stroke_width=2, color=GREY_B)
+              for i in range(3, 6)],
+        )
+
+        conv_arrow = Arrow(tbl.get_right() + RIGHT * 0.15,
+                           tc + LEFT * 3.0, color=HIGHLIGHT,
+                           stroke_width=2, buff=0.1)
+        self.play(GrowArrow(conv_arrow), run_time=0.5)
+
+        self.play(FadeIn(root))
+        self.play(Create(edges[0]), Create(edges[1]),
+                  FadeIn(tr1), FadeIn(tr2), run_time=0.8)
+        self.play(
+            LaggedStart(*[AnimationGroup(Create(edges[i + 2]), FadeIn(tds[i]))
+                          for i in range(6)], lag_ratio=0.15),
+            run_time=1.5)
+        self.wait(0.5)
+
+        # highlight asymmetry hint
+        hint_box = SurroundingRectangle(VGroup(tr1, tr2), color=HIGHLIGHT,
+                                        buff=0.15, stroke_width=2)
+        hint = Text("Rows are intermediate nodes (extra cost to delete)",
+                     font_size=18, color=HIGHLIGHT)
+        hint.to_edge(DOWN, buff=0.5)
+        self.play(Create(hint_box), Write(hint))
+        self.wait(2)
+
+        tree_all = VGroup(root, tr1, tr2, *tds, edges, conv_arrow, hint_box)
+        self.play(FadeOut(VGroup(tbl, tree_all, step, hint)))
+
+        # ─ step 2: edit operations + formula ─
+        step2 = Text("Compare trees via edit distance",
+                      font_size=22, color=HIGHLIGHT)
+        step2.next_to(sub, DOWN, buff=0.35)
+        self.play(Write(step2))
+
+        ops = [("Delete node", "cost = 1", ERR),
+               ("Insert node", "cost = 1", TEDS_COLOR),
+               ("Rename node", "cost ∈ [0,1]", HIGHLIGHT)]
+        boxes = VGroup()
+        for name, cost, col in ops:
+            box = RoundedRectangle(width=3.4, height=1.1, corner_radius=0.12,
+                                   color=col, fill_opacity=0.12, stroke_width=2)
+            n = Text(name, font_size=22, weight=BOLD, color=col)
+            c = Text(cost, font_size=16, color=GREY_B)
+            VGroup(n, c).arrange(DOWN, buff=0.12).move_to(box)
+            boxes.add(VGroup(box, n, c))
+        boxes.arrange(RIGHT, buff=0.35).next_to(step2, DOWN, buff=0.45)
+
+        self.play(LaggedStart(*[FadeIn(b, shift=UP * 0.3) for b in boxes],
+                               lag_ratio=0.25), run_time=1.3)
+        self.wait(1)
+
+        formula = MathTex(
+            r"\text{TEDS}", r"(T_a, T_b)", r"= 1 -",
+            r"\frac{\text{EditDist}(T_a, T_b)}{\max(|T_a|,\;|T_b|)}",
+            font_size=34,
+        )
+        formula[0].set_color(TEDS_COLOR)
+        formula.next_to(boxes, DOWN, buff=0.55)
+
+        score_note = Text("1 = identical  ·  0 = completely different",
+                          font_size=18, color=GREY_B)
+        score_note.next_to(formula, DOWN, buff=0.3)
+
+        self.play(Write(formula), run_time=1.5)
+        self.play(FadeIn(score_note))
+        self.wait(2.5)
+
+        self.play(FadeOut(VGroup(title, sub, step2, boxes, formula, score_note)))
+
+    # ── Scene 4 : GriTS ───────────────────────────────────────
+    def grits_section(self):
+        title = self.section_title("GriTS", color=GRITS_COLOR)
+        sub = Text("Grid Table Similarity",
+                    font_size=24, color=GREY_B)
+        sub.next_to(title, DOWN, buff=0.15)
+        self.play(Write(title), FadeIn(sub, shift=UP * 0.2))
+
+        step = Text("Represent table as a flat 2D matrix",
+                     font_size=22, color=HIGHLIGHT)
+        step.next_to(sub, DOWN, buff=0.35)
+        self.play(Write(step))
+
+        data = [["A", "B", "C"], ["D", "E", "F"]]
+        tbl, rects, _ = self.make_table(data, cw=0.75, ch=0.4, font_size=16)
+        tbl.shift(LEFT * 4.2 + DOWN * 0.8)
+        self.play(FadeIn(tbl))
+
+        conv_arrow = Arrow(tbl.get_right() + RIGHT * 0.15,
+                           LEFT * 0.5 + DOWN * 0.8, color=HIGHLIGHT,
+                           stroke_width=2, buff=0.1)
+        self.play(GrowArrow(conv_arrow), run_time=0.5)
+
+        matrix = MathTex(
+            r"M = \begin{bmatrix} A & B & C \\ D & E & F \end{bmatrix}",
+            font_size=42,
+        )
+        matrix.shift(RIGHT * 2.0 + DOWN * 0.8)
+        self.play(Write(matrix), run_time=1.2)
+
+        sym = Text("Rows and columns are treated symmetrically!",
+                    font_size=20, color=GRITS_COLOR)
+        sym.next_to(matrix, DOWN, buff=0.5)
+        self.play(Write(sym))
+        self.wait(1.5)
+
+        self.play(FadeOut(VGroup(tbl, conv_arrow, matrix, sym, step)))
+
+        # formula
+        step2 = Text("Find best cell alignment, then compute F1 score",
+                      font_size=22, color=HIGHLIGHT)
+        step2.next_to(sub, DOWN, buff=0.35)
+        self.play(Write(step2))
+
+        # Three variants
+        variants = VGroup()
+        for name, desc, col in [
+            ("GriTS-Top", "topology (span IoU)", GRITS_COLOR),
+            ("GriTS-Loc", "location (bbox IoU)", BLUE_C),
+            ("GriTS-Con", "content (text sim.)", GREEN_C),
+        ]:
+            box = RoundedRectangle(width=3.4, height=1.0, corner_radius=0.12,
+                                   color=col, fill_opacity=0.12, stroke_width=2)
+            n = Text(name, font_size=20, weight=BOLD, color=col)
+            d = Text(desc, font_size=15, color=GREY_B)
+            VGroup(n, d).arrange(DOWN, buff=0.1).move_to(box)
+            variants.add(VGroup(box, n, d))
+        variants.arrange(RIGHT, buff=0.35).next_to(step2, DOWN, buff=0.45)
+        self.play(LaggedStart(*[FadeIn(v, shift=UP * 0.3) for v in variants],
+                               lag_ratio=0.25), run_time=1.3)
+        self.wait(1)
+
+        formula = MathTex(
+            r"\text{GriTS}", r"(A, B)", r"=",
+            r"\frac{2 \displaystyle\sum_{ij} f(\tilde{A}_{ij},\tilde{B}_{ij})}"
+            r"{|A| + |B|}",
+            font_size=32,
+        )
+        formula[0].set_color(GRITS_COLOR)
+        formula.next_to(variants, DOWN, buff=0.5)
+
+        f_note = Text("f  = IoU or text similarity  ·  provides precision & recall",
+                       font_size=17, color=GREY_B)
+        f_note.next_to(formula, DOWN, buff=0.25)
+
+        self.play(Write(formula), run_time=1.5)
+        self.play(FadeIn(f_note))
+        self.wait(2.5)
+
+        self.play(FadeOut(VGroup(title, sub, step2, variants, formula, f_note)))
+
+    # ── Scene 5 : Asymmetry Demo (centerpiece) ────────────────
+    def asymmetry_demo(self):
+        title = self.section_title("The Key Difference", color=HIGHLIGHT)
+        self.play(Write(title))
+
+        sub = Text("Delete one row  vs  one column from a 4×4 table",
+                    font_size=22, color=GREY_B)
+        sub.next_to(title, DOWN, buff=0.2)
+        self.play(FadeIn(sub))
+
+        cw, ch, fs = 0.65, 0.38, 14
+
+        # Ground truth 4×4
+        gt_data = [[f"{i*4+j+1}" for j in range(4)] for i in range(4)]
+        gt, gt_r, gt_t = self.make_table(gt_data, cw=cw, ch=ch,
+                                          font_size=fs, header=False)
+        gt_lab = Text("Ground Truth  (4×4)", font_size=18, color=WHITE,
+                       weight=BOLD)
+        gt.move_to(UP * 0.7)
+        gt_lab.next_to(gt, UP, buff=0.2)
+
+        self.play(FadeIn(gt), Write(gt_lab))
+        self.wait(1)
+
+        # Shrink GT up
+        self.play(gt.animate.scale(0.75).move_to(UP * 2.6),
+                  gt_lab.animate.scale(0.75).move_to(UP * 3.35))
+
+        # ─ Prediction A: missing last row (3×4) ─
+        pa_data = [[f"{i*4+j+1}" for j in range(4)] for i in range(3)]
+        pa, pa_r, _ = self.make_table(pa_data, cw=cw, ch=ch,
+                                       font_size=fs, header=False)
+        pa_lab = Text("Missing Row  (3×4)", font_size=16, color=ERR)
+
+        # ─ Prediction B: missing last col (4×3) ─
+        pb_data = [[f"{i*4+j+1}" for j in range(3)] for i in range(4)]
+        pb, pb_r, _ = self.make_table(pb_data, cw=cw, ch=ch,
+                                       font_size=fs, header=False)
+        pb_lab = Text("Missing Column  (4×3)", font_size=16, color=ERR)
+
+        pa.move_to(LEFT * 3.5 + DOWN * 0.0)
+        pb.move_to(RIGHT * 3.5 + DOWN * 0.0)
+        pa_lab.next_to(pa, UP, buff=0.2)
+        pb_lab.next_to(pb, UP, buff=0.2)
+
+        # draw red X through missing data
+        pa_cross = Cross(stroke_color=ERR, stroke_width=3).scale(0.25)
+        pa_cross.next_to(pa, DOWN, buff=0.08)
+        pa_miss = Text("−4 cells", font_size=14, color=ERR)
+        pa_miss.next_to(pa_cross, DOWN, buff=0.08)
+
+        pb_cross = Cross(stroke_color=ERR, stroke_width=3).scale(0.25)
+        pb_cross.next_to(pb, RIGHT, buff=0.08)
+        pb_miss = Text("−4 cells", font_size=14, color=ERR)
+        pb_miss.next_to(pb_cross, RIGHT, buff=0.08)
+
+        self.play(FadeIn(pa), Write(pa_lab), FadeIn(pb), Write(pb_lab))
+        self.play(FadeIn(pa_cross), Write(pa_miss),
+                  FadeIn(pb_cross), Write(pb_miss))
+        self.wait(1.5)
+
+        # ─ TEDS calculation ─
+        teds_header = Text("TEDS", font_size=28, weight=BOLD, color=TEDS_COLOR)
+        teds_header.move_to(DOWN * 1.6)
+        self.play(Write(teds_header))
+
+        # Row delete cost explanation
+        # GT tree: 1 <table> + 4 <tr> + 16 <td> = 21 nodes
+        # Delete row: 1 <tr> + 4 <td> = 5 edits
+        # Delete col: 4 <td> = 4 edits
+        teds_row_calc = VGroup(
+            Text("Delete: 1 <tr> + 4 <td>", font_size=14, color=GREY_B),
+            Text("= 5 edits", font_size=14, color=ERR),
+        ).arrange(RIGHT, buff=0.15)
+        teds_row_score = MathTex(
+            r"\text{TEDS} = 1 - \tfrac{5}{21} \approx",
+            font_size=28,
+        )
+        teds_row_val = Text("0.762", font_size=28, weight=BOLD, color=TEDS_COLOR)
+        teds_row = VGroup(teds_row_calc,
+                          VGroup(teds_row_score, teds_row_val).arrange(RIGHT, buff=0.1)
+                          ).arrange(DOWN, buff=0.15)
+        teds_row.move_to(LEFT * 3.5 + DOWN * 2.3)
+
+        teds_col_calc = VGroup(
+            Text("Delete: 4 <td>", font_size=14, color=GREY_B),
+            Text("= 4 edits", font_size=14, color=ERR),
+        ).arrange(RIGHT, buff=0.15)
+        teds_col_score = MathTex(
+            r"\text{TEDS} = 1 - \tfrac{4}{21} \approx",
+            font_size=28,
+        )
+        teds_col_val = Text("0.810", font_size=28, weight=BOLD, color=TEDS_COLOR)
+        teds_col = VGroup(teds_col_calc,
+                          VGroup(teds_col_score, teds_col_val).arrange(RIGHT, buff=0.1)
+                          ).arrange(DOWN, buff=0.15)
+        teds_col.move_to(RIGHT * 3.5 + DOWN * 2.3)
+
+        self.play(Write(teds_row_calc), Write(teds_col_calc))
+        self.play(Write(teds_row_score), Write(teds_row_val),
+                  Write(teds_col_score), Write(teds_col_val))
+        self.wait(1)
+
+        # Highlight the difference
+        neq = MathTex(r"\neq", font_size=40, color=ERR)
+        neq.move_to(DOWN * 2.35)
+        self.play(Write(neq))
+        self.wait(1.5)
+
+        problem_note = Text(
+            "Same severity, different scores! Row deletion penalized more.",
+            font_size=18, color=ERR,
+        )
+        problem_note.to_edge(DOWN, buff=0.3)
+        self.play(Write(problem_note))
+        self.wait(2)
+
+        # ─ now show GriTS ─
+        self.play(FadeOut(VGroup(
+            teds_header, teds_row, teds_col, neq, problem_note
+        )))
+
+        grits_header = Text("GriTS", font_size=28, weight=BOLD, color=GRITS_COLOR)
+        grits_header.move_to(DOWN * 1.6)
+        self.play(Write(grits_header))
+
+        # GriTS: GT=16 cells, pred=12 cells both times
+        # GriTS = 2*12/(16+12) = 24/28 ≈ 0.857
+        grits_row_score = MathTex(
+            r"\text{GriTS} = \tfrac{2 \times 12}{16 + 12} \approx",
+            font_size=28,
+        )
+        grits_row_val = Text("0.857", font_size=28, weight=BOLD, color=GRITS_COLOR)
+        grits_row = VGroup(grits_row_score, grits_row_val).arrange(RIGHT, buff=0.1)
+        grits_row.move_to(LEFT * 3.5 + DOWN * 2.3)
+
+        grits_col_score = MathTex(
+            r"\text{GriTS} = \tfrac{2 \times 12}{16 + 12} \approx",
+            font_size=28,
+        )
+        grits_col_val = Text("0.857", font_size=28, weight=BOLD, color=GRITS_COLOR)
+        grits_col = VGroup(grits_col_score, grits_col_val).arrange(RIGHT, buff=0.1)
+        grits_col.move_to(RIGHT * 3.5 + DOWN * 2.3)
+
+        self.play(Write(grits_row_score), Write(grits_row_val),
+                  Write(grits_col_score), Write(grits_col_val))
+        self.wait(0.5)
+
+        eq = MathTex(r"=", font_size=40, color=GRITS_COLOR)
+        eq.move_to(DOWN * 2.35)
+        self.play(Write(eq))
+
+        ok_note = Text(
+            "Same severity, same score. Rows and columns treated equally.",
+            font_size=18, color=GRITS_COLOR,
+        )
+        ok_note.to_edge(DOWN, buff=0.3)
+        self.play(Write(ok_note))
+        self.wait(3)
+
+        self.play(FadeOut(VGroup(
+            title, sub, gt, gt_lab,
+            pa, pa_lab, pb, pb_lab,
+            pa_cross, pa_miss, pb_cross, pb_miss,
+            grits_header, grits_row, grits_col, eq, ok_note,
+        )))
+
+    # ── Scene 6 : Summary ─────────────────────────────────────
+    def summary(self):
+        title = self.section_title("Summary")
+        self.play(Write(title))
+
+        # Two-column comparison
+        col_w = 5.5
+        teds_box = RoundedRectangle(
+            width=col_w, height=4.5, corner_radius=0.15,
+            color=TEDS_COLOR, fill_opacity=0.08, stroke_width=2)
+        grits_box = RoundedRectangle(
+            width=col_w, height=4.5, corner_radius=0.15,
+            color=GRITS_COLOR, fill_opacity=0.08, stroke_width=2)
+
+        teds_box.shift(LEFT * 3.2 + DOWN * 0.6)
+        grits_box.shift(RIGHT * 3.2 + DOWN * 0.6)
+
+        teds_title = Text("TEDS", font_size=30, weight=BOLD, color=TEDS_COLOR)
+        grits_title = Text("GriTS", font_size=30, weight=BOLD, color=GRITS_COLOR)
+        teds_title.move_to(teds_box.get_top() + DOWN * 0.35)
+        grits_title.move_to(grits_box.get_top() + DOWN * 0.35)
+
+        def bullet_list(items, box, color):
+            texts = VGroup()
+            for item in items:
+                t = Text(item, font_size=16, color=GREY_A)
+                texts.add(t)
+            texts.arrange(DOWN, buff=0.22, aligned_edge=LEFT)
+            texts.next_to(box.get_top() + DOWN * 0.8, DOWN, buff=0.1)
+            texts.shift(LEFT * 0.3)
+            return texts
+
+        teds_items = [
+            "  HTML tree representation",
+            "  Tree edit distance algorithm",
+            "  Rows ≠ columns (asymmetric)",
+            "  Row errors penalized more",
+            "  Well-established (ICDAR)",
+            "  Single similarity score",
+        ]
+        teds_bullets = bullet_list(teds_items, teds_box, TEDS_COLOR)
+        # Color the problematic items
+        teds_bullets[2].set_color(ERR)
+        teds_bullets[3].set_color(ERR)
+
+        grits_items = [
+            "  2D grid / matrix representation",
+            "  Optimal substructure matching",
+            "  Rows = columns (symmetric)",
+            "  Equal treatment of all errors",
+            "  Newer (ICDAR 2023)",
+            "  Precision + Recall + F1",
+        ]
+        grits_bullets = bullet_list(grits_items, grits_box, GRITS_COLOR)
+        grits_bullets[2].set_color(GRITS_COLOR)
+        grits_bullets[3].set_color(GRITS_COLOR)
+
+        self.play(FadeIn(teds_box), FadeIn(grits_box),
+                  Write(teds_title), Write(grits_title))
+        self.play(
+            LaggedStart(*[FadeIn(t, shift=RIGHT * 0.2) for t in teds_bullets],
+                         lag_ratio=0.15),
+            LaggedStart(*[FadeIn(t, shift=LEFT * 0.2) for t in grits_bullets],
+                         lag_ratio=0.15),
+            run_time=2.5,
+        )
+        self.wait(3)
+
+        # Final takeaway
+        takeaway = Text(
+            "GriTS fixes TEDS's row-column asymmetry\n"
+            "and adds precision / recall breakdown.",
+            font_size=22, color=HIGHLIGHT, line_spacing=1.4,
+        )
+        takeaway.to_edge(DOWN, buff=0.35)
+        self.play(Write(takeaway), run_time=1.5)
+        self.wait(3)
+
+        self.play(FadeOut(VGroup(
+            title, teds_box, grits_box, teds_title, grits_title,
+            teds_bullets, grits_bullets, takeaway,
+        )))
+
+        # End card
+        thanks = Text("TEDS vs GriTS", font_size=48, weight=BOLD)
+        thanks[0:4].set_color(TEDS_COLOR)
+        thanks[7:12].set_color(GRITS_COLOR)
+        self.play(Write(thanks))
+        self.wait(2)
+        self.play(FadeOut(thanks))


### PR DESCRIPTION
## Summary
- Adds animated Manim visualizations under `dev/experimental/manim-visualizations/`
- **`teds_vs_grits.py`** — TEDS vs GriTS comparison covering tree vs grid representations, the row-column asymmetry problem, and formulas
- **`table_metrics.py`** — Full three-metric comparison (TEDS, GriTS, TableRecordMatch) showing how column reordering and header errors are handled differently, plus the combined GTRM metric from ParseBench

## Reproduce
```bash
pip install manim
manim -qh teds_vs_grits.py TEDSvsGRITS
manim -qh table_metrics.py TableMetrics
```

## Test plan
- [ ] Verify `pip install manim` installs cleanly
- [ ] Render both videos at low quality (`-ql`) and confirm no errors
- [ ] Review rendered videos for correctness of metric explanations

🤖 Generated with [Claude Code](https://claude.com/claude-code)