### PR TITLE
Enforce top-level root order in TitleHierarchyPercentRule

### DIFF
--- a/src/parse_bench/evaluation/metrics/parse/rules_formatting.py
+++ b/src/parse_bench/evaluation/metrics/parse/rules_formatting.py
@@ -841,6 +841,7 @@ class TitleHierarchyPercentRule(ParseTestRule):
             for i in range(len(child_titles_in_order) - 1):
                 edges.append((child_titles_in_order[i], child_titles_in_order[i + 1], False))
 
+        root_titles_in_order: list[str] = []
         for root_raw, root_children in hierarchy.items():
             if not isinstance(root_raw, str):
                 continue
@@ -848,7 +849,19 @@ class TitleHierarchyPercentRule(ParseTestRule):
             if not normalized_root:
                 continue
             titles.add(normalized_root)
+            # First occurrence only: distinct keys can normalize to the same
+            # title ("**Intro**" and "Intro"), and a duplicate would create a
+            # self-edge or contradictory order edges that no document can
+            # satisfy.
+            if normalized_root not in root_titles_in_order:
+                root_titles_in_order.append(normalized_root)
             walk_children(normalized_root, root_children)
+
+        # Preserve top-level sibling ordering, mirroring the child-sibling
+        # edges above — without these, a multi-root hierarchy scores full
+        # marks regardless of the order the roots appear in.
+        for i in range(len(root_titles_in_order) - 1):
+            edges.append((root_titles_in_order[i], root_titles_in_order[i + 1], False))
 
         return titles, edges
 

--- a/tests/parse_bench/evaluation/metrics/parse/test_title_hierarchy_rule.py
+++ b/tests/parse_bench/evaluation/metrics/parse/test_title_hierarchy_rule.py
@@ -1,0 +1,89 @@
+"""Tests for TitleHierarchyPercentRule ordering constraints.
+
+Sibling order was only enforced for children under a common parent; the
+top-level roots had no order edges, so a multi-root hierarchy scored full
+marks no matter which order the roots appeared in.
+"""
+
+from __future__ import annotations
+
+from parse_bench.evaluation.metrics.parse.rules_base import create_test_rule
+
+TWO_ROOT_HIERARCHY = {
+    "Introduction": ["Background", "Scope"],
+    "Methods": ["Sampling", "Analysis"],
+}
+
+
+def _run(md: str) -> tuple[bool, float]:
+    rule = create_test_rule({"type": "title_hierarchy_percent", "title_hierarchy": TWO_ROOT_HIERARCHY})
+    passed, _, score = rule.run(md)
+    return passed, score
+
+
+def _doc(*headings: str) -> str:
+    return "\n\n".join(headings) + "\n"
+
+
+def test_roots_in_order_scores_full():
+    md = _doc(
+        "# Introduction",
+        "## Background",
+        "## Scope",
+        "# Methods",
+        "## Sampling",
+        "## Analysis",
+    )
+    passed, score = _run(md)
+    assert passed
+    assert score == 1.0
+
+
+def test_roots_out_of_order_penalized():
+    # Same content, root sections swapped: every title and child edge is
+    # satisfied, but the root order edge must fail.
+    md = _doc(
+        "# Methods",
+        "## Sampling",
+        "## Analysis",
+        "# Introduction",
+        "## Background",
+        "## Scope",
+    )
+    passed, score = _run(md)
+    assert not passed
+    assert score < 1.0
+
+
+def test_children_out_of_order_still_penalized():
+    md = _doc(
+        "# Introduction",
+        "## Scope",
+        "## Background",
+        "# Methods",
+        "## Sampling",
+        "## Analysis",
+    )
+    passed, score = _run(md)
+    assert not passed
+    assert score < 1.0
+
+
+def test_single_root_unaffected():
+    rule = create_test_rule(
+        {"type": "title_hierarchy_percent", "title_hierarchy": {"Overview": ["Part One", "Part Two"]}}
+    )
+    passed, _, score = rule.run(_doc("# Overview", "## Part One", "## Part Two"))
+    assert passed
+    assert score == 1.0
+
+
+def test_duplicate_roots_after_normalization_do_not_poison_score():
+    # "**Intro**" and "Intro" normalize to the same title; the order edges
+    # must not include a self-edge that no document can satisfy.
+    rule = create_test_rule(
+        {"type": "title_hierarchy_percent", "title_hierarchy": {"**Intro**": None, "Intro": None, "Body": None}}
+    )
+    passed, _, score = rule.run("# Intro\n\n# Body\n")
+    assert passed
+    assert score == 1.0


### PR DESCRIPTION
## Problem

`TitleHierarchyPercentRule._collect_constraints` preserves sibling order only for children under a common parent. Top-level roots get no order edges, so a multi-root `title_hierarchy` scores 1.0 no matter which order the root sections appear in:

```python
{"Introduction": ["Background", "Scope"], "Methods": ["Sampling", "Analysis"]}
```

A document emitting the whole **Methods** section before **Introduction** satisfies every title constraint and every parent→child edge (each root still precedes its own children), so it passes with a full score — the rule silently doesn't measure top-level ordering at all.

## Fix

Collect the normalized roots in encounter order and append `(root_i, root_i+1, require_deeper_level=False)` edges, exactly mirroring the existing `child_titles_in_order` logic ten lines above. Roots are deduped to first occurrence because distinct JSON keys can normalize to the same title (`"**Intro**"` vs `"Intro"`) and a duplicate would create a self-edge (`pos < pos` is always false) that caps the score below 1.0 on every document.

## Notes for reviewers

- This makes root insertion order load-bearing, the same way child order already is. JSON object order is preserved end-to-end (json → pydantic `dict[str, Any]` → rule), verified through the loader path. Externally-authored hierarchies that deliberately listed roots out of reading order would newly lose the root-order edges — I'd expect annotators to list sections in document order, but flagging it.
- Pre-existing and unchanged: `compute_rule_id` hashes with `sort_keys=True`, so two hierarchies differing only in ordering share an id. That was already true for child order.

## Testing

New `tests/parse_bench/evaluation/metrics/parse/test_title_hierarchy_rule.py`: in-order full score, swapped roots penalized (fails against the old code, passes with the fix), swapped children still penalized, single root unaffected, duplicate-normalizing roots don't poison the score. Full suite: 214 passed; ruff clean.
