### PR TITLE
Validate and clamp layout div bboxes in the shared parsing path

### DIFF
--- a/src/parse_bench/inference/providers/parse/_layout_utils.py
+++ b/src/parse_bench/inference/providers/parse/_layout_utils.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import re
 from typing import Any
 
@@ -147,6 +148,19 @@ def split_pdf_to_pages(pdf_path: str) -> list[tuple[bytes, int, int]]:
     return results
 
 
+def _is_valid_bbox(bbox: Any) -> bool:
+    """True when *bbox* is a list of four finite numeric (non-bool) elements.
+
+    Models occasionally emit null, string, or NaN/Infinity entries (json.loads
+    accepts the latter), which would raise or clamp to garbage downstream.
+    """
+    return (
+        isinstance(bbox, list)
+        and len(bbox) == 4
+        and all(isinstance(v, (int, float)) and not isinstance(v, bool) and math.isfinite(v) for v in bbox)
+    )
+
+
 def parse_layout_blocks(content: str) -> list[dict[str, Any]]:
     """Parse <div data-bbox="..." data-label="...">content</div> blocks.
 
@@ -186,10 +200,13 @@ def parse_layout_blocks(content: str) -> list[dict[str, Any]]:
         seen_positions.add(pos)
         try:
             bbox = json.loads(bbox_str)
-            if isinstance(bbox, list) and len(bbox) == 4:
-                blocks.append({"bbox": bbox, "label": label, "text": text.strip()})
         except json.JSONDecodeError:
             logger.warning(f"Failed to parse bbox: {bbox_str}")
+            continue
+        if _is_valid_bbox(bbox):
+            blocks.append({"bbox": bbox, "label": label, "text": text.strip()})
+        else:
+            logger.warning(f"Skipping block with malformed bbox: {bbox_str}")
 
     return blocks
 
@@ -238,10 +255,21 @@ def build_layout_pages(
         label_raw = item.get("label", "text")
         text = item.get("text", "")
 
-        if len(bbox) != 4:
+        # Re-validate: items may come from raw outputs persisted before
+        # parse_layout_blocks filtered malformed bboxes (renormalization).
+        if not _is_valid_bbox(bbox):
+            logger.warning(f"Skipping layout item with malformed bbox: {bbox!r}")
             continue
 
         x1, y1, x2, y2 = bbox
+
+        # Clamp to the prompt's [0, 1000] range (as the qwen3vl layout
+        # provider does) so an out-of-range coordinate cannot produce a
+        # segment outside the unit square.
+        clamped = [max(0, min(1000, v)) for v in (x1, y1, x2, y2)]
+        if clamped != [x1, y1, x2, y2]:
+            logger.warning(f"Clamped out-of-range bbox {bbox!r} to the 0-1000 range")
+        x1, y1, x2, y2 = clamped
 
         # Convert from 0-1000 [x1,y1,x2,y2] to normalized [0,1] COCO [x,y,w,h]
         nx = x1 / 1000.0

--- a/tests/parse_bench/inference/providers/parse/test_layout_block_parsing.py
+++ b/tests/parse_bench/inference/providers/parse/test_layout_block_parsing.py
@@ -1,0 +1,108 @@
+"""Tests for layout div parsing robustness.
+
+``parse_layout_blocks`` only checked that ``data-bbox`` decoded to a
+4-element JSON list, so a model emitting ``[1, 2, 3, null]`` or string
+elements produced items that raised ``TypeError`` deep inside
+``build_layout_pages`` (``null / 1000``), failing the whole example.
+Coordinates outside the prompt's 0-1000 range likewise flowed through
+unclamped, producing layout segments outside the unit square.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from parse_bench.inference.providers.parse._layout_utils import (
+    build_layout_pages,
+    parse_layout_blocks,
+)
+
+
+def _div(bbox: str, label: str = "Text", text: str = "hello") -> str:
+    return f'<div data-bbox="{bbox}" data-label="{label}">{text}</div>'
+
+
+class TestBboxValidation(unittest.TestCase):
+    def test_valid_int_bbox_parsed(self) -> None:
+        blocks = parse_layout_blocks(_div("[100, 50, 900, 120]"))
+        self.assertEqual(len(blocks), 1)
+        self.assertEqual(blocks[0]["bbox"], [100, 50, 900, 120])
+
+    def test_float_bbox_parsed(self) -> None:
+        blocks = parse_layout_blocks(_div("[100.5, 50, 900, 120.5]"))
+        self.assertEqual(len(blocks), 1)
+
+    def test_null_element_skipped(self) -> None:
+        blocks = parse_layout_blocks(_div("[1, 2, 3, null]"))
+        self.assertEqual(blocks, [])
+
+    def test_string_elements_skipped(self) -> None:
+        blocks = parse_layout_blocks(_div('["a", "b", "c", "d"]'))
+        self.assertEqual(blocks, [])
+
+    def test_boolean_elements_skipped(self) -> None:
+        blocks = parse_layout_blocks(_div("[true, false, true, false]"))
+        self.assertEqual(blocks, [])
+
+    def test_nan_and_infinity_skipped(self) -> None:
+        # json.loads accepts NaN/Infinity; both must be rejected, not
+        # clamped into fabricated coordinates.
+        self.assertEqual(parse_layout_blocks(_div("[NaN, 0, 100, 100]")), [])
+        self.assertEqual(parse_layout_blocks(_div("[-Infinity, 0, Infinity, 100]")), [])
+
+    def test_wrong_length_skipped(self) -> None:
+        blocks = parse_layout_blocks(_div("[1, 2, 3]"))
+        self.assertEqual(blocks, [])
+
+    def test_malformed_block_does_not_drop_valid_siblings(self) -> None:
+        content = _div("[1, 2, 3, null]") + "\n" + _div("[0, 0, 500, 500]", text="ok")
+        blocks = parse_layout_blocks(content)
+        self.assertEqual(len(blocks), 1)
+        self.assertEqual(blocks[0]["text"], "ok")
+
+    def test_pipeline_no_longer_crashes_on_null_element(self) -> None:
+        # End to end: previously the null survived parse_layout_blocks and
+        # raised TypeError in build_layout_pages (null / 1000).
+        content = _div("[1, 2, 3, null]") + _div("[0, 0, 500, 500]", text="ok")
+        blocks = parse_layout_blocks(content)
+        pages = build_layout_pages(blocks, 850, 1100, "ok")
+        self.assertEqual(len(pages), 1)
+        self.assertEqual(len(pages[0].items), 1)
+
+
+class TestBuildLayoutPagesRevalidation(unittest.TestCase):
+    def test_persisted_malformed_item_skipped_not_crashed(self) -> None:
+        # Raw outputs persisted before the parse-time filter can carry
+        # malformed items into build_layout_pages via renormalization.
+        items = [
+            {"bbox": [1, 2, 3, None], "label": "Text", "text": "bad"},
+            {"bbox": [0, 0, 500, 500], "label": "Text", "text": "ok"},
+        ]
+        pages = build_layout_pages(items, 850, 1100, "ok")
+        self.assertEqual(len(pages), 1)
+        self.assertEqual(len(pages[0].items), 1)
+        self.assertEqual(pages[0].items[0].value, "ok")
+
+
+class TestCoordinateClamping(unittest.TestCase):
+    def test_out_of_range_coordinates_clamped(self) -> None:
+        blocks = parse_layout_blocks(_div("[-50, 0, 1100, 500]"))
+        pages = build_layout_pages(blocks, 850, 1100, "hello")
+        seg = pages[0].items[0].bbox
+        self.assertEqual(seg.x, 0.0)
+        self.assertEqual(seg.w, 1.0)
+        self.assertEqual(seg.y, 0.0)
+        self.assertEqual(seg.h, 0.5)
+
+    def test_in_range_coordinates_unchanged(self) -> None:
+        blocks = parse_layout_blocks(_div("[100, 200, 600, 700]"))
+        pages = build_layout_pages(blocks, 850, 1100, "hello")
+        seg = pages[0].items[0].bbox
+        self.assertAlmostEqual(seg.x, 0.1)
+        self.assertAlmostEqual(seg.y, 0.2)
+        self.assertAlmostEqual(seg.w, 0.5)
+        self.assertAlmostEqual(seg.h, 0.5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`parse_layout_blocks` only checks that `data-bbox` decodes to a 4-element JSON list. Models occasionally emit malformed entries, and each shape fails differently:

- `[1, 2, 3, null]` or string elements: accepted at parse time, then `TypeError` deep inside `build_layout_pages` (`null / 1000`) — the provider's `normalize()` raises and the whole example fails (reproduced on main):

  ```
  old parse accepts: [{'bbox': [1, 2, 3, None], ...}]
  old build crashes: TypeError: unsupported operand type(s) for -: 'NoneType' and 'int'
  ```
- `[NaN, 0, 100, 100]`: `json.loads` accepts `NaN`/`Infinity` by default and `isinstance(nan, float)` is True — `min(1000, nan)` then returns 1000, silently fabricating a right-edge segment with negative width.
- Out-of-range coordinates (e.g. pixel coords when the model ignored the 0-1000 instruction) flowed through unclamped, producing segments outside the unit square.

## Fix

- A shared `_is_valid_bbox` requires four finite numeric (non-bool) elements. `parse_layout_blocks` skips invalid blocks with a warning (valid siblings survive). `build_layout_pages` re-validates, because renormalization replays raw outputs persisted before the parse-time filter existed.
- Coordinates are clamped to `[0, 1000]` before the `/1000` conversion — the same policy as the `qwen3vl` layoutdet provider — with a warning logged only when clamping actually changes a coordinate, so a model that ignored the coordinate convention leaves a trace (the agentic-vision path drops such boxes; the shared path previously did neither).

Not addressed (pre-existing, unchanged): inverted boxes (`x2 < x1`) still produce negative-width segments; reordering would silently repair wrong model output, which feels like a policy call for the maintainers.

## Testing

New `tests/parse_bench/inference/providers/parse/test_layout_block_parsing.py` (12 cases: valid int/float boxes, null/string/bool/NaN/Infinity elements, wrong length, malformed-sibling survival, end-to-end no-crash, renormalization-path revalidation, clamp values, in-range passthrough). Full suite: 221 passed; ruff clean.
