### PR TITLE
Keep formatting-rule matches within a single span

### DIFF
--- a/src/parse_bench/evaluation/metrics/parse/rules_formatting.py
+++ b/src/parse_bench/evaluation/metrics/parse/rules_formatting.py
@@ -101,8 +101,11 @@ def _strip_other_formatting(text: str, keep_kind: str) -> str:
             continue
         for pattern, repl in replacements:
             result = pattern.sub(repl, result)
-    # Collapse whitespace and fix stray spaces before punctuation
-    result = re.sub(r"\s+", " ", result)
+    # Collapse whitespace (preserving line structure — the heading arm of
+    # the bold patterns is line-anchored) and fix stray spaces before
+    # punctuation
+    result = re.sub(r"[^\S\n]+", " ", result)
+    result = re.sub(r" ?\n ?", "\n", result)
     result = re.sub(r" ([,;:!?.\)\]\}])", r"\1", result)
     return result
 
@@ -172,21 +175,32 @@ class FormattingRule(ParseTestRule):
 
         The query may be a substring of the bold span (e.g. query
         ``Population`` matches ``**Population:**``).
+
+        The ``**`` delimiters follow CommonMark flanking (an opener is not
+        followed by whitespace, a closer is not preceded by it) and the
+        ``<b>`` filler cannot cross a closing tag — otherwise the closer of
+        one span pairs with the opener of the next and the unformatted text
+        between two bold spans (``**Name:** John **Age:**``) tests as bold.
+        The heading arm's fillers stay on the heading's own line for the
+        same reason. (The whitespace joiners inside a multi-word query can
+        still cross these boundaries; only the fillers are constrained.)
         """
         # Tempered greedy token: match any char that doesn't start a new **
         _not_bold_close = r"(?:(?!\*\*).)*?"
+        # Same idea for the HTML arm: don't cross a closing </b>
+        _not_b_close_tag = r"(?:(?!</b>).)*?"
         return [
             re.compile(
-                r"\*\*" + _not_bold_close + escaped_query + _not_bold_close + r"\*\*",
+                r"\*\*(?!\s)" + _not_bold_close + escaped_query + _not_bold_close + r"(?<!\s)\*\*",
                 re.IGNORECASE | re.DOTALL,
             ),
             re.compile(
-                r"<b>.*?" + escaped_query + r".*?</b>",
+                r"<b>" + _not_b_close_tag + escaped_query + _not_b_close_tag + r"</b>",
                 re.IGNORECASE | re.DOTALL,
             ),
             re.compile(
-                r"^\s*#{1,6}\s+.*?" + escaped_query + r".*?\s*(?:#+\s*)?$",
-                re.IGNORECASE | re.MULTILINE | re.DOTALL,
+                r"^[ \t]*#{1,6}[ \t]+[^\n]*?" + escaped_query + r"[^\n]*?[ \t]*(?:#+[ \t]*)?$",
+                re.IGNORECASE | re.MULTILINE,
             ),
         ]
 
@@ -201,6 +215,10 @@ class FormattingRule(ParseTestRule):
         _not_italic_close_star = r"(?:(?!\*(?!\*)).)*?"
         # Same idea for _
         _not_italic_close_under = r"(?:(?!_(?!_)).)*?"
+        # And for the HTML arms: the fillers must not cross a closing tag,
+        # or adjacent spans (<i>A</i> x <i>B</i>) merge into one match.
+        _not_i_close_tag = r"(?:(?!</i>).)*?"
+        _not_em_close_tag = r"(?:(?!</em>).)*?"
         return [
             # *text* but NOT **text** – use negative lookbehind/lookahead
             re.compile(
@@ -212,11 +230,11 @@ class FormattingRule(ParseTestRule):
                 re.IGNORECASE | re.DOTALL,
             ),
             re.compile(
-                r"<i>.*?" + escaped_query + r".*?</i>",
+                r"<i>" + _not_i_close_tag + escaped_query + _not_i_close_tag + r"</i>",
                 re.IGNORECASE | re.DOTALL,
             ),
             re.compile(
-                r"<em>.*?" + escaped_query + r".*?</em>",
+                r"<em>" + _not_em_close_tag + escaped_query + _not_em_close_tag + r"</em>",
                 re.IGNORECASE | re.DOTALL,
             ),
         ]

--- a/tests/parse_bench/evaluation/metrics/parse/test_formatting_rule_adjacent_spans.py
+++ b/tests/parse_bench/evaluation/metrics/parse/test_formatting_rule_adjacent_spans.py
@@ -1,0 +1,83 @@
+"""Tests for FormattingRule span boundaries.
+
+Three ways unformatted text used to test as formatted:
+
+* markdown ``**`` spans: the closer of one span paired with the opener of
+  the next, so the plain text between two bold spans matched
+  (``**Name:** John **Age:**`` -> ``** John **``),
+* HTML spans: the greedy fillers in ``<b>.*?query.*?</b>`` crossed closing
+  tags, merging adjacent elements, and
+* the heading arm: its DOTALL fillers crossed newlines, so any text
+  anywhere after any heading in the document tested as bold.
+"""
+
+from __future__ import annotations
+
+from parse_bench.evaluation.metrics.parse.rules_base import create_test_rule
+
+KV_MD = "**Name:** John **Age:** 42"
+KV_HTML = "<b>Name:</b> John <b>Age:</b> 42"
+
+
+def _run(rule_type: str, text: str, md: str) -> bool:
+    passed, _ = create_test_rule({"type": rule_type, "text": text}).run(md)
+    return passed
+
+
+class TestAdjacentMarkdownSpans:
+    def test_text_between_bold_spans_is_not_bold(self):
+        assert not _run("is_bold", "John", KV_MD)
+        assert _run("is_not_bold", "John", KV_MD)
+
+    def test_bold_span_content_still_detected(self):
+        assert _run("is_bold", "Name:", KV_MD)
+        assert _run("is_bold", "Age:", KV_MD)
+
+    def test_substring_of_bold_span_still_detected(self):
+        assert _run("is_bold", "Population", "**Population:** 5,000")
+
+    def test_multiline_bold_span_still_detected(self):
+        assert _run("is_bold", "multi line", "**multi\nline**")
+
+    def test_bold_italic_still_detected(self):
+        assert _run("is_bold", "tri", "some ***tri*** here")
+
+
+class TestAdjacentHtmlSpans:
+    def test_text_between_b_tags_is_not_bold(self):
+        assert not _run("is_bold", "John", KV_HTML)
+        assert _run("is_not_bold", "John", KV_HTML)
+
+    def test_b_tag_content_still_detected(self):
+        assert _run("is_bold", "Name:", KV_HTML)
+
+    def test_text_between_i_tags_is_not_italic(self):
+        assert not _run("is_italic", "John", "<i>Name:</i> John <i>Age:</i> 42")
+
+    def test_text_between_em_tags_is_not_italic(self):
+        assert not _run("is_italic", "John", "<em>Name:</em> John <em>Age:</em> 42")
+
+    def test_i_tag_content_still_detected(self):
+        assert _run("is_italic", "Name:", "<i>Name:</i> John")
+
+    def test_nested_markup_inside_element_still_detected(self):
+        assert _run("is_bold", "A B", "<b>A <mark>B</mark></b>")
+
+
+class TestHeadingArmStaysOnItsLine:
+    def test_body_text_after_heading_is_not_bold(self):
+        md = "# Some Heading\n\nparagraph with later text here"
+        assert not _run("is_bold", "later text here", md)
+        assert _run("is_not_bold", "later text here", md)
+
+    def test_heading_text_still_detected(self):
+        assert _run("is_bold", "Actual Heading", "# Actual Heading\n\nbody")
+
+    def test_heading_substring_still_detected(self):
+        assert _run("is_bold", "Heading", "## Longer Actual Heading Line\nbody")
+
+    def test_closed_atx_heading_still_detected(self):
+        assert _run("is_bold", "Title", "## Title ##\nbody")
+
+    def test_indented_heading_still_detected(self):
+        assert _run("is_bold", "Indented", "   # Indented\nbody")


### PR DESCRIPTION
## Problem

Unformatted text between two formatted spans tests as formatted, in three independent ways (all reproduced through `create_test_rule(...).run(...)` on current main):

```python
is_bold("John")     on "**Name:** John **Age:** 42"        → True   # '** John **'
is_bold("John")     on "<b>Name:</b> John <b>Age:</b> 42"  → True   # greedy .*? crosses </b>
is_italic("John")   on "<i>Name:</i> John <i>Age:</i> 42"  → True
is_bold("later text here") on "# Some Heading\n\nparagraph with later text here" → True
```

The first: the `**` arm's tempered fillers refuse to cross a `**`, but nothing stops the match from anchoring on the **closer** of one span and the **opener** of the next. The second/third: the HTML arms use fully greedy `.*?` fillers that cross closing tags. The fourth is the most surprising — the heading arm's `.*?` fillers carry DOTALL, so *any* text anywhere after *any* heading in the document tests as bold; even after fixing the pattern, the fallback path's `re.sub(r"\s+", " ")` in `_strip_other_formatting` collapsed the whole document onto one line, reintroducing it.

Key-value layouts (`**Label:** value`) are pervasive in document parses, so `is_not_bold`/`is_not_italic` rules currently fail on them and `is_bold` rules pass vacuously.

## Fix

- `**` arm: CommonMark flanking — an opener is not followed by whitespace, a closer is not preceded by it (the closer-of-A/opener-of-B pair is whitespace-adjacent in the KV pattern). Same approach as #68 takes for the italic `*` arm.
- `<b>`/`<i>`/`<em>` arms: tempered fillers (`(?:(?!</b>).)*?`) so a match cannot cross a closing tag.
- Heading arm: fillers restricted to the heading's own line (`[^\n]*?`, no DOTALL).
- `_strip_other_formatting`: whitespace collapse is now newline-preserving, so the fallback path can't flatten the document onto a heading's line.

## Disclosed trade-offs (all verified)

- Nested same-tag HTML (`<b>outer <b>inner</b> q</b>`): `q` renders bold but no longer matches — rare in parse output vs. the pervasive adjacent-span case.
- Space-padded `** padded **` / `**Label: **` no longer detected. Verified with markdown-it that CommonMark renders these as literal text, so this is a correction — but sloppy model output that lenient annotation treated as bold will now fail; worth a dataset-impact check.
- A multi-word query whose own whitespace joiner straddles a span boundary (e.g. rule text `"Name: John"` spanning label and value) can still match — only the fillers are constrained; a kind-aware joiner would be a deeper change.

Composes with #68 (italic `*`/`_` flanking); both touch `_build_italic_patterns`, happy to rebase whichever lands second.

## Testing

New `tests/parse_bench/evaluation/metrics/parse/test_formatting_rule_adjacent_spans.py` (16 cases: adjacent markdown/HTML spans, span content and substrings still detected, multiline bold, `***bold-italic***`, heading positives incl. closed/indented ATX, body-after-heading negatives). Full suite: 225 passed; ruff clean. Adversarial-input timing checked: tempered fillers add no new blowup class (bounded by the existing per-rule alarm).
