### PR TITLE
Upgrade extend-ai SDK to 1.8.0 and enable richer parsing options

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ runners = [
     "chunkr-ai>=0.0.43",
     "docling-core>=2.71.0",
     "datalab-python-sdk",
-    "extend-ai>=0.0.1",
+    "extend-ai>=1.8.0",
     "google-genai>=1.0.0",
     "google-cloud-documentai>=2.20.0",
     "landingai-ade>=1.4.0",

--- a/src/parse_bench/inference/pipelines/parse.py
+++ b/src/parse_bench/inference/pipelines/parse.py
@@ -93,7 +93,19 @@ def register_parse_pipelines(register_fn) -> None:  # type: ignore[no-untyped-de
                 "chunking_strategy": "page",
                 "engine": "parse_performance",
                 "engineVersion": "2.0.0-beta",
-                "block_options": {"tables": {"target_format": "html"}},
+                "block_options": {
+                    "tables": {"target_format": "html"},
+                    "figures": {
+                        "enabled": True,
+                        "figureImageClippingEnabled": True,
+                        "advancedChartExtractionEnabled": True,
+                    },
+                    "formulas": {"enabled": True},
+                },
+                "advanced_options": {
+                    "enrichmentFormat": "xml",
+                    "formattingDetection": [{"type": "change_tracking"}],
+                },
             },
         )
     )

--- a/src/parse_bench/inference/providers/parse/extend_parse.py
+++ b/src/parse_bench/inference/providers/parse/extend_parse.py
@@ -12,7 +12,7 @@ from typing import Any
 
 from extend_ai import Extend
 from extend_ai.core.api_error import ApiError
-from extend_ai.types import ParseConfig, ParseConfigChunkingStrategy, ParseRequestFile
+from extend_ai.types import FileFromId, ParseConfig, ParseConfigChunkingStrategy
 from pypdf import PdfReader
 
 from parse_bench.inference.providers.base import (
@@ -44,6 +44,11 @@ EXTEND_LABEL_MAP: dict[str, str] = {
     "text": "Text",
     "table": "Table",
     "figure": "Picture",
+    "header": "Page-header",
+    "footer": "Page-footer",
+    "key_value": "Key-Value Region",
+    "page_number": "Page-footer",
+    "formula": "Formula",
 }
 
 # Virtual page dimensions for normalized coordinate conversion.
@@ -166,7 +171,7 @@ class ExtendParseProvider(Provider):
         """
         try:
             with open(file_path, "rb") as f:
-                upload_response = self._client.file.upload(file=f)
+                upload_response = self._client.files.upload(file=f)
 
             # Extract file ID from response
             if hasattr(upload_response, "id"):
@@ -252,7 +257,7 @@ class ExtendParseProvider(Provider):
         try:
             # The Extend SDK parse method
             parse_response = self._client.parse(
-                file=ParseRequestFile(file_id=file_id),
+                file=FileFromId(id=file_id),
                 config=ParseConfig(**parse_config) if parse_config else None,
             )
 
@@ -362,24 +367,28 @@ class ExtendParseProvider(Provider):
 
         raw_output = raw_result.raw_output
 
+        # SDK 1.x wraps content under raw_output["output"]; legacy responses had it at the top level.
+        # Source the chunk-bearing payload from whichever shape applies.
+        payload = raw_output.get("output") if isinstance(raw_output.get("output"), dict) else raw_output
+
         # Extract markdown content from response
         # Extend API can return content in different formats depending on config
         markdown = ""
 
         # Try different response formats
         # 1. Direct markdown field
-        if "markdown" in raw_output:
-            markdown = raw_output["markdown"]
+        if "markdown" in payload:
+            markdown = payload["markdown"]
         # 2. Content field
-        elif "content" in raw_output:
-            content = raw_output["content"]
+        elif "content" in payload:
+            content = payload["content"]
             if isinstance(content, str):
                 markdown = content
             elif isinstance(content, dict):
                 markdown = content.get("markdown", "") or content.get("text", "")
         # 3. Chunks array (similar to Reducto)
-        elif "chunks" in raw_output:
-            chunks = raw_output["chunks"]
+        elif "chunks" in payload:
+            chunks = payload["chunks"]
             if chunks and isinstance(chunks, list):
                 # Concatenate all chunk contents
                 chunk_contents = []
@@ -392,8 +401,8 @@ class ExtendParseProvider(Provider):
                         chunk_contents.append(chunk)
                 markdown = "\n\n".join(chunk_contents)
         # 4. Pages array
-        elif "pages" in raw_output:
-            pages = raw_output["pages"]
+        elif "pages" in payload:
+            pages = payload["pages"]
             if pages and isinstance(pages, list):
                 page_contents = []
                 for page in pages:
@@ -411,7 +420,7 @@ class ExtendParseProvider(Provider):
         # Build layout_pages from chunk blocks for layout cross-evaluation
         metadata = raw_output.get("_extend_metadata", {})
         page_dims = metadata.get("page_dims", {})
-        chunks = raw_output.get("chunks", [])
+        chunks = payload.get("chunks", [])
         layout_pages = _build_layout_pages(chunks, page_dims)
 
         output = ParseOutput(
@@ -485,6 +494,8 @@ def _build_layout_pages(
             continue
 
     pages_items: dict[int, list[LayoutItemIR]] = defaultdict(list)
+    pages_headers: dict[int, list[str]] = defaultdict(list)
+    pages_footers: dict[int, list[str]] = defaultdict(list)
 
     for chunk in chunks:
         if not isinstance(chunk, dict):
@@ -573,6 +584,14 @@ def _build_layout_pages(
                 )
             )
 
+            section_content = (
+                f"<page_number>{content}</page_number>" if block_type == "page_number" else content
+            )
+            if canonical_label == "Page-header" and content:
+                pages_headers[page_num].append(section_content)
+            elif canonical_label == "Page-footer" and content:
+                pages_footers[page_num].append(section_content)
+
     layout_pages: list[ParseLayoutPageIR] = []
     for page_num in sorted(pages_items.keys()):
         layout_pages.append(
@@ -581,6 +600,8 @@ def _build_layout_pages(
                 width=_VIRTUAL_PAGE_DIM,
                 height=_VIRTUAL_PAGE_DIM,
                 items=pages_items[page_num],
+                page_header_markdown="\n\n".join(pages_headers.get(page_num, [])),
+                page_footer_markdown="\n\n".join(pages_footers.get(page_num, [])),
             )
         )
 

--- a/uv.lock
+++ b/uv.lock
@@ -690,7 +690,7 @@ wheels = [
 
 [[package]]
 name = "extend-ai"
-version = "0.0.14"
+version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -698,9 +698,9 @@ dependencies = [
     { name = "pydantic-core" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7b/a6/2629d4b2b76e72750dac14b8d3e39aeb187e890d54b40da3e892a1f55bcb/extend_ai-0.0.14.tar.gz", hash = "sha256:cf4b0a567cd3ebd3ae05f97edb337ab8a9e8451d110e7c025ca0a3c5ca94a77a", size = 106320, upload-time = "2025-11-13T18:55:54.184Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/6f/519194532dd5971d7f32ddd2df75096f09a5f1862751e465c240939c5150/extend_ai-1.8.0.tar.gz", hash = "sha256:234405ff40b55c18c8af6bc24b0ba0947c71b6e6bead181883384f5619abc0d4", size = 390736, upload-time = "2026-04-10T21:54:43.65Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/12/76e2e1af047cc07e2b9ad4d705a6cb278f2450923e934a759b67c802b717/extend_ai-0.0.14-py3-none-any.whl", hash = "sha256:4cd795a90cf3af127e3955d426ce4e044b19fd079daa3f84790b55db9a403a91", size = 258985, upload-time = "2025-11-13T18:55:53.171Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/79/89dac4a16f92b9a159e8d4979df6dad27b6b353193b3f473bfca02dc0b7b/extend_ai-1.8.0-py3-none-any.whl", hash = "sha256:d1c3373d459e4aa2fc84ec43de0e9938be7b8e78c87eb7873777021045911371", size = 929757, upload-time = "2026-04-10T21:54:41.989Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Updates the Extend AI python sdk to >1.8.0 to support new fields:

* Adds page_number/formula/header/footer/key_value to label map.
* Wires enrichmentFormat, change tracking, advanced chart, and formula extraction (features present in extend_parse_v2 (extend_parse_beta in the benchmark).
* Changes the API response handling for the latest API version. Retains compatibility with the legacy sdk for backward compatibility. 


### New results from a run with the latest parser pipeline 


**Pipeline:** extend-ai 1.8.0, `parse_performance` v2.0.0-beta, advanced chart extraction, formulas, `enrichmentFormat: xml`, change-tracking**

| Category | Headline metric | Score |
|---|---|---|
| Chart | Rule pass rate | 40.5% |
| Layout | Layout element rule pass rate | 67.2% |
| Table | GriTS-TRM composite (GTRM) | 86.2% |
| Text content | Content faithfulness | 84.6% |
| Text formatting | Semantic formatting | 59.9% |
| **Overall (unweighted avg)** | | **67.7%** |
