### PR TITLE
Add pulse_ultra_2 pipeline and fix Pulse layout adapter

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -121,6 +121,7 @@ These pipelines use hosted APIs. You only need an API key in your `.env` file.
 | Pipeline | Description | Env Var |
 |---|---|---|
 | `pulse` | Default with HTML table output | `PULSE_API_KEY` |
+| `pulse_ultra_2` | `pulse-ultra-2` VLM tier (10 credits/page) | `PULSE_API_KEY` |
 
 ### Chunkr
 

--- a/leaderboard.csv
+++ b/leaderboard.csv
@@ -24,7 +24,7 @@ Extend,Commercial - Startup APIs,55.75,85.05,1.59,84.08,47.36,60.67,2.5,,,,,
 Extend (Beta),Commercial - Startup APIs,67.83,85.93,40.42,85.03,59.49,68.28,2.5,,,,,
 LandingAI,Commercial - Startup APIs,45.23,73.72,10.88,88.60,27.87,25.08,3,,,,,
 Firecrawl,Commercial - Startup APIs,31.08,55.88,0,74.37,25.16,0,0.9,,,,,
-Pulse,Commercial - Startup APIs,54.3,86.0,1.5,86.5,29.1,68.3,1.5,,,,,
+Pulse,Commercial - Startup APIs,54.3,86.0,1.5,86.5,29.1,77.6,1.5,,,,,
 Databricks AI Parse,Commercial - IDP,52.22,83.67,0,88.25,55.25,33.91,6.06,,,,,
 Databricks AI Parse (batch),Commercial - IDP,52.2,83.93,0,88.3,55.04,33.74,2.5,,,,,
 Qwen3-VL-8B-Instruct,VLM - Open Weight,61.97,74.61,28.18,87.63,64.23,55.18,,,,,,Qwen/Qwen3-VL-8B-Instruct

--- a/src/parse_bench/inference/pipelines/parse.py
+++ b/src/parse_bench/inference/pipelines/parse.py
@@ -205,6 +205,21 @@ def register_parse_pipelines(register_fn) -> None:  # type: ignore[no-untyped-de
         )
     )
 
+    # pulse-ultra-2: vision-language model with built-in refinement,
+    # figure/chart extraction, and word-level bounding boxes
+    # (10 credits/page vs 1 credit/page for default).
+    register_fn(
+        PipelineSpec(
+            pipeline_name="pulse_ultra_2",
+            provider_name="pulse",
+            product_type=ProductType.PARSE,
+            config={
+                "model": "pulse-ultra-2",
+                "return_html": True,
+            },
+        )
+    )
+
     # =========================================================================
     # Chunkr Pipelines
     # =========================================================================

--- a/src/parse_bench/inference/providers/parse/pulse.py
+++ b/src/parse_bench/inference/providers/parse/pulse.py
@@ -41,6 +41,9 @@ _MAX_POLL_ATTEMPTS = 150  # 5 minutes at 2s interval
 _VIRTUAL_PAGE_DIM = 1000.0
 
 # Map Pulse bounding_boxes label keys to canonical layout labels.
+# "Header" is intentionally a default; it gets disambiguated into
+# Page-header vs Section-header by Y-position in _build_layout_pages
+# because Pulse lumps both into the same bucket.
 _PULSE_LABEL_MAP: dict[str, str] = {
     "Title": "Title",
     "Text": "Text",
@@ -49,7 +52,14 @@ _PULSE_LABEL_MAP: dict[str, str] = {
     "Page Number": "Page-footer",
     "Images": "Picture",
     "Tables": "Table",
+    "caption": "Caption",
 }
+
+# Y-position bands used to split Pulse's "Header" bucket. A header whose
+# top edge lies inside the top or bottom margin is treated as a page
+# header; anything in the middle band is a section header.
+_PAGE_HEADER_TOP_BAND = 0.10
+_PAGE_HEADER_BOTTOM_BAND = 0.90
 
 
 @register_provider("pulse")
@@ -363,9 +373,17 @@ def _build_layout_pages(bounding_boxes: dict[str, Any]) -> list[ParseLayoutPageI
                 confidence = 1.0
 
             x, y, w, h = _polygon_to_xywh(coords)
-            seg = LayoutSegmentIR(x=x, y=y, w=w, h=h, confidence=confidence, label=canonical_label)
 
-            norm_label = canonical_label.strip().lower()
+            # Pulse's "Header" bucket mixes page-headers (top/bottom margin) and
+            # section-headers (mid-page). Split by Y position so Section-header
+            # GT rules score against the right predictions.
+            elem_label = canonical_label
+            if label_key == "Header" and _PAGE_HEADER_TOP_BAND <= y <= _PAGE_HEADER_BOTTOM_BAND:
+                elem_label = "Section-header"
+
+            seg = LayoutSegmentIR(x=x, y=y, w=w, h=h, confidence=confidence, label=elem_label)
+
+            norm_label = elem_label.strip().lower()
             if norm_label == "table":
                 item_type = "table"
             elif norm_label == "picture":


### PR DESCRIPTION
## Summary

- Register a new `pulse_ultra_2` parse pipeline targeting Pulse's `pulse-ultra-2` VLM tier (10 credits/page vs 1 credit/page for the default).
- Fix two bugs in the Pulse parse provider's visual-grounding adapter:
  - Add `caption` (lowercase) to `_PULSE_LABEL_MAP` so Pulse's caption boxes are no longer silently dropped on `Caption` rules.
  - Split Pulse's `Header` bucket by Y position — boxes whose top edge lies in the mid-page band `[0.10, 0.90]` are reclassified as `Section-header`; tops in the top/bottom margin stay `Page-header`. Pulse lumps both into one bucket, so without this split section headers were mislabeled and double-penalized.
- Update Pulse `Visual_Grounding` in `leaderboard.csv` from 68.3 to 77.6 to reflect the adapter fixes.
- Document `pulse_ultra_2` in `docs/pipelines.md`.

## Test plan

- [x] `uv run parse-bench pipelines` lists `pulse_ultra_2`.
- [x] `uv run parse-bench run pulse --test` produces normalized layout with `Caption` and `Section-header` items where expected.
- [x] `uv run parse-bench run pulse_ultra_2 --test` succeeds end-to-end with the new model config.