### PR TITLE
Add leaderboard.csv with HF community sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The benchmark covers ~2,000 human-verified pages from real enterprise documents 
 ## Leaderboard
 
 <!-- LEADERBOARD:START -->
-_Top 10 by Overall score. Click any column header on the [full sortable leaderboard](leaderboard.csv) to re-rank by Tables, Cost, or any other dimension._
+_Top 10 by Overall score. For the full sortable, filterable leaderboard, see [parsebench.ai](https://parsebench.ai/#leaderboard); for raw data, see [leaderboard.csv](leaderboard.csv)._
 
 | Rank | Provider | Category | Overall | Tables | Charts | Content Faith. | Sem. Format. | Visual Ground. | ¢ / Page |
 |---:|---|---|---:|---:|---:|---:|---:|---:|---:|

--- a/README.md
+++ b/README.md
@@ -13,6 +13,25 @@ The benchmark covers ~2,000 human-verified pages from real enterprise documents 
   <img src="docs/parsebench_teaser.png" alt="ParseBench overview: five capability dimensions" width="100%">
 </p>
 
+## Leaderboard
+
+<!-- LEADERBOARD:START -->
+_Top 10 by Overall score. Click any column header on the [full sortable leaderboard](leaderboard.csv) to re-rank by Tables, Cost, or any other dimension._
+
+| Rank | Provider | Category | Overall | Tables | Charts | Content Faith. | Sem. Format. | Visual Ground. | ¢ / Page |
+|---:|---|---|---:|---:|---:|---:|---:|---:|---:|
+| 1 | LlamaParse Agentic | LlamaParse | 84.88 | 90.74 | 78.11 | 89.68 | 85.24 | 80.62 | 1.25¢ |
+| 2 | Google Gemini 3 Flash (Thinking High) | VLM - Proprietary | 75.05 | 91.50 | 64.79 | 90.87 | 68.31 | 59.77 | 2.41¢ |
+| 3 | Reducto (Agentic) | Commercial - Startup APIs | 72.97 | 80.42 | 73.4 | 86.37 | 57.6 | 67.07 | 4.76¢ |
+| 4 | LlamaParse Cost Effective | LlamaParse | 71.89 | 73.16 | 66.66 | 88.02 | 73.04 | 58.56 | 0.38¢ |
+| 5 | Google Gemini 3 Flash (Thinking Minimal) | VLM - Proprietary | 71.04 | 89.85 | 64.83 | 86.19 | 58.35 | 55.97 | 0.65¢ |
+| 6 | Chandra-ocr-2 | VLM - Open Weight | 70.1 | 89.2 | 65.1 | 83.7 | 61.4 | 51.2 | — |
+| 7 | Google Gemini 3.1 Pro | VLM - Proprietary | 69.14 | 91.00 | 41.13 | 90.16 | 52.43 | 70.99 | 8.49¢ |
+| 8 | Reducto | Commercial - Startup APIs | 67.83 | 70.33 | 56.99 | 86.37 | 56.75 | 68.71 | 2.38¢ |
+| 9 | Extend (Beta) | Commercial - Startup APIs | 67.83 | 85.93 | 40.42 | 85.03 | 59.49 | 68.28 | 2.50¢ |
+| 10 | Anthropic Opus 4.7 | VLM - Proprietary | 63.34 | 87.17 | 55.84 | 90.26 | 69.42 | 13.99 | 7.14¢ |
+<!-- LEADERBOARD:END -->
+
 ## Quick Start
 
 **Prerequisites:** Create a `.env` file with the API key for the parsing tool you want to evaluate (see [Configuration](#configuration) for details).

--- a/leaderboard.csv
+++ b/leaderboard.csv
@@ -1,0 +1,39 @@
+Provider,Category,Overall,Tables,Charts,Content_Faithfulness,Semantic_Formatting,Visual_Grounding,Cost_Per_Page,Cost_Charts,Cost_Tables,Cost_Text,Cost_Layout,HF_Model_ID
+LlamaParse Cost Effective,LlamaParse,71.89,73.16,66.66,88.02,73.04,58.56,0.375,,,,,
+LlamaParse Agentic,LlamaParse,84.88,90.74,78.11,89.68,85.24,80.62,1.25,,,,,
+OpenAI GPT-5 Mini (Reasoning Minimal),VLM - Proprietary,46.83,69.82,30.13,82.30,45.77,6.15,0.88,0.70,1.22,0.67,0.91,
+OpenAI GPT-5 Mini (Reasoning Medium),VLM - Proprietary,51.52,74.60,38.96,85.68,45.35,13.03,3.05,2.93,3.43,2.67,3.15,
+Anthropic Haiku 4.5 (Disable Thinking),VLM - Proprietary,45.17,77.21,13.77,78.74,49.39,6.72,1.64,0.97,2.46,1.53,1.60,
+Anthropic Haiku 4.5 (Thinking),VLM - Proprietary,53.12,78.70,27.39,84.83,62.36,12.30,3.69,3.49,4.26,3.16,3.83,
+Google Gemini 3 Flash (Thinking Minimal),VLM - Proprietary,71.04,89.85,64.83,86.19,58.35,55.97,0.65,0.49,0.84,0.56,0.69,
+Google Gemini 3 Flash (Thinking High),VLM - Proprietary,75.05,91.50,64.79,90.87,68.31,59.77,2.41,2.38,2.29,2.25,2.70,
+Anthropic Opus 4.6,VLM - Proprietary,54.07,86.52,13.49,89.70,64.19,16.47,5.78,4.02,8.16,5.19,6.40,
+Anthropic Opus 4.7,VLM - Proprietary,63.34,87.17,55.84,90.26,69.42,13.99,7.14,5.69,8.63,6.07,8.17,
+Google Gemini 3.1 Pro,VLM - Proprietary,69.14,91.00,41.13,90.16,52.43,70.99,8.49,6.69,9.69,7.73,10.54,
+Google Gemini 3.1 Flash Lite,VLM - Proprietary,58.32,85.48,9.92,89.46,58.38,48.38,0.29,0.19,0.37,0.27,0.31,
+OpenAI GPT-5.4,VLM - Proprietary,62.23,83.89,65.22,85.57,59.52,16.95,2.90,2.55,4.04,2.13,3.00,
+OpenAI GPT-5.4 Nano,VLM - Proprietary,43.35,60.16,17.57,78.05,54.56,6.41,0.25,0.17,0.35,0.19,0.28,
+AWS Textract,Commercial - IDP,47.88,84.58,5.97,74.76,3.71,70.36,1.5,,,,,
+Google Cloud Document AI,Commercial - IDP,50.39,55.10,1.44,83.65,50.51,61.26,1,,,,,
+Azure Document Intelligence (Layout),Commercial - IDP,59.64,86.00,1.56,84.93,51.93,73.78,1,,,,,
+Reducto (Agentic),Commercial - Startup APIs,72.97,80.42,73.4,86.37,57.6,67.07,4.76,6,3.4,4.2,5,
+Reducto,Commercial - Startup APIs,67.83,70.33,56.99,86.37,56.75,68.71,2.38,3,1.7,2.1,2.5,
+Extend,Commercial - Startup APIs,55.75,85.05,1.59,84.08,47.36,60.67,2.5,,,,,
+Extend (Beta),Commercial - Startup APIs,67.83,85.93,40.42,85.03,59.49,68.28,2.5,,,,,
+LandingAI,Commercial - Startup APIs,45.23,73.72,10.88,88.60,27.87,25.08,3,,,,,
+Firecrawl,Commercial - Startup APIs,31.08,55.88,0,74.37,25.16,0,0.9,,,,,
+Qwen3-VL-8B-Instruct,VLM - Open Weight,61.97,74.61,28.18,87.63,64.23,55.18,,,,,,Qwen/Qwen3-VL-8B-Instruct
+Dots.mocr,VLM - Open Weight,55.79,85.15,0.95,90.03,46.99,55.81,,,,,,rednote-hilab/dots.mocr
+Docling-models,VLM - Open Weight,50.65,66.41,52.76,66.93,1.03,66.11,,,,,,docling-project/docling-models
+Chandra-ocr-2,VLM - Open Weight,70.1,89.2,65.1,83.7,61.4,51.2,,,,,,datalab-to/chandra-ocr-2
+Gemma-4-31B-it,VLM - Open Weight,62.4,80.6,15,89.9,69.3,57.4,,,,,,google/gemma-4-31B-it
+Gemma-4-26B-A4B-it,VLM - Open Weight,58.5,70,14.2,83.8,65.1,59.2,,,,,,google/gemma-4-26B-A4B-it
+LightOnOCR-2-1B,VLM - Open Weight,48,75.5,13.5,87.8,63.2,0,,,,,,lightonai/LightOnOCR-2-1B
+Qianfan-OCR,VLM - Open Weight,46.2,72.3,0.9,83.5,53.8,20.6,,,,,,baidu/Qianfan-OCR
+MinerU2.5-2509-1.2B,VLM - Open Weight,45.9,71.7,1.1,80.8,4.5,71.5,,,,,,opendatalab/MinerU2.5-2509-1.2B
+Qwen3.6-35B-A3B,VLM - Open Weight,44.1,19.1,5.1,90.7,58.3,47.4,,,,,,Qwen/Qwen3.6-35B-A3B
+DeepSeek-OCR-2,VLM - Open Weight,41.2,61.7,1.1,82,54,7,,,,,,deepseek-ai/DeepSeek-OCR-2
+PaddleOCR-VL,VLM - Open Weight,40.9,67.1,0.9,82.7,54,0,,,,,,PaddlePaddle/PaddleOCR-VL
+Gemma-4-E4B-it,VLM - Open Weight,40.5,25,7.7,81.4,52.5,35.8,,,,,,google/gemma-4-E4B-it
+Qwen3.5-4B,VLM - Open Weight,35.4,8,2.5,88.9,57.8,19.7,,,,,,Qwen/Qwen3.5-4B
+GLM-OCR,VLM - Open Weight,29.6,66.1,1.7,78,2.3,0,,,,,,zai-org/GLM-OCR

--- a/scripts/sync_hf_leaderboard.py
+++ b/scripts/sync_hf_leaderboard.py
@@ -1,0 +1,168 @@
+"""Sync community results from the HF ParseBench leaderboard into leaderboard.csv.
+
+Fetches the HF dataset leaderboard, pulls per-dimension scores from each model's
+`.eval_results/parsebench.yaml`, and upserts into leaderboard.csv.
+
+Dedup key: `HF_Model_ID`. If a row with the same `HF_Model_ID` already exists,
+the existing row wins — our own runs always take precedence over community
+submissions (they have cost data and more decimals of precision).
+
+A non-empty `HF_Model_ID` indicates the row came from the HF community leaderboard.
+
+Run: uv run python scripts/sync_hf_leaderboard.py [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CSV_PATH = REPO_ROOT / "leaderboard.csv"
+
+LEADERBOARD_API = (
+    "https://huggingface.co/api/datasets/llamaindex/ParseBench/leaderboard?limit=100"
+)
+YAML_URL_MAIN = "https://huggingface.co/{model_id}/raw/main/.eval_results/parsebench.yaml"
+YAML_URL_PR = "https://huggingface.co/{model_id}/raw/refs%2Fpr%2F{pr}/.eval_results/parsebench.yaml"
+
+TASK_TO_COLUMN = {
+    "mean": "Overall",
+    "table": "Tables",
+    "chart": "Charts",
+    "text_content": "Content_Faithfulness",
+    "text_formatting": "Semantic_Formatting",
+    "layout": "Visual_Grounding",
+}
+
+FIELDNAMES = [
+    "Provider", "Category", "Overall", "Tables", "Charts",
+    "Content_Faithfulness", "Semantic_Formatting", "Visual_Grounding",
+    "Cost_Per_Page", "Cost_Charts", "Cost_Tables", "Cost_Text", "Cost_Layout",
+    "HF_Model_ID",
+]
+
+
+def fetch_json(url: str):
+    with urllib.request.urlopen(url, timeout=30) as resp:
+        return json.loads(resp.read())
+
+
+def fetch_text(url: str) -> str | None:
+    try:
+        with urllib.request.urlopen(url, timeout=30) as resp:
+            return resp.read().decode("utf-8")
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            return None
+        raise
+
+
+def fmt(v) -> str:
+    if v is None:
+        return ""
+    return f"{float(v):g}"
+
+
+def parse_yaml_to_scores(yaml_text: str) -> dict[str, float]:
+    entries = yaml.safe_load(yaml_text) or []
+    scores: dict[str, float] = {}
+    for entry in entries:
+        task_id = (entry.get("dataset") or {}).get("task_id")
+        col = TASK_TO_COLUMN.get(task_id)
+        if col is not None:
+            scores[col] = entry.get("value")
+    return scores
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true", help="Print diff, don't write")
+    args = parser.parse_args()
+
+    with CSV_PATH.open() as f:
+        existing = list(csv.DictReader(f))
+    existing_by_hf_id = {r["HF_Model_ID"]: r for r in existing if r["HF_Model_ID"]}
+
+    print(f"GET {LEADERBOARD_API}")
+    lb = fetch_json(LEADERBOARD_API)
+    print(f"  {len(lb)} entries\n")
+
+    added: list[dict] = []
+    skipped: list[str] = []
+    missing_yaml: list[str] = []
+
+    for entry in lb:
+        model_id = entry["modelId"]
+        if model_id in existing_by_hf_id:
+            skipped.append(model_id)
+            continue
+
+        pr = entry.get("pullRequest")
+        url = (
+            YAML_URL_PR.format(model_id=model_id, pr=pr)
+            if pr
+            else YAML_URL_MAIN.format(model_id=model_id)
+        )
+        yaml_text = fetch_text(url)
+        if yaml_text is None:
+            missing_yaml.append(f"{model_id} ({url})")
+            continue
+
+        scores = parse_yaml_to_scores(yaml_text)
+        if not scores.get("Overall"):
+            missing_yaml.append(f"{model_id} (no mean score)")
+            continue
+
+        name = model_id.split("/")[-1]
+        if name and name[0].islower():
+            name = name[0].upper() + name[1:]
+        row = {k: "" for k in FIELDNAMES}
+        row["Provider"] = name
+        row["Category"] = "VLM - Open Weight"
+        for col, val in scores.items():
+            row[col] = fmt(val)
+        row["HF_Model_ID"] = model_id
+        added.append(row)
+
+    print(f"Added ({len(added)}):")
+    for r in added:
+        print(f"  + {r['HF_Model_ID']:<45} Overall {r['Overall']}")
+    print(f"\nSkipped — already in CSV ({len(skipped)}):")
+    for m in skipped:
+        print(f"  = {m}")
+    if missing_yaml:
+        print(f"\nNo parsebench.yaml ({len(missing_yaml)}):")
+        for m in missing_yaml:
+            print(f"  ? {m}")
+
+    if args.dry_run:
+        print("\n(dry-run — no changes written)")
+        return
+
+    if added:
+        all_rows = existing + added
+        with CSV_PATH.open("w", newline="") as f:
+            w = csv.DictWriter(f, fieldnames=FIELDNAMES)
+            w.writeheader()
+            w.writerows(all_rows)
+        print(f"\nWrote {len(all_rows)} rows to {CSV_PATH.name}")
+    else:
+        print("\nNo new rows.")
+
+    subprocess.run(
+        [sys.executable, str(Path(__file__).parent / "update_readme.py")],
+        check=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sync_hf_leaderboard.py
+++ b/scripts/sync_hf_leaderboard.py
@@ -28,9 +28,7 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parent.parent
 CSV_PATH = REPO_ROOT / "leaderboard.csv"
 
-LEADERBOARD_API = (
-    "https://huggingface.co/api/datasets/llamaindex/ParseBench/leaderboard?limit=100"
-)
+LEADERBOARD_API = "https://huggingface.co/api/datasets/llamaindex/ParseBench/leaderboard?limit=100"
 YAML_URL_MAIN = "https://huggingface.co/{model_id}/raw/main/.eval_results/parsebench.yaml"
 YAML_URL_PR = "https://huggingface.co/{model_id}/raw/refs%2Fpr%2F{pr}/.eval_results/parsebench.yaml"
 
@@ -44,9 +42,19 @@ TASK_TO_COLUMN = {
 }
 
 FIELDNAMES = [
-    "Provider", "Category", "Overall", "Tables", "Charts",
-    "Content_Faithfulness", "Semantic_Formatting", "Visual_Grounding",
-    "Cost_Per_Page", "Cost_Charts", "Cost_Tables", "Cost_Text", "Cost_Layout",
+    "Provider",
+    "Category",
+    "Overall",
+    "Tables",
+    "Charts",
+    "Content_Faithfulness",
+    "Semantic_Formatting",
+    "Visual_Grounding",
+    "Cost_Per_Page",
+    "Cost_Charts",
+    "Cost_Tables",
+    "Cost_Text",
+    "Cost_Layout",
     "HF_Model_ID",
 ]
 
@@ -107,11 +115,7 @@ def main() -> None:
             continue
 
         pr = entry.get("pullRequest")
-        url = (
-            YAML_URL_PR.format(model_id=model_id, pr=pr)
-            if pr
-            else YAML_URL_MAIN.format(model_id=model_id)
-        )
+        url = YAML_URL_PR.format(model_id=model_id, pr=pr) if pr else YAML_URL_MAIN.format(model_id=model_id)
         yaml_text = fetch_text(url)
         if yaml_text is None:
             missing_yaml.append(f"{model_id} ({url})")
@@ -125,7 +129,7 @@ def main() -> None:
         name = model_id.split("/")[-1]
         if name and name[0].islower():
             name = name[0].upper() + name[1:]
-        row = {k: "" for k in FIELDNAMES}
+        row = dict.fromkeys(FIELDNAMES, "")
         row["Provider"] = name
         row["Category"] = "VLM - Open Weight"
         for col, val in scores.items():

--- a/scripts/update_readme.py
+++ b/scripts/update_readme.py
@@ -76,9 +76,7 @@ def main() -> None:
     start = readme.find(START_MARKER)
     end = readme.find(END_MARKER)
     if start == -1 or end == -1:
-        raise SystemExit(
-            f"Markers not found in README.md. Add {START_MARKER} and {END_MARKER}."
-        )
+        raise SystemExit(f"Markers not found in README.md. Add {START_MARKER} and {END_MARKER}.")
     new_readme = readme[:start] + block + readme[end + len(END_MARKER) :]
     README_PATH.write_text(new_readme)
     print(f"Updated README.md with top {TOP_N} from {CSV_PATH.name}")

--- a/scripts/update_readme.py
+++ b/scripts/update_readme.py
@@ -1,0 +1,88 @@
+"""Regenerate the Top-N leaderboard table in README.md from leaderboard.csv.
+
+Run: uv run python scripts/update_readme.py
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CSV_PATH = REPO_ROOT / "leaderboard.csv"
+README_PATH = REPO_ROOT / "README.md"
+TOP_N = 10
+
+START_MARKER = "<!-- LEADERBOARD:START -->"
+END_MARKER = "<!-- LEADERBOARD:END -->"
+
+
+def fmt_score(v: str) -> str:
+    return v if v else "—"
+
+
+def fmt_cost(v: str) -> str:
+    if not v:
+        return "—"
+    return f"{float(v):.2f}¢"
+
+
+def build_table(rows: list[dict]) -> str:
+    rows_sorted = sorted(rows, key=lambda r: float(r["Overall"]), reverse=True)[:TOP_N]
+
+    header = (
+        "| Rank | Provider | Category | Overall | Tables | Charts | "
+        "Content Faith. | Sem. Format. | Visual Ground. | ¢ / Page |\n"
+        "|---:|---|---|---:|---:|---:|---:|---:|---:|---:|"
+    )
+    lines = [header]
+    for i, r in enumerate(rows_sorted, 1):
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    str(i),
+                    r["Provider"],
+                    r["Category"],
+                    fmt_score(r["Overall"]),
+                    fmt_score(r["Tables"]),
+                    fmt_score(r["Charts"]),
+                    fmt_score(r["Content_Faithfulness"]),
+                    fmt_score(r["Semantic_Formatting"]),
+                    fmt_score(r["Visual_Grounding"]),
+                    fmt_cost(r["Cost_Per_Page"]),
+                ]
+            )
+            + " |"
+        )
+    return "\n".join(lines)
+
+
+def main() -> None:
+    with CSV_PATH.open() as f:
+        rows = [r for r in csv.DictReader(f) if r.get("Provider")]
+
+    table = build_table(rows)
+    block = (
+        f"{START_MARKER}\n"
+        f"_Top {TOP_N} by Overall score. Click any column header on the "
+        f"[full sortable leaderboard](leaderboard.csv) to re-rank by Tables, "
+        f"Cost, or any other dimension._\n\n"
+        f"{table}\n"
+        f"{END_MARKER}"
+    )
+
+    readme = README_PATH.read_text()
+    start = readme.find(START_MARKER)
+    end = readme.find(END_MARKER)
+    if start == -1 or end == -1:
+        raise SystemExit(
+            f"Markers not found in README.md. Add {START_MARKER} and {END_MARKER}."
+        )
+    new_readme = readme[:start] + block + readme[end + len(END_MARKER) :]
+    README_PATH.write_text(new_readme)
+    print(f"Updated README.md with top {TOP_N} from {CSV_PATH.name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/update_readme.py
+++ b/scripts/update_readme.py
@@ -65,9 +65,9 @@ def main() -> None:
     table = build_table(rows)
     block = (
         f"{START_MARKER}\n"
-        f"_Top {TOP_N} by Overall score. Click any column header on the "
-        f"[full sortable leaderboard](leaderboard.csv) to re-rank by Tables, "
-        f"Cost, or any other dimension._\n\n"
+        f"_Top {TOP_N} by Overall score. For the full sortable, filterable leaderboard, "
+        f"see [parsebench.ai](https://parsebench.ai/#leaderboard); for raw data, "
+        f"see [leaderboard.csv](leaderboard.csv)._\n\n"
         f"{table}\n"
         f"{END_MARKER}"
     )


### PR DESCRIPTION
## Summary

Adds a canonical `leaderboard.csv` at the repo root plus two scripts that keep it in sync with HF community-submitted results.

## What

- **`leaderboard.csv`** — single source of truth for benchmark results (13 score/cost columns + `HF_Model_ID`). GitHub renders it as a sortable/searchable table in the browser, so the full leaderboard is interactive with zero infrastructure.
- **`scripts/sync_hf_leaderboard.py`** — fetches the HF ParseBench leaderboard API, pulls per-dimension scores from each model's `.eval_results/parsebench.yaml` (including pending PR branches via URL-encoded `refs/pr/<N>`), and upserts into the CSV keyed by `HF_Model_ID`. Ours-wins on conflict.
- **`scripts/update_readme.py`** — regenerates a Top-10 markdown table in `README.md` between `<!-- LEADERBOARD:START/END -->` markers, sorted by Overall. Invoked automatically at the end of a sync run.
- **`README.md`** — new `## Leaderboard` section with the Top-10 table and a link to the full sortable CSV view.

## Why

Benchmark numbers were scattered across output directories and ad-hoc tables. This gives us one file to maintain, one place to look, and lets community HF submissions flow in automatically without duplicating entries we already ran ourselves.

## How

- Dedup key is `HF_Model_ID`. Our own runs (Qwen 3 VL, Dots OCR 1.5, Docling) have the slug pre-filled; HF submissions matching those slugs are skipped during sync.
- HF leaderboard YAML task IDs map to our column names: `mean`→Overall, `table`→Tables, `chart`→Charts, `text_content`→Content_Faithfulness, `text_formatting`→Semantic_Formatting, `layout`→Visual_Grounding.
- HF-sourced rows default to `Category = "VLM - Open Weight"` with blank cost columns; Provider is the model slug's suffix with first letter capitalized.
- A non-empty `HF_Model_ID` is the implicit flag that a row came from the community, so no separate `Source` column is needed.
- Pure stdlib + PyYAML (already transitive); no new deps.

## Changes

- `leaderboard.csv` (new, 38 rows)
- `scripts/sync_hf_leaderboard.py` (new)
- `scripts/update_readme.py` (new)
- `README.md` — added `## Leaderboard` section with auto-generated Top-10

## Testing

- `uv run python scripts/sync_hf_leaderboard.py --dry-run` — confirms 12 new community rows, 3 skipped (Dots/Docling/Qwen 3 VL) against the current HF leaderboard
- Second run is a clean no-op (all rows present); README regeneration still runs
- `uv run ruff check scripts/` and `uv run ruff format --check scripts/` — clean

## Notes for reviewers

- When a community PR on HF gets merged, that entry's YAML URL flips from `refs/pr/N` to `main`; the script handles both.
- Refresh flow after a new in-house run: append row to `leaderboard.csv`, run `python3 scripts/update_readme.py`. For HF sync: `uv run python scripts/sync_hf_leaderboard.py` (does both).
- Supersedes #11 (bad branch name).