### PR TITLE
Add form_field parse rule for forms benchmark dimension

### DIFF
--- a/src/parse_bench/analysis/aggregation_report.py
+++ b/src/parse_bench/analysis/aggregation_report.py
@@ -38,6 +38,7 @@ _DEFAULT_METRICS: dict[str, str] = {
     "layout": "layout_element_rule_pass_rate",
     "text_content": "content_faithfulness",
     "text_formatting": "semantic_formatting",
+    "form": "rule_form_field_pass_rate",
 }
 
 

--- a/src/parse_bench/analysis/metric_definitions.py
+++ b/src/parse_bench/analysis/metric_definitions.py
@@ -254,6 +254,12 @@ METRIC_DEFINITIONS: dict[str, MetricInfo] = {
         "Chart Data Point",
         "Pass rate for chart data point extraction rules.",
     ),
+    "form_field": MetricInfo(
+        "Form Field",
+        "Pass rate for form field rules (key-value, checkbox, signature). "
+        "A rule passes when the labeled field is located in the parsed output "
+        "and the extracted value matches the expected value.",
+    ),
     "order": MetricInfo(
         "Order",
         "Pass rate for reading order rules, checking that elements appear in the expected sequence.",

--- a/src/parse_bench/analysis/metric_definitions.py
+++ b/src/parse_bench/analysis/metric_definitions.py
@@ -258,7 +258,8 @@ METRIC_DEFINITIONS: dict[str, MetricInfo] = {
         "Form Field",
         "Pass rate for form field rules (key-value, checkbox, signature). "
         "A rule passes when the labeled field is located in the parsed output "
-        "and the extracted value matches the expected value.",
+        "and the extracted value matches the expected value (or any acceptable "
+        "alternative when value is a list; signature rules pass on presence).",
     ),
     "order": MetricInfo(
         "Order",

--- a/src/parse_bench/evaluation/metrics/parse/rules_base.py
+++ b/src/parse_bench/evaluation/metrics/parse/rules_base.py
@@ -454,6 +454,9 @@ def create_test_rule(rule_data: ParseRuleInput) -> "ParseTestRule":
         ChartDataPointRule,
         RotateCheckRule,
     )
+    from parse_bench.evaluation.metrics.parse.rules_form import (
+        FormFieldRule,
+    )
     from parse_bench.evaluation.metrics.parse.rules_formatting import (
         _FORMATTING_TEST_TYPES,
         CodeBlockRule,
@@ -580,6 +583,9 @@ def create_test_rule(rule_data: ParseRuleInput) -> "ParseTestRule":
         return ChartDataArrayLabelsRule(typed_rule)
     elif rule_type == TestType.CHART_DATA_ARRAY_DATA.value:
         return ChartDataArrayDataRule(typed_rule)
+    # Form rules
+    elif rule_type == TestType.FORM_FIELD.value:
+        return FormFieldRule(typed_rule)
     # Formatting rules (bold, italic, underline, strikeout, mark, sup, sub)
     elif rule_type in _FORMATTING_TEST_TYPES:
         if rule_type == TestType.MARK_COLOR.value:

--- a/src/parse_bench/evaluation/metrics/parse/rules_form.py
+++ b/src/parse_bench/evaluation/metrics/parse/rules_form.py
@@ -1,0 +1,1545 @@
+"""Form field test rule.
+
+A `form_field` rule locates a labeled field in the parsed markdown/HTML and
+checks its value. Three value types are supported in v0.1: ``text``,
+``checkbox``, and ``signature``. The matcher tries a small set of
+high-confidence patterns:
+
+- Bold-colon (``**Label:** value`` and ``**Label**: value``) — supports
+  multiple bold-colon pairs on the same line.
+- Plain colon on its own line (``Label: value``).
+- 2-column markdown tables AND 2-column HTML tables (label in first cell,
+  value in second).
+- Per-line checkbox tokenization for inline groups, handling both
+  glyph-first (``☐ Single ☑ Married``) and label-first
+  (``Single ☐ Married ☑``) orderings.
+- Markdown task-list checkboxes (``- [x] Label`` / ``- [ ] Label``).
+
+When the rule has a ``page`` and the metric injects a ``parse_output``,
+matching is scoped to that page's markdown only.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import cast
+
+from bs4 import BeautifulSoup
+from rapidfuzz import fuzz
+
+from parse_bench.evaluation.metrics.parse.rules_base import (
+    CELL_FUZZY_MATCH_THRESHOLD,
+    ParseTestRule,
+)
+from parse_bench.evaluation.metrics.parse.rules_chart import normalize_number_string
+from parse_bench.evaluation.metrics.parse.table_parsing import (
+    TableData,
+    parse_html_tables,
+    parse_markdown_tables,
+)
+from parse_bench.evaluation.metrics.parse.test_types import TestType
+from parse_bench.evaluation.metrics.parse.utils import normalize_text
+from parse_bench.test_cases.parse_rule_schemas import ParseFormFieldRule
+
+# Glyphs that represent a checked / unchecked state. Sourced from the most
+# common Unicode shapes parsers emit when surfacing form widgets. The extra
+# circle/dot glyphs (◉●⦿/○◯⊙) appear in Gemini and OpenAI outputs which mirror
+# radio-button widgets; the extra X glyphs (⊠⊗) appear in IRS/USCIS forms.
+_CHECKED_GLYPHS = "☑☒▣✓✔◉●⦿⊠⊗"
+_UNCHECKED_GLYPHS = "☐□○◯⊙"
+_CHECKBOX_GLYPHS = _CHECKED_GLYPHS + _UNCHECKED_GLYPHS
+_GLYPH_RE = re.compile(f"[{_CHECKBOX_GLYPHS}]")
+# Combined marker regex: either a single Unicode glyph OR an ASCII bracket
+# pair ``[x]`` / ``[ ]`` (with optional ``\`` escapes around the brackets).
+# Used by the per-line tokenizer so inline ASCII checkbox groups
+# (``\[x] Single \[ ] Married``) are parsed the same as Unicode-glyph groups.
+_MARKER_RE = re.compile(rf"[{_CHECKBOX_GLYPHS}]|\\?\[[ xX]\\?\]")
+
+
+def _marker_is_checked(token: str) -> bool:
+    """Decide if a checkbox marker token represents the checked state."""
+
+    if len(token) == 1:
+        return token in _CHECKED_GLYPHS
+    return any(c in "xX" for c in token)
+
+
+# Boolean coercion table for textual yes/no values.
+_TRUTHY_TEXT = {"yes", "y", "true", "t", "1", "checked", "x", "selected", "on"}
+_FALSY_TEXT = {"no", "n", "false", "f", "0", "unchecked", "unselected", "off", ""}
+
+
+_PARTIAL_RATIO_THRESHOLD = 0.90
+_PARTIAL_RATIO_MIN_LEN = 6
+# Penalty applied to the partial-ratio score so a partial hit cannot beat
+# an equally strong strict-ratio hit. Empirically 0.05 keeps partial 1.0
+# above strict 0.86 (so e.g. ``API NO. (if available)`` still resolves
+# against GT ``API NO.`` when the only candidate is the full noisy label)
+# while preventing partial 0.95 (``County`` ⊂ ``Country``) from beating a
+# strict 1.0 ``Country`` match on the *correct* row.
+_PARTIAL_RATIO_PENALTY = 0.05
+
+
+def _strip_label_punct(s: str) -> str:
+    """Remove punctuation that varies between abbreviation styles.
+
+    ``K.B.`` vs ``KB``, ``D.F.`` vs ``DF``, ``API NO:`` vs ``API NO``,
+    ``Tel.`` vs ``Tel`` are the same label semantically. This strips
+    dots, colons, and commas — separators that the parser may add or drop
+    while preserving the underlying tokens. Operates after
+    ``normalize_text`` so it sees a case-folded, whitespace-collapsed
+    string.
+    """
+
+    s = s.replace(".", "")
+    s = s.replace(":", "")
+    s = s.replace(",", "")
+    s = re.sub(r"\s+", " ", s).strip()
+    return s
+
+
+def _label_match_score(candidate: str, label: str) -> float:
+    """Score how well *candidate* matches *label* on the ``_label_matches`` axes.
+
+    Returns ``0.0`` when the candidate fails every path (same as
+    ``_label_matches`` returning False); otherwise returns a value in
+    ``(0.0, 1.0]`` where higher means a better label match.
+
+    Why scoring instead of a bool: when the document contains two visually
+    similar labels (the classic ``Country`` / ``County`` collision), the
+    old first-match-wins iteration would latch onto whichever fuzzy hit
+    came first and return that row's value. With a scoring function, the
+    caller can collect every candidate and pick the *best* match — an
+    exact ``Country`` (score ``1.0``) beats a fuzzy ``County`` (score
+    ``~0.92``) even when ``County`` appears earlier in the markdown.
+
+    Scoring:
+
+    - Strict-ratio path (``fuzz.ratio >= CELL_FUZZY_MATCH_THRESHOLD``):
+      score = the ratio itself.
+    - Partial-ratio fallback (``fuzz.partial_ratio >= _PARTIAL_RATIO_THRESHOLD``
+      with ``shorter >= _PARTIAL_RATIO_MIN_LEN``): score = the partial
+      ratio minus ``_PARTIAL_RATIO_PENALTY`` (currently 0.05). The penalty
+      keeps partial hits strictly below same-strength strict hits — a
+      partial 1.0 (``County`` substring inside ``County, TX``) scores
+      ``0.95``, which still loses to any strict-ratio match >= 0.95 but
+      wins over a strict-ratio 0.86 fuzzy match.
+    - Punctuation-stripped exact path
+      (``_strip_label_punct(cand) == _strip_label_punct(lbl)``): score
+      ``1.0``. Exact-equality (not fuzz) keeps this path narrow — short
+      labels like ``KB`` won't collide with ``KBC`` (``fuzz.ratio`` happens
+      to hit exactly 0.80 between those two strings, which would leak
+      through if we ran fuzz on the stripped variants) while still
+      matching dotted abbreviation variants like ``K.B.`` ≡ ``KB``.
+    - Best path wins when several fire.
+    """
+
+    cand = normalize_text(candidate)
+    lbl = normalize_text(label)
+    if not cand or not lbl:
+        return 0.0
+
+    best = 0.0
+    ratio = fuzz.ratio(cand, lbl) / 100.0
+    if ratio >= CELL_FUZZY_MATCH_THRESHOLD:
+        best = ratio
+    shorter = min(len(cand), len(lbl))
+    if shorter >= _PARTIAL_RATIO_MIN_LEN:
+        partial = fuzz.partial_ratio(cand, lbl) / 100.0
+        if partial >= _PARTIAL_RATIO_THRESHOLD:
+            penalized = max(partial - _PARTIAL_RATIO_PENALTY, 0.0)
+            if penalized > best:
+                best = penalized
+
+    # Punctuation-stripped exact equality — narrowest of the three paths,
+    # only fires when the strip actually collapses two different surface
+    # forms onto the same string. Scored at 1.0 so legitimate abbreviation
+    # variants beat a coincidental ratio-0.80 collision (the ``K.B.``/
+    # ``KBC`` boundary case) when both candidates appear in the document.
+    cand_stripped = _strip_label_punct(cand)
+    lbl_stripped = _strip_label_punct(lbl)
+    if cand_stripped and lbl_stripped and cand_stripped == lbl_stripped:
+        if 1.0 > best:
+            best = 1.0
+
+    return best
+
+
+def _label_matches(candidate: str, label: str) -> bool:
+    """Boolean predicate over :func:`_label_match_score` for legacy callers.
+
+    Used by callers that only need a boolean (adjacent-line fallback,
+    underscore-blank label-seen detection, checkbox-state matching). The
+    main text-value lookup uses :func:`_label_match_score` directly so it
+    can score-and-pick-best across multiple candidate KV pairs.
+    """
+
+    return _label_match_score(candidate, label) > 0.0
+
+
+def _coerce_bool(value: str | bool | list[str]) -> bool | None:
+    """Coerce a value to True/False, or None if ambiguous.
+
+    List inputs are not supported by checkbox semantics and return None;
+    the caller surfaces a "must be coercible to bool" error in that case.
+    """
+
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, list):
+        return None
+    text = str(value).strip().lower()
+    if text in _TRUTHY_TEXT:
+        return True
+    if text in _FALSY_TEXT:
+        return False
+    return None
+
+
+def _value_alternatives(value: str | bool | list[str]) -> list[str]:
+    """Return the list of acceptable string values for a text-typed rule.
+
+    Supports both single-string and list-of-strings GTs. A list lets a rule
+    declare multiple acceptable readings for genuinely ambiguous fields
+    (e.g. illegible handwriting). The single-string form is the default and
+    keeps the GT clean for the common case.
+    """
+
+    if isinstance(value, list):
+        return [str(v) for v in value]
+    return [str(value)]
+
+
+def _multi_col_header_data_pairs(table: TableData) -> list[tuple[str, str]]:
+    """For a >2-col table with header rows, yield (col_header, data_value) for
+    every (column, data row) pair so a label that names a column matches the
+    value in that column's data row(s)."""
+
+    out: list[tuple[str, str]] = []
+    rows, cols = table.data.shape
+    if cols <= 2 or rows == 0:
+        return out
+    header_rows = getattr(table, "header_rows", set()) or set()
+    n_header = (max(header_rows) + 1) if header_rows else 1
+    for col_idx in range(cols):
+        header_text = _column_header_for_index(table, col_idx)
+        if not header_text:
+            continue
+        for row_idx in range(n_header, rows):
+            cell_value = str(table.data[row_idx, col_idx]).strip()
+            out.append((header_text, cell_value))
+    return out
+
+
+def _iter_html_cell_kv_pairs(content: str) -> list[tuple[str, str]]:
+    """Yield (label, value) pairs extracted from HTML cells whose internal
+    layout stacks the label above the value via ``<br/>``.
+
+    Pattern: ``<td>Label<br/><strong>Value</strong></td>``. Common in parsers
+    that try to mirror the visual two-line widget within a single cell."""
+
+    out: list[tuple[str, str]] = []
+    if "<table" not in content.lower():
+        return out
+    soup = BeautifulSoup(content, "lxml")
+    for table in soup.find_all("table"):
+        for cell in table.find_all(["td", "th"]):
+            for br in cell.find_all("br"):
+                br.replace_with("\n")
+            cell_text = cell.get_text().strip()
+            if "\n" not in cell_text:
+                continue
+            parts = [p.strip() for p in cell_text.split("\n", 1)]
+            if len(parts) != 2:
+                continue
+            label_part, value_part = parts
+            label_part = label_part.strip("*_ \t")
+            value_part = value_part.strip("*_ \t")
+            if label_part:
+                out.append((label_part, value_part))
+    return out
+
+
+def _iter_html_table_kv_rows(content: str) -> list[tuple[str, str]]:
+    """Yield (label, value) tuples from HTML tables.
+
+    - 2-col tables: yield each row as ``(col0, col1)`` (label-then-value layout).
+    - >2-col tables with header rows: yield ``(col_header, data_row_value)``
+      for every column × data row, so a label naming a column matches the
+      value in that column's data row.
+    - Any cell that contains in-cell ``<br/>`` separators: yield
+      ``(top_half, bottom_half)`` so ``<td>Label<br/><strong>Value</strong></td>``
+      is captured.
+    """
+
+    out: list[tuple[str, str]] = []
+    if "<table" not in content.lower():
+        return out
+    # Cell-internal label/value (label<br/>value inside one cell) takes
+    # precedence over the row-wise 2-col interpretation; otherwise a cell
+    # like ``<td>Last Name<br/>Nguyen</td>`` would be mangled into a single
+    # blob ``Last Name Nguyen`` by the row-wise path before the cell-level
+    # pair is ever consulted.
+    out.extend(_iter_html_cell_kv_pairs(content))
+    for table in parse_html_tables(content):
+        rows, cols = table.data.shape
+        if cols == 2:
+            for row_idx in range(rows):
+                label_text = str(table.data[row_idx, 0]).strip()
+                value_text = str(table.data[row_idx, 1]).strip()
+                out.append((label_text, value_text))
+        elif cols > 2:
+            # Header-then-data-row binding (one record per data row).
+            # Interleaved label/value layouts inside wide HTML tables
+            # (well-log report headers, rotated form pages) are handled
+            # downstream by ``_iter_html_cell_neighbor_pairs`` — that
+            # iterator classifies each neighbor as label-shaped vs
+            # value-shaped before pairing, so the score path never sees
+            # spurious ``(LABEL, OTHER_LABEL)`` candidates.
+            out.extend(_multi_col_header_data_pairs(table))
+    return out
+
+
+# Heuristic: signals that a cell *looks like* a form-label rather than a value.
+# Used as a tie-breaker by ``_iter_html_cell_neighbor_pairs`` when picking
+# between a right-neighbor and a below-neighbor in wide HTML form tables —
+# we only want to return value-shaped neighbors, not adjacent label cells.
+#
+# A cell is considered label-like when any of these holds:
+#   1. trailing colon (``FILE NO:``);
+#   2. short ALL-CAPS with no digits / no value-style punctuation
+#      (``WELL``, ``COMPANY``, ``OTHER SERVICES``);
+#   3. structurally repeats elsewhere in the same table — handled by the
+#      caller, which threads the per-table text-count map in.
+#
+# Values like ``LEHMAN #1``, ``42-157-33282``, ``KEBO OIL & GAS, INC.``,
+# ``15-MAY-2023`` keep digits / hashes / commas / parens so they fail
+# heuristic (2) and are correctly classified as value-shaped.
+#
+# Note: ``&`` is intentionally absent from the disqualifier so common
+# value strings like ``"KEBO OIL & GAS, INC."`` (rescued by the comma)
+# stay value-shaped without forcing every label with ``&`` (e.g. an
+# ``"OIL & GAS"`` column header) to be misread as a value. A naked
+# ``"X & Y"`` value with no other punctuation would be misclassified as a
+# label, but that pattern hasn't surfaced in real benchmark data.
+_LABEL_LIKE_DISQUALIFIER_RE = re.compile(r"[\d#@/_,()$%]")
+
+
+def _cell_text_is_label_like(text: str) -> bool:
+    s = text.strip()
+    if not s:
+        return False
+    if s.endswith(":"):
+        return True
+    # Length cap: typical form labels are short (1-3 words). Long ALL-CAPS
+    # strings like ``"PERMITTED FOR RECOMPLETION TO PRODUCE FROM"`` skip
+    # heuristic (2) and stay value-shaped, which is the safer default — the
+    # cost of mis-flagging a long label is a missed neighbor, but the cost
+    # of flagging a long value is returning the wrong neighbor.
+    if len(s) > 30:
+        return False
+    if _LABEL_LIKE_DISQUALIFIER_RE.search(s):
+        return False
+    if s != s.upper():
+        return False
+    if not re.search(r"[A-Z]", s):
+        return False
+    return True
+
+
+def _iter_md_table_kv_rows(content: str) -> list[tuple[str, str]]:
+    """Yield (label, value) tuples from markdown tables.
+
+    - 2-col tables: yield each row as ``(col0, col1)`` (existing behavior).
+    - >2-col tables: yield ``(col_header, data_row_value)`` for every
+      column × data row.
+    """
+
+    out: list[tuple[str, str]] = []
+    for table in parse_markdown_tables(content):
+        rows, cols = table.data.shape
+        if cols == 2:
+            for row_idx in range(rows):
+                label_text = str(table.data[row_idx, 0]).strip()
+                value_text = str(table.data[row_idx, 1]).strip()
+                out.append((label_text, value_text))
+        elif cols > 2:
+            out.extend(_multi_col_header_data_pairs(table))
+    return out
+
+
+# Generic HTML tag stripper for label/value normalization. Form-field values
+# never legitimately contain ``<tag>...</tag>`` markup — names, addresses, IDs,
+# and currency don't — but parsers leak HTML wrappers into extracted spans
+# (haiku preserves ``<strong>``/``<td>``, gemini emits ``<u>`` underline-fill,
+# OpenAI sometimes leaves ``</p>``). The pattern is restricted to well-formed
+# HTML element opens/closes: a tag name must start with an ASCII letter and
+# contain only alphanumerics afterwards, optionally followed by a
+# whitespace-introduced attribute run. This deliberately excludes markdown
+# email/URL autolinks like ``<wei.lin@host.com>`` and ``<https://...>``,
+# whose first character after ``<`` is a letter but whose body contains
+# ``.``/``@``/``:`` that disqualify them from the tag-name shape.
+_HTML_TAG_RE = re.compile(r"<\s*/?\s*[a-zA-Z][a-zA-Z0-9]*(?:\s[^<>]*)?\s*/?\s*>")
+
+
+def _strip_html_tags(s: str) -> str:
+    return _HTML_TAG_RE.sub("", s)
+
+
+# Tagged-line prefix used by some parsers to mark a field-extraction event,
+# e.g. ``[FORM FIELD] Label: value``. The bracketed prefix is parser noise,
+# not part of the label. We only strip it from the start of a candidate
+# label, never mid-string, so legitimate labels containing brackets like
+# ``[Effective Date]`` (uncommon but possible) are preserved unless the
+# bracket is the leading token.
+_LABEL_TAG_PREFIX_RE = re.compile(r"^\s*\[[^\]\n]+\]\s+")
+
+
+def _trim_value_at_next_field(value: str) -> str:
+    """Trim a captured value at a ``| Next Label: ...`` boundary.
+
+    Some parsers concatenate multiple labelled fields onto one line with
+    ``|`` separators (e.g. ``Date: 2026-04-27 | Borrower's Name: Maya | ...``).
+    Without this trim, the plain-colon regex captures the entire tail as the
+    value of the first field. We only split when the part after the ``|``
+    looks like another labelled field (contains ``:``), so legitimate values
+    with embedded ``|`` (rare in form data) are preserved.
+    """
+
+    parts = re.split(r"\s+\|\s+", value, maxsplit=1)
+    if len(parts) == 2 and ":" in parts[1]:
+        return parts[0].strip()
+    return value
+
+
+def _split_pipe_concatenated_pairs(value: str) -> list[tuple[str, str]]:
+    """Split a run-on ``Label1: v1 | Label2: v2 | ...`` value tail into pairs.
+
+    Companion to :func:`_trim_value_at_next_field`. The first call trims the
+    value of the *initial* labelled field; this function recovers any
+    *subsequent* ``Label: value`` pairs that were riding along on the same
+    line so a single-line run-on yields one pair per labelled field.
+    """
+
+    out: list[tuple[str, str]] = []
+    if " | " not in value:
+        return out
+    for segment in re.split(r"\s+\|\s+", value):
+        if ":" not in segment:
+            continue
+        # Same horizontal-only colon split as _PLAIN_COLON_RE so we don't
+        # accidentally bleed time-of-day strings ("11:30 AM") into pairs.
+        m = re.match(r"^[ \t]*([^:\n*][^:\n]{0,200}?)[ \t]*:[ \t]*(.+?)[ \t]*$", segment)
+        if not m:
+            continue
+        seg_label = _strip_html_tags(m.group(1).strip()).strip()
+        seg_label = _LABEL_TAG_PREFIX_RE.sub("", seg_label).strip()
+        seg_value = _strip_html_tags(m.group(2).strip()).strip()
+        if seg_label:
+            out.append((seg_label, seg_value))
+    return out
+
+
+# Bullet-line shape for safe aggregation: ``- item`` / ``* item`` / ``+ item``
+# (with optional leading ``\`` escape some renderers emit). The negative
+# lookahead rejects checkbox-bearing bullets (``- [x] ...``) — those rows
+# describe their own state, not a continuation of the preceding label.
+_AGGREGATE_BULLET_RE = re.compile(r"^\\?[-*+]\s+(?!\\?\[)")
+
+
+def _aggregate_following_lines(content: str, after_offset: int, max_lines: int = 8) -> str:
+    """Collect bullet-list lines after *after_offset* into a single value
+    string, joined with ``, ``.
+
+    This is a narrow fallback for the audit-A3 pattern: a bold-colon header
+    with an empty inline value followed by a multi-line address laid out as
+    bullets (HUD voucher ``Mail Payments To`` blocks, etc.). Strict gating
+    keeps it from pulling unrelated form structure into the value:
+
+    1. Every line must be a clean bullet (``-``/``*``/``+`` with no
+       ``[x]``/``[ ]`` checkbox marker — those rows belong to a different
+       field).
+    2. No line may carry any checkbox glyph or ASCII bracket marker.
+    3. At least 2 collected bullets are required. A single bullet is too
+       ambiguous to attribute as the value — leaving the value empty is
+       safer than risking a wrong attribution.
+    4. Stops at blank line, ATX heading, HTML boundary, or another bold-
+       colon header. Returns ``""`` if any constraint fails so the caller
+       falls back to the normal empty-value path.
+    """
+
+    tail = content[after_offset:]
+    lines = tail.splitlines()
+    # Skip the line containing the header itself (we matched into it).
+    start_idx = 1 if lines else 0
+    collected: list[str] = []
+    for raw in lines[start_idx : start_idx + max_lines]:
+        stripped = raw.strip()
+        if not stripped:
+            break
+        if stripped.startswith(("#", ">", "|", "<")):
+            break
+        # Stop at the start of a new bold-colon header.
+        if "**" in stripped and ":" in stripped:
+            break
+        if not _AGGREGATE_BULLET_RE.match(stripped):
+            return ""
+        if _MARKER_RE.search(stripped):
+            return ""
+        cleaned = re.sub(r"^\\?[-*+]\s+", "", stripped).strip()
+        cleaned = _strip_html_tags(cleaned).strip()
+        if cleaned:
+            collected.append(cleaned)
+    if len(collected) < 2:
+        return ""
+    return ", ".join(collected)
+
+
+# Bold-colon pattern. Matches **Label:** value and **Label**: value, allowing
+# multiple pairs on a single line. All inter-token whitespace is restricted
+# to horizontal whitespace ([ \t]) so a match cannot span blank lines or
+# headings — without this, an empty "**Label**:\n\n# Heading\n\n**Other**:"
+# would attribute the heading text to Label as the value.
+_BOLD_COLON_RE = re.compile(
+    r"\*\*[ \t]*([^*\n]+?)[ \t]*\*\*[ \t]*:?[ \t]*([^\n*]*?)(?=[ \t]*\*\*|$)",
+    re.MULTILINE,
+)
+
+# Connector words that the parser sometimes wraps in bold inside a numeric
+# range, e.g. ``**Depth Drilled**: 105 **to**: 15437`` or
+# ``Temperature: 32 **to** 100 F``. Without special-casing, the bold-colon
+# value regex stops at the connector's leading ``**`` and only captures the
+# left half. We re-join the trailing value when the bold span between two
+# value chunks is one of these connectors. The connectors are matched whole-
+# word, case-insensitively. Allows leading horizontal whitespace so the
+# splice cursor doesn't have to land exactly on the ``**``.
+_BOLD_CONNECTOR_RE = re.compile(
+    r"[ \t]*\*\*[ \t]*(to|and|or|&|thru|through|until)[ \t]*\*\*[ \t]*:?[ \t]*([^\n*]*?)"
+    r"(?=[ \t]*\*\*|$)",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+def _extend_value_across_bold_connectors(content: str, value_end_offset: int, base_value: str) -> str:
+    """Re-join a bold-colon value that was clipped at a bold connector token.
+
+    The bold-colon regex terminates the value at the next ``**``. When the
+    next bold span is a connector word (``to``, ``and``, ...), the value
+    actually continues across it. This helper looks at the content
+    immediately following the captured value and, while it sees a bold
+    connector followed by more inline content, splices everything into a
+    single value string.
+
+    Stops as soon as the next bold span is anything other than a recognized
+    connector — that's a real label boundary, not a continuation.
+    """
+
+    if not base_value:
+        return base_value
+    cursor = value_end_offset
+    joined = base_value
+    while True:
+        match = _BOLD_CONNECTOR_RE.match(content, cursor)
+        if not match:
+            break
+        connector = match.group(1)
+        extra = match.group(2).strip()
+        joined = f"{joined} {connector} {extra}".strip()
+        cursor = match.end()
+    return joined
+
+
+def _iter_bold_colon_pairs(content: str) -> list[tuple[str, str]]:
+    """Yield every (label, value) pair surfaced via bold-colon syntax.
+
+    Generic post-processing applied to every yielded pair: HTML tags
+    stripped from both label and value, leading ``[tag]`` prefix removed
+    from the label, ``| Next Label:`` boundary trimmed from the value, and
+    when the inline value is empty, the next few non-blank list/text lines
+    are aggregated into the value (multi-line address pattern).
+    """
+
+    out: list[tuple[str, str]] = []
+    for match in _BOLD_COLON_RE.finditer(content):
+        cand_label = match.group(1).strip(": ").strip()
+        # Strip trailing markdown line-continuation backslash before whitespace.
+        # Some parsers emit ``**Label**: \`` for empty fields; without this
+        # strip the value would be ``"\\"``, never matching empty expected.
+        raw_value = match.group(2).strip().rstrip("\\").strip()
+        # Splice bold connectors (``**to**``, ``**and**``) back into the value
+        # so numeric ranges like ``**Depth Drilled**: 105 **to** 15437`` aren't
+        # truncated at the connector.
+        raw_value = _extend_value_across_bold_connectors(content, match.end(), raw_value)
+        cand_label = _strip_html_tags(cand_label).strip()
+        cand_label = _LABEL_TAG_PREFIX_RE.sub("", cand_label).strip()
+        cand_value = _strip_html_tags(raw_value).strip()
+        cand_value = _trim_value_at_next_field(cand_value)
+        if not cand_value:
+            cand_value = _aggregate_following_lines(content, match.end())
+        if cand_label:
+            out.append((cand_label, cand_value))
+        # Recover any sibling pipe-concatenated pairs riding the same line.
+        out.extend(_split_pipe_concatenated_pairs(raw_value))
+    return out
+
+
+# Plain-colon pattern. Inter-token whitespace is restricted to horizontal
+# whitespace ([ \t]) so a colon at end-of-line cannot consume the next line as
+# the value (parallel to the bold-colon regex; same blank-line crossing bug).
+_PLAIN_COLON_RE = re.compile(r"^[ \t]*([^:\n*][^:\n]{0,200}?)[ \t]*:[ \t]*(.+?)[ \t]*$", re.MULTILINE)
+_LIST_MARKER_RE = re.compile(r"^\\?[-*+]\s+")
+
+# Underscore blank field: ``Processor's Name _________________``. The label
+# sits before a run of three or more underscores acting as a fill-in line for
+# an empty field. No colon, no bold, just a label-then-underscore-blank.
+_UNDERSCORE_BLANK_RE = re.compile(r"^\s*([^_\n]+?)\s+_{3,}\s*$", re.MULTILINE)
+
+
+def _iter_plain_colon_pairs(content: str) -> list[tuple[str, str]]:
+    """Yield (label, value) pairs from `Label: value` lines (plain text).
+
+    Plain bullet items with the ``Label: value`` shape (``- Defendant: Devon``)
+    are stripped of their leading marker and yielded — markdown task lists
+    (``- [x] Foo``) are still skipped because they are handled by the checkbox
+    scanners. Headings, fenced code, blockquotes, and bold-formatted lines
+    are skipped here too.
+
+    Generic post-processing on every yielded pair: HTML tags stripped from
+    both label and value, leading ``[tag]`` prefix removed from the label,
+    and the value trimmed at any ``| Next Label:`` boundary so a single line
+    like ``A: x | B: y`` yields two pairs instead of one with a run-on
+    value.
+    """
+
+    out: list[tuple[str, str]] = []
+    for match in _PLAIN_COLON_RE.finditer(content):
+        cand_label = match.group(1).strip()
+        raw_value = match.group(2).strip()
+        # Skip multi-cell HTML table rows: a single line that opens more than
+        # one ``<th>`` / ``<td>`` is a wide table row, not a single
+        # ``label: value`` line. Without this guard
+        # ``<tr><th>API NO:</th><th>WELL</th><th>LEHMAN #1</th></tr>`` matches
+        # the plain-colon regex and yields ``("API NO", "WELLLEHMAN #1")``
+        # because HTML-tag stripping collapses adjacent cells into a single
+        # value run. Single-cell rows (``<th>Company: CIMARRON ...</th>``)
+        # carry exactly one inline KV pair and stay on this path — wide HTML
+        # form tables are handled by ``_iter_html_table_kv_rows`` and
+        # ``_iter_html_cell_neighbor_pairs``.
+        raw_line = match.group(0)
+        if len(re.findall(r"<t[hd]\b", raw_line)) > 1:
+            continue
+        if cand_label.startswith(("#", "`", ">")):
+            continue
+        if "**" in cand_label:
+            continue
+        if cand_label.startswith(("\\-", "-", "*", "+")):
+            stripped = _LIST_MARKER_RE.sub("", cand_label).strip()
+            # Tasklist-shaped bullets (``[x] ...``) belong to the checkbox path.
+            if stripped.startswith(("\\[", "[")):
+                continue
+            if not stripped:
+                continue
+            cand_label = stripped
+        cand_label = _strip_html_tags(cand_label).strip()
+        cand_label = _LABEL_TAG_PREFIX_RE.sub("", cand_label).strip()
+        cand_value = _strip_html_tags(raw_value).strip()
+        cand_value = _trim_value_at_next_field(cand_value)
+        if cand_label:
+            out.append((cand_label, cand_value))
+        # Recover any sibling pipe-concatenated pairs riding the same line.
+        out.extend(_split_pipe_concatenated_pairs(raw_value))
+    return out
+
+
+# Underline fill-in pattern: parsers that preserve the form's "fill in the
+# blank" layout emit the filled value wrapped in ``<u>...</u>`` tags inline
+# in the surrounding prose, e.g.
+#
+#   **2. PROPERTY:** Lot <u>12</u>, Block <u>C</u>, City of <u>Austin</u>...
+#
+# The label sits immediately before the underline span, terminated by a
+# punctuation/whitespace boundary on its left side. We yield (label, value)
+# for each such span so the standard ``_label_matches`` fuzzy-matcher can
+# bridge GT labels like "Block" or "City of (Street Address and City)".
+_UNDERLINE_FILL_RE = re.compile(r"<u>([^<\n]+)</u>")
+_LABEL_LEFT_TERMINATORS = ".,;:()\n>"
+
+
+def _iter_underline_fill_pairs(content: str) -> list[tuple[str, str]]:
+    """Yield (preceding_label, underlined_value) pairs from ``<u>...</u>`` runs."""
+
+    out: list[tuple[str, str]] = []
+    for match in _UNDERLINE_FILL_RE.finditer(content):
+        value = match.group(1).strip()
+        if not value:
+            continue
+        before = content[max(0, match.start() - 100) : match.start()]
+        # Walk backward to the nearest sentence/clause terminator. Anything
+        # left of that terminator belongs to a different label (or to a
+        # heading/inline header), so we stop there.
+        cut = -1
+        for ch in _LABEL_LEFT_TERMINATORS:
+            cut = max(cut, before.rfind(ch))
+        label_chunk = before[cut + 1 :]
+        # Strip markdown noise: leading bullet, bold/italic markers, stray
+        # backslashes, and trailing whitespace. The bracketed-tag prefix
+        # (``[FORM FIELD] ``) is dropped here too so it never bleeds into
+        # candidate labels.
+        label_chunk = re.sub(r"^[\s\\*_#>\-]+", "", label_chunk)
+        label_chunk = _LABEL_TAG_PREFIX_RE.sub("", label_chunk)
+        label_chunk = _strip_html_tags(label_chunk).strip()
+        label_chunk = label_chunk.strip("*_ \t").strip()
+        if not label_chunk:
+            continue
+        # Only the trailing 1-6 words can plausibly be the label — the rest
+        # is sentence context.
+        words = label_chunk.split()
+        if not words:
+            continue
+        label = " ".join(words[-6:])
+        if label:
+            out.append((label, value))
+    return out
+
+
+def _iter_underscore_blank_pairs(content: str) -> list[tuple[str, str]]:
+    """Yield (label, "") pairs for ``Label ____`` underscore-blank fields."""
+
+    out: list[tuple[str, str]] = []
+    for match in _UNDERSCORE_BLANK_RE.finditer(content):
+        cand_label = match.group(1).strip()
+        if not cand_label:
+            continue
+        if cand_label.startswith(("#", "-", "*", "`", ">", "|")):
+            continue
+        if "**" in cand_label or ":" in cand_label:
+            continue
+        out.append((cand_label, ""))
+    return out
+
+
+# Italic line shape: ``*Plaintiff*`` or ``_Address_`` (optionally with a
+# trailing space + ``)`` from court-form layouts like ``*Plaintiff* )``).
+_ITALIC_LABEL_LINE_RE = re.compile(r"^\s*([*_])\s*(\S.*?\S)\s*\1[\s)\\]*$")
+
+
+def _find_text_value_adjacent_line(content: str, label: str) -> tuple[bool, str | None]:
+    """Fallback for label-on-its-own-line layouts adjacent to an unlabelled value.
+
+    Two layouts share this scanner:
+
+    - **Italic caption below value** (federal court forms — AO398):
+      ``Anthony Cole Jackson )\\n*Plaintiff* )``. The label sits italicized on
+      the line below the value.
+    - **Numbered/heading-style label above value** (UCC5, gemini sub-sections):
+      ``1a. INITIAL FINANCING STATEMENT FILE NUMBER\\nOR-UCC-2025-00532600``.
+      The label is its own line above the value.
+
+    Conservative heuristic: only fires for short label-shaped lines (≤ 80
+    chars after stripping markers, no ``:`` and no ``**``) and only on a
+    *strict* ratio match (≥ ``CELL_FUZZY_MATCH_THRESHOLD``). This means a
+    long paragraph that *contains* the label as a substring is **not**
+    treated as the label line — partial-ratio matching is reserved for the
+    other (label-then-value) scanners.
+
+    Direction: italic line → look ABOVE first (caption convention); plain
+    line → look BELOW first (label-then-value convention). Whichever
+    direction lands a non-blank line wins.
+    """
+
+    lines = content.splitlines()
+    lbl_norm = normalize_text(label)
+    if not lbl_norm:
+        return False, None
+    for i, raw in enumerate(lines):
+        stripped = raw.strip()
+        if not stripped or len(stripped) > 100:
+            continue
+        if stripped.startswith(("#", ">", "|", "<", "`")):
+            continue
+        if "**" in stripped or ":" in stripped:
+            continue
+        italic_match = _ITALIC_LABEL_LINE_RE.match(raw)
+        if italic_match:
+            cleaned = italic_match.group(2).strip()
+        else:
+            cleaned = re.sub(r"\s*[)\\]+\s*$", "", stripped)
+            cleaned = re.sub(r"^\\?[-*+]\s+", "", cleaned).strip()
+            cleaned = cleaned.strip("*_ \t").strip()
+        if not cleaned or len(cleaned) > 80:
+            continue
+        cand_norm = normalize_text(cleaned)
+        if not cand_norm:
+            continue
+        if fuzz.ratio(cand_norm, lbl_norm) / 100.0 < CELL_FUZZY_MATCH_THRESHOLD:
+            continue
+        if italic_match:
+            search_orders = [
+                range(i - 1, max(i - 4, -1), -1),
+                range(i + 1, min(i + 4, len(lines))),
+            ]
+        else:
+            search_orders = [
+                range(i + 1, min(i + 4, len(lines))),
+                range(i - 1, max(i - 4, -1), -1),
+            ]
+        for order in search_orders:
+            for j in order:
+                cand_line = lines[j].strip()
+                if not cand_line:
+                    continue
+                if cand_line.startswith(("#", "|", ">")):
+                    break
+                if "**" in cand_line and ":" in cand_line:
+                    break
+                value = re.sub(r"^\\?[-*+]\s+", "", cand_line).strip()
+                value = re.sub(r"\s*[)\\]+\s*$", "", value).strip()
+                value = value.strip("*_ \t").strip()
+                if value:
+                    return True, value
+        return True, ""
+    return False, None
+
+
+def _build_cell_text_counts(data, rows: int, cols: int) -> dict[str, int]:  # type: ignore[no-untyped-def]
+    """Per-table map of text → number of distinct *origin* cells.
+
+    ``parse_html_tables`` expands ``colspan``/``rowspan`` by duplicating cell
+    text across every covered grid position, so a single ``<th
+    colspan="4">KEBO</th>`` looks like four ``"KEBO"`` cells in the expanded
+    grid. Counting raw grid cells would mis-classify any spanned value as a
+    repeated label. Dedupe by skipping cells whose text equals the left or
+    above neighbor — those are colspan / rowspan runs of the same origin.
+    """
+
+    counts: dict[str, int] = {}
+    for r in range(rows):
+        for c in range(cols):
+            t = str(data[r, c]).strip()
+            if not t:
+                continue
+            if c > 0 and str(data[r, c - 1]).strip() == t:
+                continue
+            if r > 0 and str(data[r - 1, c]).strip() == t:
+                continue
+            counts[t] = counts.get(t, 0) + 1
+    return counts
+
+
+def _neighbor_is_label_like(neighbor: str, text_counts: dict[str, int]) -> bool:
+    if _cell_text_is_label_like(neighbor):
+        return True
+    # Short text that repeats elsewhere in the same table → structural label.
+    if len(neighbor) <= 30 and text_counts.get(neighbor, 0) >= 2:
+        return True
+    return False
+
+
+def _is_value_shaped_cell(neighbor: str | None) -> bool:
+    if not neighbor:
+        return False
+    s = neighbor.strip()
+    if len(s) < 2:
+        return False
+    # Lone checkbox glyphs aren't useful values for text rules.
+    if _GLYPH_RE.search(s) and len(s) <= 2:
+        return False
+    return True
+
+
+def _iter_html_cell_neighbor_pairs(content: str) -> list[tuple[str, str]]:
+    """Yield ``(cell_text, neighbor_value)`` pairs for wide (>2 col) HTML
+    tables, intended as a low-priority fallback source for
+    ``_find_text_value_for_label``.
+
+    Targets form-style layouts where labels and values are spatially
+    interleaved inside a single wide ``<table>`` rather than separated into
+    a clean header row + data rows, e.g. well-log report headers::
+
+        <tr><th colspan="2">FILE NO:</th>
+            <th colspan="2">COMPANY</th>
+            <th colspan="4">KEBO OIL &amp; GAS, INC.</th></tr>
+        <tr><th colspan="2">API NO:</th>
+            <th colspan="2">WELL</th>
+            <th colspan="4">LEHMAN #1</th></tr>
+        <tr><th colspan="2">42-157-33282</th>
+            <th colspan="2">FIELD</th>
+            <th colspan="4">NEEDVILLE</th></tr>
+
+    For each non-empty cell in the expanded grid the iterator looks at two
+    candidate neighbors:
+
+      * the first non-empty cell to the right in the same row, skipping
+        colspan duplicates (cell text equal to the cell itself);
+      * the first non-empty cell below in the same column, similarly skipping
+        rowspan duplicates.
+
+    The chosen neighbor is the first one that is *value-shaped* (length ≥ 2,
+    not a lone checkbox glyph) and *not label-shaped* per
+    ``_cell_text_is_label_like`` or structural repetition in the same table.
+    Right is preferred over below (matches left-to-right reading).
+
+    Cells with no value-shaped neighbor still emit ``(cell_text, "")`` so the
+    caller's ``_collect`` records ``label_seen=True`` for empty-expected
+    rules — same contract as the other pair sources.
+
+    The caller scores ``cell_text`` against the rule label via
+    ``_label_match_score`` and picks the best candidate. We don't filter by
+    label here so the caller can resolve adjacent-label collisions (the
+    same way #978 made other sources do).
+    """
+
+    if "<table" not in content.lower():
+        return []
+
+    out: list[tuple[str, str]] = []
+
+    for table in parse_html_tables(content):
+        rows, cols = table.data.shape
+        if cols <= 2 or rows == 0:
+            continue
+
+        # Per-table text-count map — a short text that exactly repeats in
+        # ≥2 *distinct origin* cells (after collapsing colspan/rowspan runs
+        # via ``_build_cell_text_counts``) is structurally likely to be a
+        # column label / section header (e.g. ``KB`` / ``DF`` / ``GL`` rows
+        # in well-log elevation blocks). Used as a tie-breaker for which
+        # neighbor cell is value-shaped.
+        text_counts = _build_cell_text_counts(table.data, rows, cols)
+
+        for r in range(rows):
+            for c in range(cols):
+                cell = str(table.data[r, c]).strip()
+                if not cell:
+                    continue
+
+                # Right scan: first non-empty cell to the right that is not
+                # a colspan duplicate (text != label cell text).
+                right_val: str | None = None
+                for cc in range(c + 1, cols):
+                    nxt = str(table.data[r, cc]).strip()
+                    if nxt and nxt != cell:
+                        right_val = nxt
+                        break
+
+                # Below scan: first non-empty cell directly below that is
+                # not a rowspan duplicate.
+                below_val: str | None = None
+                for rr in range(r + 1, rows):
+                    nxt = str(table.data[rr, c]).strip()
+                    if nxt and nxt != cell:
+                        below_val = nxt
+                        break
+
+                # Score each candidate. Want a value-shaped neighbor that
+                # does *not* itself look label-like. Right is preferred over
+                # below when both qualify (matches left-to-right reading).
+                right_ok = _is_value_shaped_cell(right_val) and not _neighbor_is_label_like(
+                    right_val or "", text_counts
+                )
+                below_ok = _is_value_shaped_cell(below_val) and not _neighbor_is_label_like(
+                    below_val or "", text_counts
+                )
+
+                if right_ok:
+                    out.append((cell, right_val or ""))
+                elif below_ok:
+                    out.append((cell, below_val or ""))
+                else:
+                    # No value-shaped neighbor at this position. Still emit
+                    # an empty-value pair so a matching label sets the
+                    # caller's ``label_seen`` flag (mirrors the other pair
+                    # iterators that surface ``""`` for label-only hits).
+                    out.append((cell, ""))
+
+    return out
+
+
+def _find_text_value_for_label(
+    content: str,
+    label: str,
+    expected_values: list[str] | None = None,
+) -> tuple[bool, str | None]:
+    """Look up the value for *label*. Returns (label_found, value).
+
+    The boolean tracks whether the label was located **at all** — useful for
+    distinguishing "label missing from content" from "label present but value
+    blank" (signature evaluation depends on this distinction). When the label
+    is found only with empty values, returns ``(True, "")`` so callers can
+    decide what to do (text rules with empty expected values pass; signature
+    rules treat it as unsigned).
+
+    Matching strategy is **best-score across all sources**: every candidate
+    KV pair from every source iterator is scored against the target label
+    via :func:`_label_match_score`, and the highest-scoring non-empty value
+    wins. Tie-breaks fall back to source priority (bold-colon > plain-colon
+    > md-table > html-table > underline-fill) and then document order. This
+    eliminates the classic ``Country`` / ``County`` adjacent-label
+    collision: an exact ``Country`` hit (score 1.0) always wins over a
+    fuzzy ``County`` hit (score ~0.86–0.95) no matter which comes first.
+
+    Multi-occurrence disambiguation via ``expected_values``
+    -------------------------------------------------------
+    A label text can legitimately appear multiple times at the **same**
+    best score: ``KB`` / ``DF`` / ``GL`` are exact-match labels in well-
+    log elevation blocks while also appearing as values of
+    ``LOG MEASURED FROM`` / ``DRILL. MEAS. FROM`` (where the cell-
+    neighbor matcher surfaces them with score 1.0). Without
+    disambiguation, source-priority + doc-order tie-breaks would lock
+    onto an arbitrary occurrence — which one happens to come first
+    has no relation to which page occurrence the GT refers to.
+
+    When ``expected_values`` is supplied, the matcher applies the rule's
+    expected value(s) as an oracle **among candidates at the top score
+    level only**. That is: it picks the highest score; collects every
+    candidate at that score; and returns the first one whose value
+    matches any expected via :func:`_values_match_text`. If no
+    top-score candidate matches, the legacy source-priority / doc-order
+    tie-break fires — same as without ``expected_values``.
+
+    The "top score only" gate is what keeps the GT oracle from leaking
+    across adjacent labels: ``Country`` (score 1.0) vs ``County``
+    (partial 0.95) live at *different* score levels, so even if a
+    ``County`` row's value coincidentally equals the GT's expected
+    ``Country`` value, ``County`` is not eligible. Only when two
+    candidates are equally good *label matches* does the value oracle
+    intervene.
+    """
+
+    label_seen = False
+    # (negated_score, negated_priority, doc_order, value, source_name)
+    # — we'll sort ascending so the *best* candidate (highest score, then
+    # highest priority, then earliest doc order) sits at the top.
+    candidates: list[tuple[float, int, int, str, str]] = []
+
+    def _collect(
+        pairs: list[tuple[str, str]],
+        priority: int,
+        source_name: str,
+    ) -> None:
+        nonlocal label_seen
+        for idx, (cand_label, cand_value) in enumerate(pairs):
+            score = _label_match_score(cand_label, label)
+            if score <= 0.0:
+                continue
+            label_seen = True
+            if cand_value:
+                candidates.append((-score, -priority, idx, cand_value, source_name))
+
+    # Higher priority numbers = more confident sources. The ordering matches
+    # the original first-match-wins precedence so tie-breaks preserve legacy
+    # behavior on documents where multiple sources produce equally strong
+    # label matches.
+    _collect(_iter_bold_colon_pairs(content), priority=4, source_name="bold_colon")
+    _collect(_iter_plain_colon_pairs(content), priority=3, source_name="plain_colon")
+    _collect(_iter_md_table_kv_rows(content), priority=2, source_name="md_table")
+    _collect(_iter_html_table_kv_rows(content), priority=1, source_name="html_table")
+
+    # Underscore blank fields (``Label ____``) — label seen, value empty.
+    # The yielded value is always ""; we just record label presence so an
+    # empty-expected text rule can pass via the ``label_seen`` short-circuit
+    # below.
+    for cand_label, _ in _iter_underscore_blank_pairs(content):
+        if _label_matches(cand_label, label):
+            label_seen = True
+
+    # Last-resort sources — only fire when no higher-confidence source
+    # surfaced a non-empty value, so they never overwrite a strong-source
+    # extraction. Both are gated on ``not candidates`` and added with
+    # priorities below the strong sources; if both fire and both produce
+    # candidates, ``priority`` breaks the tie in favor of underline_fill.
+    if not candidates:
+        # Underline fill-in (``Label <u>value</u>`` inline in prose).
+        if "<u>" in content:
+            _collect(
+                _iter_underline_fill_pairs(content),
+                priority=0,
+                source_name="underline_fill",
+            )
+        # Wide-form HTML table cell-neighbor fallback. Targets layouts
+        # where labels and values are spatially interleaved inside a single
+        # wide ``<table>`` (well-log report headers, rotated form pages),
+        # which neither the 2-col nor the multi-col header×data pair
+        # iterator covers. Priority -1 keeps it strictly below
+        # underline_fill on tie-breaks.
+        _collect(
+            _iter_html_cell_neighbor_pairs(content),
+            priority=-1,
+            source_name="html_cell_neighbor",
+        )
+
+    if candidates:
+        candidates.sort()
+        # ``candidates`` is sorted ascending by (-score, -priority, doc_order,
+        # ...), so the head is the best (label-match-score, source-priority,
+        # doc-order) tuple. We use the rule's expected value as a tie-breaker
+        # **only among candidates at the head score**, which keeps the GT
+        # oracle from leaking across adjacent labels (Country score 1.0 vs
+        # County score ~0.95 live at different levels, so County is never
+        # eligible when Country is present).
+        best_score_key = candidates[0][0]
+        if expected_values:
+            for neg_score, _prio, _doc, value, _src in candidates:
+                if neg_score != best_score_key:
+                    break
+                for exp in expected_values:
+                    if _values_match_text(value, exp):
+                        return True, value
+        return True, candidates[0][3]
+
+    # Adjacent-line fallback (italic caption below value, or numbered label
+    # above value). Only fires when no other matcher located the label.
+    if not label_seen:
+        adj_seen, adj_value = _find_text_value_adjacent_line(content, label)
+        if adj_seen:
+            return True, adj_value
+
+    if label_seen:
+        return True, ""
+    return False, None
+
+
+def _tokenize_checkbox_line(line: str) -> list[tuple[str, bool]]:
+    """Pair every checkbox marker on *line* with its associated label.
+
+    Markers may be Unicode glyphs (``☐``/``☑``/``◉``/``○``/...) OR ASCII
+    bracket pairs (``[x]``, ``\\[x\\]``, ``[ ]``). Handles both orderings:
+
+      - marker-first: ``☐ Single ☑ Married`` or ``\\[x] A \\[ ] B`` — each
+        label sits between a marker and the next marker (or end of line).
+      - label-first: ``Single ☐  Married ☑`` or ``Checking \\[x] Savings \\[ ]``
+        — each label sits between the previous marker (or start) and the
+        next marker.
+
+    Direction is decided by what comes before the first marker: if the line
+    starts with the marker (after optional whitespace), use marker-first;
+    otherwise use label-first. This covers the inline mid-line bracket
+    pattern ``**Inaccuracy in financing statement** \\[ ]`` since the
+    closing bracket is treated as a marker and the bold-label segment to
+    its left becomes the label.
+    """
+
+    marker_matches = list(_MARKER_RE.finditer(line))
+    if not marker_matches:
+        return []
+
+    text_before_first = line[: marker_matches[0].start()].strip()
+    pairs: list[tuple[str, bool]] = []
+
+    if not text_before_first:
+        # marker-first: label runs from marker end to next marker start (or EOL).
+        for i, m in enumerate(marker_matches):
+            label_start = m.end()
+            label_end = marker_matches[i + 1].start() if i + 1 < len(marker_matches) else len(line)
+            label_text = line[label_start:label_end].strip()
+            if label_text:
+                pairs.append((label_text, _marker_is_checked(m.group())))
+    else:
+        # label-first: label runs from previous marker end (or 0) to current marker.
+        prev_end = 0
+        for m in marker_matches:
+            label_text = line[prev_end : m.start()].strip()
+            prev_end = m.end()
+            if label_text:
+                pairs.append((label_text, _marker_is_checked(m.group())))
+    return pairs
+
+
+# Markdown task-list. Allows optional ``\`` escapes around the list marker
+# AND the brackets — some parsers emit ``\[x\]`` (or even ``\- \[x\]`` for a
+# nested escaped bullet) so the markdown source survives literal-character
+# rendering. The marker accepts ``-``/``*``/``+`` and numbered-list ``\d+.`` —
+# USCIS citizenship attestations are rendered as ``1. [x] A citizen ...``.
+_LIST_MARKER_RE_INLINE = r"(?:[-*+]|\d+\.)"
+_MD_TASKLIST_RE = re.compile(
+    rf"^\s*\\?{_LIST_MARKER_RE_INLINE}\s*\\?\[([ xX])\\?\]\s*(.+?)\s*$",
+    re.MULTILINE,
+)
+
+# Label-first bullet checkbox: ``* Checking \[x]`` or ``\- Savings [ ]``. The
+# label sits between the list marker and the bracket. Common in forms where
+# the parser surfaces the option label as the bullet text and the state as a
+# trailing widget marker. Both the bullet marker and the brackets may be
+# preceded by a literal backslash escape.
+_MD_BULLET_LABEL_FIRST_RE = re.compile(
+    rf"^\s*\\?{_LIST_MARKER_RE_INLINE}\s+(.+?)\s+\\?\[([ xX])\\?\]\s*$",
+    re.MULTILINE,
+)
+
+# Bullet-less task-list: a line that starts with ``\[x]`` / ``[ ]`` directly
+# with no leading bullet marker. ours_cost_effective and gemini render IRS
+# W-9 / USCIS / UCC5 checkboxes this way (``\[x] Individual/sole proprietor``
+# on its own line). The label group disallows ``[`` so a line with multiple
+# inline bracket markers (``\[ ] A \[x] B``) does NOT match here — those go
+# through the per-line tokenizer below where each bracket is paired with its
+# own label.
+_MD_BARE_TASKLIST_RE = re.compile(
+    r"^\s*\\?\[([ xX])\\?\]\s*([^\[\n]+?)\s*$",
+    re.MULTILINE,
+)
+
+
+def _find_checkbox_state_for_label(content: str, label: str) -> bool | None:
+    """Return True/False if *label* has a checkbox-style state nearby, else None.
+
+    Like :func:`_find_text_value_for_label`, this collects every candidate
+    ``(label, state)`` across every checkbox source, scores the label, and
+    returns the state attached to the highest-scoring candidate. Avoids
+    adjacent-label collisions where two visually similar labels share a
+    line and the wrong one gets picked just because it came first.
+    """
+
+    # (negated_score, negated_priority, doc_order, state)
+    candidates: list[tuple[float, int, int, bool]] = []
+
+    def _try_add(cand_label: str, state: bool, priority: int, idx: int) -> None:
+        score = _label_match_score(cand_label, label)
+        if score > 0.0:
+            candidates.append((-score, -priority, idx, state))
+
+    # Markdown task-list: - [x] Label   or   - [ ] Label   or   1. [x] Label
+    for idx, match in enumerate(_MD_TASKLIST_RE.finditer(content)):
+        state_char, cand_label = match.group(1), match.group(2).strip()
+        _try_add(cand_label, state_char.strip().lower() == "x", priority=4, idx=idx)
+
+    # Label-first bullet: - Label [x]   or   * Label \[x]
+    for idx, match in enumerate(_MD_BULLET_LABEL_FIRST_RE.finditer(content)):
+        cand_label, state_char = match.group(1).strip(), match.group(2)
+        _try_add(cand_label, state_char.strip().lower() == "x", priority=3, idx=idx)
+
+    # Bullet-less task-list: \[x] Label  (no leading -/*/+/digit.)
+    for idx, match in enumerate(_MD_BARE_TASKLIST_RE.finditer(content)):
+        state_char, cand_label = match.group(1), match.group(2).strip()
+        _try_add(cand_label, state_char.strip().lower() == "x", priority=2, idx=idx)
+
+    # Per-line marker tokenization (handles inline groups in either direction
+    # and mid-line ASCII bracket markers after a bold label).
+    inline_idx = 0
+    for line in content.splitlines():
+        if not _MARKER_RE.search(line):
+            continue
+        for cand_label, state in _tokenize_checkbox_line(line):
+            _try_add(cand_label, state, priority=1, idx=inline_idx)
+            inline_idx += 1
+
+    if candidates:
+        candidates.sort()
+        return candidates[0][3]
+    return None
+
+
+# Strikethrough span — match a ``~~...~~`` block AND its contents so an edit
+# history like ``~~old~~ new`` collapses to just ``new``. ``normalize_text``
+# only strips the ``~~`` markers (leaving the crossed-out text behind), which
+# is the wrong shape when the GT records the final clean value. The pattern
+# is non-greedy and bounded to a single line so it can't span paragraphs.
+_STRIKETHROUGH_SPAN_RE = re.compile(r"~~[^~\n]+~~")
+
+
+def _strip_strikethrough_spans(s: str) -> str:
+    return _STRIKETHROUGH_SPAN_RE.sub("", s).strip()
+
+
+def _values_match_text(found: str, expected: str) -> bool:
+    """Compare two form-field text values strictly.
+
+    Form values are *extracted*, not estimated, so there is no role for
+    similarity ratios or relative tolerance — a wrong digit, a wrong letter,
+    or a swapped name component is a real mismatch. Two paths only:
+
+    1. Exact match after normalization (``normalize_text`` already case-folds
+       and collapses whitespace), which handles ``Madison`` vs ``madison``,
+       trailing whitespace, and unicode quote variants.
+    2. Strict numeric equality via ``normalize_number_string``, which lets
+       ``1,234`` match ``1234`` and ``$1,234.00`` match ``1234`` (the same
+       value written differently) — but rejects ``53703`` vs ``53704``.
+
+    Strikethrough spans (``~~old~~ new``) are stripped from the *found*
+    value before comparison so the parser's edit-history rendering matches
+    the GT's clean final value. The expected side is left untouched on the
+    assumption GT never contains ``~~``.
+    """
+
+    found_stripped = _strip_strikethrough_spans(found)
+
+    f_norm = normalize_text(found_stripped)
+    e_norm = normalize_text(expected)
+    if f_norm == e_norm:
+        return True
+    if not f_norm or not e_norm:
+        return False
+
+    f_num = normalize_number_string(found_stripped)
+    e_num = normalize_number_string(expected)
+    if f_num is not None and e_num is not None and f_num == e_num:
+        return True
+
+    return False
+
+
+# Trailing ``(row N)`` annotation used by the form-field test generator to
+# point a label at a specific data row of a multi-column table. The column is
+# named by the prefix; ``N`` is 1-indexed over data rows (header rows are
+# skipped). We deliberately keep this strict and simple — anything else stays
+# under the bold-colon / 2-col / glyph paths.
+_ROW_LABEL_RE = re.compile(r"\s*\(row\s+(\d+)\)\s*$", re.IGNORECASE)
+
+
+def _split_row_label(label: str) -> tuple[str, int] | None:
+    """Return ``(column_label, row_index_1based)`` if *label* has a ``(row N)``
+    suffix, else None."""
+
+    m = _ROW_LABEL_RE.search(label)
+    if not m:
+        return None
+    col_label = label[: m.start()].strip()
+    if not col_label:
+        return None
+    return col_label, int(m.group(1))
+
+
+def _column_header_for_index(table: TableData, col_idx: int) -> str:
+    """Concatenate every header cell stacked above column *col_idx* into one
+    label. If the table has no recorded column headers (e.g. a markdown table
+    where row 0 is the de facto header), fall back to row 0 of that column."""
+
+    parts: list[str] = []
+    seen: set[str] = set()
+    headers = getattr(table, "col_headers", {}) or {}
+    for _, text in headers.get(col_idx, []):
+        clean = (text or "").strip()
+        if clean and clean not in seen:
+            parts.append(clean)
+            seen.add(clean)
+    if parts:
+        return " ".join(parts)
+    if table.data.size and col_idx < table.data.shape[1]:
+        return str(table.data[0, col_idx]).strip()
+    return ""
+
+
+def _find_table_cell_for_row_label(content: str, label: str) -> tuple[bool, str | None]:
+    """Look up ``"<col_label> (row N)"`` in any multi-column table.
+
+    Returns ``(label_seen, value_or_None)``. ``label_seen`` is True if a
+    matching column was found in some table, even when the data row is out
+    of range or the cell is empty — that distinction lets text rules with
+    empty expected values pass on real empty cells without giving signature
+    rules a free pass for missing labels.
+    """
+
+    parsed = _split_row_label(label)
+    if parsed is None:
+        return False, None
+    col_label, row_n = parsed
+
+    label_seen = False
+    for table in parse_html_tables(content) + parse_markdown_tables(content):
+        if table.data.size == 0:
+            continue
+        rows, cols = table.data.shape
+        # Determine which rows are headers. For HTML tables, header_rows is
+        # populated from <thead>/<th>. For markdown tables, parse_markdown_tables
+        # records header_rows={0} when a separator row is present.
+        header_rows = getattr(table, "header_rows", set()) or set()
+        n_header = (max(header_rows) + 1) if header_rows else 0
+        data_row_idx = n_header + (row_n - 1)
+
+        for col_idx in range(cols):
+            header_text = _column_header_for_index(table, col_idx)
+            if not header_text:
+                continue
+            if not _label_matches(header_text, col_label):
+                continue
+            label_seen = True
+            if 0 <= data_row_idx < rows:
+                cell_value = str(table.data[data_row_idx, col_idx]).strip()
+                if cell_value:
+                    return True, cell_value
+            # Column matched but cell out of range or empty — keep looking
+            # in case a sibling table has the same header populated.
+
+    if label_seen:
+        return True, ""
+    return False, None
+
+
+def _scope_to_page(content: str, parse_output, page: int | None) -> str:  # type: ignore[no-untyped-def]
+    """Return per-page markdown when ``parse_output`` and ``page`` are both set.
+
+    Fail-closed: once per-page IR is present (``pages`` or ``layout_pages``),
+    scoping is strict — if the requested page has no entry (or its markdown
+    is empty), return ``""`` rather than the full document. The old lenient
+    fallback let repeated header/footer fields satisfy page-N rules on the
+    wrong page and silently masked page-level extraction failures (see
+    PR #897 for the reducto/extend variant of the same bug).
+
+    Only when no per-page IR is available (both lists empty) do we fall
+    back to the document-level ``content``. Providers that emit neither
+    list never had fair per-page scoring; the fallback preserves prior
+    behavior rather than introducing a silent regression.
+
+    When ``layout_pages`` carries the per-page split but ``md`` is empty,
+    synthesize from ``items`` (priority ``md > html > value``). ``html``
+    ranks above ``value`` so table items keep their structure for the
+    HTML cell-neighbor matcher.
+
+    ``parse_output`` is typed as ``ParseOutput`` upstream but kept loose
+    here to avoid an import cycle.
+    """
+
+    if parse_output is None or page is None:
+        return content
+
+    pages = getattr(parse_output, "pages", None) or []
+    layout_pages = getattr(parse_output, "layout_pages", None) or []
+
+    if not pages and not layout_pages:
+        # Provider produced no per-page IR at all — fall back to full doc.
+        return content
+
+    if pages:
+        for p in pages:
+            # PageIR.page_index is 0-indexed; rule.page is 1-indexed.
+            if getattr(p, "page_index", None) == page - 1:
+                return getattr(p, "markdown", "") or ""
+        # ``pages`` populated but no matching page — fail closed.
+        if not layout_pages:
+            return ""
+        # Fall through to ``layout_pages`` lookup; some providers populate
+        # only one of the two lists per page.
+
+    for lp in layout_pages:
+        if getattr(lp, "page_number", None) != page:
+            continue
+        md = getattr(lp, "md", "") or ""
+        if md:
+            return md
+        # Synthesize from items: md > html > value (html ranks above value
+        # so table items keep their structure for the HTML cell matcher).
+        parts: list[str] = []
+        for it in getattr(lp, "items", None) or []:
+            text = getattr(it, "md", "") or getattr(it, "html", "") or getattr(it, "value", "")
+            if text:
+                parts.append(text)
+        return "\n\n".join(parts)
+
+    # Per-page IR present but page not found — fail closed.
+    return ""
+
+
+class FormFieldRule(ParseTestRule):
+    """Test rule for form-field key-value extraction.
+
+    Locates a labeled field by its visible label in the parsed markdown/HTML
+    and checks the extracted value matches the expected one.
+    """
+
+    def __init__(self, rule_data: ParseFormFieldRule | dict):
+        super().__init__(rule_data)
+        rule_data = cast(ParseFormFieldRule, self._rule_data)
+
+        if self.type != TestType.FORM_FIELD.value:
+            raise ValueError(f"Invalid type for FormFieldRule: {self.type}")
+
+        self.label = rule_data.label
+        self.value = rule_data.value
+        self.value_type = rule_data.value_type
+
+        if not self.label:
+            raise ValueError("label field cannot be empty")
+
+    def _content_for_match(self, md_content: str) -> str:
+        return _scope_to_page(md_content, self.parse_output, self.page)
+
+    def run(
+        self,
+        md_content: str,
+        normalized_content: str | None = None,
+    ) -> tuple[bool, str, float]:
+        scoped = self._content_for_match(md_content)
+        if self.value_type == "text":
+            return self._run_text(scoped)
+        if self.value_type == "checkbox":
+            return self._run_checkbox(scoped)
+        if self.value_type == "signature":
+            return self._run_signature(scoped)
+        return False, f"unknown value_type: {self.value_type}", 0.0
+
+    def _run_text(self, content: str) -> tuple[bool, str, float]:
+        # `self.value` can be a list of acceptable alternatives — pass if any matches.
+        expected_alternatives = _value_alternatives(self.value)
+        # Multi-col table cell lookup ("Column Name (row N)") takes precedence
+        # over the bold-colon / 2-col / glyph paths because the suffix
+        # explicitly names a tabular position.
+        if _split_row_label(self.label) is not None:
+            label_found, value = _find_table_cell_for_row_label(content, self.label)
+        else:
+            # Thread expected_alternatives so the matcher can disambiguate
+            # among candidates at the same top label-match score. The rule's
+            # position in the test list says nothing about which page
+            # occurrence the GT refers to when a label legitimately repeats
+            # (e.g. ``KB`` appearing as both an elevation label and as the
+            # value of ``LOG MEASURED FROM`` in well-log headers). The GT
+            # oracle is applied **only** to candidates tied at the head
+            # label-match score, so it never leaks across adjacent labels
+            # like Country vs County which live at different score levels.
+            label_found, value = _find_text_value_for_label(content, self.label, expected_alternatives)
+        if not label_found:
+            return False, f"label not found: {self.label!r}", 0.0
+        # value may be "" (label found, cell/value empty); _values_match_text
+        # handles empty == empty correctly so empty-expected rules can pass.
+        for expected in expected_alternatives:
+            if _values_match_text(value or "", expected):
+                return True, "match", 1.0
+        if len(expected_alternatives) == 1:
+            return False, f"expected {expected_alternatives[0]!r}, got {(value or '')!r}", 0.0
+        return False, f"expected any of {expected_alternatives!r}, got {(value or '')!r}", 0.0
+
+    def _run_checkbox(self, content: str) -> tuple[bool, str, float]:
+        expected_bool = _coerce_bool(self.value)
+        if expected_bool is None:
+            return False, f"checkbox value must be coercible to bool, got {self.value!r}", 0.0
+
+        # Prefer a real checkbox-shaped match.
+        state = _find_checkbox_state_for_label(content, self.label)
+        if state is None:
+            # Fall back to a text-shaped value (e.g. **Married:** Yes / No).
+            if _split_row_label(self.label) is not None:
+                label_found, text_value = _find_table_cell_for_row_label(content, self.label)
+            else:
+                label_found, text_value = _find_text_value_for_label(content, self.label)
+            if not label_found or not text_value:
+                return False, f"label not found: {self.label!r}", 0.0
+            state = _coerce_bool(text_value)
+            if state is None:
+                return False, f"could not interpret {text_value!r} as checkbox state", 0.0
+
+        if state == expected_bool:
+            return True, "match", 1.0
+        return False, f"expected {expected_bool}, got {state}", 0.0
+
+    def _run_signature(self, content: str) -> tuple[bool, str, float]:
+        # Relaxed semantics: the rule's value is treated as a presence indicator,
+        # not a strict bool. A non-empty string (e.g. the actual signed name) is
+        # equivalent to True — the matcher only checks "is something signed here"
+        # rather than the exact handwriting. An empty string / False / None means
+        # "expected unsigned". A list value collapses the same way: any non-empty
+        # alternative means "expected signed".
+        if isinstance(self.value, bool):
+            expected_signed = self.value
+        elif isinstance(self.value, list):
+            expected_signed = any(bool(str(v).strip()) for v in self.value)
+        else:
+            expected_signed = bool(str(self.value).strip())
+
+        # Track label presence separately from value presence — an absent label
+        # must NOT pass an "expected unsigned" rule. A form tuple benchmark
+        # requires the parser to surface the field at all.
+        label_found, text_value = _find_text_value_for_label(content, self.label)
+        if not label_found:
+            return False, f"label not found: {self.label!r}", 0.0
+        signed = bool(text_value and text_value.strip())
+        if signed == expected_signed:
+            return True, "match", 1.0
+        return False, f"expected signed={expected_signed}, got signed={signed}", 0.0

--- a/src/parse_bench/evaluation/metrics/parse/test_rules.py
+++ b/src/parse_bench/evaluation/metrics/parse/test_rules.py
@@ -3,7 +3,7 @@
 This module re-exports all rule classes and helpers from the split submodules
 for backward compatibility. New code should import directly from the
 specific submodule (rules_base, rules_text, rules_bag, rules_formatting,
-rules_table, rules_chart).
+rules_table, rules_chart, rules_form).
 """
 
 # Base class, helpers, and factory

--- a/src/parse_bench/evaluation/metrics/parse/test_rules.py
+++ b/src/parse_bench/evaluation/metrics/parse/test_rules.py
@@ -60,6 +60,11 @@ from parse_bench.evaluation.metrics.parse.rules_chart import (  # noqa: F401
     numeric_similarity,
 )
 
+# Form rules
+from parse_bench.evaluation.metrics.parse.rules_form import (  # noqa: F401
+    FormFieldRule,
+)
+
 # Formatting rules
 from parse_bench.evaluation.metrics.parse.rules_formatting import (  # noqa: F401
     _FORMATTING_TEST_TYPES,

--- a/src/parse_bench/evaluation/metrics/parse/test_types.py
+++ b/src/parse_bench/evaluation/metrics/parse/test_types.py
@@ -83,3 +83,5 @@ class TestType(StrEnum):
     BAG_OF_DIGIT_PERCENT = "bag_of_digit_percent"
     # Rotation check
     ROTATE_CHECK = "rotate_check"
+    # Form field (key/value, checkbox, signature) extraction
+    FORM_FIELD = "form_field"

--- a/src/parse_bench/test_cases/parse_rule_schemas.py
+++ b/src/parse_bench/test_cases/parse_rule_schemas.py
@@ -468,6 +468,25 @@ class ParseRotateCheckRule(ParseRuleBase):
     value: int | float | str | None = None
 
 
+class ParseFormFieldRule(ParseRuleBase):
+    """Schema for `form_field` rules.
+
+    Locates a labeled field in the parsed markdown/HTML and checks its value.
+    Used for benchmarking form (key-value, checkbox, signature) extraction.
+
+    `value` may be a list of strings to declare acceptable alternatives for
+    genuinely ambiguous fields (e.g. illegible handwriting). The evaluator
+    passes if the parsed value matches *any* alternative. Use sparingly —
+    most rules should be a single string. List form is only for value_type
+    "text" and "signature".
+    """
+
+    type: Literal[TestType.FORM_FIELD.value]
+    label: str = ""
+    value: str | bool | list[str] = ""
+    value_type: Literal["text", "checkbox", "signature"] = "text"
+
+
 type ParseRule = (
     ParsePresenceRule
     | ParseUnexpectedSentenceRule
@@ -518,6 +537,7 @@ type ParseRule = (
     | ParsePageSectionRule
     | ParseBagOfDigitPercentRule
     | ParseRotateCheckRule
+    | ParseFormFieldRule
 )
 
 type ParseRuleInput = ParseRule | dict[str, Any]
@@ -587,6 +607,7 @@ _RULE_TYPE_TO_MODEL: dict[str, type[ParseRule]] = {
     TestType.IS_FOOTER.value: ParsePageSectionRule,
     TestType.BAG_OF_DIGIT_PERCENT.value: ParseBagOfDigitPercentRule,
     TestType.ROTATE_CHECK.value: ParseRotateCheckRule,
+    TestType.FORM_FIELD.value: ParseFormFieldRule,
 }
 
 

--- a/tests/parse_bench/evaluation/metrics/parse/test_form_field_rule.py
+++ b/tests/parse_bench/evaluation/metrics/parse/test_form_field_rule.py
@@ -1,0 +1,1485 @@
+"""Tests for ParseFormFieldRule / FormFieldRule (parse-side form KV evaluation)."""
+
+from __future__ import annotations
+
+import pytest
+
+from parse_bench.evaluation.metrics.parse.rules_base import create_test_rule
+from parse_bench.evaluation.metrics.parse.test_rules import FormFieldRule
+from parse_bench.evaluation.metrics.parse.test_types import TestType
+
+# ---------------------------------------------------------------------------
+# Factory dispatch + schema
+# ---------------------------------------------------------------------------
+
+
+def test_factory_dispatches_form_field_to_form_field_rule():
+    rule = create_test_rule({"type": "form_field", "label": "Last Name", "value": "Collins"})
+    assert isinstance(rule, FormFieldRule)
+    assert rule.type == TestType.FORM_FIELD.value
+
+
+def test_empty_label_raises():
+    with pytest.raises(ValueError, match="label"):
+        FormFieldRule({"type": "form_field", "label": "", "value": "X"})
+
+
+# ---------------------------------------------------------------------------
+# value_type = "text"
+# ---------------------------------------------------------------------------
+
+
+class TestTextValueMatching:
+    def _rule(self, label: str, value: str) -> FormFieldRule:
+        return FormFieldRule({"type": "form_field", "label": label, "value": value, "value_type": "text"})
+
+    def test_bold_colon_match(self):
+        md = "**Last Name:** Collins\n"
+        passed, _, score = self._rule("Last Name", "Collins").run(md)
+        assert passed
+        assert score == 1.0
+
+    def test_bold_no_colon_inside_then_colon_outside(self):
+        md = "**Last Name**: Collins\n"
+        passed, _, _ = self._rule("Last Name", "Collins").run(md)
+        assert passed
+
+    def test_plain_colon_match(self):
+        md = "Last Name: Collins\n"
+        passed, _, _ = self._rule("Last Name", "Collins").run(md)
+        assert passed
+
+    def test_2col_markdown_table_match(self):
+        md = "| Field | Value |\n|---|---|\n| Last Name | Collins |\n| First Name | Maya |\n"
+        passed, _, _ = self._rule("Last Name", "Collins").run(md)
+        assert passed
+
+    def test_label_not_found_returns_failure(self):
+        md = "**Other Field:** Something\n"
+        passed, expl, score = self._rule("Last Name", "Collins").run(md)
+        assert not passed
+        assert score == 0.0
+        assert "label not found" in expl
+
+    def test_value_mismatch_returns_failure(self):
+        md = "**Last Name:** Smith\n"
+        passed, expl, score = self._rule("Last Name", "Collins").run(md)
+        assert not passed
+        assert score == 0.0
+        assert "expected" in expl and "got" in expl
+
+    def test_numeric_value_with_thousands_separator(self):
+        # Numeric strict equality via normalize_number_string: "1,234" == "1234"
+        # is the same numeric value, just written differently.
+        md = "**Salary:** 1234\n"
+        passed, _, _ = self._rule("Salary", "1,234").run(md)
+        assert passed
+
+    def test_label_fuzzy_match(self):
+        # Label matching tolerates minor parser rendering noise (single-character
+        # typo). Value matching is strict; label matching uses fuzz at 0.8 so
+        # that "Last Nam" / "Last Name" still resolves the right field.
+        md = "**Last Nam:** Collins\n"
+        passed, _, _ = self._rule("Last Name", "Collins").run(md)
+        assert passed
+
+
+class TestHtmlCellNeighborFallback:
+    """Wide-form HTML table cell-neighbor fallback (well-log style headers).
+
+    Targets the ``_iter_html_cell_neighbor_pairs`` last-resort source that
+    recovers KV pairs when labels and values are interleaved inside a single
+    wide ``<table>`` rather than being separated into a header row + data
+    rows. Only fires when the strong-source patterns (bold-colon, plain-colon,
+    2-col table, multi-col header×data) have all missed.
+    """
+
+    def _rule(self, label: str, value) -> FormFieldRule:
+        return FormFieldRule({"type": "form_field", "label": label, "value": value, "value_type": "text"})
+
+    def test_right_neighbor_value_wins(self):
+        # Three-cell row: label cell, label-shaped middle cell, value-shaped
+        # right cell. The right-neighbor matcher picks the third cell as the
+        # value of the *middle* label and the *first* label.
+        md = "<table><tr><th>FILE NO:</th><th>COMPANY</th><th>KEBO OIL &amp; GAS, INC.</th></tr></table>"
+        passed, _, _ = self._rule("COMPANY", "KEBO OIL & GAS, INC.").run(md)
+        assert passed
+
+    def test_below_neighbor_when_right_is_label_like(self):
+        # API NO: in row 0 → right neighbor "WELL" is itself label-shaped, so
+        # the matcher must fall through to the below neighbor (row 1 col 0).
+        md = (
+            "<table>"
+            "<tr><th>API NO:</th><th>WELL</th><th>LEHMAN #1</th></tr>"
+            "<tr><th>42-157-33282</th><th>FIELD</th><th>NEEDVILLE</th></tr>"
+            "</table>"
+        )
+        passed, _, _ = self._rule("API NO:", "42-157-33282").run(md)
+        assert passed
+
+    def test_value_with_punctuation_not_confused_for_label(self):
+        # LEHMAN #1 looks ALL_CAPS but has '#' / digit → must be classified
+        # as a value, not a label. So WELL → LEHMAN #1 must pass.
+        md = "<table><tr><th>API NO:</th><th>WELL</th><th>LEHMAN #1</th></tr></table>"
+        passed, _, _ = self._rule("WELL", "LEHMAN #1").run(md)
+        assert passed
+
+    def test_colspan_duplicates_skipped(self):
+        # ``parse_html_tables`` expands colspan by duplicating cell text across
+        # the covered columns. The right-scan must skip those duplicates and
+        # land on the next distinct non-empty cell.
+        md = (
+            "<table><tr>"
+            '<th colspan="2">FILE NO:</th>'
+            '<th colspan="2">COMPANY</th>'
+            '<th colspan="4">KEBO OIL &amp; GAS, INC.</th>'
+            "</tr></table>"
+        )
+        passed, _, _ = self._rule("COMPANY", "KEBO OIL & GAS, INC.").run(md)
+        assert passed
+
+    def test_two_col_html_table_still_uses_strong_source(self):
+        # Sanity: ordinary 2-col HTML tables continue to match via the
+        # existing pair iterator — the new fallback must never override the
+        # strong-source path. With value=Smith the 2-col matcher returns
+        # Smith; with value=Collins it returns failure (not whatever the
+        # neighbor matcher might dredge up).
+        md = "<table><tr><th>Last Name</th><td>Smith</td></tr></table>"
+        passed_match, _, _ = self._rule("Last Name", "Smith").run(md)
+        assert passed_match
+        passed_miss, expl, _ = self._rule("Last Name", "Collins").run(md)
+        assert not passed_miss
+        assert "expected" in expl and "got" in expl
+
+    def test_no_html_table_means_no_change(self):
+        # Bold-colon already handles this and the fallback never fires; this
+        # is a guard against accidental new false positives when there is
+        # no ``<table>`` in the content.
+        md = "**Last Name:** Smith\n"
+        passed, _, _ = self._rule("Last Name", "Smith").run(md)
+        assert passed
+
+    def test_empty_expected_passes_on_label_presence(self):
+        # FILE NO: has no value-shaped right or below neighbor in this
+        # snippet; the matcher returns label_seen=True with value="" so an
+        # empty-expected rule still passes (matching the contract of the
+        # other pair sources).
+        md = "<table><tr><th>FILE NO:</th><th>COMPANY</th><th>KEBO</th></tr></table>"
+        passed, _, _ = self._rule("FILE NO:", "").run(md)
+        assert passed
+
+    def test_single_th_cell_inline_kv_still_parses_via_plain_colon(self):
+        # ``<th>Label: Value</th>`` on its own line carries exactly one inline
+        # KV pair — ``_iter_plain_colon_pairs`` must still match this so we
+        # don't regress the wide-form well-log case where one tier emits
+        # ``<th colspan="2">Company: CIMARRON ENGINEERING, LLC</th>``. Only
+        # *multi-cell* rows (multiple ``<th>`` / ``<td>`` openings on the
+        # same line) are skipped by the plain-colon iterator.
+        md = '<table><tr><th colspan="2">Company: CIMARRON ENGINEERING, LLC</th></tr></table>'
+        passed, _, _ = self._rule("Company", "CIMARRON ENGINEERING, LLC").run(md)
+        assert passed
+
+    def test_iterates_past_label_position_with_only_label_like_neighbor(self):
+        # The same label text ``API`` appears twice in this table:
+        #   row 0 col 0 → right neighbor ``WELL`` (label-shaped, ALL-CAPS
+        #                 short) and below neighbor ``API`` (rowspan-style
+        #                 dup, skipped). No value-shaped neighbor at this
+        #                 position, so the matcher must NOT bail out with
+        #                 ``label_seen=True, value=""``.
+        #   row 1 col 0 → right neighbor ``42-001`` (digits → value-shaped) —
+        #                 the matcher must keep iterating past the first
+        #                 match position and surface this neighbor.
+        # Locks in the "keep iterating" behavior for repeated label tokens.
+        md = (
+            "<table>"
+            "<tr><th>API</th><th>WELL</th><th>STATE</th></tr>"
+            "<tr><th>API</th><th>42-001</th><th>TEXAS</th></tr>"
+            "</table>"
+        )
+        passed, _, _ = self._rule("API", "42-001").run(md)
+        assert passed
+
+    def test_repeated_short_text_treated_as_label(self):
+        # ``KB`` appears three times in this elevation block. The matcher's
+        # text-count map must classify the right neighbor of ELEVATIONS as
+        # label-shaped (it repeats ≥2 times) and fall through to a value-
+        # shaped neighbor — here the matcher returns the elevation reading
+        # for the ELEVATIONS → KB row when looking up "KB" the label.
+        md = (
+            "<table>"
+            "<tr><th>ELEVATIONS:</th><th>KB</th><th>96.8 FT</th></tr>"
+            "<tr><th></th><th>DF</th><th>95.8 FT</th></tr>"
+            "<tr><th></th><th>GL</th><th>80.0 FT</th></tr>"
+            "</table>"
+        )
+        passed, _, _ = self._rule("KB", "96.8 FT").run(md)
+        assert passed
+
+
+class TestMultiOccurrenceLabelPairing:
+    """A single label text can legitimately appear at multiple page positions
+    at the *same* best score (``KB`` exact-matching in both an elevation
+    block label-row and a ``LOG MEASURED FROM`` value-row; ``Address`` in
+    a W-15 form for Cementer vs Operator). The matcher must let the rule's
+    expected value disambiguate among those tied candidates without
+    weakening the cross-label boundary (Country vs County, etc.).
+    """
+
+    def _rule(self, label: str, value) -> FormFieldRule:
+        return FormFieldRule({"type": "form_field", "label": label, "value": value, "value_type": "text"})
+
+    def test_second_occurrence_with_matching_value_wins(self):
+        # Two bold-colon ``Address`` rows; both score exactly 1.0 against
+        # the rule label ``Address``. The first carries the operator's
+        # address, the second carries the cementer's — which is what GT
+        # expects. Without GT-oracle disambiguation, the source-priority
+        # + doc-order tie-break would lock onto the first row and fail.
+        md = "**Address:** 100 Operator Way\n\n**Address:** 200 Cementer Blvd\n"
+        passed, _, _ = self._rule("Address", "200 Cementer Blvd").run(md)
+        assert passed
+
+    def test_first_occurrence_still_wins_when_it_matches(self):
+        # Symmetric: with GT matching the first row, the matcher returns it.
+        md = "**Address:** 200 Cementer Blvd\n\n**Address:** 100 Operator Way\n"
+        passed, _, _ = self._rule("Address", "200 Cementer Blvd").run(md)
+        assert passed
+
+    def test_no_occurrence_matches_returns_top_for_diagnostics(self):
+        # When no tied-top candidate matches expected, the legacy
+        # source-priority + doc-order tie-break still surfaces a value so
+        # the error message reads "expected X, got Y".
+        md = "**Address:** 100 Operator Way\n\n**Address:** 200 Cementer Blvd\n"
+        passed, expl, _ = self._rule("Address", "999 Nowhere St").run(md)
+        assert not passed
+        assert "expected '999 Nowhere St'" in expl
+        assert "got '100 Operator Way'" in expl
+
+    def test_gt_oracle_does_not_leak_across_adjacent_labels(self):
+        # Cross-label boundary: ``Country`` is an exact match (score 1.0)
+        # for the rule label, ``County`` is a partial match (score ~0.92
+        # after the partial-ratio penalty). They live at *different*
+        # score levels, so even if ``County``'s value coincidentally
+        # equals what GT expects for ``Country``, ``County`` must not be
+        # eligible. The rule must read the *correct* row and fail (or
+        # pass) based on what's actually there — never grab the wrong
+        # row just because its value matches GT.
+        md = "**County**: U.S.A.\n**Country**: Mexico\n"
+        # The correct value for ``Country`` is ``Mexico`` (extraction
+        # error in the document), so the rule must FAIL when GT says
+        # ``U.S.A.``. If the GT oracle leaked across labels, the matcher
+        # would grab ``U.S.A.`` from the County row and wrongly pass.
+        passed, expl, _ = self._rule("Country", "U.S.A.").run(md)
+        assert not passed
+        assert "expected 'U.S.A.'" in expl
+        assert "got 'Mexico'" in expl
+
+    def test_gt_oracle_does_not_promote_lower_score_partial_hit(self):
+        # Symmetric to the previous test: when the rule label is the
+        # shorter ``County``, ``County`` exact-matches (score 1.0) and
+        # ``Country`` partial-matches (score ~0.95 with penalty). Only
+        # the County row is eligible regardless of which value GT names.
+        md = "**County**: U.S.A.\n**Country**: Mexico\n"
+        passed, _, _ = self._rule("County", "U.S.A.").run(md)
+        assert passed
+        passed_neg, expl, _ = self._rule("County", "Mexico").run(md)
+        assert not passed_neg
+        assert "got 'U.S.A.'" in expl
+
+    def test_cross_source_pairing_picks_matching_value(self):
+        # Same label surfaces in bold-colon (wrong value) AND an HTML
+        # 2-col table (right value). Both score 1.0 on the label. The
+        # bold-colon entry has higher source priority so the legacy
+        # tie-break would return ``99-999-99999``; the GT oracle must
+        # promote the HTML row instead because its value matches.
+        md = "**API NO:** 99-999-99999\n<table><tr><th>API NO:</th><td>42-157-33282</td></tr></table>"
+        passed, _, _ = self._rule("API NO:", "42-157-33282").run(md)
+        assert passed
+
+    def test_cell_neighbor_multi_position_disambiguates(self):
+        # ``KB`` appears as a value (col 1 in "LOG MEASURED FROM" row)
+        # AND as a label (col 1 in "ELEVATIONS:" row with elevation
+        # reading to the right). The cell-neighbor matcher yields both
+        # candidates at score 1.0. The expected value "96.8 FT" must
+        # steer the matcher to the ELEVATIONS position, not the LOG
+        # MEASURED FROM one which would give "16.0 FT".
+        md = (
+            "<table>"
+            "<tr><th>LOG MEASURED FROM</th><th>KB</th><th>16.0 FT</th></tr>"
+            "<tr><th>ELEVATIONS:</th><th>KB</th><th>96.8 FT</th></tr>"
+            "</table>"
+        )
+        passed, _, _ = self._rule("KB", "96.8 FT").run(md)
+        assert passed
+
+    def test_cell_neighbor_first_position_still_picked_when_it_matches(self):
+        # Symmetric: if GT expects the value at the first KB position,
+        # the matcher must return it.
+        md = (
+            "<table>"
+            "<tr><th>LOG MEASURED FROM</th><th>KB</th><th>16.0 FT</th></tr>"
+            "<tr><th>ELEVATIONS:</th><th>KB</th><th>96.8 FT</th></tr>"
+            "</table>"
+        )
+        passed, _, _ = self._rule("KB", "16.0 FT").run(md)
+        assert passed
+
+    def test_legacy_call_without_expected_returns_top_candidate(self):
+        # Internal contract: callers that don't have an expected value
+        # (signature rule, label-presence-only paths) keep the legacy
+        # source-priority + doc-order pick — same as #978's behaviour.
+        from parse_bench.evaluation.metrics.parse.rules_form import (
+            _find_text_value_for_label,
+        )
+
+        md = "**Address:** 100 Operator Way\n\n**Address:** 200 Cementer Blvd\n"
+        seen, value = _find_text_value_for_label(md, "Address")
+        assert seen
+        assert value == "100 Operator Way"
+
+    def test_empty_expected_passes_via_label_seen(self):
+        # Empty-expected rule: when GT value is "", a label_seen=True /
+        # no-value outcome already satisfies the rule via
+        # _values_match_text("", ""). The GT oracle must not promote an
+        # adjacent label-like neighbor as a spurious value.
+        md = "Last Name: \n"
+        passed, _, _ = self._rule("Last Name", "").run(md)
+        assert passed
+
+
+class TestTextValueAlternatives:
+    """List-of-strings `value` declares acceptable alternatives for ambiguous fields."""
+
+    def _rule(self, label: str, value) -> FormFieldRule:
+        return FormFieldRule({"type": "form_field", "label": label, "value": value, "value_type": "text"})
+
+    def test_first_alternative_matches(self):
+        md = "**Lease/ID No.:** N/A DRY\n"
+        passed, _, _ = self._rule("Lease/ID No.", ["N/A DRY", "NIA DRY"]).run(md)
+        assert passed
+
+    def test_second_alternative_matches(self):
+        md = "**Lease/ID No.:** NIA DRY\n"
+        passed, _, _ = self._rule("Lease/ID No.", ["N/A DRY", "NIA DRY"]).run(md)
+        assert passed
+
+    def test_no_alternative_matches_fails(self):
+        md = "**Lease/ID No.:** Something Else\n"
+        passed, expl, _ = self._rule("Lease/ID No.", ["N/A DRY", "NIA DRY"]).run(md)
+        assert not passed
+        assert "any of" in expl
+
+    def test_single_element_list_behaves_like_string(self):
+        md = "**Last Name:** Collins\n"
+        passed, _, _ = self._rule("Last Name", ["Collins"]).run(md)
+        assert passed
+
+    def test_empty_string_alternative_passes_when_field_blank(self):
+        md = "| Field | Value |\n|---|---|\n| Last Name |  |\n"
+        passed, _, _ = self._rule("Last Name", ["", "N/A"]).run(md)
+        assert passed
+
+    def test_string_value_still_works_after_list_support(self):
+        # Backward compat: pre-existing string GTs must keep passing exactly as before.
+        md = "**Last Name:** Collins\n"
+        passed, _, _ = self._rule("Last Name", "Collins").run(md)
+        assert passed
+
+
+# ---------------------------------------------------------------------------
+# value_type = "checkbox"
+# ---------------------------------------------------------------------------
+
+
+class TestCheckboxValueMatching:
+    def _rule(self, label: str, value) -> FormFieldRule:
+        return FormFieldRule({"type": "form_field", "label": label, "value": value, "value_type": "checkbox"})
+
+    def test_glyph_checked_match(self):
+        md = "☑ Married\n☐ Single\n"
+        passed, _, _ = self._rule("Married", True).run(md)
+        assert passed
+
+    def test_list_value_rejected_for_checkbox(self):
+        # Checkboxes are bool-or-bust: list-of-alternatives is meaningless for a
+        # binary state, so _coerce_bool returns None and the existing
+        # "must be coercible to bool" error fires with the value in the message.
+        md = "☑ Married\n"
+        passed, expl, _ = self._rule("Married", ["Yes", "Y"]).run(md)
+        assert not passed
+        assert "must be coercible to bool" in expl
+        assert "['Yes', 'Y']" in expl
+
+    def test_glyph_unchecked_match(self):
+        md = "☑ Married\n☐ Single\n"
+        passed, _, _ = self._rule("Single", False).run(md)
+        assert passed
+
+    def test_glyph_state_mismatch(self):
+        md = "☐ Married\n"
+        passed, expl, _ = self._rule("Married", True).run(md)
+        assert not passed
+        assert "expected True" in expl
+
+    def test_md_task_list_checked(self):
+        md = "- [x] Routine service\n- [ ] Expedited service\n"
+        passed, _, _ = self._rule("Routine service", True).run(md)
+        assert passed
+
+    def test_md_task_list_unchecked(self):
+        md = "- [x] Routine service\n- [ ] Expedited service\n"
+        passed, _, _ = self._rule("Expedited service", False).run(md)
+        assert passed
+
+    def test_text_yes_coerces_to_true(self):
+        md = "**Married:** Yes\n"
+        passed, _, _ = self._rule("Married", True).run(md)
+        assert passed
+
+    def test_text_no_coerces_to_false(self):
+        md = "**Married:** No\n"
+        passed, _, _ = self._rule("Married", False).run(md)
+        assert passed
+
+    def test_label_not_found(self):
+        md = "**Other:** Yes\n"
+        passed, expl, _ = self._rule("Married", True).run(md)
+        assert not passed
+        assert "label not found" in expl
+
+
+# ---------------------------------------------------------------------------
+# value_type = "signature"
+# ---------------------------------------------------------------------------
+
+
+class TestSignatureValueMatching:
+    def _rule(self, label: str, value, value_type: str = "signature") -> FormFieldRule:
+        return FormFieldRule({"type": "form_field", "label": label, "value": value, "value_type": value_type})
+
+    def test_signed_when_text_after_label(self):
+        md = "**Applicant Signature:** Maya Collins\n"
+        passed, _, _ = self._rule("Applicant Signature", True).run(md)
+        assert passed
+
+    def test_signed_mismatch_when_label_missing(self):
+        md = "**Other Field:** something\n"
+        passed, _, _ = self._rule("Applicant Signature", True).run(md)
+        assert not passed
+
+    def test_unsigned_table_blank_value(self):
+        # Ground truth says "should be unsigned" — and the parser surfaces
+        # the field with an empty value cell. The label IS present (in column 0)
+        # so _run_signature must distinguish this from "label absent" and pass.
+        md = "| Field | Value |\n|---|---|\n| Applicant Signature |  |\n"
+        passed, _, _ = self._rule("Applicant Signature", False).run(md)
+        assert passed
+
+    def test_unsigned_does_not_pass_when_label_absent(self):
+        # Regression: a signature=false rule must FAIL when the parser omitted
+        # the signature label entirely. Otherwise pipelines that drop pages of
+        # signatures get full credit on every "unsigned" GT tuple.
+        md = "**Other Field:** something\n"
+        passed, expl, _ = self._rule("Applicant Signature", False).run(md)
+        assert not passed
+        assert "label not found" in expl
+
+    # ---- Relaxed semantics: non-empty string value == True ----
+
+    def test_string_value_passes_when_any_text_signed(self):
+        # Rule stores the actual signed name as documentation; parser surfaces
+        # *some* non-empty value under the label — that counts as "signed".
+        md = "**Applicant Signature:** Maya Collins\n"
+        passed, _, _ = self._rule("Applicant Signature", "Robert Hal Thompson").run(md)
+        assert passed
+
+    def test_string_value_passes_even_when_text_differs(self):
+        # Signature matching is relaxed: handwriting need not match the rule's
+        # text, only that *something* is signed there.
+        md = "**Applicant Signature:** Maya Collins\n"
+        passed, _, _ = self._rule("Applicant Signature", "CHRIS BUSH").run(md)
+        assert passed
+
+    def test_string_value_fails_when_field_empty(self):
+        # Rule has non-empty string (expecting signed); parser shows empty cell.
+        md = "| Field | Value |\n|---|---|\n| Applicant Signature |  |\n"
+        passed, expl, _ = self._rule("Applicant Signature", "Robert Hal Thompson").run(md)
+        assert not passed
+        assert "signed=True" in expl and "signed=False" in expl
+
+    def test_empty_string_value_treated_as_unsigned(self):
+        # Empty string == expected unsigned, same as False.
+        md = "| Field | Value |\n|---|---|\n| Applicant Signature |  |\n"
+        passed, _, _ = self._rule("Applicant Signature", "").run(md)
+        assert passed
+
+    def test_empty_string_value_fails_when_signed(self):
+        md = "**Applicant Signature:** Maya Collins\n"
+        passed, _, _ = self._rule("Applicant Signature", "").run(md)
+        assert not passed
+
+    # ---- List value: any non-empty alternative means "expected signed" ----
+
+    def test_list_value_with_any_non_empty_passes_when_signed(self):
+        # A list with at least one non-empty alternative collapses to "expected
+        # signed" — alternatives describe handwriting variants but the matcher
+        # only checks presence.
+        md = "**Applicant Signature:** Maya Collins\n"
+        passed, _, _ = self._rule("Applicant Signature", ["CHRIS BUSH", "Chris Bush"]).run(md)
+        assert passed
+
+    def test_list_value_all_empty_treated_as_unsigned(self):
+        # An all-empty list collapses to "expected unsigned", same as False.
+        md = "| Field | Value |\n|---|---|\n| Applicant Signature |  |\n"
+        passed, _, _ = self._rule("Applicant Signature", ["", ""]).run(md)
+        assert passed
+
+    def test_list_value_non_empty_fails_when_field_blank(self):
+        md = "| Field | Value |\n|---|---|\n| Applicant Signature |  |\n"
+        passed, expl, _ = self._rule("Applicant Signature", ["CHRIS BUSH"]).run(md)
+        assert not passed
+        assert "signed=True" in expl and "signed=False" in expl
+
+
+# ---------------------------------------------------------------------------
+# Inline checkbox groups (regression for ☐ Single ☑ Married ☐ Head)
+# ---------------------------------------------------------------------------
+
+
+class TestInlineCheckboxGroups:
+    def _rule(self, label: str, value: bool) -> FormFieldRule:
+        return FormFieldRule({"type": "form_field", "label": label, "value": value, "value_type": "checkbox"})
+
+    def test_glyph_first_inline_group_finds_middle_label(self):
+        # Regression: the previous regex consumed the next glyph as a delimiter,
+        # so the middle label was either skipped or paired with the wrong glyph.
+        md = "☐ Single ☑ Married ☐ Head of Household\n"
+        passed, _, _ = self._rule("Married", True).run(md)
+        assert passed
+
+    def test_glyph_first_inline_group_finds_last_label(self):
+        md = "☐ Single ☑ Married ☐ Head of Household\n"
+        passed, _, _ = self._rule("Head of Household", False).run(md)
+        assert passed
+
+    def test_glyph_first_inline_group_finds_first_label(self):
+        md = "☐ Single ☑ Married ☐ Head of Household\n"
+        passed, _, _ = self._rule("Single", False).run(md)
+        assert passed
+
+    def test_label_first_inline_group(self):
+        # Older form layout: label-first ordering (label precedes its glyph).
+        md = "Single ☐  Married ☑  Head of Household ☐\n"
+        passed, _, _ = self._rule("Married", True).run(md)
+        assert passed
+
+    def test_label_first_inline_group_unchecked(self):
+        md = "Single ☐  Married ☑  Head of Household ☐\n"
+        passed, _, _ = self._rule("Single", False).run(md)
+        assert passed
+
+
+# ---------------------------------------------------------------------------
+# Inline bold-colon multi-pair  (**First:** Maya **Last:** Collins)
+# ---------------------------------------------------------------------------
+
+
+class TestInlineBoldColonMultiPair:
+    def _rule(self, label: str, value: str) -> FormFieldRule:
+        return FormFieldRule({"type": "form_field", "label": label, "value": value, "value_type": "text"})
+
+    def test_first_field_in_inline_pair(self):
+        # Regression: the old $-anchored regex only matched the LAST pair on a line.
+        md = "**First Name:** Maya **Last Name:** Collins\n"
+        passed, _, _ = self._rule("First Name", "Maya").run(md)
+        assert passed
+
+    def test_last_field_in_inline_pair(self):
+        md = "**First Name:** Maya **Last Name:** Collins\n"
+        passed, _, _ = self._rule("Last Name", "Collins").run(md)
+        assert passed
+
+    def test_three_pairs_inline(self):
+        md = "**A:** 1 **B:** 2 **C:** 3\n"
+        for lbl, val in [("A", "1"), ("B", "2"), ("C", "3")]:
+            passed, _, _ = self._rule(lbl, val).run(md)
+            assert passed, f"{lbl}={val} should match"
+
+
+# ---------------------------------------------------------------------------
+# HTML tables
+# ---------------------------------------------------------------------------
+
+
+class TestHtmlTableMatching:
+    def _rule(self, label: str, value: str) -> FormFieldRule:
+        return FormFieldRule({"type": "form_field", "label": label, "value": value, "value_type": "text"})
+
+    def test_2col_html_table_match(self):
+        html = (
+            "<table>\n"
+            "<tr><th>Field</th><th>Value</th></tr>\n"
+            "<tr><td>Last Name</td><td>Collins</td></tr>\n"
+            "<tr><td>First Name</td><td>Maya</td></tr>\n"
+            "</table>\n"
+        )
+        passed, _, _ = self._rule("Last Name", "Collins").run(html)
+        assert passed
+
+    def test_html_table_value_mismatch(self):
+        html = "<table><tr><td>Last Name</td><td>Smith</td></tr></table>"
+        passed, _, _ = self._rule("Last Name", "Collins").run(html)
+        assert not passed
+
+
+# ---------------------------------------------------------------------------
+# Strict value matching — no fuzzy, no relative tolerance
+#
+# Form values are extracted, not estimated, so any wrong digit / letter / token
+# is a real mismatch. The only normalization applied is case-folding +
+# whitespace (via `normalize_text`) and numeric equivalence ("1,234" == "1234").
+# ---------------------------------------------------------------------------
+
+
+class TestStrictValueMatching:
+    def _rule(self, label: str, value: str) -> FormFieldRule:
+        return FormFieldRule({"type": "form_field", "label": label, "value": value, "value_type": "text"})
+
+    def test_phone_off_by_one_digit_fails(self):
+        md = "**Phone:** 555-0139\n"
+        passed, _, _ = self._rule("Phone", "555-0138").run(md)
+        assert not passed
+
+    def test_phone_exact_match_passes(self):
+        md = "**Phone:** 555-0138\n"
+        passed, _, _ = self._rule("Phone", "555-0138").run(md)
+        assert passed
+
+    def test_ssn_off_by_one_digit_fails(self):
+        md = "**SSN:** 900-12-3457\n"
+        passed, _, _ = self._rule("SSN", "900-12-3456").run(md)
+        assert not passed
+
+    def test_zip_off_by_one_digit_fails(self):
+        md = "**ZIP:** 53704\n"
+        passed, _, _ = self._rule("ZIP", "53703").run(md)
+        assert not passed
+
+    def test_date_off_by_one_day_fails(self):
+        md = "**Date of Birth:** 1991-08-15\n"
+        passed, _, _ = self._rule("Date of Birth", "1991-08-14").run(md)
+        assert not passed
+
+    def test_text_case_insensitive(self):
+        # `normalize_text` case-folds, so "madison" matches "Madison" exactly
+        # — no fuzz needed for that.
+        md = "**City:** madison\n"
+        passed, _, _ = self._rule("City", "Madison").run(md)
+        assert passed
+
+    def test_text_one_letter_off_fails(self):
+        # Single-letter typo in a name — not a fuzzy match, real mismatch.
+        md = "**First Name:** Mara\n"
+        passed, _, _ = self._rule("First Name", "Maya").run(md)
+        assert not passed
+
+    def test_currency_normalization(self):
+        # Same value written with currency + thousands separator should match.
+        md = "**Salary:** $1,234.00\n"
+        passed, _, _ = self._rule("Salary", "1234").run(md)
+        assert passed
+
+
+# ---------------------------------------------------------------------------
+# Page scoping via injected parse_output
+# ---------------------------------------------------------------------------
+
+
+class _FakePageIR:
+    def __init__(self, page_index: int, markdown: str) -> None:
+        self.page_index = page_index
+        self.markdown = markdown
+
+
+class _FakeParseOutput:
+    def __init__(self, pages: list[_FakePageIR]) -> None:
+        self.pages = pages
+        self.layout_pages: list[object] = []
+
+
+class _LayoutItem:
+    def __init__(self, md: str = "", html: str = "", value: str = "") -> None:
+        self.md = md
+        self.html = html
+        self.value = value
+
+
+class _LayoutPage:
+    def __init__(self, page_number: int, items: list[_LayoutItem], md: str = "") -> None:
+        self.page_number = page_number
+        self.items = items
+        self.md = md
+
+
+class _LayoutOnlyOutput:
+    def __init__(self, layout_pages: list[_LayoutPage]) -> None:
+        self.pages: list[object] = []
+        self.layout_pages = layout_pages
+
+
+def _layout_only_output(specs: list[tuple]) -> _LayoutOnlyOutput:
+    # Each spec is (page_number, items[, md]). Compact factory keeps tests terse.
+    pages = [_LayoutPage(s[0], s[1], s[2] if len(s) > 2 else "") for s in specs]
+    return _LayoutOnlyOutput(pages)
+
+
+class TestRelaxedLabelMatching:
+    def _rule(self, label: str, value: str) -> FormFieldRule:
+        return FormFieldRule({"type": "form_field", "label": label, "value": value, "value_type": "text"})
+
+    def test_label_with_numeric_prefix_and_hint_suffix(self):
+        # Parser preserves the field's core label but wraps it in form-specific
+        # noise: a "(3)" numeric prefix and a long parenthetical hint. The test
+        # writer's compact label should still resolve via partial-ratio.
+        md = (
+            "**(3) Account number (maximum 15 digits, include any leading zeros, "
+            "do not include check number)**: TEST-CHK-782194\n"
+        )
+        passed, _, _ = self._rule("Account number", "TEST-CHK-782194").run(md)
+        assert passed
+
+    def test_relaxed_match_does_not_fire_for_short_fragments(self):
+        # 3-char fragments must not partial-match into longer labels —
+        # otherwise "Tax" would match "Taxonomy of biological classifiers".
+        md = "**Income Tax Withheld:** 100\n"
+        passed, _, _ = self._rule("Tax", "100").run(md)
+        assert not passed
+
+    def test_relaxed_match_blocks_dropped_short_disambiguator(self):
+        # Borderline-on-purpose: when the parser drops a disambiguator and the
+        # remaining bare label is shorter than the length gate (6 chars), we
+        # do NOT auto-match. A form could have both "Date (Supervisor)" and
+        # "Date (Employee)"; matching either to bare "Date" would be wrong.
+        md = "**Date:** 04/27/2026\n"
+        passed, _, _ = self._rule("Date (Supervisor)", "04/27/2026").run(md)
+        assert not passed
+
+
+class TestEscapedAndLabelFirstCheckbox:
+    def _rule(self, label: str, value: bool) -> FormFieldRule:
+        return FormFieldRule({"type": "form_field", "label": label, "value": value, "value_type": "checkbox"})
+
+    def test_escaped_brackets_in_md_tasklist(self):
+        md = "* \\[x] Routine service\n* \\[ ] Expedited service\n"
+        passed, _, _ = self._rule("Routine service", True).run(md)
+        assert passed
+
+    def test_label_first_bullet_checked(self):
+        # Common form layout: bullet text is the option label, brackets follow.
+        md = "* Checking \\[x]\n* Savings \\[ ]\n"
+        passed, _, _ = self._rule("Checking", True).run(md)
+        assert passed
+
+    def test_label_first_bullet_unchecked(self):
+        md = "* Checking \\[x]\n* Savings \\[ ]\n"
+        passed, _, _ = self._rule("Savings", False).run(md)
+        assert passed
+
+    def test_escaped_dash_label_first_bullet(self):
+        # Some parsers emit ``\-`` so a literal dash survives markdown rendering
+        # of nested bullets. The matcher should treat it like a regular dash.
+        md = (
+            "* **Purpose of Training (mark all that apply)**:\n"
+            "  \\- Improve current job skills \\[x]\n"
+            "  \\- Learn new job skills \\[x]\n"
+            "  \\- Personal development \\[ ]\n"
+        )
+        passed, _, _ = self._rule("Improve current job skills", True).run(md)
+        assert passed
+        passed, _, _ = self._rule("Personal development", False).run(md)
+        assert passed
+
+    def test_parent_qualified_label_resolves_to_child_bullet(self):
+        # GT label is "Type of Account: Checking" but the parser only emits
+        # the child bullet "Checking [x]". Relaxed label match bridges that.
+        md = "* Checking \\[x]\n* Savings \\[ ]\n"
+        passed, _, _ = self._rule("Type of Account: Checking", True).run(md)
+        assert passed
+
+
+class TestMultiColumnTableRowLabel:
+    def _rule(self, label: str, value: str) -> FormFieldRule:
+        return FormFieldRule({"type": "form_field", "label": label, "value": value, "value_type": "text"})
+
+    def test_html_table_row_lookup(self):
+        html = (
+            "<table>\n"
+            "<thead><tr>"
+            "<th>Course Title</th><th>Start Date</th><th>End Date</th>"
+            "</tr></thead>\n"
+            "<tbody>"
+            "<tr><td>Federal Procurement Basics</td><td>05/04/2026</td><td>06/01/2026</td></tr>\n"
+            "<tr><td>Records Management 101</td><td>05/11/2026</td><td>05/29/2026</td></tr>\n"
+            "</tbody></table>"
+        )
+        passed, _, _ = self._rule("Course Title (row 1)", "Federal Procurement Basics").run(html)
+        assert passed
+        passed, _, _ = self._rule("Start Date (row 2)", "05/11/2026").run(html)
+        assert passed
+
+    def test_html_table_row_value_mismatch(self):
+        html = (
+            "<table><thead><tr><th>Course Title</th><th>Start Date</th></tr></thead>\n"
+            "<tbody><tr><td>Federal Procurement Basics</td><td>05/04/2026</td></tr></tbody></table>"
+        )
+        passed, _, _ = self._rule("Start Date (row 1)", "06/01/2026").run(html)
+        assert not passed
+
+    def test_html_table_empty_cell_with_empty_expected_passes(self):
+        # Out-of-range row with empty expected value: column was found, the
+        # cell is genuinely empty, so the rule should pass.
+        html = (
+            "<table><thead><tr><th>Course Title</th></tr></thead>\n"
+            "<tbody><tr><td>Federal Procurement Basics</td></tr></tbody></table>"
+        )
+        passed, _, _ = self._rule("Course Title (row 5)", "").run(html)
+        assert passed
+
+    def test_html_table_colspan_header_concatenated(self):
+        # A colspan parent header ("Hours") above a sub-header ("During duty")
+        # should match a GT label that combines them.
+        html = (
+            "<table>\n"
+            "<thead>\n"
+            "<tr><th rowspan='2'>Course Title</th><th colspan='2'>Hours</th></tr>\n"
+            "<tr><th>During duty</th><th>Non duty</th></tr>\n"
+            "</thead>\n"
+            "<tbody><tr><td>Federal Procurement Basics</td><td>8</td><td>2</td></tr></tbody>\n"
+            "</table>"
+        )
+        passed, _, _ = self._rule("Hours During duty (row 1)", "8").run(html)
+        assert passed
+
+    def test_markdown_table_row_lookup(self):
+        md = (
+            "| Course Title | Start Date | End Date |\n"
+            "|---|---|---|\n"
+            "| Federal Procurement Basics | 05/04/2026 | 06/01/2026 |\n"
+            "| Records Management 101 | 05/11/2026 | 05/29/2026 |\n"
+        )
+        passed, _, _ = self._rule("Course Title (row 2)", "Records Management 101").run(md)
+        assert passed
+
+
+class TestEmptyExpectedValue:
+    def _rule(self, label: str, value: str) -> FormFieldRule:
+        return FormFieldRule({"type": "form_field", "label": label, "value": value, "value_type": "text"})
+
+    def test_label_present_value_blank_with_empty_expected_passes(self):
+        # Parser surfaces the field but the cell is empty; GT also empty.
+        md = "**Account number (see instructions)**:\n"
+        passed, _, _ = self._rule("Account number (see instructions)", "").run(md)
+        assert passed
+
+    def test_label_absent_with_empty_expected_still_fails(self):
+        # An empty expected value does NOT excuse a parser that dropped the
+        # field entirely — that would let pipelines silently lose pages.
+        md = "**Other Field:** something\n"
+        passed, expl, _ = self._rule("Account number", "").run(md)
+        assert not passed
+        assert "label not found" in expl
+
+
+class TestBoldColonDoesNotCrossBlankLines:
+    def _rule(self, label: str, value: str) -> FormFieldRule:
+        return FormFieldRule({"type": "form_field", "label": label, "value": value, "value_type": "text"})
+
+    def test_empty_bold_colon_does_not_capture_next_block_value(self):
+        # Regression: previously the ``\s*`` segments in _BOLD_COLON_RE allowed
+        # the regex to consume blank lines and headings, so an empty
+        # ``**SUFFIX**:\n\nFiling Office Copy ...`` would attribute the heading
+        # text to SUFFIX. After the fix, the value is empty and an
+        # empty-expected rule passes.
+        md = "**SUFFIX**:\n\nFILING OFFICE COPY — INFORMATION STATEMENT\n"
+        passed, _, _ = self._rule("SUFFIX", "").run(md)
+        assert passed
+
+    def test_empty_bold_colon_with_blank_line_followed_by_other_field(self):
+        # Two distinct fields separated by a blank line and a heading. The
+        # empty Agency Case No. should not absorb the URLA title.
+        md = "**Agency Case No.**:\n\n# Uniform Residential Loan Application\n\n**Other Field**: x\n"
+        passed, _, _ = self._rule("Agency Case No.", "").run(md)
+        assert passed
+
+    def test_trailing_backslash_value_treated_as_empty(self):
+        # ``**Label**: \\`` is a markdown line-continuation; the value should
+        # normalize to empty so an empty-expected rule passes.
+        md = "**Suffix**: \\\n"
+        passed, _, _ = self._rule("Suffix", "").run(md)
+        assert passed
+
+
+class TestMultiColTableHeaderValueRow:
+    def _rule(self, label: str, value: str) -> FormFieldRule:
+        return FormFieldRule({"type": "form_field", "label": label, "value": value, "value_type": "text"})
+
+    def test_html_3col_header_then_data_row(self):
+        # 3-column HTML table with header row + single data row. Used by
+        # ours_cost_effective and gemini for vehicle/personal info blocks.
+        html = (
+            "<table>"
+            "<thead><tr>"
+            "<th>Vehicle Identification Number</th><th>Year</th><th>Make</th>"
+            "</tr></thead>"
+            "<tbody><tr>"
+            "<td><strong>TESTVIN0001</strong></td><td><strong>2020</strong></td><td><strong>Toyota</strong></td>"
+            "</tr></tbody>"
+            "</table>"
+        )
+        passed, _, _ = self._rule("Vehicle Identification Number", "TESTVIN0001").run(html)
+        assert passed
+        passed, _, _ = self._rule("Year", "2020").run(html)
+        assert passed
+
+    def test_html_in_cell_br_label_value_split(self):
+        # ``<td>Label<br/><strong>Value</strong></td>`` — label and value
+        # stacked inside one cell via <br/>.
+        html = (
+            "<table><tr>"
+            "<td>Last Name (Family Name)<br/><strong>Nguyen</strong></td>"
+            "<td>First Name (Given Name)<br/><strong>Erin</strong></td>"
+            "</tr></table>"
+        )
+        passed, _, _ = self._rule("Last Name (Family Name)", "Nguyen").run(html)
+        assert passed
+        passed, _, _ = self._rule("First Name (Given Name)", "Erin").run(html)
+        assert passed
+
+
+class TestPlainColonInListItems:
+    def _rule(self, label: str, value: str) -> FormFieldRule:
+        return FormFieldRule({"type": "form_field", "label": label, "value": value, "value_type": "text"})
+
+    def test_dash_bullet_with_label_colon_value(self):
+        # OpenAI emits ``- Defendant: Devon Reed`` style list items that
+        # used to be silently dropped by the plain-colon scanner.
+        md = "Form fields (filled):\n- Defendant: Devon Marcus Reed\n- Plaintiff: Anthony Cole Jackson\n"
+        passed, _, _ = self._rule("Defendant", "Devon Marcus Reed").run(md)
+        assert passed
+        passed, _, _ = self._rule("Plaintiff", "Anthony Cole Jackson").run(md)
+        assert passed
+
+    def test_tasklist_bullets_are_still_skipped(self):
+        # ``- [ ] Foo: bar`` should remain a checkbox bullet, not a colon pair.
+        md = "- [x] Single\n- [ ] Married\n"
+        passed, _, _ = self._rule("Single", "Married").run(md)
+        assert not passed
+
+
+class TestExtendedCheckboxGlyphs:
+    def _rule(self, label: str, value: bool) -> FormFieldRule:
+        return FormFieldRule({"type": "form_field", "label": label, "value": value, "value_type": "checkbox"})
+
+    def test_filled_circle_is_checked(self):
+        md = "● Checking account\n○ Savings account\n"
+        passed, _, _ = self._rule("Checking account", True).run(md)
+        assert passed
+        passed, _, _ = self._rule("Savings account", False).run(md)
+        assert passed
+
+    def test_fisheye_is_checked(self):
+        md = "Married ◉  Single ○\n"
+        passed, _, _ = self._rule("Married", True).run(md)
+        assert passed
+
+
+class TestNumberedTaskListAndBareBracketAndInlineAscii:
+    def _rule(self, label: str, value: bool) -> FormFieldRule:
+        return FormFieldRule({"type": "form_field", "label": label, "value": value, "value_type": "checkbox"})
+
+    def test_numbered_tasklist(self):
+        # USCIS citizenship attestation: ``1. [x] Citizen`` numbered list with brackets.
+        md = "1. [x] A citizen of the United States\n2. [ ] A noncitizen national\n"
+        passed, _, _ = self._rule("A citizen of the United States", True).run(md)
+        assert passed
+        passed, _, _ = self._rule("A noncitizen national", False).run(md)
+        assert passed
+
+    def test_bare_bracket_no_bullet(self):
+        # IRS W-9 / UCC5 line: ``\[x] Individual/sole proprietor`` with no
+        # leading bullet marker.
+        md = "\\[x] Individual/sole proprietor\n\\[ ] C corporation\n"
+        passed, _, _ = self._rule("Individual/sole proprietor", True).run(md)
+        assert passed
+        passed, _, _ = self._rule("C corporation", False).run(md)
+        assert passed
+
+    def test_inline_ascii_bracket_group(self):
+        # W-9 inline classification group: ``\[ ] A \[x] B \[ ] C`` on one line.
+        md = "\\[ ] Individual/sole proprietor \\[x] C corporation \\[ ] S corporation\n"
+        passed, _, _ = self._rule("C corporation", True).run(md)
+        assert passed
+        passed, _, _ = self._rule("Individual/sole proprietor", False).run(md)
+        assert passed
+
+    def test_mid_line_bracket_after_bold_label(self):
+        # UCC5 inline: ``2a. RECORD IS INACCURATE \[x] enter explanation...``
+        # The label-first inline tokenizer treats the bold label as the label
+        # for the trailing bracket marker.
+        md = "**Inaccuracy in financing statement** \\[x]\n"
+        passed, _, _ = self._rule("Inaccuracy in financing statement", True).run(md)
+        assert passed
+
+
+class TestUnderscoreBlankField:
+    def _rule(self, label: str, value: str) -> FormFieldRule:
+        return FormFieldRule({"type": "form_field", "label": label, "value": value, "value_type": "text"})
+
+    def test_label_followed_by_underscore_blank_passes_empty(self):
+        # HUD-2993 layout: ``Processor's Name _________________``.
+        md = "Processor's Name _________________\n"
+        passed, _, _ = self._rule("Processor's Name", "").run(md)
+        assert passed
+
+
+class TestAdjacentLineFallback:
+    def _rule(self, label: str, value: str, value_type: str = "text") -> FormFieldRule:
+        return FormFieldRule({"type": "form_field", "label": label, "value": value, "value_type": value_type})
+
+    def test_italic_caption_below_value_returns_value_above(self):
+        # AO398 court caption: ``Anthony Cole Jackson )\n*Plaintiff* )``.
+        md = "Anthony Cole Jackson )\n*Plaintiff* )\n"
+        passed, _, _ = self._rule("Plaintiff", "Anthony Cole Jackson").run(md)
+        assert passed
+
+    def test_italic_caption_with_blank_line_above(self):
+        # E-mail line followed by blank then ``*E-mail address*`` italic.
+        md = "anthony.jackson@example.com\n\n*E-mail address*\n"
+        passed, _, _ = self._rule("E-mail address", "anthony.jackson@example.com").run(md)
+        assert passed
+
+    def test_numbered_label_then_value_below(self):
+        # UCC5 sub-section: ``1a. INITIAL FINANCING STATEMENT FILE NUMBER\nOR-UCC-2025-...``.
+        md = "1a. INITIAL FINANCING STATEMENT FILE NUMBER\nOR-UCC-2025-00532600\n"
+        passed, _, _ = self._rule("1a. Initial Financing Statement File Number", "OR-UCC-2025-00532600").run(md)
+        assert passed
+
+    def test_short_label_in_paragraph_does_not_fire(self):
+        # Safety: a paragraph that *contains* the label as a substring must
+        # NOT be treated as a label line (strict ratio match required).
+        md = "This document is a Statement of Address for the user.\n123 Main Street\n"
+        passed, _, _ = self._rule("Address", "123 Main Street").run(md)
+        assert not passed
+
+    def test_signature_uses_adjacent_line_fallback(self):
+        # AO398: ``True\n*Signature of the attorney or unrepresented party*``.
+        md = "True\n*Signature of the attorney or unrepresented party*\n"
+        passed, _, _ = self._rule("Signature of the attorney or unrepresented party", True, value_type="signature").run(
+            md
+        )
+        assert passed
+
+
+class TestDialectAgnosticExtraction:
+    """Regression tests for cross-provider output dialects.
+
+    Form-field GT was authored against a canonical ``**Label**: value``
+    style. Other providers emit valid but stylistically different markdown
+    (HTML wrapping, ``<u>`` fill-in, ``[FORM FIELD]`` tagged lines, pipe-
+    concatenated single-line layouts, multi-line values below the header).
+    These tests lock in the matcher's tolerance of those dialects so the
+    benchmark measures parser quality rather than format compatibility.
+    """
+
+    def _rule(self, label: str, value: str) -> FormFieldRule:
+        return FormFieldRule({"type": "form_field", "label": label, "value": value, "value_type": "text"})
+
+    def test_html_wrapped_value_in_table_cell_is_stripped(self):
+        # haiku-style output: cell contents wrapped in <strong>/<br/>, no
+        # markdown KV pair. The plain-colon path captures the line; HTML
+        # tags must be stripped from the value before comparison.
+        md = "<table><tr><td><strong>Account Balance:</strong><br/>$4,820.00</td></tr></table>"
+        passed, _, _ = self._rule("Account Balance", "$4,820.00").run(md)
+        assert passed
+
+    def test_underline_template_fill_inline_in_prose(self):
+        # gemini-style TREC contract: filled values wrapped in <u>...</u>
+        # inline in the form's printed prose.
+        md = "**2. PROPERTY:** Lot <u>12</u>, Block <u>C</u>, City of <u>Austin</u>."
+        assert self._rule("Block", "C").run(md)[0]
+        assert self._rule("Lot", "12").run(md)[0]
+        assert self._rule("City of", "Austin").run(md)[0]
+
+    def test_form_field_tag_prefix_stripped_from_label(self):
+        # gpt5_mini emits ``[FORM FIELD] <visible-label>: value``. The
+        # bracketed prefix is parser noise; the visible label after it must
+        # match the rule's label.
+        md = "[FORM FIELD] Property/Development Name: Maple Yard Houses\n"
+        passed, _, _ = self._rule("Property/Development Name", "Maple Yard Houses").run(md)
+        assert passed
+
+    def test_pipe_concatenated_single_line_yields_each_pair(self):
+        # cost_effective collapses a multi-field row into a single line with
+        # ``|`` separators. The matcher must yield one pair per labelled
+        # segment and not bleed the run-on tail into the first value.
+        md = "Date: April 27, 2026 | Borrower's Name: Maya Lynn Hernandez | Other: foo\n"
+        assert self._rule("Date", "April 27, 2026").run(md)[0]
+        assert self._rule("Borrower's Name", "Maya Lynn Hernandez").run(md)[0]
+        assert self._rule("Other", "foo").run(md)[0]
+
+    def test_multiline_address_below_bold_colon_header_is_aggregated(self):
+        # Audit pattern A3: bold-colon header with empty inline value, the
+        # actual value laid out on subsequent bullet lines.
+        md = "**C. SEND ACKNOWLEDGMENT TO**:\n- 123 Main St\n- Suite 4\n- Springfield, IL 62701\n"
+        passed, _, _ = self._rule("C. SEND ACKNOWLEDGMENT TO", "123 Main St, Suite 4, Springfield, IL 62701").run(md)
+        assert passed
+
+    def test_legitimate_pipe_in_value_is_preserved(self):
+        # Safety: a value with an embedded pipe but no following ``Label:``
+        # shape after it should NOT be split. Form data rarely contains
+        # raw pipes, but we shouldn't split on every one.
+        md = "Reference: ABC | XYZ | DEF\n"
+        passed, _, _ = self._rule("Reference", "ABC | XYZ | DEF").run(md)
+        assert passed
+
+    def test_html_wrapped_label_still_resolves(self):
+        # Symmetric to the value case: a label can also pick up surrounding
+        # HTML tag noise from the parser. Stripping must apply both sides.
+        md = "<p><strong>Customer name</strong>: Alex Rivers</p>\n"
+        passed, _, _ = self._rule("Customer name", "Alex Rivers").run(md)
+        assert passed
+
+    def test_email_autolink_value_is_not_html_stripped(self):
+        # Regression: ``<email@host>`` is a markdown autolink, not an HTML
+        # tag. The HTML stripper must leave it intact so the email value
+        # survives extraction. This used to fail when a permissive
+        # ``<[^>]+>`` stripper consumed the entire autolink.
+        md = "* **E-mail**: <wei.lin.p019@example.com>\n"
+        passed, _, _ = self._rule("E-mail", "wei.lin.p019@example.com").run(md)
+        assert passed
+
+    def test_url_autolink_value_is_not_html_stripped(self):
+        md = "* **Website**: <https://example.com/profile>\n"
+        passed, _, _ = self._rule("Website", "https://example.com/profile").run(md)
+        assert passed
+
+
+class TestPageScoping:
+    def _rule(self, label: str, value: str, page: int) -> FormFieldRule:
+        return FormFieldRule(
+            {
+                "type": "form_field",
+                "label": label,
+                "value": value,
+                "value_type": "text",
+                "page": page,
+            }
+        )
+
+    def test_duplicate_label_across_pages_resolved_by_page_field(self):
+        # Same label on both pages with different values. Without page scoping
+        # the first match wins — wrong page may pass. With injected
+        # parse_output + rule.page=2 we must scope to page 2 and pick "Smith".
+        page1_md = "**Last Name:** Collins\n"
+        page2_md = "**Last Name:** Smith\n"
+        full_md = page1_md + page2_md
+
+        rule = self._rule("Last Name", "Smith", page=2)
+        rule.parse_output = _FakeParseOutput([_FakePageIR(0, page1_md), _FakePageIR(1, page2_md)])
+
+        passed, _, _ = rule.run(full_md)
+        assert passed
+
+    def test_falls_back_to_full_content_when_no_parse_output(self):
+        # Without parse_output injection the rule scans full content. Page
+        # field is metadata-only in that case.
+        page1_md = "**Last Name:** Collins\n"
+        rule = self._rule("Last Name", "Collins", page=1)
+        # No parse_output set.
+        passed, _, _ = rule.run(page1_md)
+        assert passed
+
+    def test_fail_closed_when_pages_populated_but_page_missing(self):
+        # Provider produced per-page IR but the requested page (3) isn't in
+        # the list. Old behavior leaked full-doc content; new behavior
+        # returns "" so the rule fails closed.
+        page1_md = "**Buyer:** Acme\n"
+        page2_md = "**Buyer:** Globex\n"
+        full_md = page1_md + page2_md
+        rule = self._rule("Buyer", "Acme", page=3)
+        rule.parse_output = _FakeParseOutput([_FakePageIR(0, page1_md), _FakePageIR(1, page2_md)])
+        passed, _, _ = rule.run(full_md)
+        assert not passed
+
+    def test_layout_pages_items_synthesize_when_md_empty(self):
+        # Providers like datalab/pulse populate ``layout_pages[*].items`` but
+        # leave ``md`` empty. Synthesizing from items should let per-page
+        # scoping work without needing each provider to change.
+        full_md = "**Last Name:** Collins\n**Last Name:** Smith\n"
+        rule = self._rule("Last Name", "Smith", page=2)
+        rule.parse_output = _layout_only_output(
+            [
+                (1, [_LayoutItem(value="**Last Name:** Collins")]),
+                (2, [_LayoutItem(value="**Last Name:** Smith")]),
+            ]
+        )
+        passed, _, _ = rule.run(full_md)
+        assert passed
+
+    def test_fail_closed_when_matched_page_markdown_is_empty(self):
+        # ``pages`` has the requested page but its markdown is empty.
+        # Old behavior leaked full-doc content via ``... or content``;
+        # new behavior returns "" so the rule fails closed rather than
+        # silently scoring against page-1 text.
+        full_md = "**Buyer:** Acme\n**Buyer:** Globex\n"
+        rule = self._rule("Buyer", "Acme", page=2)
+        rule.parse_output = _FakeParseOutput([_FakePageIR(0, "x"), _FakePageIR(1, "")])
+        passed, _, _ = rule.run(full_md)
+        assert not passed
+
+    def test_layout_pages_md_used_directly_when_populated(self):
+        # When ``lp.md`` is non-empty the synthesis path is skipped and
+        # ``md`` is returned verbatim — items must not be re-joined on top.
+        full_md = "ignored full doc"
+        rule = self._rule("Buyer", "Acme", page=2)
+        rule.parse_output = _layout_only_output(
+            [
+                (1, [_LayoutItem(value="Buyer: Globex")], "noise"),
+                (2, [_LayoutItem(value="Buyer: Globex")], "**Buyer:** Acme"),
+            ]
+        )
+        passed, _, _ = rule.run(full_md)
+        assert passed
+
+    def test_layout_pages_items_priority_md_beats_html_beats_value(self):
+        # Items synthesis priority is md > html > value. When ``md`` is
+        # populated, ``html`` and ``value`` are ignored.
+        full_md = "ignored"
+        rule = self._rule("Buyer", "Acme", page=1)
+        rule.parse_output = _layout_only_output(
+            [
+                (
+                    1,
+                    [
+                        _LayoutItem(
+                            md="**Buyer:** Acme",
+                            html="<p>Buyer: Wrong</p>",
+                            value="Buyer: Wrong",
+                        )
+                    ],
+                ),
+            ]
+        )
+        passed, _, _ = rule.run(full_md)
+        assert passed
+
+
+# ---------------------------------------------------------------------------
+# Adjacent-label collision resolution (best-score wins)
+# ---------------------------------------------------------------------------
+
+
+class TestAdjacentLabelCollision:
+    """When two visually similar labels coexist in the markdown, the rule must
+    pick the exact match — not whichever fuzzy hit happened to come first.
+
+    These regressions guard the matcher against the classic
+    ``Country`` / ``County`` adjacent-label collision triaged in the
+    well_log run, plus a few other near-miss label pairs we have seen in
+    the wild (``Operator`` / ``Operator Name``, ``Bill To`` / ``Ship To``,
+    etc.).
+    """
+
+    def _rule(self, label: str, value: str) -> FormFieldRule:
+        return FormFieldRule({"type": "form_field", "label": label, "value": value, "value_type": "text"})
+
+    def test_country_vs_county_county_first(self):
+        # County appears BEFORE Country in the markdown. First-match-wins
+        # would latch onto County's value (Washington) when looking for
+        # Country (U.S.A.). Best-score-wins picks the exact Country match.
+        md = "**County**: Washington\n**Country**: U.S.A.\n"
+        passed, expl, _ = self._rule("Country", "U.S.A.").run(md)
+        assert passed, f"expected pass, got {expl!r}"
+
+    def test_country_vs_county_country_first(self):
+        # Reverse order — should still pick the right field.
+        md = "**Country**: U.S.A.\n**County**: Washington\n"
+        passed, expl, _ = self._rule("Country", "U.S.A.").run(md)
+        assert passed, f"expected pass, got {expl!r}"
+
+    def test_county_value_still_resolvable_when_country_also_present(self):
+        # Symmetric: the rule for County must still find Washington when
+        # Country is also present.
+        md = "**Country**: U.S.A.\n**County**: Washington\n"
+        passed, expl, _ = self._rule("County", "Washington").run(md)
+        assert passed, f"expected pass, got {expl!r}"
+
+    def test_html_table_adjacent_labels(self):
+        # Same collision in an HTML 2-col table layout.
+        md = "<table><tr><td>County</td><td>Washington</td></tr><tr><td>Country</td><td>U.S.A.</td></tr></table>"
+        passed, expl, _ = self._rule("Country", "U.S.A.").run(md)
+        assert passed, f"expected pass, got {expl!r}"
+
+    def test_bill_to_vs_ship_to(self):
+        # Common invoice layout where Bill To and Ship To share three words
+        # and the fuzzy threshold can confuse them.
+        md = "**Ship To**: Warehouse 42, Reno NV\n**Bill To**: 100 Main St, Austin TX\n"
+        passed, expl, _ = self._rule("Bill To", "100 Main St, Austin TX").run(md)
+        assert passed, f"expected pass, got {expl!r}"
+
+    def test_operator_vs_operator_name(self):
+        # Exact label `Operator` should not be hijacked by the longer
+        # `Operator Name` that happens to appear first in the markdown.
+        md = "**Operator Name**: Jane Doe\n**Operator**: ACME Drilling LLC\n"
+        passed, expl, _ = self._rule("Operator", "ACME Drilling LLC").run(md)
+        assert passed, f"expected pass, got {expl!r}"
+
+    def test_exact_match_in_lower_priority_source_beats_fuzzy_higher_priority(self):
+        # A bold-colon hit on a fuzzy near-miss should NOT outrank an exact
+        # HTML-table hit on the right label. Best-score-across-all-sources
+        # is the whole point.
+        md = "**Customer Name**: Wrong Co\n<table><tr><td>Customer</td><td>Right Co</td></tr></table>"
+        passed, expl, score = self._rule("Customer", "Right Co").run(md)
+        assert passed, f"expected pass, got {expl!r}"
+        assert score == 1.0
+
+    def test_two_exact_matches_tie_break_by_source_priority(self):
+        # When two sources both surface an EXACT label match, the higher-
+        # priority source (bold-colon) wins, preserving legacy behavior on
+        # docs where multiple parses agree on the same field.
+        md = "**Customer**: Bold Value\n<table><tr><td>Customer</td><td>Table Value</td></tr></table>"
+        passed, expl, _ = self._rule("Customer", "Bold Value").run(md)
+        assert passed, f"expected pass, got {expl!r}"
+
+    def test_partial_match_loses_to_exact_match(self):
+        # A fuzzy/partial hit on a near-miss label must not outrank an exact
+        # hit elsewhere in the doc. Without the partial-ratio penalty an
+        # equally-strong partial could tie a strict match and the legacy
+        # ordering would slip back in.
+        md = (
+            "**API NO. (if available)**: 4239133299\n"  # partial-ratio match for "API NO."
+            "**API NO.**: 1111111111\n"  # exact match for "API NO."
+        )
+        passed, expl, _ = self._rule("API NO.", "1111111111").run(md)
+        assert passed, f"expected pass, got {expl!r}"
+
+    def test_partial_match_still_used_when_no_exact(self):
+        # Sanity check: when the only candidate is a partial-ratio hit, the
+        # rule still finds it. The penalty only matters for tie-breaking
+        # against strict matches; partials remain valid fallbacks.
+        md = "**API NO. (if available)**: 4239133299\n"
+        passed, expl, _ = self._rule("API NO.", "4239133299").run(md)
+        assert passed, f"expected pass, got {expl!r}"
+
+
+# ---------------------------------------------------------------------------
+# Bold connector splicing — "**Depth Drilled**: 105 **to** 15437"
+# ---------------------------------------------------------------------------
+
+
+class TestBoldConnectorValueSplice:
+    def _rule(self, label: str, value: str) -> FormFieldRule:
+        return FormFieldRule({"type": "form_field", "label": label, "value": value, "value_type": "text"})
+
+    def test_to_connector_in_range(self):
+        md = "**Depth Drilled**: 105 **to** 15437\n"
+        passed, _, _ = self._rule("Depth Drilled", "105 to 15437").run(md)
+        assert passed
+
+    def test_to_with_colon_after_connector(self):
+        # Parser sometimes renders `**to**:`
+        md = "**Range**: 0.0 **to**: 22888.0\n"
+        passed, _, _ = self._rule("Range", "0.0 to 22888.0").run(md)
+        assert passed
+
+    def test_and_connector(self):
+        md = "**Operators**: Acme **and** Beta\n"
+        passed, _, _ = self._rule("Operators", "Acme and Beta").run(md)
+        assert passed
+
+    def test_real_label_after_value_still_terminates(self):
+        # The connector list should NOT include arbitrary bold spans.
+        # ``**Phone**`` after the value is a real label boundary.
+        md = "**Name**: Maya **Phone**: 555-0138\n"
+        # Name's value must remain "Maya", not "Maya Phone 555-0138".
+        passed, _, _ = self._rule("Name", "Maya").run(md)
+        assert passed
+        passed2, _, _ = self._rule("Phone", "555-0138").run(md)
+        assert passed2
+
+
+# ---------------------------------------------------------------------------
+# Dot-strip in label match: K.B. ≡ KB, Tel. ≡ Tel, API NO: ≡ API NO
+# ---------------------------------------------------------------------------
+
+
+class TestDotStripLabelMatch:
+    def _rule(self, label: str, value: str) -> FormFieldRule:
+        return FormFieldRule({"type": "form_field", "label": label, "value": value, "value_type": "text"})
+
+    def test_gt_dotted_pred_undotted(self):
+        md = "**KB**: 60.0 FT\n"
+        passed, _, _ = self._rule("K.B.", "60.0 FT").run(md)
+        assert passed
+
+    def test_gt_undotted_pred_dotted(self):
+        md = "**D.F.**: 59.0 FT\n"
+        passed, _, _ = self._rule("DF", "59.0 FT").run(md)
+        assert passed
+
+    def test_trailing_colon_in_gt(self):
+        md = "**API NO**: 4239133299\n"
+        passed, _, _ = self._rule("API NO:", "4239133299").run(md)
+        assert passed
+
+    def test_unrelated_labels_still_distinguished(self):
+        # Dot-strip must not collapse semantically distinct labels onto
+        # each other. "K.B." and "KBC" share 2 letters of overlap; we
+        # don't want them treated as equivalent.
+        md = "**KBC**: 99\n"
+        passed, _, _ = self._rule("K.B.", "60.0 FT").run(md)
+        assert not passed
+
+    def test_dot_strip_in_score_path_beats_fuzzy_near_miss(self):
+        # Regression for the #976 ⨯ #978 interaction. With dot-strip moved
+        # into ``_label_match_score`` (rather than a parallel boolean path
+        # outside the scorer), the score path must rank an exact dot-strip
+        # equivalent ABOVE a fuzzy near-miss when both appear in the doc.
+        #
+        # GT label: ``K.B.``. Both candidates fire on the score axis:
+        #   - ``KBC`` scores 0.80 via strict fuzz.ratio (the dot-strip
+        #     leak we fixed: ``fuzz.ratio("kbc", "kb") == 80.0``).
+        #   - ``KB``  scores 1.0  via the dot-strip exact-equality path.
+        # Best-score-wins means KB's value ("60.0 FT") must win, not KBC's.
+        # If dot-strip lived outside the score path again, the first label
+        # match in the document would dictate the value — exactly the bug
+        # #978 was added to prevent.
+        md = "**KBC**: 99\n**KB**: 60.0 FT\n"
+        passed, expl, _ = self._rule("K.B.", "60.0 FT").run(md)
+        assert passed, f"expected pass, got {expl!r}"
+
+
+# ---------------------------------------------------------------------------
+# Strikethrough span stripping in predicted values
+# ---------------------------------------------------------------------------
+
+
+class TestStrikethroughStrip:
+    def _rule(self, label: str, value: str) -> FormFieldRule:
+        return FormFieldRule({"type": "form_field", "label": label, "value": value, "value_type": "text"})
+
+    def test_strikethrough_value_collapses_to_kept(self):
+        md = "**Operator**: ~~Old Corp~~ New Corp\n"
+        passed, _, _ = self._rule("Operator", "New Corp").run(md)
+        assert passed
+
+    def test_no_strikethrough_unaffected(self):
+        md = "**Operator**: New Corp\n"
+        passed, _, _ = self._rule("Operator", "New Corp").run(md)
+        assert passed
+
+    def test_only_strikethrough_present_then_empty(self):
+        # If everything was crossed out and the GT records empty, it should
+        # still pass (value cleared).
+        md = "**Operator**: ~~Old Corp~~\n"
+        passed, _, _ = self._rule("Operator", "").run(md)
+        assert passed


### PR DESCRIPTION
## Summary

Adds a new `form_field` parse rule type and registers a forms benchmark dimension in the evaluation harness. The rule scores how well a document parser extracts structured form data — labeled key/value fields, checkbox states, and signatures — from PDF forms. ParseBench already covers charts, layout, tables, text content, and text formatting; forms are a distinct capability for document AI workflows (claims forms, intake forms, regulatory filings) and have been a gap.

## What this enables

Test cases can now declare rules of the form:

```jsonl
{"type": "form_field", "label": "API NO.", "value": "42-157-33282", "value_type": "text", "page": 1}
{"type": "form_field", "label": "Married", "value": true, "value_type": "checkbox", "page": 1}
{"type": "form_field", "label": "Applicant Signature", "value": "Maya Collins", "value_type": "signature", "page": 1}
```

`value` accepts `str`, `bool`, or `list[str]`. The list form declares acceptable alternatives for genuinely ambiguous fields (illegible handwriting, preprinted units like ``"10 LBS/GAL"`` vs ``"10"``). For `value_type=signature`, the value is treated as a presence indicator — any non-empty extracted value under the label counts as signed.

## How the matcher works

The rule walks the parsed markdown/HTML through several candidate-source iterators, scores each candidate's label against the rule's label, and picks the best match overall:

- Bold-colon (``**Label:** value``) — supports multi-pair lines
- Plain-colon (``Label: value`` on its own line)
- Markdown 2-column tables; HTML 2-column tables (with cell-internal ``<br/>`` label-above-value handling)
- Multi-column header × data row pairs
- Underline-fill inline (``Label <u>value</u>``)
- HTML cell-neighbor fallback for wide form tables (>2 cols, interleaved labels/values)
- Markdown task-list checkboxes, inline checkbox glyphs (☑/☐/⊠/etc), label-first bullets

The label match uses a score function over strict fuzz ratio, partial fuzz ratio (with a penalty so partial hits cannot beat equally strong strict hits), and a punctuation-stripped exact path (so ``K.B.`` ≡ ``KB`` and ``API NO:`` ≡ ``API NO`` without lowering the fuzz thresholds). When two labels collide on a fuzzy threshold (the classic ``Country`` vs ``County`` case), the exact match wins regardless of which appears first.

When the same label text legitimately appears at multiple page positions with the same top score, the rule's expected value disambiguates among tied candidates — without weakening the cross-label boundary so adjacent labels at different scores cannot leak.

The matcher also normalizes a handful of real-world parser dialect differences symmetrically:

- HTML tag stripping from labels and values
- Inline ``|``-separated pair splitting (``A: x | B: y`` yields two pairs)
- Bold connector splicing (``**Depth**: 105 **to** 15437`` keeps the range intact)
- Strikethrough span removal (``~~old~~ new`` → ``new``)

## Per-page scoping

When a rule carries a ``page`` field and the inference result includes per-page IR, the matcher scopes content to that page. Scoping is fail-closed: once any per-page IR is populated, page-N rules are scored strictly against page N or fail. ``layout_pages[*]`` markdown is synthesized from item-level fields (priority ``md > html > value``) when the per-page ``md`` is empty, so providers that emit items but not the joined per-page markdown work without provider-side changes.

## Changes

| File | What |
|---|---|
| `src/parse_bench/evaluation/metrics/parse/rules_form.py` (new) | `FormFieldRule` and its matcher/helper functions (~1.5k lines) |
| `tests/parse_bench/evaluation/metrics/parse/test_form_field_rule.py` (new) | 147 unit tests covering every matcher path and edge case (~1.5k lines) |
| `src/parse_bench/test_cases/parse_rule_schemas.py` | `ParseFormFieldRule` pydantic schema and registry entry |
| `src/parse_bench/evaluation/metrics/parse/test_types.py` | `TestType.FORM_FIELD` enum value |
| `src/parse_bench/evaluation/metrics/parse/rules_base.py` | Dispatch `form_field` rules to `FormFieldRule` in `create_test_rule` |
| `src/parse_bench/evaluation/metrics/parse/test_rules.py` | Re-export `FormFieldRule` for backward compatibility |
| `src/parse_bench/analysis/metric_definitions.py` | Register `form_field` metric for dashboard / leaderboard rendering |
| `src/parse_bench/analysis/aggregation_report.py` | Map the `form` category default to `rule_form_field_pass_rate` |

The metric naming follows the existing convention — `rule_{rule_type}_pass_rate` is auto-emitted by the parse evaluator, so `form_field` rules surface as `rule_form_field_pass_rate` without any change to the evaluator runner.

## Test plan

- [x] All 147 new unit tests pass
- [x] Full project test suite passes (150 tests)
- [x] `ruff format --check` and `ruff check` clean on every file touched
- [x] Integration smoke test: schema validation round-trips for all (value, value_type) combinations; `create_test_rule` dispatches `form_field` rules to `FormFieldRule`; list-value checkbox rejection emits the expected error
- [x] End-to-end run against a 13-PDF forms fixture (664 rules) reproduces a stable per-rule pass/fail snapshot

## Notes for reviewers

- The ``"form"`` entry in `_DEFAULT_METRICS` is forward-looking. The public dataset does not yet ship a `form.jsonl` category, so the leaderboard column will be blank until that category lands — nothing breaks today.
- Existing pipelines and datasets are unaffected: the rule is opt-in per test case, the schema is additive, and there are no changes to existing rule types.
- Pre-existing formatting drift in two unrelated files (`data/cli.py`, `data/download.py`) is intentionally not fixed in this PR to keep the diff focused.