### PR TITLE
Improve annotator sidebar resizing

### DIFF
--- a/apps/annotator/annotator.css
+++ b/apps/annotator/annotator.css
@@ -845,10 +845,11 @@ body {
 .test-panel {
     width: 400px;
     min-width: 300px;
-    max-width: 700px;
+    max-width: none;
     background: var(--bg-secondary);
     display: flex;
     flex-direction: column;
+    flex: 0 0 auto;
     transition: width 0.2s ease, min-width 0.2s ease, opacity 0.2s ease;
     overflow: hidden;
 }
@@ -2309,9 +2310,9 @@ body {
 }
 
 .extract-node-key {
-    width: 220px;
-    min-width: 160px;
-    flex-shrink: 0;
+    flex: 0 1 clamp(180px, 26%, 520px);
+    min-width: min(180px, 100%);
+    max-width: min(520px, 45%);
 }
 
 .extract-node-key .extract-key {
@@ -2339,7 +2340,8 @@ body {
 
 .extract-node-row--key-editing .extract-node-key,
 .extract-node-key:focus-within {
-    width: 220px;
+    flex-basis: clamp(220px, 32%, 640px);
+    max-width: min(640px, 55%);
 }
 
 .extract-node-row--key-editing .extract-key,

--- a/apps/annotator/annotator.js
+++ b/apps/annotator/annotator.js
@@ -3083,6 +3083,7 @@ let extractPageFilterEnabled = false;
 const EXTRACT_TEXTAREA_SYNC_FULL_LIMIT = 160;
 const EXTRACT_TEXTAREA_SYNC_VIEWPORT_MARGIN = 360;
 let extractTextareaSyncFrame = null;
+let extractTextareaResizeObserver = null;
 
 /**
  * Return a Map keyed by field_path → rule (the first extract_field rule found for that path,
@@ -7635,7 +7636,15 @@ function ensureTestPanelVisible(options = {}) {
         || panel.offsetWidth
         || Number.parseFloat(window.getComputedStyle(panel).width)
         || 0;
-    const nextWidth = Math.min(Math.max(currentWidth, minWidth), maxWidth);
+    if (currentWidth >= minWidth) {
+        return;
+    }
+
+    const splitPane = document.querySelector('.split-pane');
+    const maxAvailableWidth = splitPane
+        ? getMaxTestPanelWidth(splitPane.getBoundingClientRect())
+        : maxWidth;
+    const nextWidth = Math.min(minWidth, maxWidth, maxAvailableWidth);
     panel.style.width = `${nextWidth}px`;
 }
 
@@ -12403,6 +12412,16 @@ async function confirmBrowseSelection() {
 }
 
 // === Resizer ===
+const MIN_RESIZABLE_PDF_PANEL_WIDTH = 220;
+const MIN_RESIZABLE_TEST_PANEL_WIDTH = 300;
+
+function getMaxTestPanelWidth(containerRect) {
+    return Math.max(
+        MIN_RESIZABLE_TEST_PANEL_WIDTH,
+        containerRect.width - MIN_RESIZABLE_PDF_PANEL_WIDTH,
+    );
+}
+
 function initResizer() {
     const pdfPanel = document.querySelector('.pdf-panel');
     const testPanel = document.querySelector('.test-panel');
@@ -12442,7 +12461,10 @@ function initResizer() {
         } else if (activeResizer === resizerTest && testPanel) {
             // Resizing Test panel (from right edge)
             const newWidth = containerRect.right - e.clientX;
-            if (newWidth >= 300 && newWidth <= 700) {
+            if (
+                newWidth >= MIN_RESIZABLE_TEST_PANEL_WIDTH
+                && newWidth <= getMaxTestPanelWidth(containerRect)
+            ) {
                 testPanel.style.width = `${newWidth}px`;
             }
         }
@@ -13044,6 +13066,13 @@ function initEventListeners() {
             extractTreeScroller.addEventListener('scroll', () => {
                 scheduleVisibleExtractEditorTextareaSync(elements.extractKvRows);
             }, { passive: true });
+        }
+        if (typeof ResizeObserver === 'function') {
+            const resizeTarget = extractTreeScroller || elements.extractEditorSection || elements.extractKvRows;
+            extractTextareaResizeObserver = new ResizeObserver(() => {
+                scheduleVisibleExtractEditorTextareaSync(elements.extractKvRows);
+            });
+            extractTextareaResizeObserver.observe(resizeTarget);
         }
     }
 

--- a/apps/annotator/tests/extract-key-textarea.test.mjs
+++ b/apps/annotator/tests/extract-key-textarea.test.mjs
@@ -29,7 +29,8 @@ describe('extract key field editor', () => {
         assert.match(js, /scheduleVisibleExtractEditorTextareaSync\(elements\.extractKvRows\)/);
         assert.match(js, /addEventListener\('focusin'/);
         assert.match(js, /addEventListener\('focusout'/);
-        assert.match(css, /\.extract-node-key\s*{\s*width:\s*220px;[^}]*min-width:\s*160px;/s);
+        assert.match(css, /\.extract-node-key\s*{\s*flex:\s*0 1 clamp\(180px, 26%, 520px\);[^}]*max-width:\s*min\(520px, 45%\);/s);
+        assert.match(js, /new ResizeObserver\(\(\) => \{\s*scheduleVisibleExtractEditorTextareaSync\(elements\.extractKvRows\);/s);
         assert.match(css, /\.extract-node-key \.extract-key\s*{[^}]*resize:\s*none;[^}]*word-break:\s*break-word;/s);
     });
 });


### PR DESCRIPTION
## What
- Let the annotator test panel resize wider across available workspace space.
- Scale extract-field key inputs with the sidebar width and resync textarea heights after panel resize.
- Update the focused annotator test coverage for the responsive key editor behavior.

## Why
- Wider displays had unused space while the extract-field sidebar still forced horizontal scrolling and wrapped moderately long field names.

## How
- Removed the fixed maximum width from the test panel and capped resize by the remaining PDF panel minimum width.
- Switched extract key editor sizing to responsive flex constraints.
- Added a resize observer to keep visible extract textareas measured after sidebar changes.

## How to reproduce/test
- `node --check apps/annotator/annotator.js`
- `node --test apps/annotator/tests/*.mjs`
- Manually verified the annotator sidebar can be dragged wider and field key inputs expand proportionally.