### PR TITLE
Replace Extend beta pipeline with Extend Parse 2.0

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -143,7 +143,7 @@ These pipelines use hosted APIs. You only need an API key in your `.env` file.
 | Pipeline | Description | Env Var |
 |---|---|---|
 | **`extend_parse`** | Default (In paper: *Extend*) | `EXTEND_API_KEY` |
-| `extend_parse_beta` | Beta engine (v2.0.0-beta) | `EXTEND_API_KEY` |
+| `extend_parse_2` | 2.0 engine (v2.0.0, GA) | `EXTEND_API_KEY` |
 | `extend_parse_document` | Document scope | `EXTEND_API_KEY` |
 | `extend_parse_section` | Section scope | `EXTEND_API_KEY` |
 

--- a/leaderboard.csv
+++ b/leaderboard.csv
@@ -21,7 +21,7 @@ Azure Document Intelligence (Layout),Commercial - IDP,59.64,86.00,1.56,84.93,51.
 Reducto (Agentic),Commercial - Startup APIs,72.97,80.42,73.4,86.37,57.6,67.07,4.76,6,3.4,4.2,5,
 Reducto,Commercial - Startup APIs,67.83,70.33,56.99,86.37,56.75,68.71,2.38,3,1.7,2.1,2.5,
 Extend,Commercial - Startup APIs,55.75,85.05,1.59,84.08,47.36,60.67,2.5,,,,,
-Extend (Beta),Commercial - Startup APIs,67.83,85.93,40.42,85.03,59.49,68.28,2.5,,,,,
+Extend (2.0),Commercial - Startup APIs,66.99,85.93,39.14,82.11,56.92,70.85,2.5,,,,,
 LandingAI,Commercial - Startup APIs,45.23,73.72,10.88,88.60,27.87,25.08,3,,,,,
 Firecrawl,Commercial - Startup APIs,31.08,55.88,0,74.37,25.16,0,0.9,,,,,
 Pulse,Commercial - Startup APIs,54.3,86.0,1.5,86.5,29.1,77.6,1.5,,,,,

--- a/src/parse_bench/inference/pipelines/parse.py
+++ b/src/parse_bench/inference/pipelines/parse.py
@@ -102,14 +102,14 @@ def register_parse_pipelines(register_fn) -> None:  # type: ignore[no-untyped-de
 
     register_fn(
         PipelineSpec(
-            pipeline_name="extend_parse_beta",
+            pipeline_name="extend_parse_2",
             provider_name="extend_parse",
             product_type=ProductType.PARSE,
             config={
                 "target": "markdown",
                 "chunking_strategy": "page",
                 "engine": "parse_performance",
-                "engineVersion": "2.0.0-beta",
+                "engineVersion": "2.0.0",
                 "block_options": {
                     "tables": {"target_format": "html"},
                     "figures": {


### PR DESCRIPTION
**What:** Replaces the Extend beta pipeline with Extend Parse 2.0 (GA).

**Why:** Extend's `parse_performance` engine has reached the 2.0.0 GA release, superseding the 2.0.0-beta entry.

**How:** Renames `extend_parse_beta` to `extend_parse_2` and bumps `engineVersion` from `2.0.0-beta` to `2.0.0`; updates the leaderboard row from Extend (Beta) to Extend (2.0).

**Changes:**
- `src/parse_bench/inference/pipelines/parse.py`: rename + version bump
- `docs/pipelines.md`: Extend AI section entry
- `leaderboard.csv`: Extend (Beta) row replaced by Extend (2.0)

**Testing:** Registry confirms `extend_parse_2` is present and `extend_parse_beta` is removed; `ruff check` passes.

**Notes:** Breaking change — the `extend_parse_beta` pipeline name is removed. Requires `EXTEND_API_KEY`. The Tables score is carried over from the prior beta run; the other dimensions come from the 2.0 extended runs.
