### PR TITLE
Replace Pulse leaderboard entry with Pulse Ultra 2

### DIFF
--- a/leaderboard.csv
+++ b/leaderboard.csv
@@ -24,7 +24,7 @@ Extend,Commercial - Startup APIs,55.75,85.05,1.59,84.08,47.36,60.67,2.5,,,,,
 Extend (Beta),Commercial - Startup APIs,67.83,85.93,40.42,85.03,59.49,68.28,2.5,,,,,
 LandingAI,Commercial - Startup APIs,45.23,73.72,10.88,88.60,27.87,25.08,3,,,,,
 Firecrawl,Commercial - Startup APIs,31.08,55.88,0,74.37,25.16,0,0.9,,,,,
-Pulse,Commercial - Startup APIs,54.3,86.0,1.5,86.5,29.1,77.6,1.5,,,,,
+Pulse Ultra 2,Commercial - Startup APIs,80.1,82.9,73.7,87.6,82.4,73.9,15,,,,,
 Databricks AI Parse,Commercial - IDP,52.22,83.67,0,88.25,55.25,33.91,6.06,,,,,
 Databricks AI Parse (batch),Commercial - IDP,52.2,83.93,0,88.3,55.04,33.74,2.5,,,,,
 Qwen3-VL-8B-Instruct,VLM - Open Weight,61.97,74.61,28.18,87.63,64.23,55.18,,,,,,Qwen/Qwen3-VL-8B-Instruct


### PR DESCRIPTION
The previous `Pulse` row reflects a deprecated model tier. This PR replaces it with results from Pulse Ultra 2, the current production model.

Run details:
- Pipeline: pulse_ultra_2 (already registered in docs/pipelines.md)
- Date: 2026-04-29
- Configuration: chart_to_table, figure_description, refine=true
- Cost: 15¢/page (flat, matching the convention used by other Commercial - Startup API entries)

Scores (5-dim):
- Overall: 80.1
- Tables: 82.9
- Charts: 73.7
- Content Faithfulness: 87.6
- Semantic Formatting: 82.4
- Visual Grounding: 73.9

Happy to follow up with a pipeline provider PR if it would be useful for reproducibility.