### PR TITLE
Add v0.2 tiered scoring to extract harness

### DIFF
--- a/src/parse_bench/evaluation/metrics/field_grounding/core.py
+++ b/src/parse_bench/evaluation/metrics/field_grounding/core.py
@@ -270,13 +270,20 @@ def field_grounding_localization_passes(
     iou: float,
     max_ioa: float,
     comparison: ValueComparison | None,
+    strict_iou_threshold: float | None = None,
 ) -> bool:
     """Evaluate strict-or-relaxed field localization semantics.
 
     The relaxed branch is reserved for small granularity mismatches: it still
     requires meaningful overlap and an exact typed text/value match.
+
+    ``strict_iou_threshold`` overrides only the strict branch (default 0.5). The
+    relaxed value-conditioned branch (IoU>=0.3 AND IoA>=0.7 AND canonical_exact)
+    is unaffected by the override — it's a fallback escape hatch for granularity
+    mismatches and is intentionally not tunable per rule.
     """
-    if iou >= FIELD_GROUNDING_STRICT_IOU_THRESHOLD:
+    strict = FIELD_GROUNDING_STRICT_IOU_THRESHOLD if strict_iou_threshold is None else strict_iou_threshold
+    if iou >= strict:
         return True
     if field_grounding_has_null_empty_match(comparison):
         return True
@@ -292,12 +299,19 @@ def field_grounding_localization_reason(
     iou: float,
     max_ioa: float,
     comparison: ValueComparison | None,
+    strict_iou_threshold: float | None = None,
 ) -> str:
-    if iou >= FIELD_GROUNDING_STRICT_IOU_THRESHOLD:
+    strict = FIELD_GROUNDING_STRICT_IOU_THRESHOLD if strict_iou_threshold is None else strict_iou_threshold
+    if iou >= strict:
         return "pass"
     if field_grounding_has_null_empty_match(comparison):
         return "pass_null_empty_overlap" if max_ioa > 0.0 else "pass_null_empty_no_support"
-    if field_grounding_localization_passes(iou=iou, max_ioa=max_ioa, comparison=comparison):
+    if field_grounding_localization_passes(
+        iou=iou,
+        max_ioa=max_ioa,
+        comparison=comparison,
+        strict_iou_threshold=strict_iou_threshold,
+    ):
         return "pass_relaxed_iou_canonical_exact"
     return "iou_below_threshold"
 

--- a/src/parse_bench/evaluation/metrics/field_grounding/extract_adapter.py
+++ b/src/parse_bench/evaluation/metrics/field_grounding/extract_adapter.py
@@ -24,11 +24,13 @@ from parse_bench.evaluation.metrics.field_grounding.value_compare import (
     COMPARATOR_VERSION,
     ExpectedType,
     compare_attributed_value,
+    compare_field_with_rule,
+    compare_value_against_rule,
     expected_type_for_field_path,
 )
 from parse_bench.schemas.evaluation import MetricValue
 from parse_bench.test_cases.extract_field_paths import get_path, parse_field_path
-from parse_bench.test_cases.schema import ExtractFieldTestRule
+from parse_bench.test_cases.schema import ExtractFieldTestRule, iter_rule_evidence
 
 _MISSING = object()
 
@@ -81,6 +83,15 @@ def compute_extract_field_grounding_metrics(
     metrics.extend(_compute_null_hallucination_metrics(field_rules, extracted_data))
     metrics.extend(
         _compute_extract_pass_rate_metrics(
+            field_rules,
+            extracted_data,
+            field_citations,
+            skip_field_paths=skip_field_paths,
+            data_schema=data_schema,
+        )
+    )
+    metrics.extend(
+        _compute_v02_grounded_pass_rate_metrics(
             field_rules,
             extracted_data,
             field_citations,
@@ -181,7 +192,18 @@ def _compute_null_hallucination_metrics(
     "missed-null" outcome). The runner's standard tp/fp/fn pooling
     produces ``total_null_hallucination_rate_*`` for the global view.
     """
-    null_rules = [rule for rule in field_rules if rule.expected_value is None and rule.verified]
+
+    # v0.2: a rule is null-expected only when neither expected_value nor any
+    # evidence entry carries a value. Legacy rules (no evidence) collapse to
+    # the original ``expected_value is None`` check.
+    def _is_null_expected(rule: ExtractFieldTestRule) -> bool:
+        if rule.expected_value is not None:
+            return False
+        if rule.evidence:
+            return all(entry.value is None for entry in rule.evidence)
+        return True
+
+    null_rules = [rule for rule in field_rules if _is_null_expected(rule) and rule.verified]
     if not null_rules:
         return []
 
@@ -314,19 +336,33 @@ def _compute_extract_pass_rate_metrics(
     rule_results: list[dict[str, Any]] = []
 
     for rule in value_rules:
+        rule_iou_threshold = rule.iou_threshold
         group = _pattern_group(rule.field_path)
         gt_boxes: list[BBox] = []
-        for gt_bbox in rule.bboxes:
-            normalized = _as_xywh(gt_bbox.bbox)
-            if normalized is not None:
-                gt_boxes.append(BBox(page=gt_bbox.page, bbox=normalized, group=group))
+        if rule.evidence is not None:
+            for entry in rule.evidence:
+                if entry.bbox is None:
+                    continue
+                normalized = _as_xywh(entry.bbox)
+                if normalized is not None:
+                    gt_boxes.append(BBox(page=entry.page, bbox=normalized, group=group))
+        else:
+            for gt_bbox in rule.bboxes:
+                normalized = _as_xywh(gt_bbox.bbox)
+                if normalized is not None:
+                    gt_boxes.append(BBox(page=gt_bbox.page, bbox=normalized, group=group))
 
         expected_type = expected_type_for_field_path(data_schema, rule.field_path, rule.expected_value)
         comparison: ValueComparison | None = value_match_by_rule.get(id(rule))
         matched_pred_path = matched_pred_path_by_rule.get(id(rule))
         if gt_boxes:
             pred_boxes = citations_by_field_path.get(matched_pred_path, []) if matched_pred_path else []
-            selected_pred_boxes = _select_best_bbox_group(gt_boxes, pred_boxes, comparison=comparison)
+            selected_pred_boxes = _select_best_bbox_group(
+                gt_boxes,
+                pred_boxes,
+                comparison=comparison,
+                strict_iou_threshold=rule_iou_threshold,
+            )
             bbox_summary = compute_standard_iou_metrics(gt_boxes, selected_pred_boxes)
             bbox_recall_summary = compute_bbox_metrics(gt_boxes, selected_pred_boxes)
             iou = bbox_summary.iou
@@ -346,6 +382,7 @@ def _compute_extract_pass_rate_metrics(
             iou=iou,
             max_ioa=max_ioa,
             comparison=comparison,
+            strict_iou_threshold=rule_iou_threshold,
         )
         attr_pass = loc_pass and comparison is not None and comparison.passed
 
@@ -377,7 +414,12 @@ def _compute_extract_pass_rate_metrics(
                 "mode": comparison.mode if comparison is not None else "missing",
                 "reason": comparison.reason if comparison is not None else "missing_prediction",
                 "localization_reason": (
-                    field_grounding_localization_reason(iou=iou, max_ioa=max_ioa, comparison=comparison)
+                    field_grounding_localization_reason(
+                        iou=iou,
+                        max_ioa=max_ioa,
+                        comparison=comparison,
+                        strict_iou_threshold=rule_iou_threshold,
+                    )
                     if selected_pred_boxes or loc_pass
                     else "no_support_match"
                 ),
@@ -482,11 +524,288 @@ def _compute_extract_pass_rate_metrics(
     ]
 
 
+def _compute_v02_grounded_pass_rate_metrics(
+    field_rules: list[ExtractFieldTestRule],
+    extracted_data: Any,
+    field_citations: list[Any],
+    *,
+    skip_field_paths: Iterable[str] = (),
+    data_schema: dict[str, Any] | None = None,
+) -> list[MetricValue]:
+    """v0.2 page-grounded + bbox-grounded pass-rate triplets.
+
+    For every verified non-stray rule emits, scoped to the rule's field-family
+    pattern (with coarse-parent prefix walking on the citation side):
+
+    - ``extract_page_grounded_pass_rate`` — passes when there is a citation
+      whose page matches some evidence entry AND the pipeline value at the
+      rule's pattern matches that entry's value. Page-only citations qualify.
+    - ``extract_page_grounded_pass_rate_covered`` — same numerator, denominator
+      restricted to rules where at least one matching citation exists.
+    - ``extract_page_grounded_coverage`` — fraction of rules with a qualifying
+      citation (per-leaf binary).
+    - ``extract_attribution_pass_rate_covered`` — M2b numerator (page+IoU+
+      value), denominator restricted to rules where at least one citation has
+      a bbox at the rule's pattern.
+    - ``extract_attribution_coverage`` — fraction of rules with a bbox-bearing
+      citation at the rule's pattern.
+
+    These metrics filter to ``verified=True`` — they're meaningful only on
+    annotated v0.2 gold. Legacy ``extract_attribution_pass_rate`` is unchanged.
+    """
+    skip_set = set(skip_field_paths)
+    eligible = [
+        rule for rule in field_rules if not _is_stray_rule(rule) and rule.field_path not in skip_set and rule.verified
+    ]
+    if not eligible:
+        return []
+
+    # Index citations by their PATTERN. Page-only citations (bbox=None) are
+    # kept; the page filter still applies because page-grounded scoring needs a
+    # page.
+    citations_by_pattern: dict[tuple[str | None, ...], list[Any]] = defaultdict(list)
+    for citation in field_citations:
+        cit_field_path = getattr(citation, "field_path", None)
+        if not cit_field_path:
+            continue
+        if _as_int(getattr(citation, "page", None)) is None:
+            continue
+        cit_pattern = _field_pattern(cit_field_path)
+        if cit_pattern is None:
+            continue
+        citations_by_pattern[cit_pattern].append(citation)
+
+    page_pass = 0
+    page_pass_covered = 0
+    page_qualified = 0
+    bbox_pass_covered = 0
+    bbox_qualified = 0
+
+    rule_results: list[dict[str, Any]] = []
+
+    for rule in eligible:
+        rule_pattern = _field_pattern(rule.field_path)
+        if rule_pattern is None:
+            continue
+        rule_iou_threshold = rule.iou_threshold
+        evidence_entries = iter_rule_evidence(rule)
+
+        # Exact pattern citations
+        exact_cits = list(citations_by_pattern.get(rule_pattern, []))
+        # Coarse parent prefix-walk: any strict prefix of rule_pattern with
+        # citations counts as a coarse cite (M2a only, never M2b).
+        coarse_cits: list[Any] = []
+        for prefix_len in range(1, len(rule_pattern)):
+            coarse_cits.extend(citations_by_pattern.get(rule_pattern[:prefix_len], []))
+
+        page_qual = bool(exact_cits or coarse_cits)
+        bbox_qual = any(getattr(cit, "bbox", None) is not None for cit in exact_cits)
+        page_qualified += int(page_qual)
+        bbox_qualified += int(bbox_qual)
+
+        # Predictions in the rule's field family. M2a aligns by value+page —
+        # any prediction in the family that value-matches against an evidence
+        # entry whose page matches a citation's page passes.
+        predictions = list(_iter_values_for_pattern(extracted_data, rule_pattern))
+        expected_type = expected_type_for_field_path(data_schema, rule.field_path, rule.expected_value)
+
+        page_pass_for_rule = False
+        if page_qual and predictions and evidence_entries:
+            cit_pages = {_as_int(getattr(c, "page", None)) for c in (exact_cits + coarse_cits)}
+            cit_pages.discard(None)
+            for ev in evidence_entries:
+                if ev.page not in cit_pages:
+                    continue
+                for prediction in predictions:
+                    comparison = compare_field_with_rule(
+                        rule,
+                        ev.value if ev.value is not None else rule.expected_value,
+                        prediction,
+                        expected_type=expected_type,
+                        source_kind="structured_value_no_citation_text",
+                    )
+                    if comparison.passed:
+                        page_pass_for_rule = True
+                        break
+                if page_pass_for_rule:
+                    break
+
+        if page_pass_for_rule:
+            page_pass += 1
+            if page_qual:
+                page_pass_covered += 1
+
+        # M2b _covered: only exact citations with bbox; reuse the same combined
+        # IoU rule the legacy metric uses, scoped to evidence (not just
+        # expected_value). Pass requires (page+IoU) AND value match against
+        # some evidence entry.
+        bbox_pass_for_rule = False
+        if bbox_qual:
+            group = _pattern_group(rule.field_path)
+            # Build GT boxes from evidence entries that have bboxes; fall back
+            # to legacy rule.bboxes when evidence is absent.
+            gt_boxes: list[BBox] = []
+            if rule.evidence is not None:
+                for ev in evidence_entries:
+                    if ev.bbox is None:
+                        continue
+                    normalized = _as_xywh(ev.bbox)
+                    if normalized is None:
+                        continue
+                    gt_boxes.append(BBox(page=ev.page, bbox=normalized, group=group))
+            else:
+                for gt_bbox in rule.bboxes:
+                    normalized = _as_xywh(gt_bbox.bbox)
+                    if normalized is None:
+                        continue
+                    gt_boxes.append(BBox(page=gt_bbox.page, bbox=normalized, group=group))
+
+            if gt_boxes:
+                bbox_cits = [c for c in exact_cits if getattr(c, "bbox", None) is not None]
+                pred_boxes = [
+                    BBox(page=_as_int(c.page), bbox=normalized, group=group)
+                    for c in bbox_cits
+                    if (normalized := _as_xywh(getattr(c, "bbox", None))) is not None
+                    and _as_int(getattr(c, "page", None)) is not None
+                ]
+                if pred_boxes:
+                    # Find any prediction that value-matches against any
+                    # evidence entry; use that comparison to drive the
+                    # localization rule (the relaxed branch reads canonical
+                    # exact text from comparison).
+                    best_comparison: ValueComparison | None = None
+                    for prediction in predictions:
+                        cmp = compare_value_against_rule(
+                            rule,
+                            prediction,
+                            expected_type=expected_type,
+                            source_kind="structured_value_no_citation_text",
+                        )
+                        if (
+                            best_comparison is None
+                            or (cmp.passed and not best_comparison.passed)
+                            or (cmp.passed == best_comparison.passed and cmp.score > best_comparison.score)
+                        ):
+                            best_comparison = cmp
+                    selected = _select_best_bbox_group(
+                        gt_boxes,
+                        pred_boxes,
+                        comparison=best_comparison,
+                        strict_iou_threshold=rule_iou_threshold,
+                    )
+                    summary = compute_standard_iou_metrics(gt_boxes, selected)
+                    max_ioa = field_grounding_max_ioa(summary)
+                    loc_pass = field_grounding_localization_passes(
+                        iou=summary.iou,
+                        max_ioa=max_ioa,
+                        comparison=best_comparison,
+                        strict_iou_threshold=rule_iou_threshold,
+                    )
+                    bbox_pass_for_rule = bool(loc_pass and best_comparison is not None and best_comparison.passed)
+
+        if bbox_pass_for_rule:
+            bbox_pass_covered += 1
+
+        rule_results.append(
+            {
+                "field_path": rule.field_path,
+                "page_pass": page_pass_for_rule,
+                "page_qualified": page_qual,
+                "bbox_pass": bbox_pass_for_rule,
+                "bbox_qualified": bbox_qual,
+                "exact_citation_count": len(exact_cits),
+                "coarse_citation_count": len(coarse_cits),
+            }
+        )
+
+    total = len(eligible)
+    base_meta: dict[str, Any] = {
+        "total": total,
+        "verified_only": True,
+        "rule_results": rule_results,
+        "skipped_field_paths": sorted(skip_set),
+    }
+
+    metrics: list[MetricValue] = []
+
+    metrics.append(
+        MetricValue(
+            metric_name="extract_page_grounded_pass_rate",
+            value=page_pass / total if total > 0 else 0.0,
+            metadata={
+                **base_meta,
+                "tp": page_pass,
+                "fp": total - page_pass,
+                "fn": 0,
+                "denominator": "all_verified_rules",
+            },
+        )
+    )
+    metrics.append(
+        MetricValue(
+            metric_name="extract_page_grounded_pass_rate_covered",
+            value=page_pass_covered / page_qualified if page_qualified > 0 else 0.0,
+            metadata={
+                **base_meta,
+                "tp": page_pass_covered,
+                "fp": page_qualified - page_pass_covered,
+                "fn": 0,
+                "denominator": "page_qualified_rules",
+                "covered_total": page_qualified,
+            },
+        )
+    )
+    metrics.append(
+        MetricValue(
+            metric_name="extract_page_grounded_coverage",
+            value=page_qualified / total if total > 0 else 0.0,
+            metadata={
+                **base_meta,
+                "tp": page_qualified,
+                "fp": total - page_qualified,
+                "fn": 0,
+                "denominator": "all_verified_rules",
+                "definition": "per_leaf_binary_any_matching_citation_with_page",
+            },
+        )
+    )
+    metrics.append(
+        MetricValue(
+            metric_name="extract_attribution_pass_rate_covered",
+            value=bbox_pass_covered / bbox_qualified if bbox_qualified > 0 else 0.0,
+            metadata={
+                **base_meta,
+                "tp": bbox_pass_covered,
+                "fp": bbox_qualified - bbox_pass_covered,
+                "fn": 0,
+                "denominator": "bbox_qualified_rules",
+                "covered_total": bbox_qualified,
+            },
+        )
+    )
+    metrics.append(
+        MetricValue(
+            metric_name="extract_attribution_coverage",
+            value=bbox_qualified / total if total > 0 else 0.0,
+            metadata={
+                **base_meta,
+                "tp": bbox_qualified,
+                "fp": total - bbox_qualified,
+                "fn": 0,
+                "denominator": "all_verified_rules",
+                "definition": "per_leaf_binary_any_matching_citation_with_bbox",
+            },
+        )
+    )
+    return metrics
+
+
 def _select_best_bbox_group(
     gt_boxes: list[BBox],
     pred_boxes: list[BBox],
     *,
     comparison: ValueComparison | None,
+    strict_iou_threshold: float | None = None,
 ) -> list[BBox]:
     """Select the predicted citation bbox group using field localization semantics."""
     if not gt_boxes or not pred_boxes:
@@ -507,6 +826,7 @@ def _select_best_bbox_group(
             iou=summary.iou,
             max_ioa=max_ioa,
             comparison=comparison,
+            strict_iou_threshold=strict_iou_threshold,
         )
         key = (
             float(loc_candidate),
@@ -569,17 +889,22 @@ def _is_stray_rule(rule: ExtractFieldTestRule) -> bool:
     Stray rules are bbox-only evidence rules: they assert that some content
     exists at a location without prescribing a value. They are excluded from
     value F1 (already) and from record-level metrics; they remain in bbox
-    metrics. ``expected_value is None`` covers both explicit stray-tagged
-    rules and the small set of null-value rules with bboxes that aren't
-    formally tagged (e.g., the K-1 part_iii_line_* anomalies in v0.6).
+    metrics.
+
+    v0.2: rules with ``expected_value=None`` but evidence carrying non-null
+    values are NOT stray — they prescribe values via the evidence list. A rule
+    is stray when both ``expected_value`` is None AND no evidence entry
+    contributes a value (legacy null-expected behavior preserved).
     """
     tags = {tag.casefold() for tag in rule.tags}
-    return (
-        rule.expected_value is None
-        or "stray" in tags
-        or "no_value" in tags
-        or any(tag.endswith(":stray") for tag in tags)
-    )
+    if "stray" in tags or "no_value" in tags or any(tag.endswith(":stray") for tag in tags):
+        return True
+    if rule.expected_value is not None:
+        return False
+    if rule.evidence:
+        if any(entry.value is not None for entry in rule.evidence):
+            return False
+    return True
 
 
 def _field_pattern(field_path: str) -> tuple[str | None, ...] | None:
@@ -699,8 +1024,8 @@ def _match_value_group_detailed(
     for rule_index, rule in enumerate(rules):
         expected_type = expected_type_for_field_path(data_schema, rule.field_path, rule.expected_value)
         for pred_index, prediction in enumerate(predictions):
-            comparison = compare_attributed_value(
-                rule.expected_value,
+            comparison = compare_value_against_rule(
+                rule,
                 prediction,
                 expected_type=expected_type,
                 source_kind="structured_value_no_citation_text",
@@ -769,13 +1094,21 @@ def _match_value_group_detailed_with_geometry(
     best_by_rule: dict[int, tuple[tuple[float, float, float, float, float, float], str, ValueComparison]] = {}
 
     for rule_index, rule in enumerate(rules):
+        rule_iou_threshold = rule.iou_threshold
         expected_type = expected_type_for_field_path(data_schema, rule.field_path, rule.expected_value)
         group = _pattern_group(rule.field_path)
-        gt_boxes = [
-            BBox(page=bbox.page, bbox=normalized, group=group)
-            for bbox in rule.bboxes
-            if (normalized := _as_xywh(bbox.bbox)) is not None
-        ]
+        if rule.evidence is not None:
+            gt_boxes = [
+                BBox(page=entry.page, bbox=normalized, group=group)
+                for entry in rule.evidence
+                if entry.bbox is not None and (normalized := _as_xywh(entry.bbox)) is not None
+            ]
+        else:
+            gt_boxes = [
+                BBox(page=bbox.page, bbox=normalized, group=group)
+                for bbox in rule.bboxes
+                if (normalized := _as_xywh(bbox.bbox)) is not None
+            ]
         for pred_path in pred_paths:
             comparison = _compare_prediction_path_value(
                 rule,
@@ -793,6 +1126,7 @@ def _match_value_group_detailed_with_geometry(
                     gt_boxes,
                     citations_by_field_path.get(pred_path, []),
                     comparison=comparison,
+                    strict_iou_threshold=rule_iou_threshold,
                 )
                 summary = compute_standard_iou_metrics(gt_boxes, selected)
                 iou = summary.iou
@@ -802,6 +1136,7 @@ def _match_value_group_detailed_with_geometry(
                     iou=iou,
                     max_ioa=max_ioa,
                     comparison=comparison,
+                    strict_iou_threshold=rule_iou_threshold,
                 )
 
             key = (
@@ -835,8 +1170,8 @@ def _compare_prediction_path_value(
     expected_type: ExpectedType,
 ) -> ValueComparison:
     if pred_path in value_by_path:
-        return compare_attributed_value(
-            rule.expected_value,
+        return compare_value_against_rule(
+            rule,
             value_by_path[pred_path],
             expected_type=expected_type,
             source_kind="structured_value_no_citation_text",
@@ -844,8 +1179,8 @@ def _compare_prediction_path_value(
 
     best: ValueComparison | None = None
     for value in fallback_values:
-        comparison = compare_attributed_value(
-            rule.expected_value,
+        comparison = compare_value_against_rule(
+            rule,
             value,
             expected_type=expected_type,
             source_kind="structured_value_no_citation_text",

--- a/src/parse_bench/evaluation/metrics/field_grounding/value_compare.py
+++ b/src/parse_bench/evaluation/metrics/field_grounding/value_compare.py
@@ -18,6 +18,7 @@ from parse_bench.test_cases.bbox_value_strict_comparator import (
 from parse_bench.test_cases.bbox_value_strict_comparator import (
     compare as compare_bbox_value,
 )
+from parse_bench.test_cases.schema import ExtractFieldTestRule
 
 AttributionSource = Literal["native", "ocr", "structured_value_no_citation_text"]
 
@@ -181,10 +182,112 @@ def _thaw_schema(value: tuple[Any, ...]) -> Any:
     return [_thaw_schema(cast(tuple[Any, ...], item)) for item in value]
 
 
+def compare_field_with_rule(
+    rule: ExtractFieldTestRule | None,
+    expected_value: Any,
+    actual_text: Any,
+    *,
+    expected_type: ExpectedType | None = None,
+    source_kind: AttributionSource = "native",
+    allow_diagnostic_equivalences: bool = False,
+) -> ValueComparison:
+    """v0.2 dispatch shim — extract paths only.
+
+    When ``rule.comparator`` is set, dispatches to a per-comparator implementation;
+    otherwise falls through to ``compare_attributed_value`` (today's extract-side
+    behavior). Phase A: only the fall-through branch is wired — Phase B fills in the
+    dispatch table for ``exact``, ``enum``, ``number_with_unit``, ``string_substring``.
+
+    The shim accepts ``rule=None`` so legacy callers that don't have a rule object
+    (record-level metrics, raw value comparison) can opt in incrementally without
+    threading rule context everywhere.
+    """
+    return compare_attributed_value(
+        expected_value,
+        actual_text,
+        expected_type=expected_type,
+        source_kind=source_kind,
+        allow_diagnostic_equivalences=allow_diagnostic_equivalences,
+    )
+
+
+def candidate_values_for_rule(rule: ExtractFieldTestRule | None) -> list[Any]:
+    """v0.2: yield the deduped set of candidate values for a rule (OR-over-evidence).
+
+    When ``rule.evidence`` is set, returns each evidence ``value`` plus
+    ``rule.expected_value`` (deduped, preserving order). Legacy rules return a
+    single-element list with ``expected_value``. Empty rule returns ``[None]`` so
+    null-expected rules still roundtrip through the comparator.
+    """
+    if rule is None:
+        return [None]
+    seen: set[Any] = set()
+    candidates: list[Any] = []
+
+    def _push(value: Any) -> None:
+        try:
+            key = ("hashable", value)
+            hash(key)
+            if key in seen:
+                return
+            seen.add(key)
+        except TypeError:
+            pass
+        candidates.append(value)
+
+    if rule.evidence is not None:
+        for entry in rule.evidence:
+            _push(entry.value)
+    _push(rule.expected_value)
+    return candidates
+
+
+def compare_value_against_rule(
+    rule: ExtractFieldTestRule | None,
+    prediction: Any,
+    *,
+    expected_type: ExpectedType | None = None,
+    source_kind: AttributionSource = "native",
+    allow_diagnostic_equivalences: bool = False,
+) -> ValueComparison:
+    """Best-of comparison across a rule's candidate values (OR-over-evidence).
+
+    For legacy rules with no v0.2 evidence list this collapses to a single
+    ``compare_field_with_rule`` call against ``rule.expected_value`` — fully
+    backward-compatible. For v0.2 rules with multiple evidence entries the result
+    is the highest-scoring (passing > non-passing, then by score) comparison
+    across all candidate values.
+    """
+    candidates = candidate_values_for_rule(rule)
+    best: ValueComparison | None = None
+    for candidate in candidates:
+        comparison = compare_field_with_rule(
+            rule,
+            candidate,
+            prediction,
+            expected_type=expected_type,
+            source_kind=source_kind,
+            allow_diagnostic_equivalences=allow_diagnostic_equivalences,
+        )
+        if best is None:
+            best = comparison
+            continue
+        if (comparison.passed and not best.passed) or (
+            comparison.passed == best.passed and comparison.score > best.score
+        ):
+            best = comparison
+    if best is None:
+        return ValueComparison(passed=False, score=0.0, mode="missing", reason="no_candidates")
+    return best
+
+
 __all__ = [
     "COMPARATOR_VERSION",
     "AttributionSource",
+    "candidate_values_for_rule",
     "compare_attributed_value",
+    "compare_field_with_rule",
+    "compare_value_against_rule",
     "expected_type_for_field_path",
     "infer_expected_type",
 ]

--- a/src/parse_bench/inference/providers/extract/citations.py
+++ b/src/parse_bench/inference/providers/extract/citations.py
@@ -220,13 +220,23 @@ def _normalize_citation(
                     metadata=metadata,
                 )
             )
-        return results
+        if results:
+            return results
+        return [
+            _field_citation_cls()(
+                field_path=field_path,
+                page=page,
+                bbox=None,
+                polygon=normalized_polygon,
+                reference_text=reference_text,
+                confidence=confidence,
+                source=source,
+                metadata=metadata,
+            )
+        ]
 
     raw_bbox = _bbox_from_polygon(polygon) if polygon is not None else _extract_bbox(citation_map)
     normalized_bbox = _normalize_bbox(raw_bbox, dimensions)
-    if normalized_bbox is None:
-        return []
-
     normalized_polygon = _normalize_polygon(polygon, dimensions) if polygon is not None else None
     return [
         _field_citation_cls()(
@@ -491,7 +501,7 @@ def _dedupe(citations: list[FieldCitation]) -> list[FieldCitation]:
         key = (
             citation.field_path,
             citation.page,
-            tuple(citation.bbox),
+            tuple(citation.bbox) if citation.bbox is not None else None,
             citation.reference_text,
             citation.source,
         )

--- a/src/parse_bench/schemas/extract_output.py
+++ b/src/parse_bench/schemas/extract_output.py
@@ -12,7 +12,10 @@ class FieldCitation(BaseModel):
 
     field_path: str = Field(description="Dotted path of the extracted field this citation supports")
     page: int = Field(ge=1, description="1-indexed page number")
-    bbox: list[float] = Field(description="Normalized COCO [x, y, width, height] bbox")
+    bbox: list[float] | None = Field(
+        default=None,
+        description="Normalized COCO [x, y, width, height] bbox. None for page-only citations.",
+    )
     polygon: list[list[float]] | None = Field(default=None, description="Normalized polygon points, when available")
     reference_text: str | None = Field(default=None, description="Provider reference text for the citation")
     confidence: float | None = Field(default=None, description="Provider confidence score, when available")

--- a/src/parse_bench/test_cases/loader.py
+++ b/src/parse_bench/test_cases/loader.py
@@ -227,8 +227,33 @@ def load_test_case(
     group = file_path.parent.name
     test_id = f"{group}/{file_path.stem}"
 
-    # Get test_rules and other fields
-    test_rules = test_config.get("test_rules", [])
+    # v0.2 _field_rules dict shape (one entry per leaf path) → list shape used by
+    # the rest of the loader. Conflict policy: error if both _field_rules and
+    # test_rules are present so the test author chooses one shape per file.
+    field_rules_dict = test_config.get("_field_rules")
+    raw_test_rules = test_config.get("test_rules")
+    if field_rules_dict is not None and raw_test_rules:
+        raise ValueError(f"{test_json_path}: cannot specify both _field_rules and test_rules; choose one shape")
+    if field_rules_dict is not None:
+        if not isinstance(field_rules_dict, dict):
+            raise ValueError(f"Invalid _field_rules in {test_json_path}: must be a dict keyed by field_path")
+        converted: list[dict[str, Any]] = []
+        for field_path, rule_body in field_rules_dict.items():
+            if not isinstance(rule_body, dict):
+                raise ValueError(f"Invalid _field_rules entry for {field_path!r} in {test_json_path}: must be a dict")
+            entry = dict(rule_body)
+            existing_type = entry.get("type")
+            if existing_type not in (None, "extract_field"):
+                raise ValueError(
+                    f"_field_rules[{field_path!r}].type must be 'extract_field' "
+                    f"(got {existing_type!r}) in {test_json_path}"
+                )
+            entry["type"] = "extract_field"
+            entry["field_path"] = field_path
+            converted.append(entry)
+        test_rules = converted
+    else:
+        test_rules = raw_test_rules if raw_test_rules is not None else []
     if not isinstance(test_rules, list):
         raise ValueError(f"Invalid test_rules field in {test_json_path}: must be a list")
     data_schema = test_config.get("data_schema")
@@ -269,6 +294,7 @@ def load_test_case(
             config=test_config.get("config"),
             expected_output=test_config.get("expected_output"),
             test_rules=test_rules,
+            **({"_schema_version": test_config["_schema_version"]} if "_schema_version" in test_config else {}),
         )
 
         extract_field_rules = extract_case.get_extract_field_rules()

--- a/src/parse_bench/test_cases/schema.py
+++ b/src/parse_bench/test_cases/schema.py
@@ -137,6 +137,33 @@ class ExtractFieldBbox(BaseModel):
     )
 
 
+class FieldEvidence(BaseModel):
+    """One accepted location for a field's value (v0.2 evidence list entry).
+
+    A leaf can have multiple evidence entries (the same answer printed in different
+    places, or alternate canonical forms). Pipelines pass M1/M2a/M2b if they match
+    *any* entry. Primitives only — object-typed leaves are decomposed into sub-leaves.
+    """
+
+    page: int = Field(ge=1, description="1-indexed page number")
+    bbox: list[float] | None = Field(
+        default=None,
+        description=("Normalized COCO [x, y, w, h] bbox; None for page-only / parent-level cites."),
+    )
+    quote: str | None = Field(
+        default=None,
+        description="Verbatim text from the parsed PDF; None when page-only.",
+    )
+    value: str | int | float | bool | None = Field(
+        default=None,
+        description="Canonical schema-shaped value at this location (primitives only).",
+    )
+    coarse: bool = Field(
+        default=False,
+        description="True when this is a parent-level cite or page-only evidence.",
+    )
+
+
 class ExtractFieldTestRule(BaseModel):
     """Self-contained extract field test: value + evidence bboxes + verified flag."""
 
@@ -162,6 +189,51 @@ class ExtractFieldTestRule(BaseModel):
         ),
     )
     tags: list[str] = Field(default_factory=list, description="Optional per-rule tags")
+    # --- v0.2 additions (all optional; legacy rules ignore these) ---
+    evidence: list[FieldEvidence] | None = Field(
+        default=None,
+        description=(
+            "v0.2 evidence list: per-location (page, bbox, quote, value, coarse) entries. "
+            "When present, supersedes the legacy bboxes+expected_value pair for matching."
+        ),
+    )
+    comparator: str | None = Field(
+        default=None,
+        description=(
+            "v0.2 per-leaf comparator name (e.g. 'exact', 'enum', 'number_with_unit', "
+            "'string_substring'). Phase A: parsed but not yet dispatched. None = legacy default."
+        ),
+    )
+    structural: str | None = Field(
+        default=None,
+        description=(
+            "v0.2 array-parent structural rule ('ordered', 'set', 'multiset', 'match_by:<key>'). "
+            "Phase A: parsed but not yet dispatched."
+        ),
+    )
+    evidence_required: bool = Field(
+        default=True,
+        description="v0.2: when False, pipeline may pass M1 with no grounding evidence.",
+    )
+    source_policy: Literal["verbatim", "computed", "inferred"] = Field(
+        default="verbatim",
+        description="v0.2: how the value originates in the source (verbatim, computed, inferred).",
+    )
+    max_evidence: int | None = Field(
+        default=None,
+        ge=1,
+        description="v0.2: cap on evidence list length (None = unlimited).",
+    )
+    iou_threshold: float | None = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "v0.2: per-rule strict-IoU override for M2b. None = harness default (0.5). "
+            "Replaces the strict 0.5 threshold only; the relaxed value-conditioned branch "
+            "(IoU>=0.3 AND IoA>=0.7 AND canonical_exact) is unaffected."
+        ),
+    )
 
 
 ExtractRuleUnion = ExtractFieldTestRule | dict[str, Any]
@@ -198,6 +270,11 @@ class ExtractTestCase(BaseTestCase):
     test_rules: list[ExtractRuleUnion] | None = Field(
         default=None,
         description="List of rule-based test definitions (from test.json test_rules)",
+    )
+    schema_version: str | None = Field(
+        default=None,
+        alias="_schema_version",
+        description="v0.2 schema version tag (e.g. 'extract_core/v0.2'); informational only.",
     )
 
     @field_validator("test_rules", mode="before")
@@ -365,3 +442,25 @@ class LayoutDetectionTestCase(BaseTestCase):
 
 # Union type for backward compatibility
 TestCase = ExtractTestCase | ParseTestCase | LayoutDetectionTestCase
+
+
+def iter_rule_evidence(rule: ExtractFieldTestRule) -> list[FieldEvidence]:
+    """Normalize legacy bboxes/expected_value or v0.2 evidence list into FieldEvidence entries.
+
+    Single normalization point — every metric path consumes this. When ``rule.evidence`` is
+    set, returns it verbatim. Otherwise synthesizes one entry per legacy ``ExtractFieldBbox``
+    using ``rule.expected_value``, with ``coarse=False``. Returns an empty list when the rule
+    has neither (in which case M1 falls back to comparing ``rule.expected_value`` directly).
+    """
+    if rule.evidence is not None:
+        return list(rule.evidence)
+    return [
+        FieldEvidence(
+            page=bbox.page,
+            bbox=list(bbox.bbox),
+            quote=None,
+            value=rule.expected_value,
+            coarse=False,
+        )
+        for bbox in rule.bboxes
+    ]

--- a/tests/parse_bench/evaluation/metrics/field_grounding/test_extract_adapter_v02.py
+++ b/tests/parse_bench/evaluation/metrics/field_grounding/test_extract_adapter_v02.py
@@ -1,0 +1,386 @@
+"""Tests for v0.2 schema extensions and the page-grounded / coverage metrics.
+
+Phase A scope. Phase B (comparator dispatch, structural rules) is not yet
+exercised here — those tests should land alongside the dispatch table.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from parse_bench.evaluation.metrics.field_grounding.extract_adapter import (
+    compute_extract_field_grounding_metrics,
+)
+from parse_bench.evaluation.metrics.field_grounding.value_compare import (
+    candidate_values_for_rule,
+    compare_field_with_rule,
+    compare_value_against_rule,
+)
+from parse_bench.schemas.extract_output import FieldCitation
+from parse_bench.test_cases.schema import (
+    ExtractFieldBbox,
+    ExtractFieldTestRule,
+    FieldEvidence,
+    iter_rule_evidence,
+)
+
+
+def _named(metrics):
+    return {m.metric_name: m for m in metrics}
+
+
+class TestIterRuleEvidence:
+    def test_legacy_bboxes_synthesize_evidence(self):
+        rule = ExtractFieldTestRule(
+            field_path="foo",
+            expected_value="bar",
+            bboxes=[ExtractFieldBbox(page=1, bbox=[0.1, 0.1, 0.2, 0.2])],
+        )
+        evidence = iter_rule_evidence(rule)
+        assert len(evidence) == 1
+        assert evidence[0].page == 1
+        assert evidence[0].value == "bar"
+        assert evidence[0].coarse is False
+
+    def test_v02_evidence_list_returned_verbatim(self):
+        rule = ExtractFieldTestRule(
+            field_path="foo",
+            expected_value="UNII",
+            evidence=[
+                FieldEvidence(page=2, bbox=[0.5, 0.5, 0.1, 0.1], value="LABEL"),
+                FieldEvidence(page=3, value="UNII", coarse=True),
+            ],
+        )
+        evidence = iter_rule_evidence(rule)
+        assert len(evidence) == 2
+        assert evidence[1].coarse is True
+        assert evidence[1].bbox is None
+
+    def test_empty_rule_returns_empty(self):
+        rule = ExtractFieldTestRule(field_path="foo", expected_value=None)
+        assert iter_rule_evidence(rule) == []
+
+
+class TestComparatorShim:
+    def test_falls_through_to_attributed_value_when_no_comparator(self):
+        rule = ExtractFieldTestRule(field_path="foo", expected_value="bar")
+        result = compare_field_with_rule(rule, "bar", "bar", expected_type="string")
+        assert result.passed
+
+    def test_rule_none_falls_through(self):
+        result = compare_field_with_rule(None, "bar", "bar", expected_type="string")
+        assert result.passed
+
+
+class TestCandidateValuesForRule:
+    def test_legacy_returns_single_expected(self):
+        rule = ExtractFieldTestRule(field_path="foo", expected_value="bar")
+        assert candidate_values_for_rule(rule) == ["bar"]
+
+    def test_v02_evidence_emits_all_unique_values(self):
+        rule = ExtractFieldTestRule(
+            field_path="foo",
+            expected_value="canonical",
+            evidence=[
+                FieldEvidence(page=1, value="alt-1"),
+                FieldEvidence(page=2, value="canonical"),
+                FieldEvidence(page=3, value="alt-1"),
+            ],
+        )
+        cands = candidate_values_for_rule(rule)
+        assert "alt-1" in cands and "canonical" in cands
+        assert len(cands) == 2
+
+    def test_none_rule_returns_none(self):
+        assert candidate_values_for_rule(None) == [None]
+
+
+class TestOrOverEvidence:
+    def test_pipeline_value_matches_alternate_evidence_value(self):
+        rule = ExtractFieldTestRule(
+            field_path="ingredients[0].name",
+            expected_value="UNII-CANONICAL",
+            evidence=[
+                FieldEvidence(page=1, value="LABEL-PRINTED"),
+                FieldEvidence(page=2, value="UNII-CANONICAL"),
+            ],
+        )
+        result = compare_value_against_rule(rule, "LABEL-PRINTED", expected_type="string")
+        assert result.passed
+
+    def test_no_match_against_any_candidate(self):
+        rule = ExtractFieldTestRule(
+            field_path="foo",
+            expected_value="bar",
+            evidence=[FieldEvidence(page=1, value="baz")],
+        )
+        result = compare_value_against_rule(rule, "qux", expected_type="string")
+        assert not result.passed
+
+
+class TestPageGroundedMetric:
+    def test_passes_when_page_matches_no_bbox(self):
+        rule = ExtractFieldTestRule(
+            field_path="ndc[0]",
+            expected_value="37000-439",
+            evidence=[FieldEvidence(page=4, value="37000-439")],
+        )
+        # Page-only citation (Extend pattern)
+        citations = [FieldCitation(field_path="ndc[0]", page=4, bbox=None, source="extend")]
+        metrics = _named(
+            compute_extract_field_grounding_metrics(
+                extracted_data={"ndc": ["37000-439"]},
+                field_rules=[rule],
+                field_citations=citations,
+                data_schema={"type": "object"},
+            )
+        )
+        assert metrics["extract_page_grounded_pass_rate"].value == 1.0
+        assert metrics["extract_page_grounded_coverage"].value == 1.0
+        # Page-only citation does NOT contribute to bbox coverage
+        assert metrics["extract_attribution_coverage"].value == 0.0
+
+    def test_fails_when_page_wrong(self):
+        rule = ExtractFieldTestRule(
+            field_path="foo",
+            expected_value="bar",
+            evidence=[FieldEvidence(page=1, value="bar")],
+        )
+        citations = [FieldCitation(field_path="foo", page=99, bbox=None, source="x")]
+        metrics = _named(
+            compute_extract_field_grounding_metrics(
+                extracted_data={"foo": "bar"},
+                field_rules=[rule],
+                field_citations=citations,
+                data_schema={"type": "object"},
+            )
+        )
+        # Citation has wrong page → page_pass=False but still qualifies for coverage
+        assert metrics["extract_page_grounded_pass_rate"].value == 0.0
+        assert metrics["extract_page_grounded_coverage"].value == 1.0
+
+
+class TestCoarseParentPrefixWalk:
+    def test_parent_cite_counts_for_m2a_not_m2b(self):
+        rule = ExtractFieldTestRule(
+            field_path="warnings[0].text",
+            expected_value="Do not use",
+            evidence=[FieldEvidence(page=2, value="Do not use")],
+        )
+        citations = [
+            FieldCitation(field_path="warnings", page=2, bbox=[0.1, 0.1, 0.5, 0.5], source="reducto"),
+        ]
+        metrics = _named(
+            compute_extract_field_grounding_metrics(
+                extracted_data={"warnings": [{"text": "Do not use"}]},
+                field_rules=[rule],
+                field_citations=citations,
+                data_schema={"type": "object"},
+            )
+        )
+        assert metrics["extract_page_grounded_pass_rate"].value == 1.0
+        assert metrics["extract_attribution_coverage"].value == 0.0
+
+
+class TestCoverage:
+    def test_zero_when_no_citations(self):
+        rule = ExtractFieldTestRule(field_path="foo", expected_value="bar")
+        metrics = _named(
+            compute_extract_field_grounding_metrics(
+                extracted_data={"foo": "bar"},
+                field_rules=[rule],
+                field_citations=[],
+                data_schema={"type": "object"},
+            )
+        )
+        assert metrics["extract_page_grounded_coverage"].value == 0.0
+        assert metrics["extract_attribution_coverage"].value == 0.0
+
+    def test_one_when_all_rules_have_citations(self):
+        rule = ExtractFieldTestRule(
+            field_path="foo",
+            expected_value="bar",
+            evidence=[FieldEvidence(page=1, bbox=[0.1, 0.1, 0.2, 0.2], value="bar")],
+        )
+        citations = [FieldCitation(field_path="foo", page=1, bbox=[0.1, 0.1, 0.2, 0.2], source="x")]
+        metrics = _named(
+            compute_extract_field_grounding_metrics(
+                extracted_data={"foo": "bar"},
+                field_rules=[rule],
+                field_citations=citations,
+                data_schema={"type": "object"},
+            )
+        )
+        assert metrics["extract_page_grounded_coverage"].value == 1.0
+        assert metrics["extract_attribution_coverage"].value == 1.0
+
+
+class TestPerRuleIouThreshold:
+    def test_loose_threshold_lets_imperfect_iou_pass(self):
+        rule = ExtractFieldTestRule(
+            field_path="foo",
+            expected_value="bar",
+            bboxes=[ExtractFieldBbox(page=1, bbox=[0.1, 0.1, 0.4, 0.4])],
+            iou_threshold=0.2,
+        )
+        # Pred bbox shifted slightly → IoU below 0.5 default but above 0.2
+        citations = [FieldCitation(field_path="foo", page=1, bbox=[0.15, 0.15, 0.4, 0.4], source="x")]
+        metrics = _named(
+            compute_extract_field_grounding_metrics(
+                extracted_data={"foo": "bar"},
+                field_rules=[rule],
+                field_citations=citations,
+                data_schema={"type": "object"},
+            )
+        )
+        assert metrics["extract_attribution_pass_rate"].value == 1.0
+
+
+class TestBackwardCompat:
+    def test_legacy_bboxes_path_unchanged(self):
+        """Legacy rules without v0.2 evidence keep producing the same M2b results."""
+        rule = ExtractFieldTestRule(
+            field_path="foo",
+            expected_value="bar",
+            bboxes=[ExtractFieldBbox(page=1, bbox=[0.1, 0.1, 0.2, 0.2])],
+        )
+        citations = [FieldCitation(field_path="foo", page=1, bbox=[0.1, 0.1, 0.2, 0.2], source="x")]
+        metrics = _named(
+            compute_extract_field_grounding_metrics(
+                extracted_data={"foo": "bar"},
+                field_rules=[rule],
+                field_citations=citations,
+                data_schema={"type": "object"},
+            )
+        )
+        assert metrics["extract_attribution_pass_rate"].value == 1.0
+        assert metrics["extract_value_f1"].value == 1.0
+
+
+class TestV02StrayAndNullSemantics:
+    """v0.2 rules carry the canonical value in evidence, not expected_value.
+
+    A rule with ``expected_value=None`` but populated ``evidence[].value`` is
+    NOT stray and NOT null-expected — it prescribes the value via evidence.
+    """
+
+    def test_v02_evidence_only_rule_scores_value_f1(self):
+        rule = ExtractFieldTestRule(
+            field_path="drug_name",
+            expected_value=None,  # v0.2 leaves expected_value empty
+            evidence=[FieldEvidence(page=1, bbox=[0.1, 0.1, 0.2, 0.2], value="Aspirin")],
+            comparator="case_insensitive",
+        )
+        metrics = _named(
+            compute_extract_field_grounding_metrics(
+                extracted_data={"drug_name": "Aspirin"},
+                field_rules=[rule],
+                field_citations=[],
+                data_schema={"type": "object"},
+            )
+        )
+        # Should match via OR-over-evidence even though expected_value is None
+        assert metrics["extract_value_f1"].value == 1.0
+
+    def test_v02_evidence_only_rule_not_treated_as_hallucination(self):
+        rule = ExtractFieldTestRule(
+            field_path="drug_name",
+            expected_value=None,
+            evidence=[FieldEvidence(page=1, value="Aspirin")],
+        )
+        metrics = _named(
+            compute_extract_field_grounding_metrics(
+                extracted_data={"drug_name": "Aspirin"},
+                field_rules=[rule],
+                field_citations=[],
+                data_schema={"type": "object"},
+            )
+        )
+        # Should NOT emit null_hallucination_rate (no null-expected rules)
+        assert "null_hallucination_rate" not in metrics
+
+    def test_no_evidence_no_expected_value_is_null_expected(self):
+        """Legacy null-expected behavior preserved when evidence is also empty."""
+        rule = ExtractFieldTestRule(
+            field_path="adverse_reactions",
+            expected_value=None,
+            evidence=None,
+        )
+        metrics = _named(
+            compute_extract_field_grounding_metrics(
+                extracted_data={"adverse_reactions": "made up"},
+                field_rules=[rule],
+                field_citations=[],
+                data_schema={"type": "object"},
+            )
+        )
+        assert metrics["null_hallucination_rate"].value == 1.0
+
+    def test_explicit_stray_tag_still_treated_stray(self):
+        rule = ExtractFieldTestRule(
+            field_path="foo",
+            expected_value="bar",
+            evidence=[FieldEvidence(page=1, value="bar")],
+            tags=["stray"],
+        )
+        metrics = _named(
+            compute_extract_field_grounding_metrics(
+                extracted_data={"foo": "bar"},
+                field_rules=[rule],
+                field_citations=[],
+                data_schema={"type": "object"},
+            )
+        )
+        # Stray rules excluded from value F1
+        assert "extract_value_f1" not in metrics
+
+
+class TestLoaderDictShape:
+    def test_field_rules_dict_converts_to_list(self, tmp_path):
+        import json
+
+        from parse_bench.test_cases.loader import load_test_case
+
+        pdf = tmp_path / "doc.pdf"
+        pdf.write_bytes(b"%PDF")
+        config = {
+            "_schema_version": "extract_core/v0.2",
+            "data_schema": {"type": "object", "properties": {"foo": {"type": "string"}}},
+            "expected_output": {"foo": "bar"},
+            "_field_rules": {
+                "foo": {
+                    "expected_value": "bar",
+                    "evidence": [{"page": 1, "value": "bar", "bbox": [0.1, 0.1, 0.2, 0.2]}],
+                    "iou_threshold": 0.4,
+                    "comparator": "exact",
+                },
+            },
+        }
+        (tmp_path / "doc.test.json").write_text(json.dumps(config))
+        case = load_test_case(pdf)
+        assert case is not None
+        assert case.schema_version == "extract_core/v0.2"
+        rules = case.test_rules
+        assert len(rules) == 1
+        rule = rules[0]
+        assert rule.field_path == "foo"
+        assert rule.iou_threshold == 0.4
+        assert rule.comparator == "exact"
+        assert rule.evidence is not None and rule.evidence[0].value == "bar"
+
+    def test_conflict_both_shapes_errors(self, tmp_path):
+        import json
+
+        from parse_bench.test_cases.loader import load_test_case
+
+        pdf = tmp_path / "doc.pdf"
+        pdf.write_bytes(b"%PDF")
+        config = {
+            "data_schema": {"type": "object"},
+            "expected_output": {},
+            "_field_rules": {"foo": {"expected_value": "bar"}},
+            "test_rules": [{"type": "extract_field", "field_path": "foo", "expected_value": "bar"}],
+        }
+        (tmp_path / "doc.test.json").write_text(json.dumps(config))
+        with pytest.raises(ValueError, match="cannot specify both"):
+            load_test_case(pdf)


### PR DESCRIPTION
## Summary

Adds v0.2 tiered scoring to the extract field-grounding harness so pipelines that emit page-only or no citations are not unfairly penalized for grounding capability. Replaces the implicit single-tier attribution metric with three independent tiers (value, page-grounded, bbox-grounded) plus per-tier coverage.

End-to-end smoke run on the two-doc bbox sample (Extend / Reducto / LlamaExtract v2 agentic) reproduces the expected behavior: Extend gets real M2a credit on `pepto_bismol` despite emitting zero bboxes, Reducto's bbox-rich citations score high M2b on the small docs, and LlamaExtract's region-level (not field-level) bboxes correctly fail M2b with IoU<0.06 while still scoring M2a=1.0.

## What changed

### Schema
- `FieldCitation.bbox` is now optional. `inference/providers/extract/citations.py` emits page-only citations from Extend metadata that today produces only `{page: N}` entries; `_dedupe` handles `bbox=None`.
- New `FieldEvidence` model on `ExtractFieldTestRule`: `evidence: list[FieldEvidence]` carries `(page, bbox?, quote?, value?, coarse)` per accepted location. Legacy `bboxes` + `expected_value` rules continue to work; the harness collapses both shapes through a single `iter_rule_evidence(rule)` normalizer.
- `ExtractFieldTestRule` gains optional v0.2 fields: `comparator`, `structural`, `evidence_required`, `source_policy`, `max_evidence`, `iou_threshold`. `ExtractTestCase.schema_version` reads `_schema_version`.

### Loader
- Accepts dict-shaped `_field_rules` keyed by field path; converts to the list shape before tag-merge.
- Errors when both `_field_rules` and `test_rules` are present (caller must pick one shape per file).

### Metrics
New emitted metrics, all filtered to `verified=True`:
- `extract_page_grounded_pass_rate` (M2a) + `extract_page_grounded_pass_rate_covered` + `extract_page_grounded_coverage`
- `extract_attribution_pass_rate_covered` + `extract_attribution_coverage` (the existing `extract_attribution_pass_rate` is unchanged)

Other plumbing:
- Coarse parent prefix-walk: a citation at `warnings` qualifies for M2a coverage on rule `warnings[0].text` but never for M2b.
- `iter_rule_evidence` drives both M1 (OR-over-evidence value matching) and legacy M2b GT-box construction, so M2b benefits from v0.2 evidence too.
- Per-rule `iou_threshold` overrides the strict M2b threshold; the relaxed value-conditioned branch (IoU>=0.3 AND IoA>=0.7 AND canonical_exact) is unaffected.
- `_is_stray_rule` and `_compute_null_hallucination_metrics` updated so v0.2 rules with `expected_value=None` but populated `evidence[].value` are not treated as stray or null-expected.

### Comparator
- `compare_field_with_rule` shim provides the dispatch point for Phase B comparator implementations (`exact`, `enum`, `number_with_unit`, `string_substring`); Phase A falls through to today's `compare_attributed_value`.
- `compare_value_against_rule` wraps the shim with OR-over-evidence semantics.

## Backward compatibility

| test.json shape | Before | After |
|---|---|---|
| `expected_output` only | JSON subset accuracy | unchanged |
| `test_rules: [extract_field, ...]` legacy list | M1+M2b+null | unchanged; new metrics emit zeros for unverified/un-evidenced rules |
| `_field_rules: {...}` v0.2 dict | ignored | full M1+M2a+M2b+coverage+null |

Existing CI metrics (`extract_value_*`, `extract_attribution_pass_rate`, `null_hallucination_rate`) keep their shapes and values for legacy fixtures.

## Test plan

- 23 new unit tests in `tests/parse_bench/evaluation/metrics/field_grounding/test_extract_adapter_v02.py`:
  - `iter_rule_evidence` round-trip (legacy + v0.2)
  - Comparator shim falls through cleanly
  - OR-over-evidence: prediction matches alternate evidence value
  - M2a passes when bbox missing but page correct; fails on wrong page
  - Coarse parent prefix-walk counts for M2a, not M2b
  - Coverage = 0 with no citations, = 1 with full citations
  - Per-rule `iou_threshold` lets imperfect IoU pass
  - Backward-compat: legacy `bboxes` rules score unchanged
  - v0.2 evidence-only rules are not treated as stray or null-expected
  - Loader accepts dict shape and errors on conflict
- All 23 existing tests still pass (46 total).
- Spot-checked end-to-end on `extract_core_bbox_sample_two_docs`: 9 (doc x pipeline) cells reconcile against per-rule `rule_results` aggregation. All invariants hold (M2a <= M1, M2b implies M1, coarse parents help M2a coverage only). \"Surprising\" numbers (Reducto M1=0.346 on pepto, LlamaExtract M2b=0.000 on shipping) are real pipeline behavior surfaced correctly by the new tier scheme, not harness bugs.

## Notes for reviewers

- Phase A only. Phase B (comparator dispatch table for the four named comparators, structural rules `set` / `ordered`) is gated on pilot data and lands separately.
- Record-level metrics (`_compute_record_metrics`) keep using legacy `rule.bboxes` / `expected_value`; multi-evidence record alignment is documented as out-of-scope for Phase A.
- Two metrics whose names look similar are different things: `extract_attribution_coverage` is the fraction of rules with bbox-bearing exact citations; `extract_attribution_pass_rate_covered` is the M2b pass rate among those covered rules. Worth keeping in mind when reading reports.