### PR TITLE
Update Cost Effective leaderboard results

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ _Top 10 by Overall score. For the full sortable, filterable leaderboard, see [pa
 | Rank | Provider | Category | Overall | Tables | Charts | Content Faith. | Sem. Format. | Visual Ground. | ¢ / Page |
 |---:|---|---|---:|---:|---:|---:|---:|---:|---:|
 | 1 | LlamaParse Agentic | LlamaParse | 84.88 | 90.74 | 78.11 | 89.68 | 85.24 | 80.62 | 1.25¢ |
-| 2 | KDL-Frontier-Parser-nano | VLM - Open Weight | 76.36 | 85.56 | 63.41 | 87.19 | 66.81 | 78.84 | — |
-| 3 | Google Gemini 3 Flash (Thinking High) | VLM - Proprietary | 75.05 | 91.50 | 64.79 | 90.87 | 68.31 | 59.77 | 2.41¢ |
-| 4 | Infinity-Parser2-Pro | VLM - Open Weight | 74.28 | 86.4 | 61.3 | 89.7 | 59.1 | 74.9 | — |
-| 5 | Infinity-Parser2-Flash | VLM - Open Weight | 73.25 | 82.88 | 55.56 | 89.52 | 57.7 | 80.61 | — |
-| 6 | Reducto (Agentic) | Commercial - Startup APIs | 72.97 | 80.42 | 73.4 | 86.37 | 57.6 | 67.07 | 4.76¢ |
-| 7 | MinerU2.5-Pro-2605-1.2B | VLM - Open Weight | 72.78 | 77.59 | 61.64 | 87.88 | 57.49 | 79.30 | — |
-| 8 | LlamaParse Cost Effective | LlamaParse | 71.89 | 73.16 | 66.66 | 88.02 | 73.04 | 58.56 | 0.38¢ |
+| 2 | LlamaParse Cost Effective | LlamaParse | 76.77 | 81.42 | 70.15 | 90.92 | 68.78 | 72.59 | 0.38¢ |
+| 3 | KDL-Frontier-Parser-nano | VLM - Open Weight | 76.36 | 85.56 | 63.41 | 87.19 | 66.81 | 78.84 | — |
+| 4 | Google Gemini 3 Flash (Thinking High) | VLM - Proprietary | 75.05 | 91.50 | 64.79 | 90.87 | 68.31 | 59.77 | 2.41¢ |
+| 5 | Infinity-Parser2-Pro | VLM - Open Weight | 74.28 | 86.4 | 61.3 | 89.7 | 59.1 | 74.9 | — |
+| 6 | Infinity-Parser2-Flash | VLM - Open Weight | 73.25 | 82.88 | 55.56 | 89.52 | 57.7 | 80.61 | — |
+| 7 | Reducto (Agentic) | Commercial - Startup APIs | 72.97 | 80.42 | 73.4 | 86.37 | 57.6 | 67.07 | 4.76¢ |
+| 8 | MinerU2.5-Pro-2605-1.2B | VLM - Open Weight | 72.78 | 77.59 | 61.64 | 87.88 | 57.49 | 79.30 | — |
 | 9 | Google Gemini 3 Flash (Thinking Minimal) | VLM - Proprietary | 71.04 | 89.85 | 64.83 | 86.19 | 58.35 | 55.97 | 0.65¢ |
 | 10 | Anthropic Fable 5 | VLM - Proprietary | 70.78 | 89.79 | 52.21 | 90.02 | 72.62 | 49.24 | 15.60¢ |
 <!-- LEADERBOARD:END -->

--- a/leaderboard.csv
+++ b/leaderboard.csv
@@ -1,5 +1,5 @@
 Provider,Category,Overall,Tables,Charts,Content_Faithfulness,Semantic_Formatting,Visual_Grounding,Cost_Per_Page,Cost_Charts,Cost_Tables,Cost_Text,Cost_Layout,HF_Model_ID
-LlamaParse Cost Effective,LlamaParse,71.89,73.16,66.66,88.02,73.04,58.56,0.375,,,,,
+LlamaParse Cost Effective,LlamaParse,76.77,81.42,70.15,90.92,68.78,72.59,0.375,,,,,
 LlamaParse Agentic,LlamaParse,84.88,90.74,78.11,89.68,85.24,80.62,1.25,,,,,
 OpenAI GPT-5 Mini (Reasoning Minimal),VLM - Proprietary,46.83,69.82,30.13,82.30,45.77,6.15,0.88,0.70,1.22,0.67,0.91,
 OpenAI GPT-5 Mini (Reasoning Medium),VLM - Proprietary,51.52,74.60,38.96,85.68,45.35,13.03,3.05,2.93,3.43,2.67,3.15,


### PR DESCRIPTION
## What

Refresh the LlamaParse Cost Effective leaderboard entry with the latest benchmark results and update the README Top 10 table.

## Why

The checked-in leaderboard still showed an older 71.89 overall score. The latest extended-benchmark results improve the overall score to 76.77 and move LlamaParse Cost Effective from eighth to second place.

## How

- Updated all five capability scores in `leaderboard.csv` while preserving the existing 0.375 cents-per-page cost.
- Regenerated the README leaderboard block with `scripts/update_readme.py`.

## Changes

- `leaderboard.csv`: refresh LlamaParse Cost Effective scores.
- `README.md`: reflect the updated scores and Top 10 ranking.

## Testing

- Parsed all 74 CSV rows and verified column integrity.
- Recomputed the overall score from the five capability dimensions and confirmed 76.77.
- Regenerated the README leaderboard twice to confirm the output is idempotent.
- Verified the README shows LlamaParse Cost Effective at rank 2 with the updated values.

## Notes

No pipeline implementation or benchmark evaluation logic changes are included.
