### PR TITLE
Fix --test flag silently ignored when full dataset already downloaded

### DIFF
--- a/src/parse_bench/cli.py
+++ b/src/parse_bench/cli.py
@@ -141,17 +141,24 @@ class BenchCLI:
         """
         return self.data.download(data_dir=data_dir, force=force, test=test)
 
-    def status(self, data_dir: str | Path | None = None) -> int:
+    def status(
+        self,
+        data_dir: str | Path | None = None,
+        test: bool = False,
+    ) -> int:
         """Check if the benchmark dataset is downloaded and ready.
 
         Args:
-            data_dir: Data directory to check (default: ./data)
+            data_dir: Data directory to check
+                (default: ./data, or ./data/test when --test is set)
+            test: Check the small test dataset instead of the full dataset
 
         Example:
             parse-bench status
+            parse-bench status --test
             parse-bench status data/
         """
-        return self.data.status(data_dir=data_dir)
+        return self.data.status(data_dir=data_dir, test=test)
 
     def pipelines(self) -> None:
         """List all available pipeline configurations."""

--- a/src/parse_bench/data/cli.py
+++ b/src/parse_bench/data/cli.py
@@ -3,7 +3,7 @@
 import sys
 from pathlib import Path
 
-from parse_bench.data.download import download_dataset, is_dataset_ready
+from parse_bench.data.download import default_data_dir, download_dataset, is_dataset_ready
 
 
 class DataCLI:
@@ -18,7 +18,8 @@ class DataCLI:
         """Download the parse-bench dataset from HuggingFace.
 
         Args:
-            data_dir: Local directory to store the dataset (default: ./data)
+            data_dir: Local directory to store the dataset
+                (default: ./data, or ./data/test when --test is set)
             force: Force re-download even if data already exists
             test: Download the small test dataset (3 files per category)
 
@@ -26,7 +27,7 @@ class DataCLI:
             Exit code (0 for success, non-zero for failure)
         """
         try:
-            data_path = Path(data_dir) if data_dir else None
+            data_path = Path(data_dir) if data_dir else default_data_dir(test=test)
             download_dataset(data_dir=data_path, force=force, test=test)
             return 0
         except Exception as e:
@@ -39,18 +40,23 @@ class DataCLI:
     def status(
         self,
         data_dir: str | Path | None = None,
+        test: bool = False,
     ) -> int:
         """Check if the dataset is downloaded and show summary statistics.
 
         Args:
-            data_dir: Data directory to check (default: ./data)
+            data_dir: Data directory to check
+                (default: ./data, or ./data/test when --test is set)
+            test: Check the small test dataset instead of the full dataset
 
         Returns:
             Exit code (0 if ready, 1 if not)
         """
         import json
 
-        data_path = Path(data_dir) if data_dir else Path.cwd() / "data"
+        data_path = (
+            Path(data_dir) if data_dir else Path.cwd() / default_data_dir(test=test)
+        )
         ready = is_dataset_ready(data_path)
 
         if not ready:

--- a/src/parse_bench/data/download.py
+++ b/src/parse_bench/data/download.py
@@ -20,6 +20,22 @@ DATASET_REPO = "llamaindex/ParseBench"
 DATASET_REPO_TYPE = "dataset"
 TEST_DATA_REVISION = "test-data"
 
+# Default on-disk locations. Test data lives in a sibling subdirectory so the
+# two datasets coexist and `--test` does not silently overlay or get masked
+# by an existing full download.
+DEFAULT_DATA_DIR = Path("./data")
+DEFAULT_TEST_DATA_DIR = Path("./data/test")
+
+
+def default_data_dir(test: bool = False) -> Path:
+    """Return the default on-disk dataset path for the given mode.
+
+    Used by every CLI surface that takes ``--test`` so the routing is
+    consistent between ``download``, ``run`` and ``status``.
+    """
+    return DEFAULT_TEST_DATA_DIR if test else DEFAULT_DATA_DIR
+
+
 # Files that must exist for the dataset to be considered complete
 _REQUIRED_FILES = [
     "chart.jsonl",

--- a/src/parse_bench/pipeline/cli.py
+++ b/src/parse_bench/pipeline/cli.py
@@ -10,7 +10,7 @@ import fire
 from parse_bench.analysis.aggregation_report import generate_aggregation_report
 from parse_bench.analysis.cli import AnalysisCLI
 from parse_bench.analysis.leaderboard_report import generate_leaderboard_report
-from parse_bench.data.download import download_dataset, is_dataset_ready
+from parse_bench.data.download import default_data_dir, download_dataset, is_dataset_ready
 from parse_bench.evaluation.cli import EvaluationCLI
 from parse_bench.inference.cli import InferenceCLI
 
@@ -104,9 +104,11 @@ class PipelineCLI:
                     skip_inference=skip_inference,
                 )
 
-            # Default input_dir to ./data
+            # Default input_dir based on --test (./data/test vs ./data) so
+            # the test subset doesn't silently get masked by an existing full
+            # dataset at ./data, and so the two coexist without overlay.
             if input_dir is None:
-                input_dir = "./data"
+                input_dir = default_data_dir(test=test)
 
             input_path = Path(input_dir)
             output_base = Path(output_dir) if output_dir else Path("./output")

--- a/tests/test_data_dir_routing.py
+++ b/tests/test_data_dir_routing.py
@@ -1,0 +1,107 @@
+"""Regression tests for the ``--test`` flag's data-directory routing.
+
+Background: ``parse-bench run <pipeline> --test`` and ``parse-bench download
+--test`` previously read/wrote the same ``./data`` location as the full
+dataset, so when ``./data`` already had the full dataset present, ``--test``
+was silently ignored and the runner processed all 2,078 examples instead of
+the advertised 3-files-per-category subset.
+
+Fix: route ``--test`` to ``./data/test`` by default. Both datasets now coexist.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from parse_bench.data.cli import DataCLI
+from parse_bench.data.download import (
+    DEFAULT_DATA_DIR,
+    DEFAULT_TEST_DATA_DIR,
+    default_data_dir,
+)
+
+
+class TestDefaultDataDir:
+    def test_full_dataset_default(self) -> None:
+        assert default_data_dir(False) == Path("./data")
+        assert default_data_dir(False) == DEFAULT_DATA_DIR
+
+    def test_test_dataset_default(self) -> None:
+        assert default_data_dir(True) == Path("./data/test")
+        assert default_data_dir(True) == DEFAULT_TEST_DATA_DIR
+
+    def test_full_and_test_paths_diverge(self) -> None:
+        # The whole point of the fix: the two paths cannot collide.
+        assert default_data_dir(False) != default_data_dir(True)
+
+
+class TestDownloadRouting:
+    def test_download_test_routes_to_test_subdir(self) -> None:
+        cli = DataCLI()
+        with patch("parse_bench.data.cli.download_dataset") as mock_dl:
+            cli.download(test=True)
+        mock_dl.assert_called_once()
+        kwargs = mock_dl.call_args.kwargs
+        assert kwargs["data_dir"] == DEFAULT_TEST_DATA_DIR
+        assert kwargs["test"] is True
+
+    def test_download_default_routes_to_full_dir(self) -> None:
+        cli = DataCLI()
+        with patch("parse_bench.data.cli.download_dataset") as mock_dl:
+            cli.download()
+        mock_dl.assert_called_once()
+        kwargs = mock_dl.call_args.kwargs
+        assert kwargs["data_dir"] == DEFAULT_DATA_DIR
+        assert kwargs["test"] is False
+
+    def test_explicit_data_dir_is_respected(self, tmp_path: Path) -> None:
+        # Explicit --data_dir overrides the --test default.
+        cli = DataCLI()
+        explicit = tmp_path / "elsewhere"
+        with patch("parse_bench.data.cli.download_dataset") as mock_dl:
+            cli.download(data_dir=str(explicit), test=True)
+        kwargs = mock_dl.call_args.kwargs
+        assert kwargs["data_dir"] == explicit
+
+
+class TestStatusRouting:
+    def test_status_test_flag_checks_test_subdir(self, tmp_path: Path) -> None:
+        # Use a clean cwd so the default ./data/test resolves under tmp_path.
+        cli = DataCLI()
+        with patch("parse_bench.data.cli.is_dataset_ready", return_value=False) as mock_ready, \
+             patch("parse_bench.data.cli.Path.cwd", return_value=tmp_path):
+            rc = cli.status(test=True)
+        # Status returns 1 when not ready; we only care about which path it checked.
+        assert rc == 1
+        checked_path = mock_ready.call_args.args[0]
+        assert checked_path == tmp_path / DEFAULT_TEST_DATA_DIR
+
+
+@pytest.mark.parametrize(
+    "test_flag,expected_relative",
+    [(False, Path("./data")), (True, Path("./data/test"))],
+)
+def test_pipeline_run_input_dir_routing(test_flag: bool, expected_relative: Path) -> None:
+    """The pipeline runner must default ``input_dir`` based on ``--test``.
+
+    We mock the heavy machinery (download, inference, evaluation, analysis)
+    and only inspect the ``input_dir`` that gets propagated to
+    ``InferenceCLI.run`` — that is the one parameter the bug was dropping.
+    """
+    from parse_bench.pipeline.cli import PipelineCLI
+
+    cli = PipelineCLI()
+    with patch("parse_bench.pipeline.cli.is_dataset_ready", return_value=True), \
+         patch("parse_bench.pipeline.cli.InferenceCLI") as mock_inf_cls, \
+         patch.object(cli, "_run_multi_group_evaluation", return_value=0):
+        mock_inf = mock_inf_cls.return_value
+        mock_inf.run.return_value = 0
+        rc = cli.run(pipeline="dummy", test=test_flag)
+
+    assert rc == 0
+    # InferenceCLI.run receives the resolved input_dir; assert routing works.
+    inf_kwargs = mock_inf.run.call_args.kwargs
+    assert inf_kwargs["input_dir"] == expected_relative


### PR DESCRIPTION
## Summary

`parse-bench run <pipeline> --test` and `parse-bench download --test` were silently ignored once `./data` had the full dataset, so the runner processed all 2,078 examples instead of the advertised 3-files-per-category subset. Smoke-test workflow in the README is currently broken.

Root cause: `pipeline/cli.py` only consults `--test` inside the `if not is_dataset_ready(input_path)` branch, and `data/cli.py:download` writes the test dataset into the same `./data` path as the full one (so it either overlays the full set or gets masked by it).

## Fix

Route `--test` to a separate `./data/test` directory by default. Both datasets now coexist; explicit `--input_dir` / `--data_dir` still overrides. Added `--test` to the `status` commands so users can check the test dataset's state without manually constructing the path.

Centralized in `data/download.py::default_data_dir(test: bool)` so `run`, `download`, and `status` route consistently.

## Test plan

- [x] New `tests/test_data_dir_routing.py` (9 tests, all passing) covering:
  - `default_data_dir` for both modes
  - `download` routing for `test=True` / `test=False` / explicit `--data_dir`
  - `status --test` routing
  - `pipeline.run` routing for both `test=True` / `test=False` (mocking inference)
- [x] End-to-end smoke: with the full dataset already at `./data`, `parse-bench run pymupdf_text --test --open_report=False` now processes exactly **12 examples** (3 per category × 4 inference dirs) instead of 2,078. `parse-bench status --test` reports "Total 739 / 12 unique documents" against `data/test`.
- [x] `parse-bench download --test` cleanly populates `./data/test` while leaving `./data` untouched.

## Notes

- `pyproject.toml` already configured `[tool.pytest.ini_options] testpaths = ["tests"]` but the directory didn't exist. This PR creates it; future tests should land there.
- Pre-existing lint warnings (F541 in `data/cli.py:112` and `pipeline/cli.py:395`) were not introduced by this change and are out of scope.