### PR TITLE
Lazy-load anthropic and llama_cloud to avoid import-time dependency

### DIFF
--- a/src/parse_bench/evaluation/layout_adapters/adapters.py
+++ b/src/parse_bench/evaluation/layout_adapters/adapters.py
@@ -21,11 +21,6 @@ from parse_bench.inference.layout_extraction import (
     extract_all_layouts_from_llamaparse_output,
 )
 from parse_bench.inference.providers.layoutdet.adapters import ChunkrLayoutDetLabelAdapter
-from parse_bench.inference.providers.parse.llamaparse_v2_normalization import (
-    build_pages_from_cli2_raw_payload,
-    build_pages_from_sdk_response_payload,
-    layout_pages_to_legacy_pages_payload,
-)
 from parse_bench.layout_label_mapping import (
     UnknownRawLayoutLabelError,
 )
@@ -2315,6 +2310,12 @@ def _infer_page_number_from_example_id(example_id: str) -> int | None:
 
 
 def _resolve_llamaparse_pages(inference_result: InferenceResult) -> list[dict[str, Any]]:
+    from parse_bench.inference.providers.parse.llamaparse_v2_normalization import (
+        build_pages_from_cli2_raw_payload,
+        build_pages_from_sdk_response_payload,
+        layout_pages_to_legacy_pages_payload,
+    )
+
     raw_output = inference_result.raw_output
     if isinstance(raw_output, dict):
         raw_pages = raw_output.get("pages")

--- a/src/parse_bench/evaluation/metrics/field_grounding/parse_adapter.py
+++ b/src/parse_bench/evaluation/metrics/field_grounding/parse_adapter.py
@@ -6,7 +6,6 @@ import re
 from dataclasses import dataclass
 from typing import Any
 
-from parse_bench.evaluation.layout_adapters import create_layout_adapter_for_result
 from parse_bench.evaluation.metrics.field_grounding.core import (
     FIELD_GROUNDING_CANONICAL_EXACT_SCORE_THRESHOLD,
     FIELD_GROUNDING_RELAXED_IOU_THRESHOLD,
@@ -315,6 +314,8 @@ def _build_support_sets(inference_result: InferenceResult) -> list[list[_Support
 
 def _adapter_units(inference_result: InferenceResult) -> tuple[list[_SupportUnit], list[_SupportUnit]]:
     try:
+        from parse_bench.evaluation.layout_adapters import create_layout_adapter_for_result
+
         adapter = create_layout_adapter_for_result(inference_result)
         to_granular_pages = getattr(adapter, "to_granular_pages", None)
         if not callable(to_granular_pages):

--- a/src/parse_bench/evaluation/metrics/parse/llm_normalization/__init__.py
+++ b/src/parse_bench/evaluation/metrics/parse/llm_normalization/__init__.py
@@ -19,13 +19,9 @@ from parse_bench.evaluation.metrics.parse.llm_normalization.config import (
     NormalizationMode,
     get_normalization_mode,
 )
-from parse_bench.evaluation.metrics.parse.llm_normalization.strategy_judge import (
-    JudgeNormalizer,
-)
 
 __all__ = [
     "BaseNormalizer",
-    "JudgeNormalizer",
     "JudgmentResult",
     "LabelMatch",
     "NormalizationMode",
@@ -48,6 +44,7 @@ def get_normalizer(
         mode = get_normalization_mode()
 
     if mode == NormalizationMode.JUDGE:
+        from parse_bench.evaluation.metrics.parse.llm_normalization.strategy_judge import JudgeNormalizer
         return JudgeNormalizer()
 
     return None


### PR DESCRIPTION
Move the JudgeNormalizer import inside get_normalizer(), the llamaparse_v2_normalization import inside _resolve_llamaparse_pages(), and the create_layout_adapter_for_result import inside _adapter_units() so that importing evaluation metrics no longer eagerly pulls in the anthropic or llama_cloud packages.