### PR TITLE
Add Anthropic Sonnet 5 parse pipeline

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -65,6 +65,7 @@ These pipelines use hosted APIs. You only need an API key in your `.env` file.
 | `anthropic_opus_4_6_parse_file` | Claude Opus 4.6, PDF file mode | `ANTHROPIC_API_KEY` |
 | **`anthropic_opus_4_6_parse_with_layout_file`** | Claude Opus 4.6, parse + layout, file mode (In paper: *Anthropic Opus 4.6*) | `ANTHROPIC_API_KEY` |
 | **`anthropic_opus_4_8_parse_with_layout_file`** | Claude Opus 4.8, parse + layout, file mode (In paper: *Anthropic Opus 4.8*) | `ANTHROPIC_API_KEY` |
+| `anthropic_sonnet_5_parse_with_layout_file` | Claude Sonnet 5, adaptive thinking + layout, file mode | `ANTHROPIC_API_KEY` |
 | `anthropic_fable_5_parse_with_layout_file` | Claude Fable 5, parse + layout, file mode | `ANTHROPIC_API_KEY` |
 
 ### Google Gemini

--- a/leaderboard.csv
+++ b/leaderboard.csv
@@ -13,6 +13,7 @@ Anthropic Opus 4.6,VLM - Proprietary,54.07,86.52,13.49,89.70,64.19,16.47,5.78,4.
 Anthropic Opus 4.7,VLM - Proprietary,63.34,87.17,55.84,90.26,69.42,13.99,7.14,5.69,8.63,6.07,8.17,
 Anthropic Opus 4.8,VLM - Proprietary,63.70,89.65,49.75,89.02,71.38,18.69,7.30,5.82,8.78,6.24,8.36,
 Anthropic Fable 5,VLM - Proprietary,70.78,89.79,52.21,90.02,72.62,49.24,15.60,13.04,19.36,13.03,16.99,
+Anthropic Sonnet 5,VLM - Proprietary,62.13,86.65,60.53,86.51,64.93,12.03,3.18,2.79,3.82,2.60,3.52,
 Google Gemini 3.1 Pro,VLM - Proprietary,69.14,91.00,41.13,90.16,52.43,70.99,8.49,6.69,9.69,7.73,10.54,
 Google Gemini 3.1 Flash Lite,VLM - Proprietary,58.32,85.48,9.92,89.46,58.38,48.38,0.29,0.19,0.37,0.27,0.31,
 OpenAI GPT-5.4 (Reasoning None),VLM - Proprietary,62.23,83.89,65.22,85.57,59.52,16.95,2.90,2.55,4.04,2.13,3.00,

--- a/src/parse_bench/inference/pipelines/parse.py
+++ b/src/parse_bench/inference/pipelines/parse.py
@@ -1830,6 +1830,21 @@ def register_parse_pipelines(register_fn) -> None:  # type: ignore[no-untyped-de
         )
     )
 
+    # Anthropic Sonnet 5 - Parse with Layout File - Adaptive Thinking
+    register_fn(
+        PipelineSpec(
+            pipeline_name="anthropic_sonnet_5_parse_with_layout_file",
+            provider_name="anthropic",
+            product_type=ProductType.PARSE,
+            config={
+                "model": "claude-sonnet-5",
+                "max_tokens": 32768,
+                "mode": "parse_with_layout_file",
+                "thinking": {"type": "adaptive"},
+            },
+        )
+    )
+
     # Anthropic Fable 5 - Parse with Layout File
     register_fn(
         PipelineSpec(

--- a/src/parse_bench/inference/providers/parse/anthropic.py
+++ b/src/parse_bench/inference/providers/parse/anthropic.py
@@ -3,7 +3,7 @@
 import base64
 import io
 import os
-from datetime import datetime
+from datetime import date, datetime
 from pathlib import Path
 from typing import Any
 
@@ -73,6 +73,9 @@ USER_PROMPT = (
 _ANTHROPIC_PRICING_PER_M: dict[str, tuple[float, float]] = {
     # model-prefix: (input_per_M, output_per_M)
     "claude-fable-5": (10.00, 50.00),
+    # Sonnet 5 has introductory pricing through 2026-08-31; handled in
+    # _get_pricing so benchmark costs switch to standard pricing on time.
+    "claude-sonnet-5": (3.00, 15.00),
     "claude-haiku-4-5": (1.00, 5.00),
     "claude-haiku-3-5": (0.80, 4.00),
     "claude-haiku-3": (0.25, 1.25),
@@ -153,6 +156,9 @@ class AnthropicProvider(Provider):
         Uses longest-prefix matching to avoid ambiguity when one model
         prefix is a substring of another.
         """
+        if self._model.startswith("claude-sonnet-5") and date.today() <= date(2026, 8, 31):
+            return (2.00, 10.00)
+
         matches = [(p, r) for p, r in _ANTHROPIC_PRICING_PER_M.items() if self._model.startswith(p)]
         return max(matches, key=lambda x: len(x[0]))[1] if matches else (0.0, 0.0)
 

--- a/tests/parse_bench/inference/providers/parse/test_anthropic_pricing.py
+++ b/tests/parse_bench/inference/providers/parse/test_anthropic_pricing.py
@@ -1,0 +1,39 @@
+"""Unit tests for Anthropic provider pricing, including the Sonnet 5
+introductory-rate transition."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from parse_bench.inference.providers.parse import anthropic
+from parse_bench.inference.providers.parse.anthropic import AnthropicProvider
+
+
+def _provider_for_model(model: str) -> AnthropicProvider:
+    provider = object.__new__(AnthropicProvider)
+    provider._model = model
+    return provider
+
+
+def test_sonnet_5_uses_introductory_pricing_through_august_2026(monkeypatch: pytest.MonkeyPatch) -> None:
+    class IntroDate(date):
+        @classmethod
+        def today(cls) -> date:
+            return cls(2026, 8, 31)
+
+    monkeypatch.setattr(anthropic, "date", IntroDate)
+
+    assert _provider_for_model("claude-sonnet-5")._get_pricing() == (2.00, 10.00)
+
+
+def test_sonnet_5_uses_standard_pricing_after_intro_period(monkeypatch: pytest.MonkeyPatch) -> None:
+    class StandardDate(date):
+        @classmethod
+        def today(cls) -> date:
+            return cls(2026, 9, 1)
+
+    monkeypatch.setattr(anthropic, "date", StandardDate)
+
+    assert _provider_for_model("claude-sonnet-5")._get_pricing() == (3.00, 15.00)


### PR DESCRIPTION
## Summary

Adds `anthropic_sonnet_5_parse_with_layout_file`, a raw-PDF parse-with-layout pipeline backed by `claude-sonnet-5` with adaptive thinking enabled.

## How

- Registers the pipeline with `mode="parse_with_layout_file"`, `max_tokens=32768`, and `thinking={"type": "adaptive"}`.
- Adds `claude-sonnet-5` pricing to the Anthropic provider's rate table ($3/$15 per M tokens standard), with an introductory-rate override ($2/$10 per M) that applies through 2026-08-31, handled as a date check in `_get_pricing()`.
- Adds tests covering both sides of the pricing transition.

## Changes

- **`src/parse_bench/inference/providers/parse/anthropic.py`**: add `claude-sonnet-5` pricing entry and the introductory-rate date check.
- **`src/parse_bench/inference/pipelines/parse.py`**: register `anthropic_sonnet_5_parse_with_layout_file`.
- **`tests/parse_bench/inference/providers/parse/test_anthropic_pricing.py`**: new tests for the pricing transition.
- **`docs/pipelines.md`**: document the new pipeline.
- **`leaderboard.csv`**: add the `Anthropic Sonnet 5` row (extended benchmarks, `VLM - Proprietary`).

## Validation

- `ruff check` — clean
- `parse-bench pipelines` — `anthropic_sonnet_5_parse_with_layout_file` listed
- `pytest tests/parse_bench/inference/providers/parse/test_anthropic_pricing.py` — 2 passed
- Extended benchmark scores (the leaderboard row): Tables 86.65, Charts 60.53, Content Faithfulness 86.51, Semantic Formatting 64.93, Visual Grounding 12.03 — Overall 62.13. Cost per page (cents): Tables 3.82, Charts 2.79, Text 2.60, Layout 3.52 — blended 3.18.

## Notes

- Requires `ANTHROPIC_API_KEY` in the environment.