### PR TITLE
Add Granite Vision 4.1 4B pipeline and leaderboard entry

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -202,6 +202,7 @@ These pipelines require you to deploy the model on your own infrastructure (e.g.
 | Pipeline | Description | Env Var |
 |---|---|---|
 | `granite_vision_pipeline` | PP-DocLayout + per-region Granite Vision | `GRANITE_VISION_SERVER_URL` |
+| `granite_vision_4_1_4b` | Granite Vision 4.1 4B (vLLM, multi-task) | `VLLM_API_KEY` |
 
 ### PaddleOCR-VL
 

--- a/leaderboard.csv
+++ b/leaderboard.csv
@@ -40,6 +40,7 @@ Qwen3.6-35B-A3B,VLM - Open Weight,44.1,19.1,5.1,90.7,58.3,47.4,,,,,,Qwen/Qwen3.6
 DeepSeek-OCR-2,VLM - Open Weight,41.2,61.7,1.1,82,54,7,,,,,,deepseek-ai/DeepSeek-OCR-2
 PaddleOCR-VL,VLM - Open Weight,40.9,67.1,0.9,82.7,54,0,,,,,,PaddlePaddle/PaddleOCR-VL
 Gemma-4-E4B-it,VLM - Open Weight,40.5,25,7.7,81.4,52.5,35.8,,,,,,google/gemma-4-E4B-it
+Granite Vision 4.1 4B,VLM - Open Weight,39.45,63.81,47.47,64.43,21.52,0,,,,,,ibm-granite/granite-vision-4.1-4b
 Qwen3.5-4B,VLM - Open Weight,35.4,8,2.5,88.9,57.8,19.7,,,,,,Qwen/Qwen3.5-4B
 Qwen3.5-9B,VLM - Open Weight,31.9,9.9,5.4,90.5,22,31.8,,,,,,Qwen/Qwen3.5-9B
 Qwen3.5-0.8B,VLM - Open Weight,28.4,1.5,0.4,82,43.1,15,,,,,,Qwen/Qwen3.5-0.8B

--- a/src/parse_bench/inference/pipelines/parse.py
+++ b/src/parse_bench/inference/pipelines/parse.py
@@ -1119,6 +1119,23 @@ def register_parse_pipelines(register_fn) -> None:  # type: ignore[no-untyped-de
         )
     )
 
+    # Granite Vision 4.1 4B (ibm-granite/granite-vision-4.1-4b)
+    # Native vLLM support. Provider runs three task tags concurrently per
+    # image and concatenates outputs -- one pipeline covers tables, charts,
+    # and text without per-dataset task selection.
+    register_fn(
+        PipelineSpec(
+            pipeline_name="granite_vision_4_1_4b",
+            provider_name="granite_vision",
+            product_type=ProductType.PARSE,
+            config={
+                "api_format": "openai",
+                "task": ["ocr", "tables_html", "chart2csv"],
+                "served_model_name": "granite-vision-4.1-4b",
+            },
+        )
+    )
+
     # =========================================================================
     # Gemini - Parse with Layout
     # =========================================================================

--- a/src/parse_bench/inference/providers/parse/granite_vision.py
+++ b/src/parse_bench/inference/providers/parse/granite_vision.py
@@ -39,7 +39,7 @@ from parse_bench.schemas.pipeline_io import (
 )
 from parse_bench.schemas.product import ProductType
 
-# Model name registered in vLLM
+# Default model name registered in vLLM (4.0). Override per pipeline via config.
 SERVED_MODEL_NAME = "granite-vision"
 
 # Task-specific prompts / tags for Granite Vision
@@ -47,7 +47,9 @@ TASK_PROMPTS = {
     "ocr": "Convert the text in this image to markdown.",
     "tables_html": "<tables_html>",
     "tables_json": "<tables_json>",
+    "tables_otsl": "<tables_otsl>",
     "chart2csv": "<chart2csv>",
+    "chart2code": "<chart2code>",
     "chart2summary": "<chart2summary>",
 }
 
@@ -81,12 +83,30 @@ class GraniteVisionProvider(Provider):
         if self._api_format not in ("openai", "simple"):
             raise ProviderConfigError(f"Invalid api_format '{self._api_format}'. Must be 'openai' or 'simple'.")
 
-        self._task = self.base_config.get("task", "ocr")
-        if self._task not in TASK_PROMPTS:
-            raise ProviderConfigError(f"Invalid task '{self._task}'. Must be one of: {list(TASK_PROMPTS.keys())}")
+        # `task` accepts a single string OR a list of strings. With a list,
+        # the provider runs each task tag once and concatenates the outputs --
+        # that lets one pipeline cover datasets that mix tables, charts, and
+        # text without a separate pipeline per task tag.
+        task_cfg: str | list[str] = self.base_config.get("task", "ocr")
+        if isinstance(task_cfg, str):
+            tasks: list[str] = [task_cfg]
+        elif isinstance(task_cfg, list) and all(isinstance(t, str) for t in task_cfg):
+            tasks = list(task_cfg)
+        else:
+            raise ProviderConfigError(
+                f"task must be a string or list of strings, got {type(task_cfg).__name__}: {task_cfg!r}"
+            )
+        if not tasks:
+            raise ProviderConfigError("task list cannot be empty")
+        for t in tasks:
+            if t not in TASK_PROMPTS:
+                raise ProviderConfigError(f"Invalid task '{t}'. Must be one of: {list(TASK_PROMPTS.keys())}")
+        self._tasks: list[str] = tasks
+        self._task = task_cfg
 
         self._timeout = self.base_config.get("timeout", 600)
         self._dpi = self.base_config.get("dpi", 150)
+        self._served_model_name: str = str(self.base_config.get("served_model_name", SERVED_MODEL_NAME))
 
         # API key for authenticated vLLM endpoints
         api_key_env = self.base_config.get("api_key_env", "VLLM_API_KEY")
@@ -115,11 +135,11 @@ class GraniteVisionProvider(Provider):
         except Exception as e:
             raise ProviderPermanentError(f"Error reading image file: {e}") from e
 
-    async def _call_openai_api(self, session: aiohttp.ClientSession, image_b64: str) -> str:
+    async def _call_openai_api(self, session: aiohttp.ClientSession, image_b64: str, task: str) -> str:
         api_url = f"{self._server_url.rstrip('/')}/v1/chat/completions"
 
         payload = {
-            "model": SERVED_MODEL_NAME,
+            "model": self._served_model_name,
             "messages": [
                 {
                     "role": "user",
@@ -130,7 +150,7 @@ class GraniteVisionProvider(Provider):
                         },
                         {
                             "type": "text",
-                            "text": TASK_PROMPTS.get(self._task, TASK_PROMPTS["ocr"]),
+                            "text": TASK_PROMPTS[task],
                         },
                     ],
                 }
@@ -197,9 +217,28 @@ class GraniteVisionProvider(Provider):
 
         async with aiohttp.ClientSession() as session:
             if self._api_format == "simple":
+                # Pipeline server does its own per-region task routing.
                 markdown = await self._call_simple_api(session, image_b64)
+            elif len(self._tasks) == 1:
+                markdown = await self._call_openai_api(session, image_b64, self._tasks[0])
             else:
-                markdown = await self._call_openai_api(session, image_b64)
+                # Run each task tag in parallel and concatenate. Granite Vision
+                # task tags are mutually-exclusive output formats, so a list
+                # like ["tables_html", "chart2csv"] means: extract tables AND
+                # extract chart data, glue them together.
+                results = await asyncio.gather(
+                    *[self._call_openai_api(session, image_b64, t) for t in self._tasks],
+                    return_exceptions=True,
+                )
+                parts: list[str] = []
+                for r in results:
+                    if isinstance(r, Exception):
+                        continue
+                    if r:
+                        parts.append(str(r))
+                if not parts:
+                    raise ProviderPermanentError(f"All tasks ({self._tasks}) returned empty or errored")
+                markdown = "\n\n".join(parts)
 
         return {
             "markdown": markdown,
@@ -208,6 +247,7 @@ class GraniteVisionProvider(Provider):
                 "api_format": self._api_format,
                 "task": self._task,
                 "dpi": self._dpi,
+                "served_model_name": self._served_model_name,
             },
         }
 
@@ -274,6 +314,7 @@ class GraniteVisionProvider(Provider):
                         "api_format": self._api_format,
                         "task": self._task,
                         "dpi": self._dpi,
+                        "served_model_name": self._served_model_name,
                     },
                 },
                 started_at=started_at,
@@ -295,6 +336,63 @@ class GraniteVisionProvider(Provider):
             return tag_text
 
         return re.sub(r"<[^>]+>", _quote_attrs, markdown)
+
+    @staticmethod
+    def _convert_csv_to_html(content: str) -> str:
+        """Convert CSV blocks to HTML <table> elements.
+
+        Granite Vision's <chart2csv> tag outputs CSV data, often inside a
+        ```csv code fence. The chart_data_point and TEDS/GriTS metrics expect
+        HTML <table> markup to locate cells by row/column.
+        """
+        import csv
+        import io
+
+        def csv_block_to_html(csv_text: str) -> str | None:
+            csv_text = csv_text.strip()
+            if not csv_text:
+                return None
+            try:
+                rows = list(csv.reader(io.StringIO(csv_text)))
+            except csv.Error:
+                return None
+            rows = [r for r in rows if any(c.strip() for c in r)]
+            if len(rows) < 2 or max(len(r) for r in rows) < 2:
+                return None
+
+            def esc(s: str) -> str:
+                return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+            header, *body = rows
+            ncols = max(len(r) for r in rows)
+            header = header + [""] * (ncols - len(header))
+            parts = ["<table>", "<thead>", "<tr>"]
+            parts.extend(f"<th>{esc(c)}</th>" for c in header)
+            parts.extend(["</tr>", "</thead>", "<tbody>"])
+            for row in body:
+                row = row + [""] * (ncols - len(row))
+                parts.append("<tr>")
+                parts.extend(f"<td>{esc(c)}</td>" for c in row)
+                parts.append("</tr>")
+            parts.extend(["</tbody>", "</table>"])
+            return "".join(parts)
+
+        fenced = re.compile(r"```\s*csv\s*\n(.*?)```", re.DOTALL | re.IGNORECASE)
+
+        def _fence_replace(m: re.Match) -> str:
+            html = csv_block_to_html(m.group(1))
+            return html if html is not None else m.group(0)
+
+        out = fenced.sub(_fence_replace, content)
+
+        if out == content and "<table" not in out.lower() and "|" not in out:
+            stripped = out.strip()
+            if "," in stripped and stripped.count("\n") >= 1:
+                html = csv_block_to_html(stripped)
+                if html is not None:
+                    out = html
+
+        return out
 
     @staticmethod
     def _convert_md_tables_to_html(content: str) -> str:
@@ -355,6 +453,9 @@ class GraniteVisionProvider(Provider):
 
         markdown = raw_result.raw_output.get("markdown", "")
         if markdown:
+            # <chart2csv> output is CSV (often fenced) -- convert to HTML
+            # tables so chart_data_point / TEDS / GriTS can locate cells.
+            markdown = self._convert_csv_to_html(markdown)
             # Convert any markdown pipe tables to HTML so GriTS/TEDS can score them
             markdown = self._convert_md_tables_to_html(markdown)
             markdown = self._sanitize_html_attributes(markdown)


### PR DESCRIPTION
## Summary
- New pipeline `granite_vision_4_1_4b` targets the IBM Granite Vision 4.1 4B vLLM endpoint.
- Provider now accepts a list of task tags and runs them concurrently per image, concatenating outputs -- one pipeline covers tables, charts, and text.
- New `_convert_csv_to_html()` rewrites `<chart2csv>` CSV blocks as HTML `<table>` so chart_data_point / TEDS / GriTS can score them.
- Leaderboard updated with extended-bench results: Tables 63.81, Charts 47.47, Content_Faithfulness 64.43, Semantic_Formatting 21.52, Visual_Grounding 0 (no native bbox output), Overall 39.45.

## Test plan
- [x] `uv run parse-bench pipelines | grep granite` lists `granite_vision_4_1_4b`
- [x] Provider instantiates with `task=["ocr","tables_html","chart2csv"]` and `served_model_name="granite-vision-4.1-4b"`
- [x] `_convert_csv_to_html()` parses fenced ```` ```csv ```` blocks into `<table>`/`<thead>`/`<tbody>`
- [ ] Run `uv run parse-bench run granite_vision_4_1_4b --test` against the live vLLM endpoint