### PR TITLE
feat: add infinity_parser2

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -239,6 +239,8 @@ These run entirely locally with no external dependencies.
 | `tesseract_eng` | Tesseract OCR (English) | `tesseract` installed |
 | `tesseract_fast` | Tesseract OCR (fast) | `tesseract` installed |
 | `tesseract_high_quality` | Tesseract OCR (high quality) | `tesseract` installed |
+| `infinity_parser2_flash` | Infinity-Parser2-Flash (vLLM server, JSON layout) | `infinity_parser2`, running vLLM server |
+| `infinity_parser2_pro` | Infinity-Parser2-Pro (vLLM server, JSON layout) | `infinity_parser2`, running vLLM server |
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ runners = [
     "google-genai>=1.0.0",
     "google-cloud-documentai>=2.20.0",
     "httpx>=0.28.0",
+    "infinity-parser2>=0.3.0",
     "landingai-ade>=1.4.0",
     "llama-cloud>=1.4.1",
     "openai>=1.0.0",

--- a/src/parse_bench/evaluation/layout_adapters/adapters.py
+++ b/src/parse_bench/evaluation/layout_adapters/adapters.py
@@ -2119,6 +2119,102 @@ class Chandra2LayoutAdapter(LayoutAdapter):
         )
 
 
+@register_layout_adapter("infinity_parser2", priority=90)
+class InfinityParser2LayoutAdapter(LayoutAdapter):
+    """Adapter that extracts LayoutOutput from InfinityParser2 ParseOutput.layout_pages.
+
+    Enables cross-evaluation: the ``infinity_parser2`` PARSE pipeline can be
+    evaluated against layout detection datasets using the native bboxes from
+    the model output.
+
+    InfinityParser2 stores bboxes in pixel coordinates (page_width x page_height),
+    unlike Chandra2 which stores them in normalized [0,1] space. The adapter
+    converts pixel bboxes to absolute coordinates before building LayoutOutput.
+    """
+
+    @classmethod
+    def matches(cls, inference_result: InferenceResult) -> bool:
+        if not isinstance(inference_result.output, ParseOutput):
+            return False
+        if not inference_result.output.layout_pages:
+            return False
+        raw_output = inference_result.raw_output
+        if isinstance(raw_output, dict):
+            config = raw_output.get("_config", {})
+            return (
+                isinstance(config, dict)
+                and config.get("backend") == "vllm-server"
+                and config.get("model_name") == "infly/Infinity-Parser2-Flash"
+            )
+        return False
+
+    def to_layout_output(
+        self,
+        inference_result: InferenceResult,
+        *,
+        page_filter: int | None = None,
+    ) -> LayoutOutput:
+        if isinstance(inference_result.output, LayoutOutput):
+            if page_filter is None:
+                return inference_result.output
+            filtered = [p for p in inference_result.output.predictions if p.page == page_filter]
+            return inference_result.output.model_copy(update={"predictions": filtered})
+
+        if not isinstance(inference_result.output, ParseOutput):
+            raise ValueError("InfinityParser2LayoutAdapter requires ParseOutput or LayoutOutput")
+
+        layout_pages = inference_result.output.layout_pages
+        if not layout_pages:
+            raise ValueError("InfinityParser2LayoutAdapter requires non-empty layout_pages")
+
+        first_page = layout_pages[0]
+        output_width = int(first_page.width or 1)
+        output_height = int(first_page.height or 1)
+
+        predictions: list[LayoutPrediction] = []
+
+        for lp in layout_pages:
+            page_number = lp.page_number
+            if page_filter is not None and page_number != page_filter:
+                continue
+
+            for item in lp.items:
+                for seg in item.layout_segments:
+                    label = seg.label or item.type or "Text"
+
+                    # InfinityParser2 stores bboxes in pixel coordinates (x, y, w, h).
+                    # seg.x, seg.y are already pixel values — no normalization needed.
+                    x1 = float(seg.x)
+                    y1 = float(seg.y)
+                    x2 = float(seg.x + seg.w)
+                    y2 = float(seg.y + seg.h)
+
+                    content = _build_vendor_content(label, item.value)
+
+                    predictions.append(
+                        LayoutPrediction(
+                            bbox=[x1, y1, x2, y2],
+                            score=float(seg.confidence or 1.0),
+                            label=label,
+                            page=page_number,
+                            content=content,
+                            provider_metadata={
+                                "order_index": len(predictions),
+                            },
+                        )
+                    )
+
+        return LayoutOutput(
+            task_type="layout_detection",
+            example_id=inference_result.request.example_id,
+            pipeline_name=inference_result.pipeline_name,
+            model=LayoutDetectionModel.INFINITY_PARSER2_LAYOUT,
+            image_width=max(output_width, 1),
+            image_height=max(output_height, 1),
+            predictions=predictions,
+        )
+
+
 @register_layout_adapter("qfocr", priority=90)
 class QfOcrLayoutAdapter(LayoutAdapter):
     """Adapter that extracts LayoutOutput from Qianfan-OCR ParseOutput.layout_pages.

--- a/src/parse_bench/evaluation/layout_adapters/adapters.py
+++ b/src/parse_bench/evaluation/layout_adapters/adapters.py
@@ -2141,11 +2141,10 @@ class InfinityParser2LayoutAdapter(LayoutAdapter):
         raw_output = inference_result.raw_output
         if isinstance(raw_output, dict):
             config = raw_output.get("_config", {})
-            return (
-                isinstance(config, dict)
-                and config.get("backend") == "vllm-server"
-                and config.get("model_name") == "infly/Infinity-Parser2-Flash"
-            )
+            if not isinstance(config, dict) or config.get("backend") != "vllm-server":
+                return False
+            model_name = config.get("model_name") or ""
+            return isinstance(model_name, str) and model_name.startswith("infly/Infinity-Parser2")
         return False
 
     def to_layout_output(

--- a/src/parse_bench/inference/pipelines/parse.py
+++ b/src/parse_bench/inference/pipelines/parse.py
@@ -1624,6 +1624,36 @@ def register_parse_pipelines(register_fn) -> None:  # type: ignore[no-untyped-de
     # Databricks ai_parse_document
     # =========================================================================
 
+    # Infinity-Parser2-Flash (infly/Infinity-Parser2-Flash, vLLM server)
+    register_fn(
+        PipelineSpec(
+            pipeline_name="infinity_parser2_flash",
+            provider_name="infinity_parser2",
+            product_type=ProductType.PARSE,
+            config={
+                "model_name": "infly/Infinity-Parser2-Flash",
+                "backend": "vllm-server",
+                "task_type": "doc2json",
+                "output_format": "json",
+            },
+        )
+    )
+
+    # Infinity-Parser2-Pro (infly/Infinity-Parser2-Pro, vLLM server)
+    register_fn(
+        PipelineSpec(
+            pipeline_name="infinity_parser2_pro",
+            provider_name="infinity_parser2",
+            product_type=ProductType.PARSE,
+            config={
+                "model_name": "infly/Infinity-Parser2-Pro",
+                "backend": "vllm-server",
+                "task_type": "doc2json",
+                "output_format": "json",
+            },
+        )
+    )
+
     register_fn(
         PipelineSpec(
             pipeline_name="databricks_ai_parse",

--- a/src/parse_bench/inference/providers/parse/__init__.py
+++ b/src/parse_bench/inference/providers/parse/__init__.py
@@ -21,6 +21,7 @@ _PROVIDER_MODULES = [
     "google",
     "google_docai",
     "granite_vision",
+    "infinity_parser2",
     "landingai",
     "llamaparse",
     "llamaparse_v2_normalization",

--- a/src/parse_bench/inference/providers/parse/infinity_parser2.py
+++ b/src/parse_bench/inference/providers/parse/infinity_parser2.py
@@ -66,6 +66,7 @@ class InfinityParser2Provider(Provider):
         - batch_size (int, default=4): Batch size for processing
         - max_new_tokens (int, default=None): Override max tokens for generation
         - temperature (float, default=0.0): Sampling temperature
+        - deep_parsing_mode (bool, default=True): Parse figure content.
     """
 
     def __init__(self, provider_name: str, base_config: dict[str, Any] | None = None):
@@ -80,6 +81,7 @@ class InfinityParser2Provider(Provider):
         self._batch_size = self.base_config.get("batch_size", 4)
         self._max_new_tokens = self.base_config.get("max_new_tokens")
         self._temperature = self.base_config.get("temperature", 0.0)
+        self._deep_parsing_mode = self.base_config.get("deep_parsing_mode", True)
 
         try:
             from infinity_parser2 import InfinityParser2
@@ -121,6 +123,9 @@ class InfinityParser2Provider(Provider):
 
             pil_image, page_width, page_height = load_image(file_path)
             result = self._parser.parse(pil_image, **parse_kwargs)
+
+            if self._deep_parsing_mode:
+                result = self._apply_deep_parsing(result, pil_image)
 
             return {
                 "result": result,
@@ -206,7 +211,8 @@ class InfinityParser2Provider(Provider):
             stripped = re.sub(r"^[\s$\(\)\[\]]+|[\s$\(\)\[\]]+$", "", text)
             return f"$${stripped}$$"
         elif label == "Picture":
-            return _convert_nonstandard_table(text)
+            text = _convert_nonstandard_table(text)
+            return text if _is_valid_md_table(text) else ""
         elif label == "Table":
             return _convert_table_header(text)
         else:
@@ -228,6 +234,58 @@ class InfinityParser2Provider(Provider):
             "bbox": layout_seg,
             "layout_segments": [layout_seg],
         }
+
+    def _apply_deep_parsing(
+        self,
+        result: str,
+        pil_image: PILImage.Image,
+    ) -> str:
+        """Apply deep parsing on figure elements, re-parsing cropped figure images as markdown tables.
+
+        Extracts all ``figure`` elements from the parsed JSON, crops each figure region from
+        ``pil_image``, re-parses the cropped images with a custom table-extraction prompt,
+        and overwrites ``elem["text"]`` in place before serializing back to JSON.
+
+        Returns the (possibly modified) JSON string.
+        """
+        try:
+            elements: list[dict] = json.loads(result)
+            if not isinstance(elements, list):
+                return result
+
+            figure_elements = [
+                elem for elem in elements
+                if elem.get("category", "").strip().lower() == "figure"
+            ]
+            if not figure_elements:
+                return result
+
+            pil_figure_images = [
+                pil_image.crop(
+                    (
+                        max(0, int(elem["bbox"][0])),
+                        max(0, int(elem["bbox"][1])),
+                        min(pil_image.width, int(elem["bbox"][2])),
+                        min(pil_image.height, int(elem["bbox"][3])),
+                    )
+                )
+                for elem in figure_elements
+            ]
+
+            deep_parse_kwargs = {
+                "task_type": "custom",
+                "custom_prompt": "please convert the image to a markdown table",
+                "max_new_tokens": 2048,
+            }
+            deep_results = [self._parser.parse(img, **deep_parse_kwargs) for img in pil_figure_images]
+            for elem, deep_result in zip(figure_elements, deep_results):
+                elem["text"] = deep_result
+
+            return json.dumps(elements)
+
+        except Exception:
+            traceback.print_exc()
+            return result
 
     def _normalize(self, raw_result: RawInferenceResult) -> ParseOutput:
         """Normalize JSON layout result into ParseOutput with pages, layout_pages, and markdown."""
@@ -364,6 +422,22 @@ def load_image(file_path: str) -> tuple[PILImage.Image, float, float]:
 # =============================================================================
 # Postprocess for chart2table
 # =============================================================================
+
+def _is_valid_md_table(table_text: str) -> bool:
+    """Check if a markdown table is valid (non-empty)."""
+    if not table_text or not table_text.strip():
+        return False
+
+    if not all(ch in table_text for ch in ["|", "-", "\n"]):
+        return False
+
+    stripped = table_text[table_text.find("|") : table_text.rfind("|") + 1]
+    stripped = re.sub(r"^\s*\|[\s\-:|]+\|\s*$", "", stripped, flags=re.MULTILINE)
+    if not stripped.replace(" ", "").replace("\n", "").replace("|", ""):
+        return False
+
+    return True
+
 
 def _is_nonstandard_table(text: str) -> bool:
     """Check if text is a non-standard markdown table (no leading '|', contains '&' separators)."""

--- a/src/parse_bench/inference/providers/parse/infinity_parser2.py
+++ b/src/parse_bench/inference/providers/parse/infinity_parser2.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime
 import json
+import logging
 from pathlib import Path
 import re
 import traceback
@@ -14,6 +15,7 @@ from parse_bench.inference.providers.base import (
     Provider,
     ProviderConfigError,
     ProviderPermanentError,
+    ProviderTransientError,
 )
 from parse_bench.inference.providers.registry import register_provider
 from parse_bench.schemas.parse_output import ParseLayoutPageIR, ParseOutput, PageIR
@@ -24,6 +26,8 @@ from parse_bench.schemas.pipeline_io import (
     RawInferenceResult,
 )
 from parse_bench.schemas.product import ProductType
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_MODEL_NAME = "infly/Infinity-Parser2-Flash"
 
@@ -37,7 +41,7 @@ INFINITY_CATEGORY_MAP: dict[str, str] = {
     "formula": "Formula",
     "figure_caption": "Caption",
     "table_caption": "Caption",
-    "formula_caption": "Text",
+    "formula_caption": "Caption",
     "figure_footnote": "Footnote",
     "table_footnote": "Footnote",
     "page_footnote": "Footnote",
@@ -118,7 +122,7 @@ class InfinityParser2Provider(Provider):
             if self._max_new_tokens is not None:
                 parse_kwargs["max_new_tokens"] = self._max_new_tokens
 
-            if self._temperature != 0.0:
+            if "temperature" in self.base_config:
                 parse_kwargs["temperature"] = self._temperature
 
             pil_image, page_width, page_height = load_image(file_path)
@@ -145,7 +149,7 @@ class InfinityParser2Provider(Provider):
             error_str = str(e).lower()
             transient_keywords = ["timeout", "network", "connection", "cuda", "out of memory", "oom"]
             if any(keyword in error_str for keyword in transient_keywords):
-                raise ProviderConfigError(f"Error during parsing (GPU/memory): {e}") from e
+                raise ProviderTransientError(f"Error during parsing (GPU/memory): {e}") from e
             raise ProviderPermanentError(f"Error parsing document: {e}") from e
 
     def run_inference(self, pipeline: PipelineSpec, request: InferenceRequest) -> RawInferenceResult:
@@ -176,7 +180,7 @@ class InfinityParser2Provider(Provider):
                 latency_in_ms=latency_ms,
             )
 
-        except (ProviderPermanentError, ProviderConfigError):
+        except (ProviderPermanentError, ProviderTransientError, ProviderConfigError):
             raise
         except Exception as e:
             raise ProviderPermanentError(f"Unexpected error during inference: {e}") from e
@@ -212,7 +216,7 @@ class InfinityParser2Provider(Provider):
             return f"$${stripped}$$"
         elif label == "Picture":
             text = _convert_nonstandard_table(text)
-            return text if _is_valid_md_table(text) else ""
+            return text
         elif label == "Table":
             return _convert_table_header(text)
         else:
@@ -284,7 +288,7 @@ class InfinityParser2Provider(Provider):
             return json.dumps(elements)
 
         except Exception:
-            traceback.print_exc()
+            logger.exception("Deep parsing pass failed; returning shallow parse result")
             return result
 
     def _normalize(self, raw_result: RawInferenceResult) -> ParseOutput:
@@ -315,7 +319,11 @@ class InfinityParser2Provider(Provider):
         if not pages_dict:
             pages_dict = {1: []}
 
-        assert len(pages_dict) == 1, "Infinity-Parser2 should only return one page"
+        if len(pages_dict) != 1:
+            raise ProviderPermanentError(
+                f"Infinity-Parser2 provider only supports single-page documents; "
+                f"got {len(pages_dict)} pages for example {raw_result.request.example_id}"
+            )
 
         # Get layout pages and markdown
         pages: list[PageIR] = []
@@ -551,7 +559,7 @@ def _is_gender_cell(text: str) -> bool:
 def _is_pure_text_cell(text: str) -> bool:
     """Return True if text contains no digits at all."""
     text = text.strip()
-    return bool(text) and any(c.lower() >= 'a' and c.lower() <= 'z' for c in text)
+    return bool(text) and any(c.isalpha() for c in text)
 
 
 def _is_pure_number_cell(text: str) -> bool:
@@ -565,9 +573,7 @@ def _is_pure_number_cell(text: str) -> bool:
         return False
     # Allow: digits, comma, dot, minus, plus, $, %, parentheses
     allowed = set("0123456789,.-+()$% ")
-    if all(c in allowed for c in text):
-        return True
-    return False
+    return all(c in allowed for c in text)
 
 
 def _determine_header_row_count(rows: list) -> int:

--- a/src/parse_bench/inference/providers/parse/infinity_parser2.py
+++ b/src/parse_bench/inference/providers/parse/infinity_parser2.py
@@ -1,0 +1,603 @@
+"""Provider for Infinity-Parser2 PARSE via infinity_parser2 SDK with vLLM server."""
+
+from datetime import datetime
+import json
+from pathlib import Path
+import re
+import traceback
+from typing import Any
+
+from pdf2image import convert_from_path
+from PIL import Image as PILImage
+
+from parse_bench.inference.providers.base import (
+    Provider,
+    ProviderConfigError,
+    ProviderPermanentError,
+)
+from parse_bench.inference.providers.registry import register_provider
+from parse_bench.schemas.parse_output import ParseLayoutPageIR, ParseOutput, PageIR
+from parse_bench.schemas.pipeline import PipelineSpec
+from parse_bench.schemas.pipeline_io import (
+    InferenceRequest,
+    InferenceResult,
+    RawInferenceResult,
+)
+from parse_bench.schemas.product import ProductType
+
+DEFAULT_MODEL_NAME = "infly/Infinity-Parser2-Flash"
+
+# Infinity-Parser2 category → Canonical17 label mapping
+INFINITY_CATEGORY_MAP: dict[str, str] = {
+    "header": "Page-header",
+    "title": "Section-header",
+    "text": "Text",
+    "figure": "Picture",
+    "table": "Table",
+    "formula": "Formula",
+    "figure_caption": "Caption",
+    "table_caption": "Caption",
+    "formula_caption": "Text",
+    "figure_footnote": "Footnote",
+    "table_footnote": "Footnote",
+    "page_footnote": "Footnote",
+    "footer": "Page-footer",
+}
+
+
+@register_provider("infinity_parser2")
+class InfinityParser2Provider(Provider):
+    """
+    Provider for Infinity-Parser2 via the infinity_parser2 SDK.
+
+    Infinity-Parser2 is a document understanding model that converts PDFs
+    and images to structured markdown/JSON. This provider uses the
+    ``vllm-server`` backend which communicates with a running vLLM OpenAI-
+    compatible server over HTTP. This avoids thread-safety issues in the
+    ``vllm-engine`` backend when running concurrent requests.
+
+    Configuration options:
+        - model_name (str, default="infly/Infinity-Parser2-Flash"): Model name (must match server)
+        - api_url (str, default="http://localhost:8000/v1/chat/completions"): vLLM server endpoint
+        - api_key (str, default="EMPTY"): API key for the server
+        - timeout (int, default=300): Request timeout in seconds
+        - task_type (str, default="doc2json"): Parse task type
+        - output_format (str, default="json"): Output format (json returns per-element layout with bboxes)
+        - batch_size (int, default=4): Batch size for processing
+        - max_new_tokens (int, default=None): Override max tokens for generation
+        - temperature (float, default=0.0): Sampling temperature
+    """
+
+    def __init__(self, provider_name: str, base_config: dict[str, Any] | None = None):
+        super().__init__(provider_name, base_config)
+
+        self._model_name = self.base_config.get("model_name", DEFAULT_MODEL_NAME)
+        self._api_url = self.base_config.get("api_url", "http://localhost:8000/v1/chat/completions")
+        self._api_key = self.base_config.get("api_key", "EMPTY")
+        self._timeout = self.base_config.get("timeout", 300)
+        self._task_type = self.base_config.get("task_type", "doc2json")
+        self._output_format = self.base_config.get("output_format", "json")
+        self._batch_size = self.base_config.get("batch_size", 4)
+        self._max_new_tokens = self.base_config.get("max_new_tokens")
+        self._temperature = self.base_config.get("temperature", 0.0)
+
+        try:
+            from infinity_parser2 import InfinityParser2
+        except ImportError as e:
+            traceback.print_exc()
+            raise ProviderConfigError("import infinity_parser2 failed") from e
+
+        kwargs: dict[str, Any] = {
+            "model_name": self._model_name,
+            "backend": "vllm-server",
+            "api_url": self._api_url,
+            "api_key": self._api_key,
+            "timeout": self._timeout,
+        }
+
+        self._parser = InfinityParser2(**kwargs)
+
+    def _parse_document(self, file_path: str) -> dict[str, Any]:
+        """
+        Parse a document using InfinityParser2.
+
+        :param file_path: Path to the PDF or image file
+        :return: Raw parsing result
+        """
+        try:
+            parse_kwargs: dict[str, Any] = {
+                "task_type": self._task_type,
+                "batch_size": self._batch_size,
+            }
+
+            if self._output_format:
+                parse_kwargs["output_format"] = self._output_format
+
+            if self._max_new_tokens is not None:
+                parse_kwargs["max_new_tokens"] = self._max_new_tokens
+
+            if self._temperature != 0.0:
+                parse_kwargs["temperature"] = self._temperature
+
+            pil_image, page_width, page_height = load_image(file_path)
+            result = self._parser.parse(pil_image, **parse_kwargs)
+
+            return {
+                "result": result,
+                "_config": {
+                    "model_name": self._model_name,
+                    "backend": "vllm-server",
+                    "api_url": self._api_url,
+                    "task_type": self._task_type,
+                    "output_format": self._output_format,
+                    "batch_size": self._batch_size,
+                    "page_width": page_width,
+                    "page_height": page_height,
+                },
+            }
+
+        except Exception as e:
+            error_str = str(e).lower()
+            transient_keywords = ["timeout", "network", "connection", "cuda", "out of memory", "oom"]
+            if any(keyword in error_str for keyword in transient_keywords):
+                raise ProviderConfigError(f"Error during parsing (GPU/memory): {e}") from e
+            raise ProviderPermanentError(f"Error parsing document: {e}") from e
+
+    def run_inference(self, pipeline: PipelineSpec, request: InferenceRequest) -> RawInferenceResult:
+        if request.product_type != ProductType.PARSE:
+            raise ProviderPermanentError(
+                f"InfinityParser2Provider only supports PARSE product type, got {request.product_type}"
+            )
+
+        file_path = Path(request.source_file_path)
+        if not file_path.exists():
+            raise ProviderPermanentError(f"Source file not found: {file_path}")
+
+        started_at = datetime.now()
+
+        try:
+            raw_output = self._parse_document(str(file_path))
+            completed_at = datetime.now()
+            latency_ms = int((completed_at - started_at).total_seconds() * 1000)
+
+            return RawInferenceResult(
+                request=request,
+                pipeline=pipeline,
+                pipeline_name=pipeline.pipeline_name,
+                product_type=request.product_type,
+                raw_output=raw_output,
+                started_at=started_at,
+                completed_at=completed_at,
+                latency_in_ms=latency_ms,
+            )
+
+        except (ProviderPermanentError, ProviderConfigError):
+            raise
+        except Exception as e:
+            raise ProviderPermanentError(f"Unexpected error during inference: {e}") from e
+
+    def _build_layout_segment(self, bbox: list, label: str) -> dict:
+        """Build a LayoutSegmentIR from a bbox."""
+        if len(bbox) == 4:
+            x1, y1, x2, y2 = bbox
+            x, y, w, h = float(x1), float(y1), float(x2 - x1), float(y2 - y1)
+        else:
+            x, y, w, h = 0.0, 0.0, 0.0, 0.0
+
+        return {
+            "x": x,
+            "y": y,
+            "w": w,
+            "h": h,
+            "confidence": 1.0,
+            "label": label,
+            "start_index": None,
+            "end_index": None,
+        }
+
+    def _reassemble_text(self, label: str, text: str) -> str:
+        """Reassemble text content based on label."""
+        if not text:
+            return ""
+
+        if label == "Section-header":
+            return f"# {text.lstrip('# ')}"
+        elif label == "Formula":
+            stripped = re.sub(r"^[\s$\(\)\[\]]+|[\s$\(\)\[\]]+$", "", text)
+            return f"$${stripped}$$"
+        elif label == "Picture":
+            return _convert_nonstandard_table(text)
+        elif label == "Table":
+            return _convert_table_header(text)
+        else:
+            return text
+
+    def _build_layout_item(self, elem: dict, label: str) -> dict:
+        """Build a single LayoutItemIR from an infinity-parser2 JSON element."""
+        bbox = elem.get("bbox", [0, 0, 0, 0])
+        text = elem.get("text", "")
+
+        layout_seg = self._build_layout_segment(bbox, label)
+        text = self._reassemble_text(label, text)
+
+        return {
+            "type": label,
+            "md": text,
+            "html": text if label == "Table" else "",
+            "value": text,
+            "bbox": layout_seg,
+            "layout_segments": [layout_seg],
+        }
+
+    def _normalize(self, raw_result: RawInferenceResult) -> ParseOutput:
+        """Normalize JSON layout result into ParseOutput with pages, layout_pages, and markdown."""
+        result_str = raw_result.raw_output.get("result", "")
+        if not result_str:
+            raise ProviderPermanentError(f"Empty result from InfinityParser2 for {raw_result.pipeline_name}")
+
+        page_width = raw_result.raw_output["_config"]["page_width"]
+        page_height = raw_result.raw_output["_config"]["page_height"]
+
+        # Load elements
+        try:
+            elements: list[dict] = json.loads(result_str)
+            if not isinstance(elements, list):
+                elements = []
+        except json.JSONDecodeError:
+            elements = []
+
+        # Group elements by page
+        pages_dict: dict[int, list[dict]] = {}
+        for elem in elements:
+            page_num = elem.get("page", 1)
+            if page_num not in pages_dict:
+                pages_dict[page_num] = []
+            pages_dict[page_num].append(elem)
+
+        if not pages_dict:
+            pages_dict = {1: []}
+
+        assert len(pages_dict) == 1, "Infinity-Parser2 should only return one page"
+
+        # Get layout pages and markdown
+        pages: list[PageIR] = []
+        layout_pages: list[ParseLayoutPageIR] = []
+        markdown_parts: list[str] = []
+
+        for page_num in sorted(pages_dict.keys()):
+            page_elements = pages_dict[page_num]
+
+            header_items: list[dict] = []
+            footer_items: list[dict] = []
+            regular_items: list[dict] = []
+
+            for elem in page_elements:
+                raw_cat = elem.get("category", "text").strip().lower()
+                norm_cat = INFINITY_CATEGORY_MAP.get(raw_cat, "Text")
+                item = self._build_layout_item(elem, norm_cat)
+                if norm_cat == "Page-header":
+                    header_items.append(item)
+                elif norm_cat == "Page-footer":
+                    footer_items.append(item)
+                else:
+                    regular_items.append(item)
+
+            page_items = header_items + regular_items + footer_items
+            page_md_parts = [item.get("md", "") for item in page_items if item.get("md")]
+            page_md = "\n\n".join(page_md_parts)
+
+            header_md = " ".join(c.get("value", "") for c in header_items)
+            footer_md = " ".join(c.get("value", "") for c in footer_items)
+
+            layout_pages.append(
+                ParseLayoutPageIR(
+                    page_number=page_num,
+                    width=page_width,
+                    height=page_height,
+                    md=page_md,
+                    text=page_md,
+                    page_header_markdown=header_md,
+                    page_footer_markdown=footer_md,
+                    printed_page_number="",
+                    original_orientation_angle=0,
+                    items=page_items,
+                )
+            )
+
+            pages.append(PageIR(page_index=page_num - 1, markdown=page_md))
+            if page_md:
+                markdown_parts.append(page_md)
+
+        full_markdown = "\n\n".join(markdown_parts)
+
+        return ParseOutput(
+            task_type="parse",
+            example_id=raw_result.request.example_id,
+            pipeline_name=raw_result.pipeline_name,
+            pages=pages,
+            layout_pages=layout_pages,
+            markdown=full_markdown,
+        )
+
+    def normalize(self, raw_result: RawInferenceResult) -> InferenceResult:
+        if raw_result.product_type != ProductType.PARSE:
+            raise ProviderPermanentError(
+                f"InfinityParser2Provider only supports PARSE product type, got {raw_result.product_type}"
+            )
+
+        output = self._normalize(raw_result)
+
+        return InferenceResult(
+            request=raw_result.request,
+            pipeline_name=raw_result.pipeline_name,
+            product_type=raw_result.product_type,
+            raw_output=raw_result.raw_output,
+            output=output,
+            started_at=raw_result.started_at,
+            completed_at=raw_result.completed_at,
+            latency_in_ms=raw_result.latency_in_ms,
+        )
+
+
+def load_image(file_path: str) -> tuple[PILImage.Image, float, float]:
+    """Load a PDF or image file as a PIL Image and return its dimensions.
+
+    - PDF: converts the first page to RGB image at 300 DPI.
+    - Image: opens and converts to RGB.
+
+    Returns:
+        Tuple of (PIL Image, width, height) where width and height are in pixels.
+    """
+    path = Path(file_path)
+    if path.suffix.lower() == ".pdf":
+        images = convert_from_path(str(path), dpi=300, first_page=1, last_page=1)
+        if not images:
+            raise ProviderPermanentError(f"Failed to render PDF page: {file_path}")
+        pil_image = images[0].convert("RGB")
+    else:
+        pil_image = PILImage.open(str(path)).convert("RGB")
+
+    width, height = pil_image.size
+    return pil_image, float(width), float(height)
+
+
+# =============================================================================
+# Postprocess for chart2table
+# =============================================================================
+
+def _is_nonstandard_table(text: str) -> bool:
+    """Check if text is a non-standard markdown table (no leading '|', contains '&' separators)."""
+    if not text:
+        return False
+    stripped = text.strip()
+    if stripped.startswith("|"):
+        return False
+    return "&" in text
+
+
+def _find_column_number(text: str) -> int:
+    """Find the column number from a nonstandard table.
+
+    Split the text by '&' and count '|' in each segment. The header row always
+    has the most pipes (full cells). Column count = max(pipe_counts) + 1.
+    """
+    if "&" not in text:
+        return 0
+    raw_segments = text.split("&")
+    segments = [s.strip() for s in raw_segments if s.strip()]
+    if not segments:
+        return 0
+    pipe_counts = [s.count("|") for s in segments]
+    return max(pipe_counts) + 1
+
+
+def _find_all_separator_indices(text: str, col_num: int) -> list[int]:
+    """Identify which '&' characters are row-group separators based on pipe counts."""
+    if col_num == 0:
+        return []
+    expected_pipes = col_num - 1
+    sep_positions = []
+    prev_sep = -1
+    i = 0
+    while i < len(text):
+        amp = text.find("&", i)
+        if amp == -1:
+            break
+
+        # Count pipes between prev_sep+1 and amp-1
+        pipe_count = 0
+        for j in range(prev_sep + 1, amp):
+            if text[j] == "|":
+                pipe_count += 1
+
+        if pipe_count == expected_pipes:
+            sep_positions.append(amp)
+            prev_sep = amp
+
+        i = amp + 1
+    return sep_positions
+
+
+def _convert_nonstandard_table(text: str) -> str:
+    """Convert a non-standard markdown table (with '&' row-group separators) to proper markdown table format."""
+    if not _is_nonstandard_table(text):
+        return text
+
+    col_num = _find_column_number(text)
+    if col_num == 0:
+        return text
+
+    sep_indices = _find_all_separator_indices(text, col_num)
+    if not sep_indices:
+        return text
+
+    segments = []
+    prev = 0
+    for idx in sep_indices:
+        segments.append(text[prev:idx].strip())
+        prev = idx + 1
+    segments.append(text[prev:].strip())
+
+    header = segments[0]
+    if not header.startswith("|"):
+        header = "| " + header
+    if not header.rstrip().endswith("|"):
+        header = header.rstrip() + " |"
+
+    separator = "| " + " | ".join(["---"] * col_num) + " |"
+    normalized_lines = [header, separator]
+
+    for seg in segments[1:]:
+        if not seg:
+            continue
+        cells = [c.strip() for c in seg.split("|") if c.strip()]
+        padded = cells + [""] * max(0, col_num - len(cells))
+        row = "| " + " | ".join(padded[:col_num]).rstrip() + " |"
+        normalized_lines.append(row)
+
+    return "\n".join(normalized_lines)
+
+
+# =============================================================================
+# Postprocess for HTML table header
+# =============================================================================
+
+def _is_year_cell(text: str) -> bool:
+    """Return True if text looks like a date/year (yyyy, yyyymm, yyyymmdd, etc.)."""
+    text = text.strip()
+    return bool(re.fullmatch(r"(19|20)\d{2,4}([-/]?\d{2}([-/]?\d{2})?)?", text))
+
+
+def _is_gender_cell(text: str) -> bool:
+    """Return True if text looks like gender."""
+    text = text.strip().lower()
+    return text in ("male", "female", "non-binary", "other", "undisclosed")
+
+
+def _is_pure_text_cell(text: str) -> bool:
+    """Return True if text contains no digits at all."""
+    text = text.strip()
+    return bool(text) and any(c.lower() >= 'a' and c.lower() <= 'z' for c in text)
+
+
+def _is_pure_number_cell(text: str) -> bool:
+    """Return True if text looks like a pure numeric value.
+
+    Accepts numbers with commas, decimals, dollar sign, percent sign,
+    plus/minus sign, and parentheses (for negative numbers).
+    """
+    text = text.strip()
+    if not text:
+        return False
+    # Allow: digits, comma, dot, minus, plus, $, %, parentheses
+    allowed = set("0123456789,.-+()$% ")
+    if all(c in allowed for c in text):
+        return True
+    return False
+
+
+def _determine_header_row_count(rows: list) -> int:
+    """Determine how many top rows are header rows (year/gender/value rules + rowspan fallback)."""
+    if not rows:
+        return 0
+
+    def non_empty_cells(row):
+        return [td.get_text(strip=True) for td in row.find_all("td", recursive=False)
+                if td.get_text(strip=True)]
+
+    def stats(row_list):
+        """Return (pure_text_count, pure_number_count, total) for a list of rows."""
+        text_count = number_count = total = 0
+        for row in row_list:
+            for cell in non_empty_cells(row):
+                total += 1
+                if _is_pure_text_cell(cell):
+                    text_count += 1
+                elif _is_pure_number_cell(cell):
+                    number_count += 1
+        return text_count, number_count, total
+
+    # Rule 1: Year
+    for i, row in enumerate(rows):
+        if i > 3:
+            break
+        cells = non_empty_cells(row)
+        if not cells:
+            continue
+        year_count = sum(1 for c in cells if _is_year_cell(c))
+        if year_count / len(cells) >= 0.5:
+            return i + 1
+
+    # Rule 2: Gender
+    for i, row in enumerate(rows):
+        if i > 3:
+            break
+        cells = non_empty_cells(row)
+        if not cells:
+            continue
+        gender_count = sum(1 for c in cells if _is_gender_cell(c))
+        if gender_count / len(cells) >= 0.5:
+            return i + 1
+
+    # Rule 3: Value (pure-text header region followed by pure-number data region)
+    best_i = -1
+    best_score = -1.0
+    for i in range(3):
+        header_rows = rows[:i + 1]
+        data_rows = rows[i + 1:]
+        if not header_rows or not data_rows:
+            continue
+        header_text, header_num, header_total = stats(header_rows)
+        data_text, data_num, data_total = stats(data_rows)
+        if header_total == 0 or data_total == 0:
+            continue
+        if (header_text / header_total >= 0.5 and data_num / data_total >= 0.5):
+            score = header_text / header_total + data_num / data_total
+            if score > best_score:
+                best_score = score
+                best_i = i
+    if best_i >= 0:
+        return best_i + 1
+
+    # Rule 4: Fallback — max rowspan in row 0
+    first_row = rows[0]
+    max_rowspan = 1
+    for td in first_row.find_all("td", recursive=False):
+        rowspan = int(td.get("rowspan", 1))
+        if rowspan > max_rowspan:
+            max_rowspan = rowspan
+    return max_rowspan
+
+
+def _convert_table_header(html: str) -> str:
+    """Convert <td> tags in HTML table header rows to <th> for TEDS/GriTS evaluation."""
+    if not html or "<table" not in html.lower():
+        return html
+
+    try:
+        from bs4 import BeautifulSoup
+    except ImportError:
+        return html
+
+    soup = BeautifulSoup(html, "html.parser")
+    tables = soup.find_all("table")
+
+    for table in tables:
+        rows = table.find_all("tr", recursive=False)
+        if not rows:
+            continue
+
+        header_row_count = _determine_header_row_count(rows)
+
+        for i, row in enumerate(rows):
+            if i >= header_row_count:
+                break
+            tds = row.find_all("td", recursive=False)
+            for td in tds:
+                new_th = soup.new_tag("th")
+                for key, value in td.attrs.items():
+                    new_th[key] = value
+                new_th.string = td.get_text()
+                td.replace_with(new_th)
+
+    return str(soup)

--- a/src/parse_bench/schemas/layout_detection_output.py
+++ b/src/parse_bench/schemas/layout_detection_output.py
@@ -429,6 +429,10 @@ LAYOUT_MODEL_INFO: dict[LayoutDetectionModel, dict[str, str]] = {
         "name": "Databricks ai_parse_document Layout",
         "hf_url": "https://docs.databricks.com/aws/en/sql/language-manual/functions/ai_parse_document",
     },
+    LayoutDetectionModel.INFINITY_PARSER2_LAYOUT: {
+        "name": "Infinity-Parser2 Layout",
+        "hf_url": "https://huggingface.co/collections/infly/infinity-parser2",
+    },
 }
 
 

--- a/src/parse_bench/schemas/layout_detection_output.py
+++ b/src/parse_bench/schemas/layout_detection_output.py
@@ -313,6 +313,7 @@ class LayoutDetectionModel(StrEnum):
     ANTHROPIC_LAYOUT = "anthropic_layout"
     GEMMA4_LAYOUT = "gemma4_layout"
     DATABRICKS_LAYOUT = "databricks_layout"
+    INFINITY_PARSER2_LAYOUT = "infinity_parser2_layout"
 
 
 LAYOUT_MODEL_INFO: dict[LayoutDetectionModel, dict[str, str]] = {

--- a/tests/parse_bench/inference/providers/parse/test_infinity_parser2.py
+++ b/tests/parse_bench/inference/providers/parse/test_infinity_parser2.py
@@ -1,0 +1,157 @@
+"""Unit tests for InfinityParser2 table-header heuristics.
+
+These tests pin down the rule-driven behavior of the post-processing helpers
+in ``infinity_parser2.py`` so future model/format changes don't silently
+regress them.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from bs4 import BeautifulSoup
+
+from parse_bench.inference.providers.parse.infinity_parser2 import (
+    _convert_nonstandard_table,
+    _convert_table_header,
+    _determine_header_row_count,
+    _find_column_number,
+    _is_gender_cell,
+    _is_nonstandard_table,
+    _is_pure_number_cell,
+    _is_pure_text_cell,
+    _is_year_cell,
+)
+
+
+class TestCellClassifiers(unittest.TestCase):
+    """Cell-level predicates used by the header-row heuristics."""
+
+    def test_year_cell(self) -> None:
+        self.assertTrue(_is_year_cell("2024"))
+        self.assertTrue(_is_year_cell("202401"))
+        self.assertTrue(_is_year_cell("2024-01-15"))
+        self.assertFalse(_is_year_cell("Revenue"))
+
+    def test_gender_cell(self) -> None:
+        self.assertTrue(_is_gender_cell("Male"))
+        self.assertTrue(_is_gender_cell("female"))
+        self.assertFalse(_is_gender_cell("Total"))
+
+    def test_pure_text_vs_pure_number(self) -> None:
+        # pure text: has alpha, no all-numeric requirement
+        self.assertTrue(_is_pure_text_cell("Revenue"))
+        self.assertFalse(_is_pure_text_cell("123"))
+        self.assertFalse(_is_pure_text_cell(""))
+
+        # pure number: digits + permitted symbols only
+        self.assertTrue(_is_pure_number_cell("1,234.56"))
+        self.assertTrue(_is_pure_number_cell("$(45.00)"))
+        self.assertTrue(_is_pure_number_cell("-12%"))
+        self.assertFalse(_is_pure_number_cell("12 apples"))
+        self.assertFalse(_is_pure_number_cell(""))
+
+
+class TestNonstandardTable(unittest.TestCase):
+    """Detection and conversion of '&'-separated tables emitted by the model."""
+
+    def test_is_nonstandard_table(self) -> None:
+        # Has '&' and does not start with '|' → nonstandard
+        self.assertTrue(_is_nonstandard_table("a | b | c & 1 | 2 | 3"))
+        # Already a proper markdown table → not nonstandard
+        self.assertFalse(_is_nonstandard_table("| a | b |\n| - | - |"))
+        # No '&' → not nonstandard
+        self.assertFalse(_is_nonstandard_table("plain text"))
+        self.assertFalse(_is_nonstandard_table(""))
+
+    def test_find_column_number(self) -> None:
+        # 3 columns → header has 2 pipes between cells
+        self.assertEqual(_find_column_number("a | b | c & 1 | 2 | 3"), 3)
+        self.assertEqual(_find_column_number("no ampersand here"), 0)
+
+    def test_convert_nonstandard_table_roundtrip(self) -> None:
+        raw = "Year | Revenue | Profit & 2023 | 100 | 20 & 2024 | 150 | 35"
+        out = _convert_nonstandard_table(raw)
+        lines = out.splitlines()
+        # Header + separator + 2 data rows
+        self.assertEqual(len(lines), 4)
+        self.assertTrue(lines[0].startswith("|") and lines[0].endswith("|"))
+        self.assertEqual(lines[1], "| --- | --- | --- |")
+        self.assertIn("2023", lines[2])
+        self.assertIn("2024", lines[3])
+
+    def test_convert_nonstandard_table_passthrough(self) -> None:
+        # Already-valid markdown tables must be returned unchanged.
+        already_md = "| a | b |\n| - | - |\n| 1 | 2 |"
+        self.assertEqual(_convert_nonstandard_table(already_md), already_md)
+
+
+class TestDetermineHeaderRowCount(unittest.TestCase):
+    """Header-row count is determined by year/gender/value rules, then rowspan."""
+
+    @staticmethod
+    def _rows(html: str) -> list:
+        soup = BeautifulSoup(html, "html.parser")
+        table = soup.find("table")
+        return table.find_all("tr", recursive=False)
+
+    def test_year_rule_single_header_row(self) -> None:
+        html = """
+        <table>
+          <tr><td>2022</td><td>2023</td><td>2024</td></tr>
+          <tr><td>10</td><td>20</td><td>30</td></tr>
+          <tr><td>11</td><td>21</td><td>31</td></tr>
+        </table>
+        """
+        self.assertEqual(_determine_header_row_count(self._rows(html)), 1)
+
+    def test_value_rule_text_then_numbers(self) -> None:
+        # First row pure text, rest pure numbers → 1 header row by value rule.
+        html = """
+        <table>
+          <tr><td>Region</td><td>Revenue</td><td>Profit</td></tr>
+          <tr><td>100</td><td>200</td><td>30</td></tr>
+          <tr><td>110</td><td>210</td><td>35</td></tr>
+        </table>
+        """
+        self.assertEqual(_determine_header_row_count(self._rows(html)), 1)
+
+    def test_rowspan_fallback(self) -> None:
+        # No year/gender/value signal → fallback to rowspan of first row.
+        html = """
+        <table>
+          <tr><td rowspan="2">A</td><td rowspan="2">B</td></tr>
+          <tr></tr>
+          <tr><td>x</td><td>y</td></tr>
+        </table>
+        """
+        self.assertEqual(_determine_header_row_count(self._rows(html)), 2)
+
+
+class TestConvertTableHeader(unittest.TestCase):
+    """End-to-end: <td> in detected header rows is rewritten to <th>."""
+
+    def test_td_to_th_in_header_row(self) -> None:
+        html = (
+            "<table>"
+            "<tr><td>2022</td><td>2023</td></tr>"
+            "<tr><td>10</td><td>20</td></tr>"
+            "</table>"
+        )
+        out = _convert_table_header(html)
+        soup = BeautifulSoup(out, "html.parser")
+        rows = soup.find_all("tr")
+        # Row 0: both cells become <th>
+        self.assertEqual(len(rows[0].find_all("th")), 2)
+        self.assertEqual(len(rows[0].find_all("td")), 0)
+        # Row 1: data cells remain <td>
+        self.assertEqual(len(rows[1].find_all("td")), 2)
+        self.assertEqual(len(rows[1].find_all("th")), 0)
+
+    def test_non_table_html_unchanged(self) -> None:
+        self.assertEqual(_convert_table_header(""), "")
+        self.assertEqual(_convert_table_header("plain text"), "plain text")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Here is how to reproduce the results of `infinity_parser2`, taking `infinity_parser2_pro` as an example:

1. Navigate to the ParseBench directory:
```shell
cd /path/to/ParseBench
```

2. Start the vLLM server:
```shell
vllm serve infly/Infinity-Parser2-Pro \
    --trust-remote-code \
    --reasoning-parser qwen3 \
    --host 0.0.0.0 \
    --port 8000 \
    --tensor-parallel-size 8 \
    --gpu-memory-utilization 0.85 \
    --max-model-len 65536 \
    --mm-encoder-tp-mode data \
    --mm-processor-cache-type shm \
    --enable-prefix-caching
```

3. Run parse-bench:
```shell
uv run parse-bench run infinity_parser2_pro
```

<img width="1336" height="791" alt="image" src="https://github.com/user-attachments/assets/4af146d1-47f8-4a4f-add0-decce6792d9b" />

**Environment Dependencies:**

- `torch==2.10.0`
- `flash_attn_3`
- `vllm==0.17.1`
- `transformers==5.3.0`
- `infinity_parser2==0.3.0`
```