### PR TITLE
Apply CommonMark flanking rules to italic delimiter detection

### DIFF
--- a/src/parse_bench/evaluation/metrics/parse/rules_formatting.py
+++ b/src/parse_bench/evaluation/metrics/parse/rules_formatting.py
@@ -65,8 +65,11 @@ _STRIP_PATTERNS: dict[str, list[tuple[re.Pattern, str]]] = {
         (re.compile(r"</?b>", re.IGNORECASE), ""),
     ],
     "italic": [
-        (re.compile(r"(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)"), r"\1"),
-        (re.compile(r"(?<!_)_(?!_)(.+?)(?<!_)_(?!_)"), r"\1"),
+        # Flanking-aware (see _build_italic_patterns): a ``*`` followed by
+        # whitespace or an ``_`` inside a word is not an emphasis delimiter,
+        # so list bullets and snake_case survive the strip.
+        (re.compile(r"(?<!\*)\*(?![*\s])(.+?)(?<!\s)\*(?!\*)"), r"\1"),
+        (re.compile(r"(?<!\w)_(?!_)(.+?)(?<!_)_(?!\w)"), r"\1"),
         (re.compile(r"</?(?:i|em)>", re.IGNORECASE), ""),
     ],
     "underline": [
@@ -196,19 +199,36 @@ class FormattingRule(ParseTestRule):
 
         The query may be a substring of the italic span (e.g. query
         ``Grazing Line`` matches ``*Grazing Line, Macquarie Marshes, NSW*``).
+
+        The markdown delimiters follow CommonMark's flanking rules: a ``*``
+        followed by whitespace (a list bullet, ``5 * 3``) cannot open
+        emphasis and one preceded by whitespace cannot close it; an ``_``
+        with word characters on both sides (``snake_case``) is not a
+        delimiter at all. Without these rules, bulleted lists and
+        identifier-heavy text score as one giant italic span.
         """
         # Tempered greedy token: any char that isn't a lone * (i.e. not * unless followed by *)
         _not_italic_close_star = r"(?:(?!\*(?!\*)).)*?"
-        # Same idea for _
-        _not_italic_close_under = r"(?:(?!_(?!_)).)*?"
+        # Same idea for _, except an intraword ``_`` (snake_case) is not a
+        # delimiter, so the span content may cross it.
+        _not_italic_close_under = r"(?:(?!_(?!_)).|(?<=\w)_(?!_)(?=\w))*?"
         return [
-            # *text* but NOT **text** – use negative lookbehind/lookahead
+            # *text* but NOT **text** – use negative lookbehind/lookahead.
+            # An opening ``*`` must not be followed by whitespace and a
+            # closing one must not be preceded by it (CommonMark flanking).
             re.compile(
-                r"(?<!\*)\*(?!\*)" + _not_italic_close_star + escaped_query + _not_italic_close_star + r"\*(?!\*)",
+                r"(?<!\*)\*(?![*\s])"
+                + _not_italic_close_star
+                + escaped_query
+                + _not_italic_close_star
+                + r"(?<!\s)\*(?!\*)",
                 re.IGNORECASE | re.DOTALL,
             ),
+            # _text_ but NOT __text__ and NOT intraword (snake_case): an
+            # opening ``_`` must not be preceded by a word char, a closing
+            # one must not be followed by one.
             re.compile(
-                r"(?<!_)_(?!_)" + _not_italic_close_under + escaped_query + _not_italic_close_under + r"_(?!_)",
+                r"(?<!\w)_(?!_)" + _not_italic_close_under + escaped_query + _not_italic_close_under + r"(?<!_)_(?!\w)",
                 re.IGNORECASE | re.DOTALL,
             ),
             re.compile(

--- a/tests/parse_bench/evaluation/metrics/parse/test_formatting_rule_italic.py
+++ b/tests/parse_bench/evaluation/metrics/parse/test_formatting_rule_italic.py
@@ -1,0 +1,107 @@
+"""Tests for FormattingRule italic detection (CommonMark flanking rules).
+
+Two classes of markdown ``*``/``_`` characters are not emphasis delimiters:
+
+* a ``*`` followed by whitespace cannot open emphasis and one preceded by
+  whitespace cannot close it — so list bullets and arithmetic (``5 * 3``)
+  are not delimiters, and
+* an intraword ``_`` (``snake_case``) is not a delimiter under CommonMark's
+  flanking rules.
+
+Without these distinctions, ``is_italic`` rules pass spuriously on bulleted
+lists and identifier-heavy text, and ``is_not_italic`` rules fail on them.
+"""
+
+from __future__ import annotations
+
+from parse_bench.evaluation.metrics.parse.rules_base import create_test_rule
+
+
+def _run(rule_type: str, text: str, md: str) -> bool:
+    passed, _ = create_test_rule({"type": rule_type, "text": text}).run(md)
+    return passed
+
+
+class TestStarFlanking:
+    def test_bulleted_list_is_not_emphasis(self):
+        md = "* item one\n* item two\n"
+        assert not _run("is_italic", "item one", md)
+        assert _run("is_not_italic", "item one", md)
+
+    def test_indented_bullets_are_not_emphasis(self):
+        md = "  * nested item\n  * second item\n"
+        assert not _run("is_italic", "nested item", md)
+
+    def test_blockquoted_bullets_are_not_emphasis(self):
+        md = "> * item one\n> * item two\n"
+        assert not _run("is_italic", "item one", md)
+
+    def test_trailing_bullet_at_end_of_string(self):
+        # A bare bullet as the last character is not a closing delimiter.
+        md = "*alpha beta\n*"
+        assert _run("is_not_italic", "alpha", md)
+
+    def test_midline_arithmetic_stars_are_not_emphasis(self):
+        md = "cost is 5 * 3 apples and 7 * 2 pears total"
+        assert not _run("is_italic", "3 apples and 7", md)
+
+    def test_real_emphasis_inside_bullet_still_detected(self):
+        md = "* item with *emph* here\n"
+        assert _run("is_italic", "emph", md)
+
+    def test_plain_star_emphasis_still_detected(self):
+        assert _run("is_italic", "real italic", "some *real italic* text")
+
+    def test_star_emphasis_substring_query(self):
+        assert _run("is_italic", "Grazing Line", "*Grazing Line, Macquarie Marshes, NSW*")
+
+    def test_bold_detection_unaffected_by_bullets(self):
+        md = "* item with **bold** here\n"
+        assert _run("is_bold", "bold", md)
+
+
+class TestUnderscoreFlanking:
+    def test_snake_case_is_not_emphasis(self):
+        md = "the snake_case_word identifier"
+        assert not _run("is_italic", "case", md)
+        assert _run("is_not_italic", "case", md)
+
+    def test_span_between_identifiers_is_not_emphasis(self):
+        md = "Call parse_config and load_data now"
+        assert not _run("is_italic", "config and load", md)
+
+    def test_trailing_underscore_identifiers_are_not_emphasis(self):
+        md = "the file_ and dir_ paths"
+        assert not _run("is_italic", "and", md)
+
+    def test_leading_underscore_identifiers_are_not_emphasis(self):
+        md = "call _init and _load helpers"
+        assert not _run("is_italic", "init and", md)
+
+    def test_real_underscore_emphasis_still_detected(self):
+        assert _run("is_italic", "this", "see _this_ word")
+
+    def test_underscore_emphasis_at_string_edges(self):
+        assert _run("is_italic", "leading", "_leading_ emphasis")
+        assert _run("is_italic", "trailing", "emphasis _trailing_")
+
+    def test_underscore_emphasis_with_punctuation(self):
+        assert _run("is_italic", "title", "(_title_)")
+
+    def test_emphasis_containing_snake_case_still_detected(self):
+        # An intraword ``_`` inside a real italic span is content, not a
+        # delimiter — the span must still be found around and across it.
+        md = "_see config_yaml for details_"
+        assert _run("is_italic", "details", md)
+        assert _run("is_italic", "see", md)
+
+    def test_double_underscore_is_bold_not_italic(self):
+        assert not _run("is_italic", "bold", "some __bold__ text")
+
+
+class TestStripConsistency:
+    def test_bold_query_containing_snake_case_survives_fallback(self):
+        # The fallback path strips italic markup from content when testing
+        # bold; flanking-aware stripping must not eat intraword underscores.
+        md = "**use ~~snake_case_word~~ now** here"
+        assert _run("is_bold", "use snake_case_word now", md)


### PR DESCRIPTION
## Problem

`FormattingRule`'s italic patterns treat every lone `*`/`_` as an emphasis delimiter. Two very common markdown constructs therefore score as italic spans:

**List bullets** — in `* item one\n* item two`, the first bullet's `*` "opens" and the second bullet's `*` "closes" (DOTALL), so the whole list reads as one italic span:

```
is_italic("item one")      → passes (wrong)
is_not_italic("item one")  → fails  (wrong)
```

**Intraword underscores** — `snake_case` underscores open/close emphasis, so identifier-heavy text like `Call parse_config and load_data now` matches `is_italic("config and load")`.

Driven through `ParseEvaluator` on a small document with 2 `is_not_italic` + 2 `is_italic` rules: `rule_pass_rate` goes 0.5 → 1.0 with this change (the two real emphasis spans still detected).

## Fix

Apply CommonMark's flanking rules to the markdown delimiters:

- a `*` followed by whitespace cannot open emphasis; one preceded by whitespace cannot close it. This handles plain/indented/blockquoted bullets, trailing bare bullets, and mid-line arithmetic (`5 * 3`) in the pattern itself — no content preprocessing.
- an `_` with word characters on both sides is not a delimiter. The span filler still crosses intraword underscores, so genuine emphasis containing an identifier (`_see config_yaml for details_`) is still found.
- the italic entries in `_STRIP_PATTERNS` get the same flanking so the strip-other-formatting fallback no longer eats intraword underscores out of bold/strikeout queries (`is_bold("use snake_case_word now")` on `**use ~~snake_case_word~~ now**` now passes).

## Behavior changes (all consistent with CommonMark)

- Bulleted docs: `is_italic` rules that passed spuriously now fail; `is_not_italic` rules flip fail→pass. This shifts semantic-formatting scores on list-heavy documents for all pipelines.
- Legacy intraword emphasis (`_word_s`, `_Chapter_7`) and doubled closers (`_italic__`) are no longer detected — CommonMark rejects these forms too.
- Unspaced CJK `_` emphasis is not detected, matching CommonMark's own well-known CJK flanking limitation (`*` emphasis is unaffected).

## Testing

New `tests/parse_bench/evaluation/metrics/parse/test_formatting_rule_italic.py` (19 cases: bullets in plain/indented/blockquote/EOF positions, arithmetic stars, snake_case exclusions, leading/trailing-underscore identifiers, real emphasis at string edges and with punctuation, emphasis containing snake_case, `__bold__` exclusion, strip-consistency). Full suite: 228 passed; ruff clean.
