### PR TITLE
Add configurable LlamaParse API base URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,8 @@
 
 # LlamaParse (llama_cost_effective, llama_agentic, llama_agentic_plus)
 LLAMA_CLOUD_API_KEY=
+# Optional: override LlamaParse API base URL, e.g. http://localhost:8000 for self-hosted/BYOC
+LLAMA_CLOUD_BASE_URL=
 
 # OpenAI (openai_gpt5_mini_*, openai_gpt_5_4_*)
 OPENAI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -215,6 +215,10 @@ Each pipeline calls a specific parsing tool's API. You only need the API key for
 # Only add the keys you need. For example, to evaluate LlamaParse:
 LLAMA_CLOUD_API_KEY=...
 
+# Optional: point LlamaParse at a custom API base URL (self-hosted / BYOC),
+# e.g. http://localhost:8000. Takes precedence over staging/EU/prod selection.
+LLAMA_CLOUD_BASE_URL=...
+
 # To evaluate OpenAI-based pipelines:
 OPENAI_API_KEY=...
 

--- a/src/parse_bench/inference/providers/parse/llamaparse.py
+++ b/src/parse_bench/inference/providers/parse/llamaparse.py
@@ -58,7 +58,7 @@ class LlamaParseProvider(Provider):
     }
 
     # Parameters that are handled by the provider and should not be forwarded to the SDK
-    _PROVIDER_ONLY_PARAMS = {"use_staging", "use_europe", "api_key"}
+    _PROVIDER_ONLY_PARAMS = {"use_staging", "use_europe", "api_key", "base_url"}
 
     def __init__(
         self,
@@ -71,6 +71,10 @@ class LlamaParseProvider(Provider):
         :param provider_name: Name of the provider
         :param base_config: Optional configuration. Provider-specific parameters:
             - `api_key`: LlamaCloud API key (defaults to LLAMA_CLOUD_API_KEY env var)
+            - `base_url`: Override the LlamaParse API base URL (defaults to
+              LLAMA_CLOUD_BASE_URL env var). When set, it takes precedence over
+              use_staging/use_europe and the default prod URL. Useful for
+              self-hosted / BYOC targets, e.g. http://localhost:8000.
             - `use_staging`: Use staging environment (default: False)
             - `use_europe`: Use European Union (EU) region (default: False)
               Note: use_staging and use_europe cannot both be True
@@ -99,7 +103,17 @@ class LlamaParseProvider(Provider):
                 "use_staging and use_europe cannot both be True. Please choose one environment: staging or EU region."
             )
 
-        if use_staging:
+        # An explicit base URL override wins over staging/EU/prod selection.
+        # Precedence: base_config["base_url"] -> LLAMA_CLOUD_BASE_URL env var.
+        explicit_base_url = self.base_config.get("base_url") or os.getenv("LLAMA_CLOUD_BASE_URL")
+
+        if explicit_base_url:
+            # Custom / self-hosted (BYOC) target. Such a target may accept any or
+            # an empty key, so don't hard-fail when no API key is provided; fall
+            # back to an empty string so the SDK client can still initialize.
+            self._api_key = self.base_config.get("api_key") or os.getenv("LLAMA_CLOUD_API_KEY") or ""
+            self._base_url = explicit_base_url
+        elif use_staging:
             staging_key = self.base_config.get("api_key") or os.getenv("LLAMA_CLOUD_STAGING_API_KEY")
             if not staging_key:
                 raise ProviderConfigError(

--- a/tests/test_llamaparse_base_url.py
+++ b/tests/test_llamaparse_base_url.py
@@ -1,0 +1,108 @@
+"""Tests for the configurable LlamaParse API base URL (self-hosted / BYOC).
+
+The base URL is resolved with the precedence:
+``base_config["base_url"]`` -> ``LLAMA_CLOUD_BASE_URL`` env var ->
+``use_staging`` / ``use_europe`` -> default prod (``None``).
+
+An explicit override must win over staging/EU selection, and must be
+forwarded into the underlying llama-cloud SDK client constructor. A
+self-hosted target may accept any/empty key, so an empty key must not
+crash provider initialization when an explicit base URL is set.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import parse_bench.inference.providers.parse.llamaparse as llamaparse_module
+from parse_bench.inference.providers.base import ProviderPermanentError
+from parse_bench.inference.providers.parse.llamaparse import LlamaParseProvider
+
+
+@pytest.fixture(autouse=True)
+def _clean_llama_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Isolate tests from any ambient LlamaCloud env vars."""
+    for var in (
+        "LLAMA_CLOUD_API_KEY",
+        "LLAMA_CLOUD_BASE_URL",
+        "LLAMA_CLOUD_STAGING_API_KEY",
+        "LLAMA_CLOUD_EU_API_KEY",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    # Pretend the V2 SDK is installed so __init__ proceeds past the guard.
+    monkeypatch.setattr(llamaparse_module, "_HAS_V2_SDK", True)
+
+
+def _make_provider(base_config: dict) -> LlamaParseProvider:
+    return LlamaParseProvider("llamaparse", base_config)
+
+
+def test_base_url_from_base_config_wins() -> None:
+    provider = _make_provider({"api_key": "k", "base_url": "http://localhost:8000"})
+    assert provider._base_url == "http://localhost:8000"
+
+
+def test_base_url_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LLAMA_CLOUD_BASE_URL", "http://localhost:9000")
+    provider = _make_provider({"api_key": "k"})
+    assert provider._base_url == "http://localhost:9000"
+
+
+def test_base_config_overrides_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LLAMA_CLOUD_BASE_URL", "http://from-env:9000")
+    provider = _make_provider({"api_key": "k", "base_url": "http://from-config:8000"})
+    assert provider._base_url == "http://from-config:8000"
+
+
+def test_explicit_base_url_beats_use_staging() -> None:
+    provider = _make_provider({"api_key": "k", "use_staging": True, "base_url": "http://localhost:8000"})
+    assert provider._base_url == "http://localhost:8000"
+
+
+def test_explicit_base_url_beats_use_europe() -> None:
+    provider = _make_provider({"api_key": "k", "use_europe": True, "base_url": "http://localhost:8000"})
+    assert provider._base_url == "http://localhost:8000"
+
+
+def test_empty_key_does_not_crash_with_explicit_base_url() -> None:
+    # Self-hosted target with no key configured.
+    provider = _make_provider({"base_url": "http://localhost:8000"})
+    assert provider._base_url == "http://localhost:8000"
+    assert provider._api_key == ""
+
+
+def test_base_url_not_forwarded_to_sdk_config() -> None:
+    provider = _make_provider({"api_key": "k", "base_url": "http://localhost:8000"})
+    assert "base_url" not in provider._sdk_config
+
+
+def test_no_override_keeps_default_prod_behavior() -> None:
+    provider = _make_provider({"api_key": "k"})
+    assert provider._base_url is None
+
+
+def test_no_override_keeps_staging_behavior() -> None:
+    provider = _make_provider({"api_key": "k", "use_staging": True})
+    assert provider._base_url == "https://api.staging.llamaindex.ai"
+
+
+def test_override_forwarded_to_sdk_client() -> None:
+    """A non-None base_url must reach the llama-cloud client constructor."""
+    provider = _make_provider({"api_key": "k", "base_url": "http://localhost:8000"})
+
+    captured: dict = {}
+
+    def fake_client(**kwargs):
+        captured.update(kwargs)
+        # Short-circuit the rest of _parse_pdf; we only care about init kwargs.
+        raise RuntimeError("stop after client init")
+
+    with patch.object(llamaparse_module, "LlamaCloud", MagicMock(side_effect=fake_client)):
+        # _parse_pdf wraps the RuntimeError raised after client init.
+        with pytest.raises(ProviderPermanentError):
+            provider._parse_pdf("dummy.pdf")
+
+    assert captured.get("base_url") == "http://localhost:8000"
+    assert captured.get("api_key") == "k"


### PR DESCRIPTION
## Summary

The LlamaParse provider previously only supported three hardcoded base URLs (prod / staging / EU), so it couldn't point at a custom target. This adds a configurable base URL.

The base URL is now resolved with the following precedence, where an explicit override wins over everything else:

1. `base_config["base_url"]`
2. `LLAMA_CLOUD_BASE_URL` env var
3. existing `use_staging` / `use_europe` / prod logic (unchanged)

## Changes

- **`llamaparse.py`**: Resolve an explicit `base_url` override before the staging/EU/prod selection. When an explicit base URL is set, allow an empty/dummy API key (falls back to `""`) so a self-hosted target that accepts any key doesn't crash client init. `base_url` is added to `_PROVIDER_ONLY_PARAMS` so it isn't forwarded as a parse kwarg. The override is already plumbed into the `LlamaCloud(...)` client constructor via `base_url=self._base_url` (a non-`None` value is forwarded).
- **`.env.example` / `README.md`**: Document `LLAMA_CLOUD_BASE_URL` ("override LlamaParse API base URL, e.g. http://localhost:8000").
- **`tests/test_llamaparse_base_url.py`**: New tests covering precedence (config beats env), explicit override beats `use_staging`/`use_europe`, empty-key init doesn't crash, `base_url` not forwarded to SDK config, default prod/staging behavior unchanged, and that the override reaches the SDK client constructor.

## Validation

- `ruff check` — clean
- `mypy` — `Success: no issues found`
- `pytest tests/test_llamaparse_base_url.py` — 10 passed

Backward-compatible: with no override set, behavior is identical to today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016tmEm1zwUJSWNLT6miDztb

---
_Generated by [Claude Code](https://claude.ai/code/session_016tmEm1zwUJSWNLT6miDztb)_