### PR TITLE
Skip dataset auto-download when --input_dir is explicit

### DIFF
--- a/src/parse_bench/pipeline/cli.py
+++ b/src/parse_bench/pipeline/cli.py
@@ -106,6 +106,11 @@ class PipelineCLI:
             # Default input_dir based on --test (./data/test vs ./data) so
             # the test subset doesn't silently get masked by an existing full
             # dataset at ./data, and so the two coexist without overlay.
+            # When the user passes --input_dir explicitly we treat that as a
+            # custom dataset and skip the public-dataset readiness check /
+            # auto-download — otherwise running on a custom dataset would
+            # silently scribble HuggingFace files into the user's directory.
+            input_dir_explicit = input_dir is not None
             if input_dir is None:
                 input_dir = default_data_dir(test=test)
 
@@ -113,8 +118,8 @@ class PipelineCLI:
             output_base = Path(output_dir) if output_dir else Path("./output")
             pipeline_output_dir = output_base / pipeline
 
-            # Auto-download dataset if input_dir doesn't exist or is incomplete
-            if not is_dataset_ready(input_path):
+            # Auto-download dataset only when using the default location.
+            if not input_dir_explicit and not is_dataset_ready(input_path):
                 label = "test dataset" if test else "dataset"
                 print(f"{label.capitalize()} not found at {input_path}, downloading from HuggingFace...")
                 try:


### PR DESCRIPTION
## Summary

`parse-bench run` currently calls `is_dataset_ready()` against whatever `--input_dir` resolves to, and if the public dataset's required JSONLs are missing, downloads the HuggingFace snapshot into that directory. That behavior is correct for the default `./data` location, but it silently scribbles `chart.jsonl` / `layout.jsonl` / `table.jsonl` / `text_content.jsonl` / `text_formatting.jsonl` plus their `docs/{chart,layout,table,text}/` subdirs into any user-supplied directory.

This PR treats an explicitly-passed `--input_dir` as a custom dataset and skips the readiness check / download path entirely. When `--input_dir` is omitted (and the default location is used) the current auto-download behavior is preserved.

## Why

Running the benchmark on a custom dataset is a normal use case (an internal benchmark, a curated subset, a per-document smoke test, etc.). Mixing the public dataset's PDFs and JSONLs into that directory has two bad consequences:

1. Subsequent runs evaluate **both** datasets together. The reported aggregate then conflates two different distributions, which is rarely what the caller wanted.
2. The user's directory mutates without warning, which is a surprise for read-only mounts and reproducibility-sensitive workflows.

The two-step nested-subcommand path (`parse-bench inference run` + `parse-bench evaluation run`) already worked correctly because it never invoked `is_dataset_ready`. This change brings the top-level convenience command in line with that contract.

## How

In `PipelineCLI.run`, capture whether `--input_dir` was explicitly passed before the `None`-to-default substitution, and gate the auto-download branch on the negation:

```python
input_dir_explicit = input_dir is not None
if input_dir is None:
    input_dir = default_data_dir(test=test)
...
if not input_dir_explicit and not is_dataset_ready(input_path):
    download_dataset(...)
```

The default path (`parse-bench run llamaparse_agentic`) keeps auto-downloading from HuggingFace exactly as before. Only an explicit `--input_dir` short-circuits the check.

## Changes

- `src/parse_bench/pipeline/cli.py` — gate `download_dataset(...)` on `not input_dir_explicit`; comment clarifying the contract.

## Test plan

- [x] `ruff format --check` and `ruff check` clean on the changed file
- [x] Full project test suite passes (162 tests)
- [x] Manual: `parse-bench run llamaparse_agentic --input_dir <custom-dataset> --output_dir <out> --skip_inference` exits without writing any public-dataset files into `<custom-dataset>`
- [x] Manual: the default `parse-bench run llamaparse_agentic` invocation still downloads to `./data` on a fresh clone

## Notes for reviewers

- Pure no-op for any existing workflow that relies on the default `./data` path; only the explicit-input-dir branch is changed.
- Single-file mode (`--file`) returns earlier in the function and is unaffected.
- No schema, no JSONL format, and no evaluator behavior change.