### PR TITLE
Add Gemma 4 31B vLLM layout pipeline

### DIFF
--- a/src/parse_bench/inference/pipelines/parse.py
+++ b/src/parse_bench/inference/pipelines/parse.py
@@ -964,6 +964,19 @@ def register_parse_pipelines(register_fn) -> None:  # type: ignore[no-untyped-de
         )
     )
 
+    # Gemma 4 31B vLLM — layout mode (div+bbox wrappers, Gemini-style)
+    register_fn(
+        PipelineSpec(
+            pipeline_name="gemma4_31b_vllm_with_layout",
+            provider_name="gemma4",
+            product_type=ProductType.PARSE,
+            config={
+                "model": "gemma-4-31b",
+                "prompt_mode": "layout",
+            },
+        )
+    )
+
     # Gemma 4 E4B vLLM — dense 8B variant (4.5B effective)
     register_fn(
         PipelineSpec(

--- a/src/parse_bench/inference/providers/parse/gemma4.py
+++ b/src/parse_bench/inference/providers/parse/gemma4.py
@@ -1,7 +1,7 @@
-"""Provider for Gemma 4 26B-A4B Modal vLLM server.
+"""Provider for Gemma 4 Modal vLLM server.
 
-Gemma 4 is Google's MoE multimodal model (26B total, 3.8B active) with
-built-in vision. Supports OCR, document parsing, and chart comprehension.
+Gemma 4 is Google's multimodal model family with built-in vision.
+Supports OCR, document parsing, and chart comprehension.
 
 Supports two prompt modes:
 - "parse" (default): Pure markdown output, with md-table-to-HTML conversion


### PR DESCRIPTION
## What
Registers a new `gemma4_31b_vllm_with_layout` pipeline for the dense Gemma 4 31B-it model in layout mode.

## Why
Expanding the Gemma 4 benchmark coverage beyond the 26B-A4B MoE and E4B variants with the dense 31B model.

## How
- Reuses the existing `gemma4` provider — same model family, same prompts, same layout output format.
- Pipeline config sets `model="gemma-4-31b"` and `prompt_mode="layout"`; server URL comes from `GEMMA4_SERVER_URL` (matches the pattern used by `gemma4_26b_vllm_with_layout`).
- Updates the `gemma4.py` module docstring to describe the provider as covering the Gemma 4 family rather than specifically the 26B-A4B variant.

## Changes
- `src/parse_bench/inference/pipelines/parse.py` — register `gemma4_31b_vllm_with_layout`.
- `src/parse_bench/inference/providers/parse/gemma4.py` — generalize docstring.

## Testing
- `uv run parse-bench pipelines` lists `gemma4_31b_vllm_with_layout`.
- `ruff check` passes on both modified files.

## Notes
Requires `GEMMA4_SERVER_URL` env var pointing at a deployed Gemma 4 31B vLLM server.