### PR TITLE
Add oi_parser parse provider and pipeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,12 @@ LANDING_AI_API_KEY=
 # Unstructured (unstructured_auto, unstructured_fast, unstructured_hi_res)
 UNSTRUCTURED_API_KEY=
 
+# OpenInnovation Parser (oi_parser) — hosted /v1/extract API
+# Sign up at https://oi-parser.ai/ to create an account and get an API key.
+OI_PARSER_API_KEY=
+# Optional: override the API base URL (defaults to the service's public endpoint)
+OI_PARSER_BASE_URL=
+
 # -----------------------------------------------------------------------------
 # Self-hosted Model Endpoints
 # These pipelines require you to deploy the model yourself and provide the URL.

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -168,6 +168,14 @@ These pipelines use hosted APIs. You only need an API key in your `.env` file.
 | `unstructured_fast` | Fast strategy | `UNSTRUCTURED_API_KEY` |
 | `unstructured_hi_res` | Hi-res strategy | `UNSTRUCTURED_API_KEY` |
 
+### OpenInnovation Parser (oi-parser)
+
+Hosted document-parsing API. Sign up at [oi-parser.ai](https://oi-parser.ai/) to get an API key.
+
+| Pipeline | Description | Env Vars |
+|---|---|---|
+| **`oi_parser`** | oi-parser hosted `/v1/extract` API | `OI_PARSER_API_KEY`, `OI_PARSER_BASE_URL` (optional) |
+
 ---
 
 ## Self-hosted Model Pipelines

--- a/src/parse_bench/evaluation/layout_adapters/adapters.py
+++ b/src/parse_bench/evaluation/layout_adapters/adapters.py
@@ -1332,6 +1332,103 @@ class ReductoLayoutAdapter(LayoutAdapter):
         )
 
 
+@register_layout_adapter("oi_parser", priority=90)
+class OIParserLayoutAdapter(LayoutAdapter):
+    """Adapter that extracts LayoutOutput from oi-parser ParseOutput.layout_pages.
+
+    Enables cross-evaluation: the ``oi_parser`` PARSE pipeline is scored against the
+    layout-detection dataset using the block bboxes the API returns in
+    ``output.layout_pages`` (absolute-pixel xywh + a raw label per item; label casing
+    is canonicalized to Canonical17 by ``OIParserLabelMapper``).
+    """
+
+    @classmethod
+    def matches(cls, inference_result: InferenceResult) -> bool:
+        return isinstance(inference_result.output, ParseOutput) and bool(
+            inference_result.output.layout_pages
+        )
+
+    def to_layout_output(
+        self,
+        inference_result: InferenceResult,
+        *,
+        page_filter: int | None = None,
+    ) -> LayoutOutput:
+        # Handle synthetic LayoutOutput results (e.g. from cross-eval re-runs).
+        if isinstance(inference_result.output, LayoutOutput):
+            if page_filter is None:
+                return inference_result.output
+            filtered = [p for p in inference_result.output.predictions if p.page == page_filter]
+            return inference_result.output.model_copy(update={"predictions": filtered})
+
+        if not isinstance(inference_result.output, ParseOutput):
+            raise ValueError("OIParserLayoutAdapter requires ParseOutput or LayoutOutput")
+
+        layout_pages = inference_result.output.layout_pages
+        if not layout_pages:
+            # Doc produced markdown but no layout segments (e.g. a huge table whose
+            # layout-detect response was truncated). Emit an EMPTY LayoutOutput so the
+            # doc is still COUNTED (scores ~0 on layout) rather than erroring and being
+            # dropped — dropping would inflate the average (anti-cheat concern).
+            return LayoutOutput(
+                task_type="layout_detection",
+                example_id=inference_result.request.example_id,
+                pipeline_name=inference_result.pipeline_name,
+                model=LayoutDetectionModel.OI_PARSER_LAYOUT,
+                image_width=1,
+                image_height=1,
+                predictions=[],
+            )
+
+        first_page = layout_pages[0]
+        output_width = int(first_page.width or 1)
+        output_height = int(first_page.height or 1)
+
+        predictions: list[LayoutPrediction] = []
+
+        for lp in layout_pages:
+            page_number = lp.page_number
+            if page_filter is not None and page_number != page_filter:
+                continue
+
+            for item in lp.items:
+                for seg in item.layout_segments:
+                    # Emit the raw API label; OIParserLabelMapper canonicalizes casing.
+                    label = seg.label or item.type or "Text"
+
+                    # oi-parser emits ABSOLUTE pixel xywh (in the page's width/height
+                    # pixel space), so map straight to pixel xyxy — no [0,1] scaling.
+                    x1 = seg.x
+                    y1 = seg.y
+                    x2 = seg.x + seg.w
+                    y2 = seg.y + seg.h
+
+                    content = _build_vendor_content(label, item.value)
+
+                    predictions.append(
+                        LayoutPrediction(
+                            bbox=[x1, y1, x2, y2],
+                            score=float(seg.confidence or 1.0),
+                            label=label,
+                            page=page_number,
+                            content=content,
+                            provider_metadata={
+                                "order_index": len(predictions),
+                            },
+                        )
+                    )
+
+        return LayoutOutput(
+            task_type="layout_detection",
+            example_id=inference_result.request.example_id,
+            pipeline_name=inference_result.pipeline_name,
+            model=LayoutDetectionModel.OI_PARSER_LAYOUT,
+            image_width=max(output_width, 1),
+            image_height=max(output_height, 1),
+            predictions=predictions,
+        )
+
+
 @register_layout_adapter("pulse", priority=90)
 class PulseLayoutAdapter(LayoutAdapter):
     """Adapter that extracts LayoutOutput from Pulse ParseOutput.layout_pages.

--- a/src/parse_bench/evaluation/layout_label_mappers/mappers.py
+++ b/src/parse_bench/evaluation/layout_label_mappers/mappers.py
@@ -109,6 +109,30 @@ class DoclingParseLabelMapper(LayoutLabelMapper):
         return canonical
 
 
+@register_layout_label_mapper("oi_parser", "model:oi_parser_layout", priority=90)
+class OIParserLabelMapper(LayoutLabelMapper):
+    """Mapper for oi-parser layout labels.
+
+    oi-parser emits Canonical17 labels in lowercase-hyphenated form (e.g.
+    ``page-header``); normalize the casing back to the Canonical17 enum values.
+    """
+
+    # Canonical17 values keyed by their lowercased form for case-insensitive lookup.
+    _BY_LOWER: dict[str, CanonicalLabel] = {label.value.lower(): label for label in CanonicalLabel}
+
+    def to_canonical(
+        self,
+        label: str,
+        prediction: LayoutPrediction,
+        context: MappingContext,
+    ) -> CanonicalLabel:
+        del prediction, context
+        canonical = self._BY_LOWER.get(label.strip().lower())
+        if canonical is None:
+            raise UnknownRawLayoutLabelError(f"Unknown oi-parser layout label '{label}'")
+        return canonical
+
+
 @register_layout_label_mapper(
     "model:yolo_doclaynet",
     "model:docling_layout_old",

--- a/src/parse_bench/inference/pipelines/parse.py
+++ b/src/parse_bench/inference/pipelines/parse.py
@@ -2122,3 +2122,18 @@ def register_parse_pipelines(register_fn) -> None:  # type: ignore[no-untyped-de
             },
         )
     )
+
+    # =========================================================================
+    # OpenInnovation Parser (oi-parser)
+    # =========================================================================
+    register_fn(
+        PipelineSpec(
+            pipeline_name="oi_parser",
+            provider_name="oi_parser",
+            product_type=ProductType.PARSE,
+            # Endpoint resolves in the provider: OI_PARSER_BASE_URL env → the provider's
+            # default public endpoint. Left unset here so the env override is honored
+            # (matches the LlamaParse configurable-base-URL convention).
+            config={},
+        )
+    )

--- a/src/parse_bench/inference/providers/parse/__init__.py
+++ b/src/parse_bench/inference/providers/parse/__init__.py
@@ -48,6 +48,7 @@ _PROVIDER_MODULES = [
     "unlimitedocr",
     "unstructured",
     "warp_ingest",
+    "oi_parser",
 ]
 
 for _mod in _PROVIDER_MODULES:

--- a/src/parse_bench/inference/providers/parse/oi_parser.py
+++ b/src/parse_bench/inference/providers/parse/oi_parser.py
@@ -1,0 +1,230 @@
+"""Provider for the OpenInnovation Parser public API (``oi-parser``).
+
+The provider calls a single **synchronous** ``POST {base_url}/v1/extract`` with
+``X-API-Key`` auth and the document as a multipart ``file`` (one doc per call, N
+parallel — the runner's ``ThreadPoolExecutor``). The API is synchronous: the full
+result is in the 200 body, which is an already-normalized ``InferenceResult`` JSON
+(with ``output.markdown`` / ``output.layout_pages`` / ``output.pages``, plus
+top-level ``status`` / ``metrics`` that the evaluator ignores). ``normalize()``
+therefore just re-hydrates the body's ``output`` into a :class:`ParseOutput`,
+forcing ``example_id`` to the request's id (the eval matches on it) and
+``pipeline_name`` to the registered pipeline name.
+
+Config keys
+-----------
+api_key : str
+    oi-parser API key. Falls back to the ``OI_PARSER_API_KEY`` env var. Required.
+base_url : str
+    Base URL of the public API. Falls back to ``OI_PARSER_BASE_URL``, else the
+    default below.
+timeout : int
+    HTTP request timeout in seconds (default 900, matching the server's extract cap).
+
+Recommended ``--max_concurrent``: **20** — the server enforces a per-key concurrency
+cap (20 on the validated key); exceeding it wastes retries and can drop docs.
+"""
+
+import html as _html
+import os
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import requests
+
+from parse_bench.inference.providers.base import (
+    Provider,
+    ProviderConfigError,
+    ProviderPermanentError,
+    ProviderRateLimitError,
+    ProviderTransientError,
+)
+from parse_bench.inference.providers.registry import register_provider
+from parse_bench.schemas.parse_output import ParseOutput
+from parse_bench.schemas.pipeline import PipelineSpec
+from parse_bench.schemas.pipeline_io import (
+    InferenceRequest,
+    InferenceResult,
+    RawInferenceResult,
+)
+from parse_bench.schemas.product import ProductType
+
+_DEFAULT_BASE_URL = "https://parse.prod.openinnovation.ai"
+
+# ParseBench's table metric (GriTS/TEDS) only scores HTML <table>; oi-parser markdown
+# may render tables as GitHub-flavored pipe tables (correct data, wrong format for
+# GriTS). normalize() converts pipe tables → HTML for scoring — same as the reference
+# mistral_ocr provider. Only valid pipe-table blocks (header + separator + >=1 row) are
+# converted; all other content (incl. HTML-native tables) is left byte-identical.
+_SEP_RE = re.compile(r"^\|?[\s:|-]+\|?$")
+
+
+def _is_pipe_row(line: str) -> bool:
+    s = line.strip()
+    return "|" in s and not s.startswith("<!--")
+
+
+def _cells(row: str) -> list[str]:
+    r = row.strip()
+    if r.startswith("|"):
+        r = r[1:]
+    if r.endswith("|"):
+        r = r[:-1]
+    return [c.strip() for c in r.split("|")]
+
+
+def _block_to_html(block: list[str]) -> str | None:
+    sep_idx = next((i for i, ln in enumerate(block) if _SEP_RE.match(ln.strip())), None)
+    if sep_idx is None or sep_idx == 0 or len(block) < 3:
+        return None
+    header = _cells(block[sep_idx - 1])
+    data = [_cells(ln) for ln in block[sep_idx + 1 :] if ln.strip()]
+    if not data:
+        return None
+    th = "".join(f"<th>{_html.escape(c)}</th>" for c in header)
+    body = "".join(
+        "<tr>" + "".join(f"<td>{_html.escape(c)}</td>" for c in row) + "</tr>" for row in data
+    )
+    return f"<table><thead><tr>{th}</tr></thead><tbody>{body}</tbody></table>"
+
+
+def _pipe_tables_to_html(md: str) -> str:
+    """Replace markdown pipe tables with HTML <table>; leave everything else byte-identical."""
+    if not md or "|" not in md:
+        return md
+    lines = md.split("\n")
+    out: list[str] = []
+    i = 0
+    n = len(lines)
+    while i < n:
+        if _is_pipe_row(lines[i]):
+            j = i
+            block: list[str] = []
+            while j < n and _is_pipe_row(lines[j]):
+                block.append(lines[j])
+                j += 1
+            html_table = _block_to_html(block)
+            if html_table is not None:
+                out.append(html_table)
+            else:
+                out.extend(block)
+            i = j
+        else:
+            out.append(lines[i])
+            i += 1
+    return "\n".join(out)
+
+
+@register_provider("oi_parser")
+class OIParserProvider(Provider):
+    """Provider for the oi-parser public ``/v1/extract`` API."""
+
+    def __init__(self, provider_name: str, base_config: dict[str, Any] | None = None):
+        super().__init__(provider_name, base_config)
+
+        api_key = self.base_config.get("api_key") or os.getenv("OI_PARSER_API_KEY")
+        if not api_key:
+            raise ProviderConfigError(
+                "oi-parser API key is required. Set OI_PARSER_API_KEY environment "
+                "variable or pass api_key in base_config."
+            )
+        self._api_key: str = str(api_key)
+        self._base_url: str = (
+            self.base_config.get("base_url") or os.getenv("OI_PARSER_BASE_URL") or _DEFAULT_BASE_URL
+        ).rstrip("/")
+        self._timeout: int = int(self.base_config.get("timeout", 900))
+
+    def run_inference(self, pipeline: PipelineSpec, request: InferenceRequest) -> RawInferenceResult:
+        if request.product_type != ProductType.PARSE:
+            raise ProviderPermanentError(
+                f"OIParserProvider only supports PARSE, got {request.product_type}"
+            )
+
+        path = Path(request.source_file_path)
+        if not path.exists():
+            raise ProviderPermanentError(f"File not found: {path}")
+
+        started_at = datetime.now()
+        try:
+            with open(path, "rb") as fh:
+                resp = requests.post(
+                    f"{self._base_url}/v1/extract",
+                    headers={"X-API-Key": self._api_key},
+                    files={"file": (path.name, fh, "application/octet-stream")},
+                    data={"example_id": request.example_id},
+                    timeout=self._timeout,
+                )
+        except requests.exceptions.RequestException as e:
+            # Any transport-level failure — timeout, connection reset ("peer closed
+            # connection" under over-cap admission), or a ChunkedEncodingError
+            # ("Response ended prematurely") when the body stream is cut — is
+            # transient, so the runner retries it. A 4xx/5xx does NOT raise here
+            # (requests returns a Response); those are classified by status below.
+            raise ProviderTransientError(f"oi-parser request error: {type(e).__name__}: {e}") from e
+
+        sc = resp.status_code
+        if sc == 401:
+            raise ProviderConfigError(f"oi-parser unauthorized (401): {resp.text[:300]}")
+        if sc == 429:
+            raise ProviderRateLimitError(f"oi-parser rate limit (429): {resp.text[:300]}")
+        if sc >= 500:
+            raise ProviderTransientError(f"oi-parser server error ({sc}): {resp.text[:300]}")
+        if sc >= 400:
+            raise ProviderPermanentError(f"oi-parser client error ({sc}): {resp.text[:300]}")
+
+        try:
+            raw_output: dict[str, Any] = resp.json()
+        except (ValueError, requests.exceptions.RequestException) as e:
+            # Truncated/invalid body (e.g. ChunkedEncodingError surfacing at read
+            # time, or non-JSON) — transient; let the runner retry.
+            raise ProviderTransientError(
+                f"oi-parser bad/truncated response body: {type(e).__name__}: {e}"
+            ) from e
+        completed_at = datetime.now()
+        latency_ms = int((completed_at - started_at).total_seconds() * 1000)
+
+        return RawInferenceResult(
+            request=request,
+            pipeline=pipeline,
+            pipeline_name=pipeline.pipeline_name,
+            product_type=request.product_type,
+            raw_output=raw_output,
+            started_at=started_at,
+            completed_at=completed_at,
+            latency_in_ms=latency_ms,
+        )
+
+    def normalize(self, raw_result: RawInferenceResult) -> InferenceResult:
+        if raw_result.product_type != ProductType.PARSE:
+            raise ProviderPermanentError(
+                f"OIParserProvider only supports PARSE, got {raw_result.product_type}"
+            )
+
+        body_output = raw_result.raw_output.get("output")
+        if not isinstance(body_output, dict):
+            raise ProviderPermanentError("oi-parser response missing an 'output' object")
+
+        # The API returns an already-normalized, ParseOutput-shaped body. Re-hydrate it,
+        # forcing two fields:
+        #   example_id    -> the ParseBench request id (REQUIRED; the eval matches on it)
+        #   pipeline_name -> the registered pipeline name ("oi_parser"); the body carries
+        #                    the server-side "oi-parser" (hyphen), which is NOT registered.
+        # The body's markdown / layout_pages / pages are preserved verbatim.
+        out_dict = dict(body_output)
+        out_dict["example_id"] = raw_result.request.example_id
+        out_dict["pipeline_name"] = raw_result.pipeline_name
+        if out_dict.get("markdown"):
+            out_dict["markdown"] = _pipe_tables_to_html(out_dict["markdown"])
+        output = ParseOutput.model_validate(out_dict)
+
+        return InferenceResult(
+            request=raw_result.request,
+            pipeline_name=raw_result.pipeline_name,
+            product_type=raw_result.product_type,
+            raw_output=raw_result.raw_output,
+            output=output,
+            started_at=raw_result.started_at,
+            completed_at=raw_result.completed_at,
+            latency_in_ms=raw_result.latency_in_ms,
+        )

--- a/src/parse_bench/schemas/layout_detection_output.py
+++ b/src/parse_bench/schemas/layout_detection_output.py
@@ -315,6 +315,7 @@ class LayoutDetectionModel(StrEnum):
     GEMMA4_LAYOUT = "gemma4_layout"
     DATABRICKS_LAYOUT = "databricks_layout"
     INFINITY_PARSER2_LAYOUT = "infinity_parser2_layout"
+    OI_PARSER_LAYOUT = "oi_parser_layout"
 
 
 LAYOUT_MODEL_INFO: dict[LayoutDetectionModel, dict[str, str]] = {
@@ -365,6 +366,10 @@ LAYOUT_MODEL_INFO: dict[LayoutDetectionModel, dict[str, str]] = {
     LayoutDetectionModel.DOTS_OCR: {
         "name": "dots.ocr",
         "hf_url": "https://huggingface.co/rednote-hilab/dots.ocr",
+    },
+    LayoutDetectionModel.OI_PARSER_LAYOUT: {
+        "name": "oi-parser",
+        "hf_url": "https://oi-parser.ai/",
     },
     LayoutDetectionModel.PULSE_LAYOUT: {
         "name": "Pulse Layout",


### PR DESCRIPTION
This resubmits #77, which was closed because oi-parser API keys required manual admin approval (not self-serve). That's now fixed — details below. Opening a new PR since closed PRs can't be reopened.

---

Adds an `oi_parser` parse provider + pipeline for the hosted **oi-parser** document-parsing API (`POST /v1/extract`, `X-API-Key` auth, returns markdown + layout). Also includes a layout cross-eval adapter + label mapper so the pipeline can be scored on the layout-detection dataset.

**Getting an API key:** sign up at https://oi-parser.ai/ — keys are now issued **instantly and active** on signup, with no admin review or "Pending approval" step. One active key per user, valid 14 days, and a new key can be self-issued anytime — also with no approval. Set it via `OI_PARSER_API_KEY` (optionally override the endpoint with `OI_PARSER_BASE_URL`).

**Recommended run flags:**
- `--max_concurrent 20` — the per-API-key concurrency cap on the default key; exceeding it only wastes retries. Raise it if your key is provisioned with a higher limit.
- `--per_file_timeout 900` — the service allows up to ~900s per document; the default 600s can cut off the slowest documents.

Example:
```
parse-bench inference run oi_parser --input_dir <dir> --max_concurrent 20 --per_file_timeout 900
parse-bench evaluation run <output>
```

