### PR TITLE
Fix heading/formula delimiter doubling in items_to_markdown

### DIFF
--- a/src/parse_bench/inference/providers/parse/_layout_utils.py
+++ b/src/parse_bench/inference/providers/parse/_layout_utils.py
@@ -194,8 +194,48 @@ def parse_layout_blocks(content: str) -> list[dict[str, Any]]:
     return blocks
 
 
+# A markdown ATX heading marker: optional indent, 1-6 hashes, then whitespace.
+# The trailing whitespace is required (as in CommonMark), so literal text like
+# "#1 Best Seller" is not mistaken for a marker.
+_LEADING_HEADING_MARKER = re.compile(r"^[ \t]*(#{1,6})[ \t]+")
+
+
+def _strip_heading_marker(text: str) -> str:
+    """Strip a leading markdown heading marker, if any, from item text."""
+    match = _LEADING_HEADING_MARKER.match(text)
+    if not match:
+        return text
+    bare = text[match.end() :].strip()
+    return bare if bare else text
+
+
+def _strip_outer_formula_delimiters(text: str) -> str:
+    """Strip one outer pair of ``$$``/``$`` delimiters when unambiguous.
+
+    Only strips when the interior contains no further ``$``, so multi-formula
+    items (``$a$ + $b$``) and text with interior dollar signs pass through
+    verbatim rather than being corrupted.
+    """
+    stripped = text.strip()
+    for delim in ("$$", "$"):
+        if len(stripped) > 2 * len(delim) and stripped.startswith(delim) and stripped.endswith(delim):
+            interior = stripped[len(delim) : -len(delim)]
+            if "$" not in interior and interior.strip():
+                return interior.strip()
+    return text
+
+
 def items_to_markdown(items: list[dict[str, Any]]) -> str:
-    """Assemble clean markdown from parsed layout items."""
+    """Assemble clean markdown from parsed layout items.
+
+    The layout prompt asks for clean markdown inside each div, so models
+    frequently emit heading markers (``# Heading``) and formula delimiters
+    (``$$...$$``) in the item text already. Any existing markers are stripped
+    before the label-derived ones are applied, so they don't double up
+    (``# # Heading``, nested ``$$`` blocks) — doubled markers defeat the
+    heading/formula detection in downstream scoring. Title still always
+    renders as H1 and Section-header as H2.
+    """
     parts: list[str] = []
     for item in items:
         label = item.get("label", "").lower()
@@ -203,11 +243,11 @@ def items_to_markdown(items: list[dict[str, Any]]) -> str:
         if not text:
             continue
         if label == "title":
-            parts.append(f"# {text}")
+            parts.append(f"# {_strip_heading_marker(text)}")
         elif label in ("section-header", "section_header"):
-            parts.append(f"## {text}")
+            parts.append(f"## {_strip_heading_marker(text)}")
         elif label == "formula":
-            parts.append(f"$$\n{text}\n$$")
+            parts.append(f"$$\n{_strip_outer_formula_delimiters(text)}\n$$")
         else:
             parts.append(text)
     return "\n\n".join(parts)

--- a/tests/parse_bench/inference/providers/parse/test_layout_utils.py
+++ b/tests/parse_bench/inference/providers/parse/test_layout_utils.py
@@ -1,0 +1,123 @@
+"""Unit tests for ``_layout_utils.items_to_markdown``.
+
+The layout prompt asks the model for clean markdown inside each div, so
+Title/Section-header items usually already carry a leading ``#`` marker and
+Formula items their own ``$$`` delimiters. These tests pin down that the
+assembler does not double those markers, which would break downstream
+heading/formula scoring (``TitleLevelRule`` matches ``^#{1,6}\\s+<text>``, so
+``# # Heading`` never matches), while never mutating item text in ambiguous
+cases.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from parse_bench.inference.providers.parse._layout_utils import items_to_markdown
+
+
+class TestHeadingAssembly(unittest.TestCase):
+    def test_unmarked_title_gets_h1(self) -> None:
+        out = items_to_markdown([{"label": "title", "text": "CHRISM MASS"}])
+        self.assertEqual(out, "# CHRISM MASS")
+
+    def test_unmarked_section_header_gets_h2(self) -> None:
+        out = items_to_markdown([{"label": "section-header", "text": "Schedule"}])
+        self.assertEqual(out, "## Schedule")
+
+    def test_premarked_title_not_doubled(self) -> None:
+        out = items_to_markdown([{"label": "title", "text": "# CHRISM MASS"}])
+        self.assertEqual(out, "# CHRISM MASS")
+
+    def test_premarked_section_header_not_doubled(self) -> None:
+        out = items_to_markdown([{"label": "section-header", "text": "## Schedule"}])
+        self.assertEqual(out, "## Schedule")
+
+    def test_label_level_wins_over_model_level(self) -> None:
+        # Title always renders H1 and Section-header H2, regardless of the
+        # marker level the model emitted — same contract as before.
+        out = items_to_markdown([{"label": "section-header", "text": "### Subsection"}])
+        self.assertEqual(out, "## Subsection")
+        out = items_to_markdown([{"label": "title", "text": "## Doc Title"}])
+        self.assertEqual(out, "# Doc Title")
+
+    def test_indented_marker_stripped(self) -> None:
+        out = items_to_markdown([{"label": "section-header", "text": "  ## Schedule"}])
+        self.assertEqual(out, "## Schedule")
+
+    def test_literal_hash_content_preserved(self) -> None:
+        # "#1" is content, not a heading marker (no whitespace after the
+        # hashes) — it must not be consumed.
+        out = items_to_markdown([{"label": "title", "text": "#1 Best Seller"}])
+        self.assertEqual(out, "# #1 Best Seller")
+
+    def test_marker_only_text_kept_verbatim(self) -> None:
+        # Degenerate marker-only text falls back to the old verbatim behavior
+        # instead of producing an empty heading.
+        out = items_to_markdown([{"label": "title", "text": "# "}])
+        self.assertEqual(out, "# # ")
+
+    def test_underscore_label_variant(self) -> None:
+        out = items_to_markdown([{"label": "section_header", "text": "## Schedule"}])
+        self.assertEqual(out, "## Schedule")
+
+
+class TestFormulaAssembly(unittest.TestCase):
+    def test_bare_formula_wrapped(self) -> None:
+        out = items_to_markdown([{"label": "formula", "text": "E = mc^2"}])
+        self.assertEqual(out, "$$\nE = mc^2\n$$")
+
+    def test_predelimited_formula_not_nested(self) -> None:
+        out = items_to_markdown([{"label": "formula", "text": "$$E = mc^2$$"}])
+        self.assertEqual(out, "$$\nE = mc^2\n$$")
+
+    def test_inline_delimited_formula_not_nested(self) -> None:
+        out = items_to_markdown([{"label": "formula", "text": "$E = mc^2$"}])
+        self.assertEqual(out, "$$\nE = mc^2\n$$")
+
+    def test_multiline_predelimited_formula(self) -> None:
+        out = items_to_markdown([{"label": "formula", "text": "$$\na + b\n$$"}])
+        self.assertEqual(out, "$$\na + b\n$$")
+
+    def test_multiple_formulas_left_intact(self) -> None:
+        # First/last '$' of two separate formulas are not an outer pair;
+        # stripping them would corrupt the math.
+        out = items_to_markdown([{"label": "formula", "text": "$x = 1$, $y = 2$"}])
+        self.assertEqual(out, "$$\n$x = 1$, $y = 2$\n$$")
+
+    def test_interior_dollar_left_intact(self) -> None:
+        # An unbalanced interior '$' is not an outer delimiter.
+        out = items_to_markdown([{"label": "formula", "text": "x = $5.00"}])
+        self.assertEqual(out, "$$\nx = $5.00\n$$")
+
+    def test_delimiter_only_text_kept_verbatim(self) -> None:
+        out = items_to_markdown([{"label": "formula", "text": "$$"}])
+        self.assertEqual(out, "$$\n$$\n$$")
+
+
+class TestPassthrough(unittest.TestCase):
+    def test_plain_text_unchanged(self) -> None:
+        out = items_to_markdown([{"label": "text", "text": "# not a heading item"}])
+        self.assertEqual(out, "# not a heading item")
+
+    def test_empty_items_skipped(self) -> None:
+        out = items_to_markdown(
+            [
+                {"label": "title", "text": ""},
+                {"label": "text", "text": "body"},
+            ]
+        )
+        self.assertEqual(out, "body")
+
+    def test_items_joined_with_blank_line(self) -> None:
+        out = items_to_markdown(
+            [
+                {"label": "title", "text": "# Title"},
+                {"label": "text", "text": "body"},
+            ]
+        )
+        self.assertEqual(out, "# Title\n\nbody")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

The shared layout prompt asks models for "clean, well-structured markdown" inside each `<div>` wrapper, so models routinely emit their own heading markers and formula delimiters in the item text (`# CHRISM MASS`, `$$E = mc^2$$`). `items_to_markdown` then unconditionally prepends the label-derived marker on top:

```
# # CHRISM MASS

## ## Schedule

$$
$$E = mc^2$$
$$
```

The doubled markers defeat downstream scoring: `TitleLevelRule`/`is_title` match `^#{1,6}\s+<text>` (which can never match `# # <text>`), `normalize_text` never strips `#`, and `is_latex` block extraction breaks on the nested `$$`.

Repro through the real chain (provider `normalize()` → `ParseEvaluator`), feeding the div response above with rules `is_title("CHRISM MASS")`, `is_title("Schedule")`, `is_latex("E = mc^2")`:

- before: `rule_pass_rate 0.0 (0/3)` — "Expected 'CHRISM MASS' to be a title, but no matching heading or bold formatting found"
- after: `rule_pass_rate 1.0 (3/3)`

The hazard is already known in this repo — `infinity_parser2._reassemble_text` and the `kdl_frontier_nano` pipeline each carry their own local stripping — but the shared helper used by the anthropic / openai / google / gemma4 layout pipelines was never fixed (`google_agentic_vision` mitigates via prompt wording only).

## Fix

Deliberately conservative — output is never worse than today's:

- **Headings**: strip one leading ATX marker before re-applying the label-derived one. Whitespace after the hashes is required (per CommonMark), so literal content like `#1 Best Seller` is untouched; indent is tolerated; marker-only text (`# `) falls back to verbatim. Title still always renders H1 and Section-header H2 — the model's own marker level is *not* trusted, preserving the level contract that `TitleHierarchyPercentRule` and ground-truth `level` conventions rely on.
- **Formulas**: strip one outer `$$`/`$` pair only when the interior contains no further `$`, so multi-formula items (`$x = 1$, $y = 2$`) and interior dollar amounts (`x = $5.00`) pass through verbatim instead of being corrupted.

Scope notes: this touches only the markdown render path (`LayoutItemIR.value` keeps the raw div text for the layout track, unchanged); bracket delimiters (`\[..\]`, `\(..\)`) are a possible follow-up, left out to keep this minimal.

## Impact

Scores for `*_parse_with_layout` pipelines will shift upward on heading/formula rules wherever the model emitted its own markers — this corrects a scoring artifact rather than changing what is measured, but pre-/post-fix leaderboard numbers for those pipelines are not directly comparable.

## Testing

- New `tests/parse_bench/inference/providers/parse/test_layout_utils.py` (19 cases: doubling, literal `#` content, marker-only, indented markers, multi-formula, interior `$`, passthrough).
- Full suite: 228 passed. `ruff check` / `ruff format --check` clean.
