### PR TITLE
Add Gemini 3.5 Flash parse-with-layout pipelines

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -86,6 +86,10 @@ These pipelines use hosted APIs. You only need an API key in your `.env` file.
 | `google_gemini_3_1_flash_lite_thinking_high_parse` | Gemini 3.1 Flash Lite, high thinking | `GOOGLE_GEMINI_API_KEY` |
 | `google_gemini_3_1_pro_parse` | Gemini 3.1 Pro, default thinking | `GOOGLE_GEMINI_API_KEY` |
 | **`google_gemini_3_1_pro_parse_with_layout_file`** | Gemini 3.1 Pro, parse + layout, file mode (In paper: *Google Gemini 3.1 Pro*) | `GOOGLE_GEMINI_API_KEY` |
+| `google_gemini_3_5_flash_parse_with_layout` | Gemini 3.5 Flash, default thinking + layout | `GOOGLE_GEMINI_API_KEY` |
+| `google_gemini_3_5_flash_no_thinking_parse_with_layout` | Gemini 3.5 Flash, minimal thinking + layout | `GOOGLE_GEMINI_API_KEY` |
+| **`google_gemini_3_5_flash_parse_with_layout_file`** | Gemini 3.5 Flash, default thinking + layout, file mode (In paper: *Google Gemini 3.5 Flash (Thinking Medium)*) | `GOOGLE_GEMINI_API_KEY` |
+| **`google_gemini_3_5_flash_no_thinking_parse_with_layout_file`** | Gemini 3.5 Flash, minimal thinking + layout, file mode (In paper: *Google Gemini 3.5 Flash (Thinking Minimal)*) | `GOOGLE_GEMINI_API_KEY` |
 
 ### Azure Document Intelligence
 

--- a/leaderboard.csv
+++ b/leaderboard.csv
@@ -7,6 +7,8 @@ Anthropic Haiku 4.5 (Disable Thinking),VLM - Proprietary,45.17,77.21,13.77,78.74
 Anthropic Haiku 4.5 (Thinking),VLM - Proprietary,53.12,78.70,27.39,84.83,62.36,12.30,3.69,3.49,4.26,3.16,3.83,
 Google Gemini 3 Flash (Thinking Minimal),VLM - Proprietary,71.04,89.85,64.83,86.19,58.35,55.97,0.65,0.49,0.84,0.56,0.69,
 Google Gemini 3 Flash (Thinking High),VLM - Proprietary,75.05,91.50,64.79,90.87,68.31,59.77,2.41,2.38,2.29,2.25,2.70,
+Google Gemini 3.5 Flash (Thinking Medium),VLM - Proprietary,69.92,91.12,44.01,90.19,59.14,65.14,,,,,,
+Google Gemini 3.5 Flash (Thinking Minimal),VLM - Proprietary,63.09,86.24,18.74,88.22,68.09,54.18,,,,,,
 Anthropic Opus 4.6,VLM - Proprietary,54.07,86.52,13.49,89.70,64.19,16.47,5.78,4.02,8.16,5.19,6.40,
 Anthropic Opus 4.7,VLM - Proprietary,63.34,87.17,55.84,90.26,69.42,13.99,7.14,5.69,8.63,6.07,8.17,
 Google Gemini 3.1 Pro,VLM - Proprietary,69.14,91.00,41.13,90.16,52.43,70.99,8.49,6.69,9.69,7.73,10.54,

--- a/src/parse_bench/inference/pipelines/parse.py
+++ b/src/parse_bench/inference/pipelines/parse.py
@@ -1347,6 +1347,70 @@ def register_parse_pipelines(register_fn) -> None:  # type: ignore[no-untyped-de
     )
 
     # =========================================================================
+    # Gemini 3.5 Flash (GA) - Parse with Layout
+    # =========================================================================
+
+    # Gemini 3.5 Flash - Parse with Layout (default thinking)
+    register_fn(
+        PipelineSpec(
+            pipeline_name="google_gemini_3_5_flash_parse_with_layout",
+            provider_name="google",
+            product_type=ProductType.PARSE,
+            config={
+                "model": "gemini-3.5-flash",
+                "dpi": 150,
+                "max_tokens": 32768,
+                "mode": "parse_with_layout",
+            },
+        )
+    )
+
+    # Gemini 3.5 Flash - Parse with Layout - Thinking Minimal
+    register_fn(
+        PipelineSpec(
+            pipeline_name="google_gemini_3_5_flash_no_thinking_parse_with_layout",
+            provider_name="google",
+            product_type=ProductType.PARSE,
+            config={
+                "model": "gemini-3.5-flash",
+                "dpi": 150,
+                "max_tokens": 32768,
+                "mode": "parse_with_layout",
+                "thinking_level": "minimal",
+            },
+        )
+    )
+
+    # Gemini 3.5 Flash - Parse with Layout File (default thinking)
+    register_fn(
+        PipelineSpec(
+            pipeline_name="google_gemini_3_5_flash_parse_with_layout_file",
+            provider_name="google",
+            product_type=ProductType.PARSE,
+            config={
+                "model": "gemini-3.5-flash",
+                "max_tokens": 32768,
+                "mode": "parse_with_layout_file",
+            },
+        )
+    )
+
+    # Gemini 3.5 Flash - Parse with Layout File - Thinking Minimal
+    register_fn(
+        PipelineSpec(
+            pipeline_name="google_gemini_3_5_flash_no_thinking_parse_with_layout_file",
+            provider_name="google",
+            product_type=ProductType.PARSE,
+            config={
+                "model": "gemini-3.5-flash",
+                "max_tokens": 32768,
+                "mode": "parse_with_layout_file",
+                "thinking_level": "minimal",
+            },
+        )
+    )
+
+    # =========================================================================
     # Gemini - Agentic Vision
     # =========================================================================
 


### PR DESCRIPTION
**What:** Adds Gemini 3.5 Flash (GA) parse pipelines.

**Why:** Gemini 3.5 Flash is the current GA Flash model; we want it benchmarked alongside the existing Gemini parse pipelines.

**How:** Registers four pipelines on the existing `google` provider with model `gemini-3.5-flash` — image and PDF file modes, each in default and minimal thinking (via `thinking_level`).

**Changes:**
- `src/parse_bench/inference/pipelines/parse.py`: four `google_gemini_3_5_flash_*` pipelines
- `docs/pipelines.md`: Google Gemini section entries
- `leaderboard.csv`: two rows for the file-mode variants

**Testing:** Pipeline registry loads the four new pipelines; `ruff check` passes.

**Notes:** Requires `GOOGLE_GEMINI_API_KEY`. Leaderboard rows cover the two `_with_layout_file` variants (Thinking Medium / Thinking Minimal).
