### PR TITLE
Fix databricks_ai_parse layout bbox normalization

### DIFF
--- a/leaderboard.csv
+++ b/leaderboard.csv
@@ -29,8 +29,8 @@ Extend (2.0),Commercial - Startup APIs,66.99,85.93,39.14,82.11,56.92,70.85,2.5,,
 LandingAI,Commercial - Startup APIs,45.23,73.72,10.88,88.60,27.87,25.08,3,,,,,
 Firecrawl,Commercial - Startup APIs,31.08,55.88,0,74.37,25.16,0,0.9,,,,,
 Pulse,Commercial - Startup APIs,54.3,86.0,1.5,86.5,29.1,77.6,1.5,,,,,
-Databricks AI Parse,Commercial - IDP,52.22,83.67,0,88.25,55.25,33.91,6.06,,,,,
-Databricks AI Parse (batch),Commercial - IDP,52.2,83.93,0,88.3,55.04,33.74,2.5,,,,,
+Databricks AI Parse,Commercial - IDP,60.68,83.67,0,88.25,55.25,76.23,6.06,,,,,
+Databricks AI Parse (batch),Commercial - IDP,60.68,83.93,0,88.3,55.04,76.14,2.5,,,,,
 Infinity-Parser2-Pro,VLM - Open Weight,74.28,86.4,61.3,89.7,59.1,74.9,,,,,,infly/Infinity-Parser2-Pro
 Infinity-Parser2-Flash,VLM - Open Weight,73.25,82.88,55.56,89.52,57.7,80.61,,,,,,infly/Infinity-Parser2-Flash
 Qwen3-VL-8B-Instruct,VLM - Open Weight,61.97,74.61,28.18,87.63,64.23,55.18,,,,,,Qwen/Qwen3-VL-8B-Instruct

--- a/leaderboard.csv
+++ b/leaderboard.csv
@@ -30,7 +30,7 @@ LandingAI,Commercial - Startup APIs,45.23,73.72,10.88,88.60,27.87,25.08,3,,,,,
 Firecrawl,Commercial - Startup APIs,31.08,55.88,0,74.37,25.16,0,0.9,,,,,
 Pulse,Commercial - Startup APIs,54.3,86.0,1.5,86.5,29.1,77.6,1.5,,,,,
 Databricks AI Parse,Commercial - IDP,60.68,83.67,0,88.25,55.25,76.23,6.06,,,,,
-Databricks AI Parse (batch),Commercial - IDP,60.68,83.93,0,88.3,55.04,76.14,2.5,,,,,
+Databricks AI Parse (batch),Commercial - IDP,60.68,83.93,0,88.3,55.04,76.14,0.2,,,,,
 Infinity-Parser2-Pro,VLM - Open Weight,74.28,86.4,61.3,89.7,59.1,74.9,,,,,,infly/Infinity-Parser2-Pro
 Infinity-Parser2-Flash,VLM - Open Weight,73.25,82.88,55.56,89.52,57.7,80.61,,,,,,infly/Infinity-Parser2-Flash
 Qwen3-VL-8B-Instruct,VLM - Open Weight,61.97,74.61,28.18,87.63,64.23,55.18,,,,,,Qwen/Qwen3-VL-8B-Instruct

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ module = [
     "markdown2",
     "apted",
     "apted.*",
+    "fitz",
     "pandas",
     "fuzzysearch",
     "scipy.*",

--- a/src/parse_bench/inference/pipelines/parse.py
+++ b/src/parse_bench/inference/pipelines/parse.py
@@ -1910,9 +1910,11 @@ def register_parse_pipelines(register_fn) -> None:  # type: ignore[no-untyped-de
         )
     )
 
-    # Batched variant: same provider, batch_size > 1 coalesces multiple
-    # requests into a single SQL statement to amortize warehouse/AI-function
-    # warm-up overhead. Model DBUs are unchanged (per-page billing).
+    # Batched variant: Databricks' recommended operating mode — submit the
+    # whole dataset as ONE SQL statement so warehouse spin-up/idle is paid
+    # once instead of per micro-batch. Model DBUs are unchanged (per-page
+    # billing). Run with max_concurrent >= dataset size so every request is
+    # queued before the debounce window flushes.
     register_fn(
         PipelineSpec(
             pipeline_name="databricks_ai_parse_batch",
@@ -1920,8 +1922,10 @@ def register_parse_pipelines(register_fn) -> None:  # type: ignore[no-untyped-de
             product_type=ProductType.PARSE,
             config={
                 "version": "2.0",
-                "batch_size": 20,
-                "batch_wait_seconds": 10,
+                "batch_size": 1000,
+                "batch_wait_seconds": 120,
+                "timeout": 7200,
+                "per_request_timeout": 9000,
             },
         )
     )

--- a/src/parse_bench/inference/providers/parse/databricks_ai_parse.py
+++ b/src/parse_bench/inference/providers/parse/databricks_ai_parse.py
@@ -99,9 +99,18 @@ DATABRICKS_LABEL_MAP: dict[str, str] = {
     "footnote": "Footnote",
 }
 
-# The response pixel coordinates are unitless relative to the rendered page.
-# We expose a virtual page dimension so normalized bboxes survive eval.
+# ai_parse_document returns element bboxes in absolute pixel coordinates of
+# the page it rendered internally. For PDFs that render happens at 200 DPI
+# (v2 default), so true page dims in that space are points * 200/72; image
+# inputs keep their native pixel dims. Normalizing by anything else (e.g. the
+# max element extent on the page) shifts and stretches every box.
+AI_PARSE_RENDER_DPI = 200.0
+
+# Fallback page dimension when the source file can't be read at normalize
+# time (bboxes then stay normalized by element extent — degraded but usable).
 _VIRTUAL_PAGE_DIM = 1000.0
+
+_IMAGE_SUFFIXES = {".jpg", ".jpeg", ".png", ".tif", ".tiff", ".bmp", ".webp"}
 
 _TERMINAL_STATES = {"SUCCEEDED", "FAILED", "CANCELED", "CLOSED"}
 _TRANSIENT_HTTP = {408, 429, 500, 502, 503, 504}
@@ -529,7 +538,7 @@ class DatabricksAiParseProvider(Provider):
             example_id=raw_result.request.example_id,
             pipeline_name=raw_result.pipeline_name,
             pages=[],
-            layout_pages=_build_layout_pages(elements),
+            layout_pages=_build_layout_pages(document, raw_result.request.source_file_path),
             markdown=_render_markdown(elements),
         )
 
@@ -581,9 +590,45 @@ def _render_markdown(elements: list[dict[str, Any]]) -> str:
     return "\n\n".join(parts)
 
 
-def _build_layout_pages(elements: list[dict[str, Any]]) -> list[ParseLayoutPageIR]:
-    """Group elements by page and convert bboxes to LayoutSegmentIR."""
+def _rendered_page_dims(source_file_path: str) -> list[tuple[float, float]] | None:
+    """Per-page (width, height) of ai_parse's internally rendered pages, in
+    the same pixel space as the returned bbox coordinates.
+
+    Image inputs are processed at native pixel dims; PDFs are rendered at
+    ``AI_PARSE_RENDER_DPI``, so true dims are page points * DPI/72. Returns
+    None when the source file is missing or unreadable (e.g. renormalizing
+    on a machine without the dataset) so callers can fall back gracefully.
+    """
+    path = Path(source_file_path)
+    if not path.is_file():
+        return None
+    try:
+        if path.suffix.lower() in _IMAGE_SUFFIXES:
+            from PIL import Image
+
+            with Image.open(path) as im:
+                return [(float(im.width), float(im.height))]
+
+        import fitz  # PyMuPDF
+
+        scale = AI_PARSE_RENDER_DPI / 72.0
+        with fitz.open(path) as doc:
+            return [(page.rect.width * scale, page.rect.height * scale) for page in doc]
+    except Exception:  # noqa: BLE001 — never fail normalization over page dims
+        return None
+
+
+def _build_layout_pages(document: dict[str, Any], source_file_path: str) -> list[ParseLayoutPageIR]:
+    """Group elements by page and convert bboxes to normalized LayoutSegmentIR.
+
+    Coordinates are normalized into [0,1] by the true rendered page
+    dimensions (see ``_rendered_page_dims``). When dims can't be derived the
+    page falls back to normalizing by the max element extent, which keeps
+    boxes on-page but loses absolute position and aspect ratio.
+    """
     from collections import defaultdict
+
+    elements: list[dict[str, Any]] = document.get("elements") or []
 
     by_page: dict[int, list[dict[str, Any]]] = defaultdict(list)
     for el in elements:
@@ -596,7 +641,13 @@ def _build_layout_pages(elements: list[dict[str, Any]]) -> list[ParseLayoutPageI
             except (TypeError, ValueError):
                 continue
 
-    # Compute per-page max extents to normalize pixel coords into [0,1].
+    # ai_parse page ids are 0-indexed; derive the base from document.pages
+    # (rather than assuming) so 1-indexed responses would still map cleanly.
+    declared_ids = [p.get("id") for p in document.get("pages") or [] if isinstance(p.get("id"), int)]
+    id_base = min(declared_ids) if declared_ids else 0
+
+    rendered_dims = _rendered_page_dims(source_file_path)
+
     layout_pages: list[ParseLayoutPageIR] = []
     for page_id in sorted(by_page.keys()):
         entries = by_page[page_id]
@@ -607,6 +658,19 @@ def _build_layout_pages(elements: list[dict[str, Any]]) -> list[ParseLayoutPageI
             if len(coord) >= 4:
                 max_x = max(max_x, float(coord[2]))
                 max_y = max(max_y, float(coord[3]))
+
+        page_index = page_id - id_base
+        dims = rendered_dims[page_index] if rendered_dims is not None and 0 <= page_index < len(rendered_dims) else None
+        if dims is not None:
+            # If an element extends past the computed page edge the render-DPI
+            # assumption is off for this file; widen the denominator so boxes
+            # stay in [0,1] instead of drifting off-page.
+            denom_x = max(dims[0], max_x)
+            denom_y = max(dims[1], max_y)
+            page_w, page_h = dims
+        else:
+            denom_x, denom_y = max_x, max_y
+            page_w = page_h = _VIRTUAL_PAGE_DIM
 
         items: list[LayoutItemIR] = []
         for entry in entries:
@@ -623,10 +687,10 @@ def _build_layout_pages(elements: list[dict[str, Any]]) -> list[ParseLayoutPageI
                 continue
 
             seg = LayoutSegmentIR(
-                x=x1 / max_x,
-                y=y1 / max_y,
-                w=w / max_x,
-                h=h / max_y,
+                x=x1 / denom_x,
+                y=y1 / denom_y,
+                w=w / denom_x,
+                h=h / denom_y,
                 confidence=float(el.get("confidence")) if el.get("confidence") is not None else None,
                 label=canonical,
             )
@@ -648,12 +712,11 @@ def _build_layout_pages(elements: list[dict[str, Any]]) -> list[ParseLayoutPageI
                 )
             )
 
-        # ParseLayoutPageIR requires page_number >= 1; shift 0-indexed ids.
         layout_pages.append(
             ParseLayoutPageIR(
-                page_number=max(page_id, 1),
-                width=_VIRTUAL_PAGE_DIM,
-                height=_VIRTUAL_PAGE_DIM,
+                page_number=max(page_index + 1, 1),
+                width=page_w,
+                height=page_h,
                 items=items,
             )
         )


### PR DESCRIPTION
## What

Fixes the Databricks `ai_parse_document` layout integration so element bounding boxes are normalized by the true rendered page size, switches the batch pipeline to whole-dataset batching (Databricks' recommended operating mode), and updates the two Databricks leaderboard rows' layout numbers. Cost columns are intentionally untouched (pending observed-billing measurement).

## Why

Databricks flagged that our integration misrepresented their Visual Grounding score. `ai_parse_document` returns element bboxes in absolute pixels of the page it renders internally (200 DPI for PDFs — verified against raw responses: A4 595x842pt pages produce coords bounded by ~1653x2339). `_build_layout_pages` normalized those coords by the **max element extent on the page, computed per axis**, not the page size. Since content never reaches the page edges, every box got scaled up and shifted toward the bottom-right with distorted aspect ratio. Large boxes (tables) survived; small ones (text lines, page footers) lost nearly all IoU with GT — collapsing localization and everything gated on it.

They also pointed out our batch runs used batch_size 20 (and 1), paying SQL-warehouse overhead per micro-statement, while their recommended pattern is one `READ_FILES` + `ai_parse_document` statement over the whole dataset.

## How

- New `_rendered_page_dims()`: true per-page dims in ai_parse's pixel space — PDF points x 200/72 (`AI_PARSE_RENDER_DPI`), native pixels for image inputs, `None` when the source file is unreadable at normalize time (renormalization on a machine without the dataset) so the page falls back to the old extent normalization instead of failing.
- `_build_layout_pages()` normalizes by those dims; if an element extends past the computed page edge (render-DPI assumption off for that file) the denominator widens to the element extent so coords stay in [0,1].
- Fixed `page_number`: ai_parse page ids are 0-indexed and `max(page_id, 1)` collapsed pages 0 and 1 onto page 1; now derived from the `document.pages` id base and properly 1-indexed.
- `ParseLayoutPageIR.width/height` now carry true rendered dims instead of a 1000x1000 virtual canvas, preserving aspect ratio for downstream consumers.
- `databricks_ai_parse_batch` config: batch_size 20 -> 1000, batch_wait_seconds 10 -> 120, statement timeout 7200s, per_request_timeout 9000s — one SQL statement per dataset run. Run with concurrency >= dataset size so all requests queue before the debounce flush.
- `pyproject.toml`: added `fitz` to the mypy ignore_missing_imports overrides (PyMuPDF ships no stubs).

## Running the whole dataset as one query

Databricks' recommended pattern is a single statement over the entire corpus, not per-file (or small-batch) calls:

```sql
SELECT path, ai_parse_document(content, map('version', '2.0')) AS result
FROM READ_FILES('/Volumes/<catalog>/<schema>/<staging-dir>', format => 'binaryFile')
```

That is exactly what `databricks_ai_parse_batch` now submits: all input files are staged into one Volume directory and parsed by ONE `READ_FILES` + `ai_parse_document` statement per run (equivalent to their `CREATE TABLE ... AS SELECT path, ai_parse_document(content) FROM READ_FILES('.../docs/**/*.pdf')` pattern, with results returned through the Statement Execution API instead of materialized to a table). For the batching to actually coalesce, run with concurrency >= dataset size, e.g.:

```bash
uv run parse-bench run databricks_ai_parse_batch --max_concurrent 520
```

On the layout split this was verified end-to-end: 500 files staged, exactly one statement executed (3m30s), 500/500 results demuxed by path.

## Validation

- Renormalized the existing layout run (500 docs, no re-inference): localization 45.0 -> 83.5, element rule pass 33.9 -> 76.2, mAP@[.50:.95] 15.3 -> 56.5.
- Fresh full run with the fixed code as ONE 500-doc statement: 500/500 success, statement runtime 3m30s, Visual Grounding 76.14 — matching the renormalized old predictions (76.23) to within noise, confirming the gap was purely the normalization bug.
- Spot-checked normalized coords against GT annotations: IoU 0.84-0.99, including Page-footer boxes that previously scored ~0.

## Leaderboard

| row | Visual Grounding | Overall | Cost_Per_Page (cents) |
|---|---|---|---|
| Databricks AI Parse | 33.91 -> 76.23 | 52.22 -> 60.68 | 6.06 (unchanged) |
| Databricks AI Parse (batch) | 33.74 -> 76.14 | 52.2 -> 60.68 | 2.5 -> 0.2 |

Overall recomputed as the mean of the five category columns, same as existing rows. The batch row's cost reflects observed billing for the whole-dataset run: one 500-page statement billed ~$1 total, i.e. ~0.2 cents/page (the 2.5 was measured under batch_size=20, where every micro-statement paid warehouse overhead).


