### PR TITLE
Add Anthropic Opus 4.8 parse-with-layout pipeline

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -64,6 +64,7 @@ These pipelines use hosted APIs. You only need an API key in your `.env` file.
 | `anthropic_opus_4_6_parse` | Claude Opus 4.6, image mode | `ANTHROPIC_API_KEY` |
 | `anthropic_opus_4_6_parse_file` | Claude Opus 4.6, PDF file mode | `ANTHROPIC_API_KEY` |
 | **`anthropic_opus_4_6_parse_with_layout_file`** | Claude Opus 4.6, parse + layout, file mode (In paper: *Anthropic Opus 4.6*) | `ANTHROPIC_API_KEY` |
+| **`anthropic_opus_4_8_parse_with_layout_file`** | Claude Opus 4.8, parse + layout, file mode (In paper: *Anthropic Opus 4.8*) | `ANTHROPIC_API_KEY` |
 
 ### Google Gemini
 

--- a/leaderboard.csv
+++ b/leaderboard.csv
@@ -9,6 +9,7 @@ Google Gemini 3 Flash (Thinking Minimal),VLM - Proprietary,71.04,89.85,64.83,86.
 Google Gemini 3 Flash (Thinking High),VLM - Proprietary,75.05,91.50,64.79,90.87,68.31,59.77,2.41,2.38,2.29,2.25,2.70,
 Anthropic Opus 4.6,VLM - Proprietary,54.07,86.52,13.49,89.70,64.19,16.47,5.78,4.02,8.16,5.19,6.40,
 Anthropic Opus 4.7,VLM - Proprietary,63.34,87.17,55.84,90.26,69.42,13.99,7.14,5.69,8.63,6.07,8.17,
+Anthropic Opus 4.8,VLM - Proprietary,63.70,89.65,49.75,89.02,71.38,18.69,7.30,5.82,8.78,6.24,8.36,
 Google Gemini 3.1 Pro,VLM - Proprietary,69.14,91.00,41.13,90.16,52.43,70.99,8.49,6.69,9.69,7.73,10.54,
 Google Gemini 3.1 Flash Lite,VLM - Proprietary,58.32,85.48,9.92,89.46,58.38,48.38,0.29,0.19,0.37,0.27,0.31,
 OpenAI GPT-5.4 (Reasoning None),VLM - Proprietary,62.23,83.89,65.22,85.57,59.52,16.95,2.90,2.55,4.04,2.13,3.00,

--- a/src/parse_bench/inference/pipelines/parse.py
+++ b/src/parse_bench/inference/pipelines/parse.py
@@ -1639,6 +1639,20 @@ def register_parse_pipelines(register_fn) -> None:  # type: ignore[no-untyped-de
         )
     )
 
+    # Anthropic Opus 4.8 - Parse with Layout File
+    register_fn(
+        PipelineSpec(
+            pipeline_name="anthropic_opus_4_8_parse_with_layout_file",
+            provider_name="anthropic",
+            product_type=ProductType.PARSE,
+            config={
+                "model": "claude-opus-4-8",
+                "max_tokens": 32768,
+                "mode": "parse_with_layout_file",
+            },
+        )
+    )
+
     # Anthropic Haiku - Parse with Layout File - Thinking
     register_fn(
         PipelineSpec(

--- a/src/parse_bench/inference/providers/parse/anthropic.py
+++ b/src/parse_bench/inference/providers/parse/anthropic.py
@@ -77,6 +77,7 @@ _ANTHROPIC_PRICING_PER_M: dict[str, tuple[float, float]] = {
     "claude-haiku-3": (0.25, 1.25),
     "claude-sonnet-4": (3.00, 15.00),
     "claude-sonnet-3": (3.00, 15.00),
+    "claude-opus-4-8": (5.00, 25.00),
     "claude-opus-4-7": (5.00, 25.00),
     "claude-opus-4-6": (5.00, 25.00),
     "claude-opus-4-5": (5.00, 25.00),
@@ -122,7 +123,7 @@ class AnthropicProvider(Provider):
         self._thinking = self.base_config.get("thinking")  # e.g. {"type": "enabled", "budget_tokens": 32768}
         self._effort = self.base_config.get("effort")  # e.g. "high", "xhigh" — for Opus 4.7+
         # Opus 4.7+ rejects temperature/top_p/top_k at non-default values (400 error)
-        self._supports_temperature = not self._model.startswith("claude-opus-4-7")
+        self._supports_temperature = not self._model.startswith(("claude-opus-4-7", "claude-opus-4-8"))
 
         if self._mode not in ("image", "file", "parse_with_layout", "parse_with_layout_file"):
             raise ProviderConfigError(


### PR DESCRIPTION
**What:** Adds the Claude Opus 4.8 parse-with-layout (file mode) pipeline, with correct pricing and request handling.

**Why:** Benchmark the latest Opus model, and make sure a fresh run both computes the right cost and doesn't 400 on the API call.

**How:**
- Registers `anthropic_opus_4_8_parse_with_layout_file` on the `anthropic` provider (`model=claude-opus-4-8`).
- Adds `claude-opus-4-8` pricing (5.00/25.00 USD per 1M) so generated reports compute cost from the correct rate instead of silently matching the shorter `claude-opus-4` prefix (15/75).
- Excludes Opus 4.8 from the `temperature` kwarg (like 4.7) — Opus 4.7+ reject non-default temperature with a 400.

**Changes:**
- `src/parse_bench/inference/pipelines/parse.py`: new pipeline
- `src/parse_bench/inference/providers/parse/anthropic.py`: pricing entry + temperature guard
- `docs/pipelines.md`, `leaderboard.csv`

**Testing:** Registry loads the pipeline; pricing resolver returns 5/25 for `claude-opus-4-8`; `ruff check` passes.

**Notes:** Requires `ANTHROPIC_API_KEY`.
