### PR TITLE
Add Qwen3.5-9B / 2B / 0.8B vLLM layout pipelines

### DIFF
--- a/leaderboard.csv
+++ b/leaderboard.csv
@@ -37,4 +37,7 @@ DeepSeek-OCR-2,VLM - Open Weight,41.2,61.7,1.1,82,54,7,,,,,,deepseek-ai/DeepSeek
 PaddleOCR-VL,VLM - Open Weight,40.9,67.1,0.9,82.7,54,0,,,,,,PaddlePaddle/PaddleOCR-VL
 Gemma-4-E4B-it,VLM - Open Weight,40.5,25,7.7,81.4,52.5,35.8,,,,,,google/gemma-4-E4B-it
 Qwen3.5-4B,VLM - Open Weight,35.4,8,2.5,88.9,57.8,19.7,,,,,,Qwen/Qwen3.5-4B
+Qwen3.5-9B,VLM - Open Weight,31.9,9.9,5.4,90.5,22,31.8,,,,,,Qwen/Qwen3.5-9B
+Qwen3.5-0.8B,VLM - Open Weight,28.4,1.5,0.4,82,43.1,15,,,,,,Qwen/Qwen3.5-0.8B
+Qwen3.5-2B,VLM - Open Weight,27.3,0,0.1,87.2,31.1,18.3,,,,,,Qwen/Qwen3.5-2B
 GLM-OCR,VLM - Open Weight,29.6,66.1,1.7,78,2.3,0,,,,,,zai-org/GLM-OCR

--- a/src/parse_bench/inference/pipelines/parse.py
+++ b/src/parse_bench/inference/pipelines/parse.py
@@ -886,6 +886,45 @@ def register_parse_pipelines(register_fn) -> None:  # type: ignore[no-untyped-de
         )
     )
 
+    # Qwen3.5-9B vLLM — layout mode (structured JSON with bboxes + content)
+    register_fn(
+        PipelineSpec(
+            pipeline_name="qwen3_5_9b_vllm_layout",
+            provider_name="qwen3_5",
+            product_type=ProductType.PARSE,
+            config={
+                "model": "qwen3.5-9b",
+                "prompt_mode": "layout",
+            },
+        )
+    )
+
+    # Qwen3.5-2B vLLM — layout mode
+    register_fn(
+        PipelineSpec(
+            pipeline_name="qwen3_5_2b_vllm_layout",
+            provider_name="qwen3_5",
+            product_type=ProductType.PARSE,
+            config={
+                "model": "qwen3.5-2b",
+                "prompt_mode": "layout",
+            },
+        )
+    )
+
+    # Qwen3.5-0.8B vLLM — layout mode
+    register_fn(
+        PipelineSpec(
+            pipeline_name="qwen3_5_0_8b_vllm_layout",
+            provider_name="qwen3_5",
+            product_type=ProductType.PARSE,
+            config={
+                "model": "qwen3.5-0.8b",
+                "prompt_mode": "layout",
+            },
+        )
+    )
+
     # =========================================================================
     # Qwen3.5-35B-A3B FP8 (unified multimodal, GDN + attention hybrid, MoE 35B/3B)
     # =========================================================================


### PR DESCRIPTION
## What

Registers three new bench pipelines for the smaller dense Qwen3.5 sizes:

- `qwen3_5_9b_vllm_layout` — model `qwen3.5-9b`
- `qwen3_5_2b_vllm_layout` — model `qwen3.5-2b`
- `qwen3_5_0_8b_vllm_layout` — model `qwen3.5-0.8b`

## Why

The repo currently only exposes Qwen3.5-4B and the 35B-A3B variants. Adding 9B/2B/0.8B gives coverage across the dense Qwen3.5 size ladder so parse quality can be compared against model size and GPU cost on the standard benchmarks.

## How

- Each pipeline reuses the existing `qwen3_5` provider with `prompt_mode: layout` (JSON with bboxes + content).
- No provider code changed; config shape matches the existing `qwen3_5_4b_vllm_layout` entry exactly.
- All three share the `QWEN35_SERVER_URL` env var — point it at whichever deployment you're running at the time.

## Changes

- `src/parse_bench/inference/pipelines/parse.py` — register the three new layout pipelines.

## Testing

- `uv run --extra runners parse-bench pipelines` lists all three new pipelines alongside the existing Qwen3.5 entries.
- `uv run ruff check src/parse_bench/inference/pipelines/parse.py` — clean.

## Notes

- Set `QWEN35_SERVER_URL` to the appropriate vLLM endpoint (one deployment per model size) before running.
- Qwen3.5 requires vLLM nightly for the GDN architecture.