### PR TITLE
Add Anthropic Fable 5 parse-with-layout pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ _Top 10 by Overall score. For the full sortable, filterable leaderboard, see [pa
 | 5 | Reducto (Agentic) | Commercial - Startup APIs | 72.97 | 80.42 | 73.4 | 86.37 | 57.6 | 67.07 | 4.76¢ |
 | 6 | LlamaParse Cost Effective | LlamaParse | 71.89 | 73.16 | 66.66 | 88.02 | 73.04 | 58.56 | 0.38¢ |
 | 7 | Google Gemini 3 Flash (Thinking Minimal) | VLM - Proprietary | 71.04 | 89.85 | 64.83 | 86.19 | 58.35 | 55.97 | 0.65¢ |
-| 8 | Chandra-ocr-2 | VLM - Open Weight | 70.1 | 89.2 | 65.1 | 83.7 | 61.4 | 51.2 | — |
-| 9 | Google Gemini 3.1 Pro | VLM - Proprietary | 69.14 | 91.00 | 41.13 | 90.16 | 52.43 | 70.99 | 8.49¢ |
-| 10 | Reducto | Commercial - Startup APIs | 67.83 | 70.33 | 56.99 | 86.37 | 56.75 | 68.71 | 2.38¢ |
+| 8 | Anthropic Fable 5 | VLM - Proprietary | 70.78 | 89.79 | 52.21 | 90.02 | 72.62 | 49.24 | 15.60¢ |
+| 9 | Chandra-ocr-2 | VLM - Open Weight | 70.1 | 89.2 | 65.1 | 83.7 | 61.4 | 51.2 | — |
+| 10 | Google Gemini 3.5 Flash (Thinking Medium) | VLM - Proprietary | 69.92 | 91.12 | 44.01 | 90.19 | 59.14 | 65.14 | 4.28¢ |
 <!-- LEADERBOARD:END -->
 
 **Inclusion criteria:**

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -65,6 +65,7 @@ These pipelines use hosted APIs. You only need an API key in your `.env` file.
 | `anthropic_opus_4_6_parse_file` | Claude Opus 4.6, PDF file mode | `ANTHROPIC_API_KEY` |
 | **`anthropic_opus_4_6_parse_with_layout_file`** | Claude Opus 4.6, parse + layout, file mode (In paper: *Anthropic Opus 4.6*) | `ANTHROPIC_API_KEY` |
 | **`anthropic_opus_4_8_parse_with_layout_file`** | Claude Opus 4.8, parse + layout, file mode (In paper: *Anthropic Opus 4.8*) | `ANTHROPIC_API_KEY` |
+| `anthropic_fable_5_parse_with_layout_file` | Claude Fable 5, parse + layout, file mode | `ANTHROPIC_API_KEY` |
 
 ### Google Gemini
 

--- a/leaderboard.csv
+++ b/leaderboard.csv
@@ -12,6 +12,7 @@ Google Gemini 3.5 Flash (Thinking Minimal),VLM - Proprietary,63.09,86.24,18.74,8
 Anthropic Opus 4.6,VLM - Proprietary,54.07,86.52,13.49,89.70,64.19,16.47,5.78,4.02,8.16,5.19,6.40,
 Anthropic Opus 4.7,VLM - Proprietary,63.34,87.17,55.84,90.26,69.42,13.99,7.14,5.69,8.63,6.07,8.17,
 Anthropic Opus 4.8,VLM - Proprietary,63.70,89.65,49.75,89.02,71.38,18.69,7.30,5.82,8.78,6.24,8.36,
+Anthropic Fable 5,VLM - Proprietary,70.78,89.79,52.21,90.02,72.62,49.24,15.60,13.04,19.36,13.03,16.99,
 Google Gemini 3.1 Pro,VLM - Proprietary,69.14,91.00,41.13,90.16,52.43,70.99,8.49,6.69,9.69,7.73,10.54,
 Google Gemini 3.1 Flash Lite,VLM - Proprietary,58.32,85.48,9.92,89.46,58.38,48.38,0.29,0.19,0.37,0.27,0.31,
 OpenAI GPT-5.4 (Reasoning None),VLM - Proprietary,62.23,83.89,65.22,85.57,59.52,16.95,2.90,2.55,4.04,2.13,3.00,

--- a/src/parse_bench/inference/pipelines/parse.py
+++ b/src/parse_bench/inference/pipelines/parse.py
@@ -1757,6 +1757,20 @@ def register_parse_pipelines(register_fn) -> None:  # type: ignore[no-untyped-de
         )
     )
 
+    # Anthropic Fable 5 - Parse with Layout File
+    register_fn(
+        PipelineSpec(
+            pipeline_name="anthropic_fable_5_parse_with_layout_file",
+            provider_name="anthropic",
+            product_type=ProductType.PARSE,
+            config={
+                "model": "claude-fable-5",
+                "max_tokens": 32768,
+                "mode": "parse_with_layout_file",
+            },
+        )
+    )
+
     # Anthropic Haiku - Parse with Layout File - Thinking
     register_fn(
         PipelineSpec(

--- a/src/parse_bench/inference/providers/parse/anthropic.py
+++ b/src/parse_bench/inference/providers/parse/anthropic.py
@@ -72,6 +72,7 @@ USER_PROMPT = (
 # Source: https://platform.claude.com/docs/en/about-claude/pricing (2026-03-25)
 _ANTHROPIC_PRICING_PER_M: dict[str, tuple[float, float]] = {
     # model-prefix: (input_per_M, output_per_M)
+    "claude-fable-5": (10.00, 50.00),
     "claude-haiku-4-5": (1.00, 5.00),
     "claude-haiku-3-5": (0.80, 4.00),
     "claude-haiku-3": (0.25, 1.25),
@@ -122,8 +123,10 @@ class AnthropicProvider(Provider):
         self._mode = self.base_config.get("mode", "image")  # "image", "file", or "parse_with_layout"
         self._thinking = self.base_config.get("thinking")  # e.g. {"type": "enabled", "budget_tokens": 32768}
         self._effort = self.base_config.get("effort")  # e.g. "high", "xhigh" — for Opus 4.7+
-        # Opus 4.7+ rejects temperature/top_p/top_k at non-default values (400 error)
-        self._supports_temperature = not self._model.startswith(("claude-opus-4-7", "claude-opus-4-8"))
+        # Opus 4.7+ and Fable 5 reject temperature/top_p/top_k at non-default values (400 error)
+        self._supports_temperature = not self._model.startswith(
+            ("claude-opus-4-7", "claude-opus-4-8", "claude-fable-5")
+        )
 
         if self._mode not in ("image", "file", "parse_with_layout", "parse_with_layout_file"):
             raise ProviderConfigError(


### PR DESCRIPTION
**What:** Adds the Claude Fable 5 parse-with-layout (file mode) pipeline, with pricing, request handling, and leaderboard results.

**Why:** Benchmark Anthropic's newest flagship model and publish its scores.

**How:**
- Registers `anthropic_fable_5_parse_with_layout_file` on the `anthropic` provider (`model=claude-fable-5`).
- Adds `claude-fable-5` pricing (10.00/50.00 USD per 1M) so generated reports compute cost from the correct rate.
- Excludes Fable 5 from the `temperature` kwarg (like Opus 4.7/4.8) — it rejects non-default sampling params with a 400.
- Adds the leaderboard row (Overall 70.78: Tables 89.79, Charts 52.21, Content Faithfulness 90.02, Semantic Formatting 72.62, Visual Grounding 49.24; 15.60 cents/page average) and regenerates the README top-10, where it enters at rank 8.

**Changes:**
- `src/parse_bench/inference/pipelines/parse.py`: new pipeline
- `src/parse_bench/inference/providers/parse/anthropic.py`: pricing entry + temperature guard
- `leaderboard.csv`, `README.md`, `docs/pipelines.md`

**Testing:** `uv run parse-bench pipelines` lists the new pipeline; pricing resolver returns 10/50 for `claude-fable-5`; README top-10 regenerated with `scripts/update_readme.py`; `ruff check` passes.

**Notes:** Requires `ANTHROPIC_API_KEY`.