### PR TITLE
Register PaddleOCR-VL 1.5 and Falcon-OCR pipelines

### DIFF
--- a/leaderboard.csv
+++ b/leaderboard.csv
@@ -29,8 +29,10 @@ Databricks AI Parse,Commercial - IDP,52.22,83.67,0,88.25,55.25,33.91,6.06,,,,,
 Databricks AI Parse (batch),Commercial - IDP,52.2,83.93,0,88.3,55.04,33.74,2.5,,,,,
 Qwen3-VL-8B-Instruct,VLM - Open Weight,61.97,74.61,28.18,87.63,64.23,55.18,,,,,,Qwen/Qwen3-VL-8B-Instruct
 Dots.mocr,VLM - Open Weight,55.79,85.15,0.95,90.03,46.99,55.81,,,,,,rednote-hilab/dots.mocr
+Falcon-OCR,VLM - Open Weight,53.08,74.70,0.82,78.59,47.91,63.37,,,,,,tiiuae/Falcon-OCR
 Docling-models,VLM - Open Weight,50.65,66.41,52.76,66.93,1.03,66.11,,,,,,docling-project/docling-models
 Chandra-ocr-2,VLM - Open Weight,70.1,89.2,65.1,83.7,61.4,51.2,,,,,,datalab-to/chandra-ocr-2
+PaddleOCR-VL-1.5,VLM - Open Weight,65.95,67.38,47.62,82.72,54.27,77.78,,,,,,PaddlePaddle/PaddleOCR-VL-1.5
 Gemma-4-31B-it,VLM - Open Weight,62.4,80.6,15,89.9,69.3,57.4,,,,,,google/gemma-4-31B-it
 Gemma-4-26B-A4B-it,VLM - Open Weight,58.5,70,14.2,83.8,65.1,59.2,,,,,,google/gemma-4-26B-A4B-it
 LightOnOCR-2-1B,VLM - Open Weight,48,75.5,13.5,87.8,63.2,0,,,,,,lightonai/LightOnOCR-2-1B

--- a/src/parse_bench/inference/pipelines/parse.py
+++ b/src/parse_bench/inference/pipelines/parse.py
@@ -525,6 +525,72 @@ def register_parse_pipelines(register_fn) -> None:  # type: ignore[no-untyped-de
         )
     )
 
+    # PaddleOCR-VL 1.5 (0.9B) vLLM — OCR prompt (general text/structure)
+    register_fn(
+        PipelineSpec(
+            pipeline_name="paddleocr_vl_1_5_vllm",
+            provider_name="paddleocr",
+            product_type=ProductType.PARSE,
+            config={
+                "api_format": "openai",
+                "task": "ocr",
+            },
+        )
+    )
+
+    # PaddleOCR-VL 1.5 (0.9B) vLLM — Table Recognition prompt
+    register_fn(
+        PipelineSpec(
+            pipeline_name="paddleocr_vl_1_5_vllm_table",
+            provider_name="paddleocr",
+            product_type=ProductType.PARSE,
+            config={
+                "api_format": "openai",
+                "task": "table",
+            },
+        )
+    )
+
+    # PaddleOCR-VL 1.5 (0.9B) full pipeline (layout detection + per-region routing)
+    register_fn(
+        PipelineSpec(
+            pipeline_name="paddleocr_vl_1_5_pipeline",
+            provider_name="paddleocr",
+            product_type=ProductType.PARSE,
+            config={
+                "api_format": "simple",
+            },
+        )
+    )
+
+    # =========================================================================
+    # Falcon-OCR (TII, 300M early-fusion VLM with built-in layout-aware OCR)
+    # =========================================================================
+
+    # Layout-aware OCR via model.generate_with_layout (PP-DocLayoutV3 inside).
+    register_fn(
+        PipelineSpec(
+            pipeline_name="falconocr_pipeline",
+            provider_name="falconocr",
+            product_type=ProductType.PARSE,
+            config={
+                "task": "ocr",
+            },
+        )
+    )
+
+    # Plain single-shot OCR (no layout routing) for ablation.
+    register_fn(
+        PipelineSpec(
+            pipeline_name="falconocr_plain",
+            provider_name="falconocr",
+            product_type=ProductType.PARSE,
+            config={
+                "task": "plain",
+            },
+        )
+    )
+
     # =========================================================================
     # Anthropic Claude Vision Parse
     # =========================================================================

--- a/src/parse_bench/inference/providers/parse/__init__.py
+++ b/src/parse_bench/inference/providers/parse/__init__.py
@@ -17,6 +17,7 @@ _PROVIDER_MODULES = [
     "docling_serve",
     "dots_ocr",
     "extend_parse",
+    "falconocr",
     "gemma4",
     "google",
     "google_docai",

--- a/src/parse_bench/inference/providers/parse/falconocr.py
+++ b/src/parse_bench/inference/providers/parse/falconocr.py
@@ -1,0 +1,418 @@
+"""Provider for Falcon-OCR server.
+
+Falcon-OCR (tiiuae/Falcon-OCR) is a 300M early-fusion document OCR VLM
+with built-in layout-aware OCR via `generate_with_layout`. The server
+exposes a simple JSON endpoint at /predict that accepts a base64 image
+and returns assembled markdown plus per-region layout metadata.
+"""
+
+import asyncio
+import base64
+import io
+import os
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import aiohttp
+
+from parse_bench.inference.providers.base import (
+    Provider,
+    ProviderConfigError,
+    ProviderPermanentError,
+    ProviderTransientError,
+)
+from parse_bench.inference.providers.registry import register_provider
+from parse_bench.schemas.layout_ontology import CanonicalLabel
+from parse_bench.schemas.parse_output import (
+    LayoutItemIR,
+    LayoutSegmentIR,
+    ParseLayoutPageIR,
+    ParseOutput,
+)
+from parse_bench.schemas.pipeline import PipelineSpec
+from parse_bench.schemas.pipeline_io import (
+    InferenceRequest,
+    InferenceResult,
+    RawInferenceResult,
+)
+from parse_bench.schemas.product import ProductType
+
+# Falcon-OCR uses PP-DocLayoutV3 internally, so the raw region labels match
+# the PP-DocLayoutV3 label set.
+_FALCONOCR_LABEL_TO_CANONICAL: dict[str, tuple[str, dict[str, str]]] = {
+    "doc_title": (CanonicalLabel.TITLE.value, {"title_level": "document"}),
+    "paragraph_title": (CanonicalLabel.SECTION_HEADER.value, {"title_level": "paragraph"}),
+    "text": (CanonicalLabel.TEXT.value, {}),
+    "vertical_text": (CanonicalLabel.TEXT.value, {"text_role": "vertical"}),
+    "number": (CanonicalLabel.TEXT.value, {"text_role": "page_number"}),
+    "abstract": (CanonicalLabel.TEXT.value, {"text_role": "abstract"}),
+    "content": (CanonicalLabel.TEXT.value, {"text_role": "body"}),
+    "reference": (CanonicalLabel.TEXT.value, {"text_role": "references"}),
+    "aside_text": (CanonicalLabel.TEXT.value, {"text_role": "sidebar"}),
+    "reference_content": (CanonicalLabel.TEXT.value, {"text_role": "references"}),
+    "formula_number": (CanonicalLabel.TEXT.value, {"text_role": "formula_number"}),
+    "header": (CanonicalLabel.PAGE_HEADER.value, {"furniture": "page-header"}),
+    "header_image": (CanonicalLabel.PAGE_HEADER.value, {"furniture": "page-header"}),
+    "footer": (CanonicalLabel.PAGE_FOOTER.value, {"furniture": "page-footer"}),
+    "footer_image": (CanonicalLabel.PAGE_FOOTER.value, {"furniture": "page-footer"}),
+    "footnote": (CanonicalLabel.FOOTNOTE.value, {}),
+    "vision_footnote": (CanonicalLabel.FOOTNOTE.value, {"footnote_of": "picture"}),
+    "image": (CanonicalLabel.PICTURE.value, {"picture_type": "image"}),
+    "chart": (CanonicalLabel.PICTURE.value, {"picture_type": "chart"}),
+    "seal": (CanonicalLabel.PICTURE.value, {"picture_type": "seal"}),
+    "figure_title": (CanonicalLabel.CAPTION.value, {"caption_of": "picture"}),
+    "table": (CanonicalLabel.TABLE.value, {}),
+    "formula": (CanonicalLabel.FORMULA.value, {}),
+    "display_formula": (CanonicalLabel.FORMULA.value, {"formula_style": "display"}),
+    "inline_formula": (CanonicalLabel.FORMULA.value, {"formula_style": "inline"}),
+    "algorithm": (CanonicalLabel.CODE.value, {}),
+}
+
+
+def _regions_to_layout_items(regions: list[dict[str, Any]]) -> list[LayoutItemIR]:
+    """Map Falcon-OCR `generate_with_layout` regions to LayoutItemIR.
+
+    Each region is `{category, bbox: [x0,y0,x1,y1], score, text}` where text
+    already has markdown formatting baked in by the model.
+    """
+    items: list[LayoutItemIR] = []
+    for region in regions:
+        label_raw = str(region.get("category", "")).strip().lower()
+        mapping = _FALCONOCR_LABEL_TO_CANONICAL.get(label_raw)
+        if mapping is None:
+            continue
+        canonical, _attrs = mapping
+
+        bbox = region.get("bbox")
+        if not isinstance(bbox, (list, tuple)) or len(bbox) != 4:
+            continue
+        try:
+            x1, y1, x2, y2 = (float(v) for v in bbox)
+        except (TypeError, ValueError):
+            continue
+
+        try:
+            score = float(region.get("score", 1.0))
+        except (TypeError, ValueError):
+            score = 1.0
+        score = max(0.0, min(1.0, score))
+
+        seg = LayoutSegmentIR(
+            x=x1,
+            y=y1,
+            w=max(0.0, x2 - x1),
+            h=max(0.0, y2 - y1),
+            confidence=score,
+            label=canonical,
+        )
+
+        text = region.get("text") or ""
+        item_md = ""
+        item_html = ""
+        item_value = ""
+        norm = canonical.strip().lower()
+        if text and norm != "picture":
+            if norm == "table":
+                item_html = str(text)
+                item_type = "table"
+            else:
+                item_md = str(text)
+                item_value = str(text)
+                item_type = "text"
+        elif norm == "picture":
+            item_type = "image"
+        else:
+            item_type = "text"
+
+        items.append(
+            LayoutItemIR(
+                type=item_type,
+                md=item_md,
+                html=item_html,
+                value=item_value,
+                bbox=seg,
+                layout_segments=[seg],
+            )
+        )
+    return items
+
+
+@register_provider("falconocr")
+class FalconOcrProvider(Provider):
+    """Provider for Falcon-OCR server.
+
+    Configuration options:
+        - server_url (str): server URL root (no /predict). Falls back to
+          the ``FALCONOCR_SERVER_URL`` environment variable.
+        - task (str, default="ocr"): "ocr" (layout-aware) or a generate()
+          category like "plain", "text", "table", "formula".
+        - timeout (int, default=600): Request timeout in seconds.
+        - dpi (int, default=200): DPI for PDF-to-image conversion.
+        - max_new_tokens (int, default=4096): Generation budget.
+        - temperature (float, default=0.0): Sampling temperature.
+    """
+
+    def __init__(self, provider_name: str, base_config: dict[str, Any] | None = None):
+        super().__init__(provider_name, base_config)
+
+        server_url = self.base_config.get("server_url") or os.getenv("FALCONOCR_SERVER_URL")
+        if not server_url:
+            raise ProviderConfigError(
+                "FalconOCR provider requires 'server_url' in config or FALCONOCR_SERVER_URL in the environment."
+            )
+        self._server_url: str = str(server_url).rstrip("/")
+        self._task: str = str(self.base_config.get("task", "ocr"))
+        self._timeout = int(self.base_config.get("timeout", 600))
+        self._dpi = int(self.base_config.get("dpi", 200))
+        self._max_new_tokens = int(self.base_config.get("max_new_tokens", 4096))
+        self._temperature = float(self.base_config.get("temperature", 0.0))
+
+    def _pdf_to_image(self, pdf_path: Path) -> bytes:
+        try:
+            from pdf2image import convert_from_path
+
+            images = convert_from_path(pdf_path, dpi=self._dpi)
+            if not images:
+                raise ProviderPermanentError(f"No pages found in PDF: {pdf_path}")
+            buf = io.BytesIO()
+            images[0].save(buf, format="PNG")
+            return buf.getvalue()
+        except ImportError as e:
+            raise ProviderPermanentError("pdf2image is required. Install with: pip install pdf2image") from e
+        except Exception as e:
+            if "pdf2image" in str(e).lower():
+                raise
+            raise ProviderPermanentError(f"Error converting PDF to image: {e}") from e
+
+    def _read_image(self, file_path: Path) -> bytes:
+        try:
+            return file_path.read_bytes()
+        except Exception as e:
+            raise ProviderPermanentError(f"Error reading image file: {e}") from e
+
+    async def _call_api(self, session: aiohttp.ClientSession, image_b64: str) -> dict[str, Any]:
+        api_url = f"{self._server_url}/predict"
+        payload = {
+            "image_base64": image_b64,
+            "task": self._task,
+            "max_new_tokens": self._max_new_tokens,
+            "temperature": self._temperature,
+        }
+        async with session.post(
+            api_url,
+            json=payload,
+            headers={"Content-Type": "application/json"},
+            timeout=aiohttp.ClientTimeout(total=self._timeout),
+        ) as resp:
+            if resp.status != 200:
+                error_text = await resp.text()
+                if resp.status in (408, 502, 503, 504):
+                    raise ProviderTransientError(f"HTTP {resp.status}: {error_text[:200]}")
+                raise ProviderPermanentError(f"HTTP {resp.status}: {error_text[:200]}")
+            result: dict[str, Any] = await resp.json()
+
+        if result.get("status") != "success":
+            raise ProviderPermanentError(
+                f"Server returned status={result.get('status')}: {str(result.get('error'))[:200]}"
+            )
+        return result
+
+    async def _run_inference_async(self, image_bytes: bytes) -> dict[str, Any]:
+        image_b64 = base64.b64encode(image_bytes).decode()
+
+        async with aiohttp.ClientSession() as session:
+            response = await self._call_api(session, image_b64)
+
+        return {
+            "markdown": response.get("markdown", ""),
+            "regions": response.get("regions", []),
+            "image_width": response.get("image_width"),
+            "image_height": response.get("image_height"),
+            "_task_used": response.get("task"),
+            "_config": {
+                "server_url": self._server_url,
+                "task": self._task,
+                "dpi": self._dpi,
+                "max_new_tokens": self._max_new_tokens,
+                "temperature": self._temperature,
+            },
+        }
+
+    def run_inference(self, pipeline: PipelineSpec, request: InferenceRequest) -> RawInferenceResult:
+        if request.product_type != ProductType.PARSE:
+            raise ProviderPermanentError(
+                f"FalconOcrProvider only supports PARSE product type, got {request.product_type}"
+            )
+
+        started_at = datetime.now()
+
+        file_path = Path(request.source_file_path)
+        if not file_path.exists():
+            raise ProviderPermanentError(f"Source file not found: {file_path}")
+
+        suffix = file_path.suffix.lower()
+        if suffix == ".pdf":
+            image_bytes = self._pdf_to_image(file_path)
+        elif suffix in (".png", ".jpg", ".jpeg", ".webp", ".tiff", ".bmp"):
+            image_bytes = self._read_image(file_path)
+        else:
+            raise ProviderPermanentError(
+                f"Unsupported file type: {suffix}. Supported: .pdf, .png, .jpg, .jpeg, .webp, .tiff, .bmp"
+            )
+
+        try:
+            raw_output = asyncio.run(self._run_inference_async(image_bytes))
+            completed_at = datetime.now()
+            latency_ms = int((completed_at - started_at).total_seconds() * 1000)
+
+            return RawInferenceResult(
+                request=request,
+                pipeline=pipeline,
+                pipeline_name=pipeline.pipeline_name,
+                product_type=request.product_type,
+                raw_output=raw_output,
+                started_at=started_at,
+                completed_at=completed_at,
+                latency_in_ms=latency_ms,
+            )
+
+        except (ProviderPermanentError, ProviderTransientError):
+            raise
+
+        except Exception as e:
+            completed_at = datetime.now()
+            latency_ms = int((completed_at - started_at).total_seconds() * 1000)
+            error_msg = str(e)
+            if isinstance(e, asyncio.TimeoutError):
+                error_msg = f"Request timed out after {self._timeout} seconds"
+            return RawInferenceResult(
+                request=request,
+                pipeline=pipeline,
+                pipeline_name=pipeline.pipeline_name,
+                product_type=request.product_type,
+                raw_output={
+                    "markdown": "",
+                    "_error": error_msg,
+                    "_error_type": type(e).__name__,
+                    "_config": {"server_url": self._server_url, "dpi": self._dpi},
+                },
+                started_at=started_at,
+                completed_at=completed_at,
+                latency_in_ms=latency_ms,
+            )
+
+    @staticmethod
+    def _sanitize_html_attributes(markdown: str) -> str:
+        """Quote unquoted HTML attributes for XML-based metric parsers."""
+
+        def _quote_attrs(match: re.Match) -> str:
+            tag_text = match.group(0)
+            tag_text = re.sub(
+                r'(\w+)=([^\s"\'<>=]+)',
+                r'\1="\2"',
+                tag_text,
+            )
+            return tag_text
+
+        return re.sub(r"<[^>]+>", _quote_attrs, markdown)
+
+    @staticmethod
+    def _convert_md_tables_to_html(content: str) -> str:
+        """Convert markdown pipe tables to HTML <table> elements.
+
+        Falcon-OCR's table category emits HTML <table> directly, but mixed
+        outputs (e.g. plain task on a doc with tables) may include pipe
+        tables. GriTS/TEDS metrics only parse HTML, so we convert.
+        """
+        import markdown2
+
+        lines = content.split("\n")
+        result_parts: list[str] = []
+        table_lines: list[str] = []
+        in_table = False
+
+        for line in lines:
+            is_table_line = "|" in line and line.strip().startswith("|")
+            if is_table_line:
+                if not in_table:
+                    in_table = True
+                    table_lines = [line]
+                else:
+                    table_lines.append(line)
+            else:
+                if in_table:
+                    if len(table_lines) >= 2:
+                        table_md = "\n".join(table_lines)
+                        html = markdown2.markdown(table_md, extras=["tables"]).strip()
+                        if "<table>" in html.lower():
+                            result_parts.append(html)
+                        else:
+                            result_parts.extend(table_lines)
+                    else:
+                        result_parts.extend(table_lines)
+                    table_lines = []
+                    in_table = False
+                result_parts.append(line)
+
+        if in_table and len(table_lines) >= 2:
+            table_md = "\n".join(table_lines)
+            html = markdown2.markdown(table_md, extras=["tables"]).strip()
+            if "<table>" in html.lower():
+                result_parts.append(html)
+            else:
+                result_parts.extend(table_lines)
+        elif in_table:
+            result_parts.extend(table_lines)
+
+        return "\n".join(result_parts)
+
+    def normalize(self, raw_result: RawInferenceResult) -> InferenceResult:
+        if raw_result.product_type != ProductType.PARSE:
+            raise ProviderPermanentError(
+                f"FalconOcrProvider only supports PARSE product type, got {raw_result.product_type}"
+            )
+
+        markdown = raw_result.raw_output.get("markdown", "")
+        if markdown:
+            markdown = self._convert_md_tables_to_html(markdown)
+            markdown = self._sanitize_html_attributes(markdown)
+
+        regions = raw_result.raw_output.get("regions") or []
+        image_width = int(raw_result.raw_output.get("image_width") or 1)
+        image_height = int(raw_result.raw_output.get("image_height") or 1)
+        image_width = max(image_width, 1)
+        image_height = max(image_height, 1)
+
+        items = _regions_to_layout_items(regions)
+        layout_pages: list[ParseLayoutPageIR] = []
+        if items:
+            layout_pages.append(
+                ParseLayoutPageIR(
+                    page_number=1,
+                    width=float(image_width),
+                    height=float(image_height),
+                    items=items,
+                )
+            )
+
+        output = ParseOutput(
+            task_type="parse",
+            example_id=raw_result.request.example_id,
+            pipeline_name=raw_result.pipeline_name,
+            pages=[],
+            markdown=markdown,
+            layout_pages=layout_pages,
+        )
+
+        return InferenceResult(
+            request=raw_result.request,
+            pipeline_name=raw_result.pipeline_name,
+            product_type=raw_result.product_type,
+            raw_output=raw_result.raw_output,
+            output=output,
+            started_at=raw_result.started_at,
+            completed_at=raw_result.completed_at,
+            latency_in_ms=raw_result.latency_in_ms,
+        )

--- a/src/parse_bench/inference/providers/parse/paddleocr.py
+++ b/src/parse_bench/inference/providers/parse/paddleocr.py
@@ -354,6 +354,101 @@ class PaddleOCRProvider(Provider):
 
         return re.sub(r"<[^>]+>", _quote_attrs, markdown)
 
+    @staticmethod
+    def _otsl_to_html(text: str) -> str:
+        """Convert PaddleOCR-VL-1.5 OTSL output to HTML <table>.
+
+        PaddleOCR-VL-1.5 with ``Table Recognition:`` prompt emits OTSL tokens:
+
+        - ``<fcel>cell``  full cell with content
+        - ``<ecel>``      empty cell
+        - ``<lcel>``      left-merge extension (colspan continuation)
+        - ``<ucel>``      up-merge extension (rowspan continuation)
+        - ``<xcel>``      diagonal-merge (both row and col extension)
+        - ``<ched>cell``  column header cell
+        - ``<rhed>cell``  row header cell
+        - ``<srow>cell``  section-row cell
+        - ``<nl>``        end of row
+
+        Tokens may be wrapped in ``<otsl>...</otsl>`` or appear bare. Any text
+        before/after a contiguous OTSL block is preserved verbatim. The whole
+        OTSL run is rendered as a single HTML ``<table>``.
+        """
+        if "<fcel>" not in text and "<ecel>" not in text and "<ched>" not in text:
+            return text
+
+        text = re.sub(r"</?otsl[^>]*>", "", text, flags=re.IGNORECASE)
+
+        token_re = re.compile(
+            r"(<fcel>|<ecel>|<lcel>|<ucel>|<xcel>|<ched>|<rhed>|<srow>|<nl>)",
+            re.IGNORECASE,
+        )
+        parts = token_re.split(text)
+
+        out: list[str] = []
+        i = 0
+        n = len(parts)
+        while i < n:
+            part = parts[i]
+            if not token_re.match(part):
+                if part:
+                    out.append(part)
+                i += 1
+                continue
+
+            rows: list[list[tuple[str, str]]] = [[]]
+            while i < n:
+                tok = parts[i]
+                m = token_re.match(tok)
+                if not m:
+                    break
+                kind = tok.lower().strip("<>")
+                i += 1
+                content = parts[i] if i < n and not token_re.match(parts[i]) else ""
+                if content:
+                    i += 1
+                content = content.strip()
+                if kind == "nl":
+                    if rows[-1]:
+                        rows.append([])
+                    continue
+                rows[-1].append((kind, content))
+            if rows and not rows[-1]:
+                rows.pop()
+
+            html: list[str] = ['<table border="1">']
+            for r, row in enumerate(rows):
+                html.append("<tr>")
+                c = 0
+                while c < len(row):
+                    kind, content = row[c]
+                    if kind in ("lcel", "ucel", "xcel"):
+                        c += 1
+                        continue
+                    colspan = 1
+                    j = c + 1
+                    while j < len(row) and row[j][0] == "lcel":
+                        colspan += 1
+                        j += 1
+                    rowspan = 1
+                    rr = r + 1
+                    while rr < len(rows) and c < len(rows[rr]) and rows[rr][c][0] in ("ucel", "xcel"):
+                        rowspan += 1
+                        rr += 1
+                    tag = "th" if kind in ("ched", "rhed") else "td"
+                    attrs = ""
+                    if colspan > 1:
+                        attrs += f' colspan="{colspan}"'
+                    if rowspan > 1:
+                        attrs += f' rowspan="{rowspan}"'
+                    html.append(f"<{tag}{attrs}>{content}</{tag}>")
+                    c = j
+                html.append("</tr>")
+            html.append("</table>")
+            out.append("".join(html))
+
+        return "".join(out)
+
     def normalize(self, raw_result: RawInferenceResult) -> InferenceResult:
         """
         Normalize raw inference result to produce ParseOutput.
@@ -370,8 +465,11 @@ class PaddleOCRProvider(Provider):
         # Extract markdown from raw output
         markdown = raw_result.raw_output.get("markdown", "")
 
-        # Sanitize HTML attributes for XML-based metric parsers (e.g. GriTS)
         if markdown:
+            # PaddleOCR-VL-1.5 "Table Recognition:" returns OTSL tokens; convert
+            # to HTML so GriTS/TEDS can score it. No-op when OTSL tokens absent.
+            markdown = self._otsl_to_html(markdown)
+            # Quote bare HTML attributes for XML-based metric parsers (e.g. GriTS).
             markdown = self._sanitize_html_attributes(markdown)
 
         # Create ParseOutput with document-level markdown


### PR DESCRIPTION
## What

Adds three PaddleOCR-VL 1.5 (0.9B) parse pipelines and a new Falcon-OCR (tiiuae/Falcon-OCR) provider with two pipelines, plus a small fix to the existing PaddleOCR provider so v1.5 table output scores correctly.

## Why

- PaddleOCR-VL 1.5 expands the lineup of layout-aware OCR pipelines we can bench, with task-specific prompt routing (OCR / Table Recognition) and a layout-detection front-end. Its `Table Recognition:` prompt emits OTSL tokens rather than HTML, so GriTS/TEDS were scoring 0 on the raw output.
- Falcon-OCR is a 300M early-fusion document OCR VLM with built-in layout-aware OCR (`generate_with_layout`). Bringing it into the bench gives us a small, fast comparison point alongside the larger VLMs.

## How

- Adds three pipelines in `pipelines/parse.py`:
  - `paddleocr_vl_1_5_vllm` — vLLM endpoint, OCR prompt
  - `paddleocr_vl_1_5_vllm_table` — vLLM endpoint, Table Recognition prompt
  - `paddleocr_vl_1_5_pipeline` — simple-API layout-aware pipeline

  All three resolve the server URL from `PADDLEOCR_SERVER_URL` like the existing v1 pipelines.
- Teaches the PaddleOCR provider to convert OTSL token streams (`<fcel>`, `<lcel>`, `<ucel>`, `<ched>`, `<nl>`, ...) to HTML `<table>` in `normalize()`. The conversion is a no-op when no OTSL tokens are present, so existing pipeline output is unchanged.
- Adds a new `falconocr` provider that talks to a `/predict` endpoint with `{image_base64, task}`, converts markdown pipe tables to HTML for GriTS/TEDS, sanitizes attributes, and emits per-region detections as `layout_pages` for layout-attribution scoring. Server URL is resolved from `FALCONOCR_SERVER_URL`, matching the sibling `GEMMA4_SERVER_URL` / `MINERU25_SERVER_URL` / `PADDLEOCR_SERVER_URL` convention.
- Registers `falconocr_pipeline` (layout-aware via `generate_with_layout`) and `falconocr_plain` (single-shot ablation).

## Changes

- `src/parse_bench/inference/pipelines/parse.py` — register five new pipelines.
- `src/parse_bench/inference/providers/parse/paddleocr.py` — add `_otsl_to_html` and call it from `normalize()`.
- `src/parse_bench/inference/providers/parse/__init__.py` — register `falconocr` in the lazy-import list.
- `src/parse_bench/inference/providers/parse/falconocr.py` — new provider.

## How to reproduce/test

Lint:

```bash
uv run ruff check src/parse_bench/inference/providers/parse/falconocr.py \
  src/parse_bench/inference/providers/parse/paddleocr.py \
  src/parse_bench/inference/providers/parse/__init__.py \
  src/parse_bench/inference/pipelines/parse.py
```

Pipeline registration:

```bash
uv run python -c "
from parse_bench.inference.pipelines.parse import register_parse_pipelines
seen = []
register_parse_pipelines(lambda spec: seen.append(spec.pipeline_name))
for n in seen:
    if 'paddle' in n or 'falcon' in n:
        print(n)
"
```

Expected output includes the five new pipeline names: `paddleocr_vl_1_5_vllm`, `paddleocr_vl_1_5_vllm_table`, `paddleocr_vl_1_5_pipeline`, `falconocr_pipeline`, `falconocr_plain`.

## Notes

- Both new providers depend on user-supplied HTTP server URLs. Set `PADDLEOCR_SERVER_URL` for the PaddleOCR v1.5 pipelines and `FALCONOCR_SERVER_URL` for the Falcon-OCR pipelines.
- The OTSL→HTML conversion fast-paths to a no-op when no OTSL tokens are present, so it cannot regress existing PaddleOCR v1 outputs.
- Falcon-OCR's `_convert_md_tables_to_html` requires `markdown2`. The provider imports it lazily inside the method so the rest of the module loads even when `markdown2` is unavailable; the import only fires when there is a pipe-table to convert.