### PR TITLE
Fix exponential regex backtracking in markup-tolerant matching

### DIFF
--- a/src/parse_bench/evaluation/metrics/parse/rules_formatting.py
+++ b/src/parse_bench/evaluation/metrics/parse/rules_formatting.py
@@ -31,7 +31,14 @@ from parse_bench.test_cases.parse_rule_schemas import (
 # Matches optional inline formatting tokens that may appear between words
 # in raw markdown: strikethrough (~~), bold (**), italic (* or _), and
 # any HTML open/close/self-closing tags (<b>, </b>, <mark>, <sup>, etc.).
-_INLINE_MARKUP_OPT = r"(?:\*{1,2}|~~|__?|</?\w+(?:\s[^>]*)?>)*"
+#
+# The ``*`` and ``_`` alternatives are lookahead-disambiguated (``\*\*`` vs
+# ``\*(?!\*)``) instead of ``\*{1,2}``/``__?`` so each position has exactly
+# one tokenization. The ambiguous form has the classic ``(a|aa)*`` shape,
+# which backtracks exponentially when the following context fails to match -
+# a rule whose text spans a long ``_``/``*`` run (fill-in blanks, horizontal
+# rules) hangs until the per-rule timeout fires and the rule scores 0.
+_INLINE_MARKUP_OPT = r"(?:\*\*|\*(?!\*)|~~|__|_(?!_)|</?\w+(?:\s[^>]*)?>)*"
 
 # Markdown allows backslash-escaping of ASCII punctuation characters.
 # Model output often contains these (e.g. ``\~``, ``\*``) which prevent

--- a/tests/parse_bench/evaluation/metrics/parse/test_inline_markup_backtracking.py
+++ b/tests/parse_bench/evaluation/metrics/parse/test_inline_markup_backtracking.py
@@ -1,0 +1,71 @@
+"""Regression tests for ``_INLINE_MARKUP_OPT`` backtracking behavior.
+
+The markup-tolerant joiner is inserted between every pair of words in a
+rule's text, so a formatting rule evaluated against content containing a
+long ``_``/``*`` run (fill-in blanks, horizontal rules, table borders) used
+to backtrack exponentially — the ambiguous ``\\*{1,2}``/``__?`` alternatives
+gave ``(a|aa)*``-style tokenizations — hanging until the per-rule timeout
+fired and scoring the rule 0. The disambiguated alternatives match the same
+language with a single tokenization per position.
+"""
+
+from __future__ import annotations
+
+import time
+
+from parse_bench.evaluation.metrics.parse.rules_base import create_test_rule
+
+
+def _timed_run(rule_type: str, text: str, md: str) -> tuple[bool, float]:
+    rule = create_test_rule({"type": rule_type, "text": text})
+    start = time.monotonic()
+    passed, _ = rule.run(md)
+    return passed, time.monotonic() - start
+
+
+class TestLongMarkerRunsCompleteQuickly:
+    # Each case previously exceeded the 120s per-rule alarm by many orders
+    # of magnitude (the blowup is ~phi^n in the run length). The 10s bound
+    # leaves ample headroom for loaded CI runners (measured ~0.25s) while
+    # still failing decisively if the exponential behavior returns.
+
+    def test_long_underscore_run(self):
+        # The '**hello' prefix anchors the bold pattern so the joiner engages
+        # the underscore run before 'world' fails to match.
+        md = "**hello " + "_" * 3000 + " tail**"
+        passed, elapsed = _timed_run("is_bold", "hello world", md)
+        assert not passed
+        assert elapsed < 10.0
+
+    def test_long_asterisk_run_after_emphasis(self):
+        md = "*hello " + "*" * 3000 + " tail"
+        passed, elapsed = _timed_run("is_italic", "hello world", md)
+        assert not passed
+        assert elapsed < 10.0
+
+    def test_long_underscore_run_in_heading(self):
+        # The heading arm of the bold patterns engages the joiner too.
+        md = "# hello " + "_" * 3000 + " tail"
+        passed, elapsed = _timed_run("is_bold", "hello world", md)
+        assert not passed
+        assert elapsed < 10.0
+
+
+class TestMarkupToleranceUnchanged:
+    # The rewritten token matches the same language: nested/adjacent markup
+    # between words is still tolerated.
+
+    def test_bold_with_nested_strikethrough(self):
+        rule = create_test_rule({"type": "is_bold", "text": "hello world"})
+        passed, _ = rule.run("**hello ~~world~~**")
+        assert passed
+
+    def test_bold_with_adjacent_italic_markers(self):
+        rule = create_test_rule({"type": "is_bold", "text": "hello world"})
+        passed, _ = rule.run("**hello *world***")
+        assert passed
+
+    def test_bold_with_html_tag_between_words(self):
+        rule = create_test_rule({"type": "is_bold", "text": "hello world"})
+        passed, _ = rule.run("<b>hello <mark>world</mark></b>")
+        assert passed


### PR DESCRIPTION
## Problem

`_INLINE_MARKUP_OPT` — the token inserted between every pair of words by `_make_markup_tolerant` — contains the ambiguous quantifiers `\*{1,2}` and `__?`. That's the classic `(a|aa)*` ReDoS shape: over a run of n underscores or asterisks the engine explores Fibonacci-many tokenizations before the following pattern fails.

Measured on `is_bold("hello world")` against `**hello ____…____ tail**`:

| run length | time |
|---|---|
| 20 | 0.7 ms |
| 24 | 4.6 ms |
| 28 | 32 ms |
| 32 | 0.77 s |

…doubling every +4 characters. Documents genuinely contain long `_`/`*` runs (fill-in blanks, horizontal rules, table borders), and any multi-word formatting rule evaluated against them hangs until the 120 s per-rule `signal.alarm` fires and the rule scores 0 — a scoring artifact plus 2 minutes of wasted wall-clock per affected rule.

## Fix

One-line change: replace the ambiguous quantifiers with lookahead-disambiguated alternatives (`\*\*|\*(?!\*)`, `__|_(?!_)`) so every position has exactly one tokenization.

- **Language unchanged**: verified by exhaustive brute-force comparison (fullmatch old vs new) over all strings up to length 7 of the markup alphabet, and by 100k-case randomized fuzzing of the full joiner pattern.
- **Common case ~13% faster** (disambiguation prunes alternation work).
- The `signal.alarm` backstop stays — it still covers a residual *quadratic* (not exponential) tail that only matters past ~200k-char marker runs.

One disclosed edge: with the old token, a rule text containing a word-initial literal `*`/`_` (e.g. `"x *y"`) could match content like `**x* **y**` by splitting a `**` pair between the token and the query. The new token treats `**` atomically, so those matches are gone — arguably more correct, and no rule text in the published datasets has that shape as far as I can tell.

## Testing

New `tests/parse_bench/evaluation/metrics/parse/test_inline_markup_backtracking.py`: three adversarial-run cases (bold, italic, heading arms) that hang >20s before the fix and complete in <0.5s after, plus three markup-tolerance cases pinning the language. Full suite: 215 passed; ruff clean.
