### PR TITLE
Add PaddleOCR-VL-1.6 parse pipelines

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -210,6 +210,9 @@ These pipelines require you to deploy the model on your own infrastructure (e.g.
 |---|---|---|
 | `paddleocr_vl_vllm` | OpenAI-compatible vLLM API | `PADDLEOCR_SERVER_URL` |
 | `paddleocr_vl_pipeline` | Full pipeline (layout + chart routing) | `PADDLEOCR_SERVER_URL` |
+| `paddleocr_vl_1_6_vllm` | PaddleOCR-VL-1.6, OCR prompt | `PADDLEOCR_SERVER_URL` |
+| `paddleocr_vl_1_6_vllm_table` | PaddleOCR-VL-1.6, table recognition prompt | `PADDLEOCR_SERVER_URL` |
+| `paddleocr_vl_1_6_pipeline` | PaddleOCR-VL-1.6, full pipeline (layout + routing) | `PADDLEOCR_SERVER_URL` |
 
 ### dots.ocr
 

--- a/leaderboard.csv
+++ b/leaderboard.csv
@@ -34,6 +34,7 @@ Dots.mocr,VLM - Open Weight,55.79,85.15,0.95,90.03,46.99,55.81,,,,,,rednote-hila
 Falcon-OCR,VLM - Open Weight,53.08,74.70,0.82,78.59,47.91,63.37,,,,,,tiiuae/Falcon-OCR
 Docling-models,VLM - Open Weight,50.65,66.41,52.76,66.93,1.03,66.11,,,,,,docling-project/docling-models
 Chandra-ocr-2,VLM - Open Weight,70.1,89.2,65.1,83.7,61.4,51.2,,,,,,datalab-to/chandra-ocr-2
+PaddleOCR-VL-1.6,VLM - Open Weight,67.43,67.77,54.24,82.71,54.64,77.8,,,,,,PaddlePaddle/PaddleOCR-VL-1.6
 PaddleOCR-VL-1.5,VLM - Open Weight,65.95,67.38,47.62,82.72,54.27,77.78,,,,,,PaddlePaddle/PaddleOCR-VL-1.5
 Gemma-4-31B-it,VLM - Open Weight,62.4,80.6,15,89.9,69.3,57.4,,,,,,google/gemma-4-31B-it
 Gemma-4-26B-A4B-it,VLM - Open Weight,58.5,70,14.2,83.8,65.1,59.2,,,,,,google/gemma-4-26B-A4B-it

--- a/src/parse_bench/inference/pipelines/parse.py
+++ b/src/parse_bench/inference/pipelines/parse.py
@@ -563,6 +563,46 @@ def register_parse_pipelines(register_fn) -> None:  # type: ignore[no-untyped-de
         )
     )
 
+    # PaddleOCR-VL 1.6 (0.9B) vLLM — OCR prompt (general text/structure)
+    register_fn(
+        PipelineSpec(
+            pipeline_name="paddleocr_vl_1_6_vllm",
+            provider_name="paddleocr",
+            product_type=ProductType.PARSE,
+            config={
+                "api_format": "openai",
+                "task": "ocr",
+                "served_model_name": "PaddleOCR-VL-1.6-0.9B",
+            },
+        )
+    )
+
+    # PaddleOCR-VL 1.6 (0.9B) vLLM — Table Recognition prompt
+    register_fn(
+        PipelineSpec(
+            pipeline_name="paddleocr_vl_1_6_vllm_table",
+            provider_name="paddleocr",
+            product_type=ProductType.PARSE,
+            config={
+                "api_format": "openai",
+                "task": "table",
+                "served_model_name": "PaddleOCR-VL-1.6-0.9B",
+            },
+        )
+    )
+
+    # PaddleOCR-VL 1.6 (0.9B) full pipeline (layout detection + per-region routing)
+    register_fn(
+        PipelineSpec(
+            pipeline_name="paddleocr_vl_1_6_pipeline",
+            provider_name="paddleocr",
+            product_type=ProductType.PARSE,
+            config={
+                "api_format": "simple",
+            },
+        )
+    )
+
     # =========================================================================
     # Falcon-OCR (TII, 300M early-fusion VLM with built-in layout-aware OCR)
     # =========================================================================

--- a/src/parse_bench/inference/providers/parse/paddleocr.py
+++ b/src/parse_bench/inference/providers/parse/paddleocr.py
@@ -86,6 +86,10 @@ class PaddleOCRProvider(Provider):
         self._timeout = self.base_config.get("timeout", 600)
         self._dpi = self.base_config.get("dpi", 150)
 
+        # Model name sent to the vLLM server. Defaults to the 1.5 model; override
+        # via the ``served_model_name`` key for other releases (e.g. PaddleOCR-VL-1.6-0.9B).
+        self._served_model_name = self.base_config.get("served_model_name", SERVED_MODEL_NAME)
+
     def _pdf_to_image(self, pdf_path: Path) -> bytes:
         """
         Convert a PDF to a PNG image (first page only).
@@ -141,7 +145,7 @@ class PaddleOCRProvider(Provider):
         api_url = f"{self._server_url.rstrip('/')}/v1/chat/completions"  # type: ignore[union-attr]
 
         payload = {
-            "model": SERVED_MODEL_NAME,
+            "model": self._served_model_name,
             "messages": [
                 {
                     "role": "user",


### PR DESCRIPTION
**What:** Adds PaddleOCR-VL-1.6 parse pipelines.

**Why:** Benchmark the 1.6 release alongside the existing 1.5 pipelines.

**How:** Adds OCR, table, and full-pipeline variants, and extends the PaddleOCR provider to accept a configurable `served_model_name` (defaulting to the 1.5 model) so the 1.6 model name reaches the vLLM server. The endpoint is read from `PADDLEOCR_SERVER_URL`.

**Changes:**
- `src/parse_bench/inference/providers/parse/paddleocr.py`: configurable `served_model_name`
- `src/parse_bench/inference/pipelines/parse.py`: three `paddleocr_vl_1_6_*` pipelines
- `docs/pipelines.md`: PaddleOCR-VL section entries
- `leaderboard.csv`: one row (PaddleOCR-VL-1.6)

**Testing:** Registry loads the three pipelines; provider instantiation confirms the `served_model_name` override and the unchanged 1.5 default; `ruff check` passes.

**Notes:** Requires `PADDLEOCR_SERVER_URL` pointing at a PaddleOCR-VL-1.6 deployment. Only the full-pipeline variant has a leaderboard row.
