### PR TITLE
Add Claude Opus 4.7 parse benchmark pipeline

### DIFF
--- a/src/parse_bench/inference/pipelines/parse.py
+++ b/src/parse_bench/inference/pipelines/parse.py
@@ -1289,6 +1289,20 @@ def register_parse_pipelines(register_fn) -> None:  # type: ignore[no-untyped-de
         )
     )
 
+    # Anthropic Opus 4.7 - Parse with Layout File
+    register_fn(
+        PipelineSpec(
+            pipeline_name="anthropic_opus_4_7_parse_with_layout_file",
+            provider_name="anthropic",
+            product_type=ProductType.PARSE,
+            config={
+                "model": "claude-opus-4-7",
+                "max_tokens": 32768,
+                "mode": "parse_with_layout_file",
+            },
+        )
+    )
+
     # Anthropic Haiku - Parse with Layout File - Thinking
     register_fn(
         PipelineSpec(

--- a/src/parse_bench/inference/pipelines/parse.py
+++ b/src/parse_bench/inference/pipelines/parse.py
@@ -804,6 +804,21 @@ def register_parse_pipelines(register_fn) -> None:  # type: ignore[no-untyped-de
         )
     )
 
+    register_fn(
+        PipelineSpec(
+            pipeline_name="reducto_agentic_formatting",
+            provider_name="reducto",
+            product_type=ProductType.PARSE,
+            config={
+                "ocr_system": "standard",
+                "agentic": True,
+                "agentic_scopes": ["text", "table", "figure"],
+                "table_output_format": "html",
+                "formatting_include": ["change_tracking", "highlight", "comments"],
+            },
+        )
+    )
+
     # =========================================================================
     # DeepSeek-OCR-2
     # =========================================================================
@@ -1256,6 +1271,20 @@ def register_parse_pipelines(register_fn) -> None:  # type: ignore[no-untyped-de
             product_type=ProductType.PARSE,
             config={
                 "model": "claude-opus-4-6",
+                "max_tokens": 32768,
+                "mode": "parse_with_layout_file",
+            },
+        )
+    )
+
+    # Anthropic Opus 4.7 - Parse with Layout File
+    register_fn(
+        PipelineSpec(
+            pipeline_name="anthropic_opus_4_7_parse_with_layout_file",
+            provider_name="anthropic",
+            product_type=ProductType.PARSE,
+            config={
+                "model": "claude-opus-4-7",
                 "max_tokens": 32768,
                 "mode": "parse_with_layout_file",
             },

--- a/src/parse_bench/inference/providers/parse/anthropic.py
+++ b/src/parse_bench/inference/providers/parse/anthropic.py
@@ -77,6 +77,7 @@ _ANTHROPIC_PRICING_PER_M: dict[str, tuple[float, float]] = {
     "claude-haiku-3": (0.25, 1.25),
     "claude-sonnet-4": (3.00, 15.00),
     "claude-sonnet-3": (3.00, 15.00),
+    "claude-opus-4-7": (5.00, 25.00),
     "claude-opus-4-6": (5.00, 25.00),
     "claude-opus-4-5": (5.00, 25.00),
     "claude-opus-4-1": (15.00, 75.00),
@@ -119,6 +120,9 @@ class AnthropicProvider(Provider):
         self._timeout = self.base_config.get("timeout", 120)
         self._mode = self.base_config.get("mode", "image")  # "image", "file", or "parse_with_layout"
         self._thinking = self.base_config.get("thinking")  # e.g. {"type": "enabled", "budget_tokens": 32768}
+        self._effort = self.base_config.get("effort")  # e.g. "high", "xhigh" — for Opus 4.7+
+        # Opus 4.7+ rejects temperature/top_p/top_k at non-default values (400 error)
+        self._supports_temperature = not self._model.startswith("claude-opus-4-7")
 
         if self._mode not in ("image", "file", "parse_with_layout", "parse_with_layout_file"):
             raise ProviderConfigError(
@@ -286,8 +290,10 @@ class AnthropicProvider(Provider):
             extra_kwargs: dict[str, Any] = {}
             if self._thinking:
                 extra_kwargs["thinking"] = self._thinking
-            else:
+            elif self._supports_temperature:
                 extra_kwargs["temperature"] = 0
+            if self._effort:
+                extra_kwargs["output_config"] = {"effort": self._effort}
 
             response = self._client.messages.create(
                 model=self._model,
@@ -340,8 +346,10 @@ class AnthropicProvider(Provider):
             extra_kwargs: dict[str, Any] = {}
             if self._thinking:
                 extra_kwargs["thinking"] = self._thinking
-            else:
+            elif self._supports_temperature:
                 extra_kwargs["temperature"] = 0
+            if self._effort:
+                extra_kwargs["output_config"] = {"effort": self._effort}
 
             response = self._client.messages.create(
                 model=self._model,
@@ -405,8 +413,10 @@ class AnthropicProvider(Provider):
             extra_kwargs: dict[str, Any] = {}
             if self._thinking:
                 extra_kwargs["thinking"] = self._thinking
-            else:
+            elif self._supports_temperature:
                 extra_kwargs["temperature"] = 0
+            if self._effort:
+                extra_kwargs["output_config"] = {"effort": self._effort}
 
             response = self._client.beta.messages.create(
                 model=self._model,
@@ -460,8 +470,10 @@ class AnthropicProvider(Provider):
             extra_kwargs: dict[str, Any] = {}
             if self._thinking:
                 extra_kwargs["thinking"] = self._thinking
-            else:
+            elif self._supports_temperature:
                 extra_kwargs["temperature"] = 0
+            if self._effort:
+                extra_kwargs["output_config"] = {"effort": self._effort}
 
             response = self._client.beta.messages.create(
                 model=self._model,


### PR DESCRIPTION
## What

Add `anthropic_opus_4_7_parse_with_layout_file` pipeline for benchmarking Claude Opus 4.7 on ParseBench.

## Why

Opus 4.7 launched with improved vision and knowledge capabilities. This adds a benchmark pipeline to evaluate its document parsing quality against the existing Opus 4.6 baseline.

## How

- Registered new pipeline (`claude-opus-4-7`, `parse_with_layout_file` mode, 32k max tokens)
- Updated the Anthropic provider to handle Opus 4.7 API breaking changes:
  - **Skip `temperature=0`**: Opus 4.7 rejects non-default sampling parameters with a 400 error
  - **Support `effort` config**: New parameter for controlling thinking depth on 4.7+
  - **Add pricing entry**: $5/$25 per MTok (same as 4.6)
- All changes are gated on the model string; Haiku and Opus 4.6 pipelines are completely unaffected

## Changes

- `src/parse_bench/inference/providers/parse/anthropic.py` — Provider: pricing, temperature guard, effort support
- `src/parse_bench/inference/pipelines/parse.py` — Pipeline registration
