### PR TITLE
Fix stale dataset-layout docstrings in download/loader

### DIFF
--- a/src/parse_bench/data/download.py
+++ b/src/parse_bench/data/download.py
@@ -7,9 +7,10 @@ Structure after download:
     ├── chart.jsonl
     ├── layout.jsonl
     ├── table.jsonl
-    ├── text.jsonl
+    ├── text_content.jsonl
+    ├── text_formatting.jsonl
     ├── expected_markdown.json
-    └── pdfs/{chart,layout,table,text}/*.pdf
+    └── docs/{chart,layout,table,text}/*.pdf
 """
 
 from __future__ import annotations

--- a/src/parse_bench/test_cases/loader.py
+++ b/src/parse_bench/test_cases/loader.py
@@ -53,9 +53,9 @@ def _load_jsonl_dataset(root_dir: Path) -> list[TestCase]:
 
     Expected layout:
       <root>/
-        {category}.jsonl       # e.g., table.jsonl, chart.jsonl, text.jsonl, layout.jsonl
+        {category}.jsonl       # e.g., table.jsonl, chart.jsonl, text_content.jsonl
         expected_markdown.json  # optional: {pdf_path: markdown_string}
-        pdfs/{category}/*.pdf
+        docs/{category}/*.pdf
 
     Each JSONL line has: pdf, page, category, id, type, verified, rule (JSON string or dict)
     """
@@ -368,7 +368,7 @@ def load_test_cases(
     <root>/
       {category}.jsonl
       expected_markdown.json
-      pdfs/{category}/*.pdf
+      docs/{category}/*.pdf
 
     :param root_dir: Root directory containing test case groups
     :param require_test_json: If True, skip files without test.json. If False,


### PR DESCRIPTION
Docs-only. The module docstrings in `data/download.py` and `test_cases/loader.py` still describe the old dataset layout:

- `text.jsonl` — the code (`_REQUIRED_FILES`) actually requires `text_content.jsonl` and `text_formatting.jsonl`
- `pdfs/{chart,layout,table,text}/*.pdf` — the code (`_REQUIRED_DOC_DIRS`) validates `docs/{chart,layout,table,text}`

Anyone assembling a local dataset (e.g. with `--input_dir`) from the docstrings gets a directory `is_dataset_ready` rejects. Updated the three docstrings to match the validation constants and the published HF dataset layout. No code changes.
