### PR TITLE
Add Qwen3.5-35B and Qwen3.6-35B FP8 parse benchmark pipelines

### DIFF
--- a/src/parse_bench/evaluation/layout_adapters/adapters.py
+++ b/src/parse_bench/evaluation/layout_adapters/adapters.py
@@ -1969,7 +1969,7 @@ class Qwen35LayoutAdapter(LayoutAdapter):
             config = raw_output.get("_config", {})
             if isinstance(config, dict):
                 model = config.get("model", "")
-                return isinstance(model, str) and model.startswith("qwen3.5")
+                return isinstance(model, str) and (model.startswith("qwen3.5") or model.startswith("qwen3.6"))
         return False
 
     def to_layout_output(

--- a/src/parse_bench/inference/pipelines/parse.py
+++ b/src/parse_bench/inference/pipelines/parse.py
@@ -887,6 +887,54 @@ def register_parse_pipelines(register_fn) -> None:  # type: ignore[no-untyped-de
     )
 
     # =========================================================================
+    # Qwen3.5-35B-A3B FP8 (unified multimodal, GDN + attention hybrid, MoE 35B/3B)
+    # =========================================================================
+
+    # Qwen3.5-35B-A3B FP8 vLLM — parse mode (pure markdown, no layout)
+    register_fn(
+        PipelineSpec(
+            pipeline_name="qwen3_5_35b_a3b_fp8_vllm_parse",
+            provider_name="qwen3_5",
+            product_type=ProductType.PARSE,
+            config={
+                "model": "qwen3.5-35b-a3b-fp8",
+                "prompt_mode": "parse",
+            },
+        )
+    )
+
+    # =========================================================================
+    # Qwen3.6-35B-A3B FP8 (unified multimodal, GDN + attention hybrid, MoE 35B/3B)
+    # =========================================================================
+
+    # Qwen3.6-35B-A3B FP8 vLLM — parse mode (pure markdown, no layout)
+    register_fn(
+        PipelineSpec(
+            pipeline_name="qwen3_6_35b_a3b_fp8_vllm_parse",
+            provider_name="qwen3_5",
+            product_type=ProductType.PARSE,
+            config={
+                "model": "qwen3.6-35b-a3b-fp8",
+                "prompt_mode": "parse",
+            },
+        )
+    )
+
+    # Qwen3.6-35B-A3B FP8 vLLM — parse_layout (unified: one layout-prompt call,
+    # cross-evaluated on both parse and layout detection, same pattern as dots_ocr_1_5_parse)
+    register_fn(
+        PipelineSpec(
+            pipeline_name="qwen3_6_35b_a3b_fp8_vllm_parse_layout",
+            provider_name="qwen3_5",
+            product_type=ProductType.PARSE,
+            config={
+                "model": "qwen3.6-35b-a3b-fp8",
+                "prompt_mode": "layout",
+            },
+        )
+    )
+
+    # =========================================================================
     # Gemma 4
     # =========================================================================
 

--- a/src/parse_bench/inference/providers/parse/qwen3_5.py
+++ b/src/parse_bench/inference/providers/parse/qwen3_5.py
@@ -94,14 +94,27 @@ PROMPT_LAYOUT = (
 
 
 class LayoutItem(BaseModel):
-    """Single layout element from the model response."""
+    """Single layout element from the model response.
+
+    Different Qwen model versions use different field names:
+    - 4B: bbox_2d, category, text
+    - 3.5-35B: bbox_2d, label (no text)
+    - 3.6-35B: bbox, category, text
+    We normalize all variants here.
+    """
 
     model_config = {"extra": "ignore"}
 
     bbox: list[float] | None = None
     bbox_2d: list[float] | None = None
     category: str = "Text"
+    label: str | None = None
     text: str = ""
+
+    def model_post_init(self, __context: Any) -> None:
+        # Some models use "label" instead of "category"
+        if self.label is not None and self.category == "Text":
+            self.category = self.label
 
     @property
     def coords(self) -> list[float]:


### PR DESCRIPTION
## Summary
- Register `qwen3_5_35b_a3b_fp8_vllm_parse` (pure markdown)
- Register `qwen3_6_35b_a3b_fp8_vllm_parse` (pure markdown)
- Register `qwen3_6_35b_a3b_fp8_vllm_parse_layout` (layout cross-eval)
- Update `LayoutItem` to handle `label` field alias (used by 3.5-35B)
- Update `Qwen35LayoutAdapter` to also match qwen3.6 models