### PR TITLE
Improve PyMuPDF4LLM OCR pipeline and benchmark results

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -283,7 +283,7 @@ These run entirely locally and do not require API keys.
 | `pypdf_baseline` | PyPDF text extraction | None |
 | `pymupdf_text` | PyMuPDF text extraction | None |
 | `pymupdf_html` | PyMuPDF HTML extraction | None |
-| `pymupdf4llm_markdown` | PyMuPDF4LLM Markdown with native HTML tables and modern RapidOCR at 150 DPI | Python 3.12, `pymupdf4llm==1.28.2`, and `rapidocr==3.9.2` |
+| `pymupdf4llm_markdown` | PyMuPDF4LLM Markdown with native HTML tables and RapidOCR at 150 DPI | Python 3.12, `pymupdf4llm==1.28.2`, and `rapidocr==3.9.2` |
 | `warp_ingest` | Warp-Ingest local parser | `warp-ingest[ocr]>=2.0.1` installed |
 | `tesseract_eng` | Tesseract OCR (English) | `tesseract` installed |
 | `tesseract_fast` | Tesseract OCR (fast) | `tesseract` installed |
@@ -294,9 +294,6 @@ These run entirely locally and do not require API keys.
 Create the isolated Python environment for `pymupdf4llm_markdown` with
 `uv sync --python 3.12 --extra pymupdf4llm`, then run it with
 `uv run --python 3.12 --extra pymupdf4llm parse-bench run pymupdf4llm_markdown --max_concurrent 1`.
-The dedicated extra is isolated from `runners` so the legacy
-`rapidocr-onnxruntime` dependency used by other pipelines cannot affect
-PyMuPDF4LLM's modern `rapidocr` backend selection.
 
 ---
 

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -283,7 +283,7 @@ These run entirely locally and do not require API keys.
 | `pypdf_baseline` | PyPDF text extraction | None |
 | `pymupdf_text` | PyMuPDF text extraction | None |
 | `pymupdf_html` | PyMuPDF HTML extraction | None |
-| `pymupdf4llm_markdown` | PyMuPDF4LLM Markdown with RapidOCR detection, Tesseract recognition at 150 DPI, and normalized HTML tables | Python 3.12, `pymupdf4llm==1.28.0`, `rapidocr-onnxruntime==1.2.3`, and system Tesseract with English language data installed |
+| `pymupdf4llm_markdown` | PyMuPDF4LLM Markdown with native HTML tables and modern RapidOCR at 150 DPI | Python 3.12, `pymupdf4llm==1.28.2`, and `rapidocr==3.9.2` |
 | `warp_ingest` | Warp-Ingest local parser | `warp-ingest[ocr]>=2.0.1` installed |
 | `tesseract_eng` | Tesseract OCR (English) | `tesseract` installed |
 | `tesseract_fast` | Tesseract OCR (fast) | `tesseract` installed |
@@ -291,13 +291,12 @@ These run entirely locally and do not require API keys.
 | `infinity_parser2_flash` | Infinity-Parser2-Flash (vLLM server, JSON layout) | `infinity_parser2`, running vLLM server |
 | `infinity_parser2_pro` | Infinity-Parser2-Pro (vLLM server, JSON layout) | `infinity_parser2`, running vLLM server |
 
-On Ubuntu/Debian, install the system dependency for `pymupdf4llm_markdown` with
-`sudo apt-get install tesseract-ocr tesseract-ocr-eng`.
-Create its isolated Python environment with
+Create the isolated Python environment for `pymupdf4llm_markdown` with
 `uv sync --python 3.12 --extra pymupdf4llm`, then run it with
 `uv run --python 3.12 --extra pymupdf4llm parse-bench run pymupdf4llm_markdown --max_concurrent 1`.
-The dedicated extra is isolated because `warp-ingest[ocr]` requires a newer,
-incompatible `rapidocr-onnxruntime` release.
+The dedicated extra is isolated from `runners` so the legacy
+`rapidocr-onnxruntime` dependency used by other pipelines cannot affect
+PyMuPDF4LLM's modern `rapidocr` backend selection.
 
 ---
 

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -276,19 +276,28 @@ These pipelines require you to deploy the model on your own infrastructure (e.g.
 
 ## Local Pipelines (No API key needed)
 
-These run entirely locally with no external dependencies.
+These run entirely locally and do not require API keys.
 
 | Pipeline | Description | Requirements |
 |---|---|---|
 | `pypdf_baseline` | PyPDF text extraction | None |
 | `pymupdf_text` | PyMuPDF text extraction | None |
 | `pymupdf_html` | PyMuPDF HTML extraction | None |
+| `pymupdf4llm_markdown` | PyMuPDF4LLM Markdown with RapidOCR detection, Tesseract recognition at 150 DPI, and normalized HTML tables | Python 3.12, `pymupdf4llm==1.28.0`, `rapidocr-onnxruntime==1.2.3`, and system Tesseract with English language data installed |
 | `warp_ingest` | Warp-Ingest local parser | `warp-ingest[ocr]>=2.0.1` installed |
 | `tesseract_eng` | Tesseract OCR (English) | `tesseract` installed |
 | `tesseract_fast` | Tesseract OCR (fast) | `tesseract` installed |
 | `tesseract_high_quality` | Tesseract OCR (high quality) | `tesseract` installed |
 | `infinity_parser2_flash` | Infinity-Parser2-Flash (vLLM server, JSON layout) | `infinity_parser2`, running vLLM server |
 | `infinity_parser2_pro` | Infinity-Parser2-Pro (vLLM server, JSON layout) | `infinity_parser2`, running vLLM server |
+
+On Ubuntu/Debian, install the system dependency for `pymupdf4llm_markdown` with
+`sudo apt-get install tesseract-ocr tesseract-ocr-eng`.
+Create its isolated Python environment with
+`uv sync --python 3.12 --extra pymupdf4llm`, then run it with
+`uv run --python 3.12 --extra pymupdf4llm parse-bench run pymupdf4llm_markdown --max_concurrent 1`.
+The dedicated extra is isolated because `warp-ingest[ocr]` requires a newer,
+incompatible `rapidocr-onnxruntime` release.
 
 ---
 

--- a/leaderboard.csv
+++ b/leaderboard.csv
@@ -77,7 +77,7 @@ GLM-OCR,VLM - Open Weight,29.6,66.1,1.7,78,2.3,0,,,,,,zai-org/GLM-OCR
 KDL-Frontier-Parser-nano,VLM - Open Weight,76.36,85.56,63.41,87.19,66.81,78.84,,,,,,KDLAI/KDL-Frontier-Parser-nano
 MarkItDown,Open Source - Local,18.63,15.77,2.02,64.54,0.91,9.90,,,,,,
 OpenDataLoader,Open Source - Local,29.40,35.18,0.92,66.06,34.07,10.77,,,,,,
-PyMuPDF4LLM,Open Source - Local,49.22,57.04,2.29,75.25,53.11,58.38,,,,,,
+PyMuPDF4LLM,Open Source - Local,53.49,72.00,2.19,79.34,52.04,61.89,,,,,,
 PyMuPDF (Text),Open Source - Local,16.02,0.00,0.00,68.28,0.95,10.86,,,,,,
 PyMuPDF (HTML),Open Source - Local,16.62,0.00,0.00,55.63,18.26,9.20,,,,,,
 pypdf,Open Source - Local,14.87,0.00,0.00,62.50,0.91,10.92,,,,,,

--- a/leaderboard.csv
+++ b/leaderboard.csv
@@ -77,7 +77,7 @@ GLM-OCR,VLM - Open Weight,29.6,66.1,1.7,78,2.3,0,,,,,,zai-org/GLM-OCR
 KDL-Frontier-Parser-nano,VLM - Open Weight,76.36,85.56,63.41,87.19,66.81,78.84,,,,,,KDLAI/KDL-Frontier-Parser-nano
 MarkItDown,Open Source - Local,18.63,15.77,2.02,64.54,0.91,9.90,,,,,,
 OpenDataLoader,Open Source - Local,29.40,35.18,0.92,66.06,34.07,10.77,,,,,,
-PyMuPDF4LLM,Open Source - Local,30.88,36.68,1.58,60.85,44.63,10.68,,,,,,
+PyMuPDF4LLM,Open Source - Local,49.22,57.04,2.29,75.25,53.11,58.38,,,,,,
 PyMuPDF (Text),Open Source - Local,16.02,0.00,0.00,68.28,0.95,10.86,,,,,,
 PyMuPDF (HTML),Open Source - Local,16.62,0.00,0.00,55.63,18.26,9.20,,,,,,
 pypdf,Open Source - Local,14.87,0.00,0.00,62.50,0.91,10.92,,,,,,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "huggingface-hub>=0.20.0",
     "lxml>=5.0.0",
     "markdown>=3.0",
+    "markdown-it-py>=3.0",
     "markdown2>=2.4.0",
     "numpy>=1.24.0",
     "pandas>=2.0.0",
@@ -57,6 +58,10 @@ runners = [
     "unstructured-client>=0.26.0",
     "warp-ingest[ocr]>=2.0.1",
 ]
+pymupdf4llm = [
+    "pymupdf4llm==1.28.0",
+    "rapidocr-onnxruntime==1.2.3",
+]
 fast = [
     "numba>=0.59.0",
 ]
@@ -76,6 +81,14 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/parse_bench"]
+
+[tool.uv]
+conflicts = [
+    [
+        { extra = "runners" },
+        { extra = "pymupdf4llm" },
+    ],
+]
 
 [tool.ruff]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ dependencies = [
     "huggingface-hub>=0.20.0",
     "lxml>=5.0.0",
     "markdown>=3.0",
-    "markdown-it-py>=3.0",
     "markdown2>=2.4.0",
     "numpy>=1.24.0",
     "pandas>=2.0.0",
@@ -59,8 +58,8 @@ runners = [
     "warp-ingest[ocr]>=2.0.1",
 ]
 pymupdf4llm = [
-    "pymupdf4llm==1.28.0",
-    "rapidocr-onnxruntime==1.2.3",
+    "pymupdf4llm==1.28.2",
+    "rapidocr==3.9.2",
 ]
 fast = [
     "numba>=0.59.0",

--- a/src/parse_bench/evaluation/layout_adapters/adapters.py
+++ b/src/parse_bench/evaluation/layout_adapters/adapters.py
@@ -2943,3 +2943,89 @@ class KdlFrontierNanoLayoutAdapter(LayoutAdapter):
             image_height=S,
             predictions=predictions,
         )
+
+
+@register_layout_adapter("pymupdf4llm", priority=90)
+class PyMuPDF4LLMLayoutAdapter(LayoutAdapter):
+    """Extract layout predictions from PyMuPDF4LLM parse output."""
+
+    @classmethod
+    def matches(cls, inference_result: InferenceResult) -> bool:
+        if not isinstance(inference_result.output, ParseOutput) or not inference_result.output.layout_pages:
+            return False
+        pages = inference_result.raw_output.get("pages")
+        if not isinstance(pages, list) or not pages or not isinstance(pages[0], dict):
+            return False
+        return isinstance(pages[0].get("page_boxes"), list)
+
+    def to_layout_output(
+        self,
+        inference_result: InferenceResult,
+        *,
+        page_filter: int | None = None,
+    ) -> LayoutOutput:
+        if isinstance(inference_result.output, LayoutOutput):
+            if page_filter is None:
+                return inference_result.output
+            filtered = [
+                prediction for prediction in inference_result.output.predictions if prediction.page == page_filter
+            ]
+            return inference_result.output.model_copy(update={"predictions": filtered})
+        if not isinstance(inference_result.output, ParseOutput):
+            raise ValueError("PyMuPDF4LLMLayoutAdapter requires ParseOutput or LayoutOutput")
+
+        layout_pages = inference_result.output.layout_pages
+        selected_pages = [page for page in layout_pages if page_filter is None or page.page_number == page_filter]
+        reference_page = selected_pages[0] if selected_pages else (layout_pages[0] if layout_pages else None)
+        output_width = int(reference_page.width or 1) if reference_page is not None else 1
+        output_height = int(reference_page.height or 1) if reference_page is not None else 1
+
+        predictions: list[LayoutPrediction] = []
+        for page in layout_pages:
+            if page_filter is not None and page.page_number != page_filter:
+                continue
+            page_width = float(page.width or output_width)
+            page_height = float(page.height or output_height)
+            for item in page.items:
+                segments = item.layout_segments or ([item.bbox] if item.bbox is not None else [])
+                for segment in segments:
+                    if segment is None:
+                        continue
+                    label = segment.label or item.type or "Text"
+                    is_table = item.type == "table"
+                    content_text = item.html if is_table and item.html else item.md or item.value
+                    content = _build_docling_parse_content(
+                        "table" if is_table else "text",
+                        content_text,
+                    )
+                    predictions.append(
+                        LayoutPrediction(
+                            bbox=[
+                                segment.x * page_width,
+                                segment.y * page_height,
+                                (segment.x + segment.w) * page_width,
+                                (segment.y + segment.h) * page_height,
+                            ],
+                            score=segment.confidence if segment.confidence is not None else 1.0,
+                            label=label,
+                            page=page.page_number,
+                            content=content,
+                            provider_metadata={
+                                "order_index": len(predictions),
+                                "score_source": (
+                                    "provider" if segment.confidence is not None else "unavailable_default"
+                                ),
+                            },
+                        )
+                    )
+
+        return LayoutOutput(
+            task_type="layout_detection",
+            example_id=inference_result.request.example_id,
+            pipeline_name=inference_result.pipeline_name,
+            model=LayoutDetectionModel.PYMUPDF4LLM_LAYOUT,
+            image_width=max(output_width, 1),
+            image_height=max(output_height, 1),
+            predictions=predictions,
+            markdown=inference_result.output.markdown,
+        )

--- a/src/parse_bench/evaluation/layout_label_mappers/mappers.py
+++ b/src/parse_bench/evaluation/layout_label_mappers/mappers.py
@@ -134,6 +134,58 @@ class OIParserLabelMapper(LayoutLabelMapper):
 
 
 @register_layout_label_mapper(
+    "pymupdf4llm",
+    "model:pymupdf4llm_layout",
+    priority=95,
+)
+class PyMuPDF4LLMLabelMapper(LayoutLabelMapper):
+    """Map raw PyMuPDF4LLM boxclass labels into the benchmark ontology."""
+
+    _MAPPING: dict[str, CanonicalLabel] = {
+        "caption": CanonicalLabel.CAPTION,
+        "footnote": CanonicalLabel.FOOTNOTE,
+        "formula": CanonicalLabel.FORMULA,
+        "list-item": CanonicalLabel.LIST_ITEM,
+        "listitem": CanonicalLabel.LIST_ITEM,
+        "page-footer": CanonicalLabel.PAGE_FOOTER,
+        "pagefooter": CanonicalLabel.PAGE_FOOTER,
+        "page-header": CanonicalLabel.PAGE_HEADER,
+        "pageheader": CanonicalLabel.PAGE_HEADER,
+        "picture": CanonicalLabel.PICTURE,
+        "image": CanonicalLabel.PICTURE,
+        "section-header": CanonicalLabel.SECTION_HEADER,
+        "sectionheader": CanonicalLabel.SECTION_HEADER,
+        "heading": CanonicalLabel.SECTION_HEADER,
+        "table": CanonicalLabel.TABLE,
+        "text": CanonicalLabel.TEXT,
+        "title": CanonicalLabel.TITLE,
+        "code": CanonicalLabel.CODE,
+        "document-index": CanonicalLabel.DOCUMENT_INDEX,
+        "documentindex": CanonicalLabel.DOCUMENT_INDEX,
+        "form": CanonicalLabel.FORM,
+        "key-value-region": CanonicalLabel.KEY_VALUE_REGION,
+        "keyvalueregion": CanonicalLabel.KEY_VALUE_REGION,
+        "checkbox-selected": CanonicalLabel.CHECKBOX_SELECTED,
+        "checkboxselected": CanonicalLabel.CHECKBOX_SELECTED,
+        "checkbox-unselected": CanonicalLabel.CHECKBOX_UNSELECTED,
+        "checkboxunselected": CanonicalLabel.CHECKBOX_UNSELECTED,
+    }
+
+    def to_canonical(
+        self,
+        label: str,
+        prediction: LayoutPrediction,
+        context: MappingContext,
+    ) -> CanonicalLabel:
+        del prediction, context
+        normalized = label.strip().lower().replace("_", "-").replace(" ", "-")
+        mapped = self._MAPPING.get(normalized)
+        if mapped is None:
+            raise UnknownRawLayoutLabelError(f"Unknown PyMuPDF4LLM raw layout label '{label}'")
+        return mapped
+
+
+@register_layout_label_mapper(
     "model:yolo_doclaynet",
     "model:docling_layout_old",
     "model:docling_layout_heron_101",

--- a/src/parse_bench/inference/pipelines/parse.py
+++ b/src/parse_bench/inference/pipelines/parse.py
@@ -546,7 +546,11 @@ def register_parse_pipelines(register_fn) -> None:  # type: ignore[no-untyped-de
             pipeline_name="pymupdf4llm_markdown",
             provider_name="pymupdf4llm",
             product_type=ProductType.PARSE,
-            config={},
+            config={
+                "use_ocr": True,
+                "ocr_backend": "rapidtess",
+                "ocr_dpi": 150,
+            },
         )
     )
 

--- a/src/parse_bench/inference/pipelines/parse.py
+++ b/src/parse_bench/inference/pipelines/parse.py
@@ -548,8 +548,9 @@ def register_parse_pipelines(register_fn) -> None:  # type: ignore[no-untyped-de
             product_type=ProductType.PARSE,
             config={
                 "use_ocr": True,
-                "ocr_backend": "rapidtess",
+                "ocr_backend": "rapidocr",
                 "ocr_dpi": 150,
+                "table_output": "html",
             },
         )
     )

--- a/src/parse_bench/inference/providers/parse/pymupdf4llm.py
+++ b/src/parse_bench/inference/providers/parse/pymupdf4llm.py
@@ -1,15 +1,11 @@
 """Provider for PyMuPDF4LLM PARSE."""
 
-import html
 import importlib
 import math
-import re
 from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
 from typing import Any, cast
-
-from markdown_it import MarkdownIt
 
 from parse_bench.inference.providers.base import (
     Provider,
@@ -32,223 +28,20 @@ from parse_bench.schemas.pipeline_io import (
 )
 from parse_bench.schemas.product import ProductType
 
-# Raw HTML is disabled so extracted document content cannot inject markup while
-# cell-level Markdown is rendered. A separate parser identifies blocks where
-# table recovery must not run.
-_MD = MarkdownIt("commonmark", {"html": False}).enable("table")
-_BLOCK_MD = MarkdownIt("commonmark")
-_BR_TAG_RE = re.compile(r"<br\s*/?>", re.IGNORECASE)
-_BR_PLACEHOLDER = "\ue000"
-
 _OCR_BACKEND_MODULES = {
-    "rapidtess": "pymupdf4llm.ocr.rapidtess_api",
+    "rapidocr": "pymupdf4llm.ocr.rapidocr_api",
 }
-
-
-def _is_pipe_table_line(line: str) -> bool:
-    stripped = line.strip()
-    return stripped.startswith("|") and stripped.endswith("|") and stripped.count("|") >= 2
-
-
-def _is_separator_row(line: str) -> bool:
-    stripped = line.strip().strip("|")
-    if not stripped:
-        return False
-    cells = [cell.strip() for cell in stripped.split("|")]
-    return all(cell and re.fullmatch(r":?-+:?", cell) for cell in cells)
-
-
-def _split_pipe_row(line: str) -> list[str]:
-    stripped = line.strip()
-    if stripped.startswith("|"):
-        stripped = stripped[1:]
-    if stripped.endswith("|"):
-        stripped = stripped[:-1]
-
-    cells: list[str] = []
-    current: list[str] = []
-    code_delimiter_length = 0
-    i = 0
-    while i < len(stripped):
-        char = stripped[i]
-        if char == "\\" and i + 1 < len(stripped):
-            current.extend((char, stripped[i + 1]))
-            i += 2
-            continue
-        if char == "`":
-            end = i + 1
-            while end < len(stripped) and stripped[end] == "`":
-                end += 1
-            delimiter_length = end - i
-            if code_delimiter_length == 0:
-                code_delimiter_length = delimiter_length
-            elif code_delimiter_length == delimiter_length:
-                code_delimiter_length = 0
-            current.extend(stripped[i:end])
-            i = end
-            continue
-        if char == "|" and code_delimiter_length == 0:
-            cells.append("".join(current).strip())
-            current = []
-        else:
-            current.append(char)
-        i += 1
-
-    cells.append("".join(current).strip())
-    return cells
-
-
-def _render_cell_inline(cell: str) -> str:
-    if cell.startswith("**") and not cell.endswith("**"):
-        cell = cell[2:]
-    if cell.endswith("**") and not cell.startswith("**"):
-        cell = cell[:-2]
-    # PyMuPDF4LLM uses HTML line breaks inside Markdown table cells. Preserve
-    # only that structural tag while keeping arbitrary raw HTML disabled.
-    protected_cell = _BR_TAG_RE.sub(_BR_PLACEHOLDER, cell)
-    rendered = _MD.renderInline(protected_cell).strip().replace(_BR_PLACEHOLDER, "<br>")
-    return rendered if rendered else html.escape(cell)
-
-
-def _render_html_table(
-    rows: list[list[str]],
-    *,
-    header_rows: int = 1,
-    alignments: list[str | None] | None = None,
-) -> str:
-    if not rows:
-        return ""
-
-    max_cols = max(len(row) for row in rows)
-    normalized_rows = [row + [""] * (max_cols - len(row)) for row in rows]
-    normalized_alignments = (alignments or []) + [None] * max_cols
-
-    def render_cell(tag: str, cell: str, column_index: int) -> str:
-        alignment = normalized_alignments[column_index]
-        style = f' style="text-align:{alignment}"' if alignment else ""
-        return f"<{tag}{style}>{_render_cell_inline(cell)}</{tag}>"
-
-    parts = ["<table>"]
-    if header_rows > 0:
-        parts.append("<thead>")
-        for row in normalized_rows[:header_rows]:
-            cells = "".join(render_cell("th", cell, index) for index, cell in enumerate(row))
-            parts.append(f"<tr>{cells}</tr>")
-        parts.append("</thead>")
-
-    body_rows = normalized_rows[header_rows:]
-    if body_rows:
-        parts.append("<tbody>")
-        for row in body_rows:
-            cells = "".join(render_cell("td", cell, index) for index, cell in enumerate(row))
-            parts.append(f"<tr>{cells}</tr>")
-        parts.append("</tbody>")
-
-    parts.append("</table>")
-    return "\n".join(parts)
-
-
-def _render_forgiving_pipe_table(block: list[str], *, min_columns: int = 2) -> str | None:
-    if len(block) < 2:
-        return None
-    separator_idx = next((idx for idx, line in enumerate(block) if _is_separator_row(line)), None)
-    if separator_idx is None:
-        return None
-
-    alignments: list[str | None] = []
-    for cell in _split_pipe_row(block[separator_idx]):
-        stripped = cell.strip()
-        if stripped.startswith(":") and stripped.endswith(":"):
-            alignments.append("center")
-        elif stripped.startswith(":"):
-            alignments.append("left")
-        elif stripped.endswith(":"):
-            alignments.append("right")
-        else:
-            alignments.append(None)
-
-    header = [_split_pipe_row(line) for line in block[:separator_idx]]
-    body = [_split_pipe_row(line) for line in block[separator_idx + 1 :]]
-    while header and not any(cell.strip() for cell in header[0]):
-        header.pop(0)
-
-    rows = [*header, *body]
-    non_empty_rows = [row for row in rows if any(cell.strip() for cell in row)]
-    if len(non_empty_rows) < 2 or max(len(row) for row in non_empty_rows) < min_columns:
-        return None
-    return _render_html_table(rows, header_rows=len(header), alignments=alignments)
-
-
-def _protected_block_lines(text: str) -> set[int]:
-    protected: set[int] = set()
-    for token in _BLOCK_MD.parse(text):
-        if token.type in {"fence", "code_block", "html_block"} and token.map:
-            start, end = token.map
-            protected.update(range(start, end))
-    return protected
-
-
-def _render_strict_pipe_tables(text: str) -> str:
-    tokens = _MD.parse(text)
-    lines = text.split("\n")
-    protected = _protected_block_lines(text)
-    spans: list[tuple[int, int, str]] = []
-    i = 0
-    while i < len(tokens):
-        token = tokens[i]
-        if token.type != "table_open" or not token.map:
-            i += 1
-            continue
-        start, end = token.map
-        j = i
-        while j < len(tokens) and tokens[j].type != "table_close":
-            j += 1
-        if not any(line_number in protected for line_number in range(start, end)):
-            # Markdown-it has already established that this is a structural
-            # table, so valid one-column tables are safe to render here.
-            rendered = _render_forgiving_pipe_table(lines[start:end], min_columns=1)
-            if rendered is not None:
-                spans.append((start, end, rendered))
-        i = j + 1
-
-    for start, end, rendered in sorted(spans, reverse=True):
-        lines[start:end] = [rendered]
-    return "\n".join(lines)
-
-
-def _render_forgiving_pipe_tables(text: str) -> str:
-    lines = text.split("\n")
-    protected = _protected_block_lines(text)
-    result: list[str] = []
-    i = 0
-    while i < len(lines):
-        if i in protected or not _is_pipe_table_line(lines[i]):
-            result.append(lines[i])
-            i += 1
-            continue
-        start = i
-        while i < len(lines) and i not in protected and _is_pipe_table_line(lines[i]):
-            i += 1
-        block = lines[start:i]
-        rendered = _render_forgiving_pipe_table(block)
-        result.extend(block if rendered is None else [rendered])
-    return "\n".join(result)
-
-
-def convert_pipe_tables_to_html(text: str) -> str:
-    """Convert structural GFM pipe tables without touching protected blocks."""
-    converted = _render_strict_pipe_tables(text) if "|" in text else text
-    return _render_forgiving_pipe_tables(converted) if "|" in converted else converted
 
 
 @register_provider("pymupdf4llm")
 class PyMuPDF4LLMProvider(Provider):
-    """Provider for PyMuPDF4LLM (markdown). AGPL — runtime dep only."""
+    """Provider for PyMuPDF4LLM native HTML table output. AGPL — runtime dep only."""
 
     def __init__(self, provider_name: str, base_config: dict[str, Any] | None = None):
         super().__init__(provider_name, base_config)
 
     def _markdown_options(self) -> dict[str, Any]:
+        """Build serializable options for ``pymupdf4llm.to_markdown``."""
         options: dict[str, Any] = {
             "page_chunks": True,
             "show_progress": False,
@@ -281,6 +74,15 @@ class PyMuPDF4LLMProvider(Provider):
                 raise ProviderConfigError("PyMuPDF4LLM 'ocr_language' must be a non-empty string")
             options["ocr_language"] = ocr_language
 
+        table_output = self.base_config.get("table_output")
+        if table_output is not None:
+            if not isinstance(table_output, str):
+                raise ProviderConfigError("PyMuPDF4LLM 'table_output' must be a string")
+            normalized_table_output = table_output.strip().lower()
+            if normalized_table_output not in ("markdown", "html"):
+                raise ProviderConfigError("PyMuPDF4LLM 'table_output' must be 'markdown' or 'html'")
+            options["table_output"] = normalized_table_output
+
         raw_backend = self.base_config.get("ocr_backend")
         if raw_backend is None:
             return options
@@ -309,10 +111,6 @@ class PyMuPDF4LLMProvider(Provider):
         ocr_function = getattr(ocr_module, "exec_ocr", None)
         if not callable(ocr_function):
             raise ProviderConfigError(f"PyMuPDF4LLM OCR backend '{raw_backend}' does not expose exec_ocr")
-        if getattr(ocr_module, "TESSDATA", True) is None:
-            raise ProviderConfigError(
-                f"PyMuPDF4LLM OCR backend '{raw_backend}' is unavailable: Tesseract language data was not found"
-            )
         return cast(Callable[..., Any], ocr_function)
 
     def _extract(self, pdf_path: str) -> dict[str, Any]:
@@ -401,10 +199,6 @@ class PyMuPDF4LLMProvider(Provider):
             raise ProviderPermanentError(f"Unexpected error: {e}") from e
 
     @staticmethod
-    def _convert_md_tables_to_html(content: str) -> str:
-        return convert_pipe_tables_to_html(content)
-
-    @staticmethod
     def _coerce_bbox(
         raw_bbox: Any,
         *,
@@ -459,6 +253,7 @@ class PyMuPDF4LLMProvider(Provider):
         *,
         raw_markdown: str,
     ) -> ParseLayoutPageIR | None:
+        """Convert native PyMuPDF page boxes into benchmark visual-grounding IR."""
         try:
             page_number = int(page_data.get("page_number", 0))
             page_width = float(page_data.get("width", 0.0))
@@ -515,7 +310,7 @@ class PyMuPDF4LLMProvider(Provider):
             )
             if normalized_class == "table":
                 item_type = "table"
-                item_html = cls._convert_md_tables_to_html(content)
+                item_html = content
             elif normalized_class == "picture":
                 item_type = "image"
                 item_html = ""
@@ -552,9 +347,8 @@ class PyMuPDF4LLMProvider(Provider):
             layout_page = self._build_layout_page(page_data, raw_markdown=raw_markdown)
             if layout_page is not None:
                 layout_pages.append(layout_page)
-            text = self._convert_md_tables_to_html(raw_markdown)
-            pages.append(PageIR(page_index=page_index, markdown=text))
-            page_texts.append(text)
+            pages.append(PageIR(page_index=page_index, markdown=raw_markdown))
+            page_texts.append(raw_markdown)
 
         full_text = "\n\n".join(page_texts)
         output = ParseOutput(

--- a/src/parse_bench/inference/providers/parse/pymupdf4llm.py
+++ b/src/parse_bench/inference/providers/parse/pymupdf4llm.py
@@ -1,8 +1,15 @@
 """Provider for PyMuPDF4LLM PARSE."""
 
+import html
+import importlib
+import math
+import re
+from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
+
+from markdown_it import MarkdownIt
 
 from parse_bench.inference.providers.base import (
     Provider,
@@ -10,7 +17,13 @@ from parse_bench.inference.providers.base import (
     ProviderPermanentError,
 )
 from parse_bench.inference.providers.registry import register_provider
-from parse_bench.schemas.parse_output import PageIR, ParseOutput
+from parse_bench.schemas.parse_output import (
+    LayoutItemIR,
+    LayoutSegmentIR,
+    PageIR,
+    ParseLayoutPageIR,
+    ParseOutput,
+)
 from parse_bench.schemas.pipeline import PipelineSpec
 from parse_bench.schemas.pipeline_io import (
     InferenceRequest,
@@ -18,6 +31,214 @@ from parse_bench.schemas.pipeline_io import (
     RawInferenceResult,
 )
 from parse_bench.schemas.product import ProductType
+
+# Raw HTML is disabled so extracted document content cannot inject markup while
+# cell-level Markdown is rendered. A separate parser identifies blocks where
+# table recovery must not run.
+_MD = MarkdownIt("commonmark", {"html": False}).enable("table")
+_BLOCK_MD = MarkdownIt("commonmark")
+_BR_TAG_RE = re.compile(r"<br\s*/?>", re.IGNORECASE)
+_BR_PLACEHOLDER = "\ue000"
+
+_OCR_BACKEND_MODULES = {
+    "rapidtess": "pymupdf4llm.ocr.rapidtess_api",
+}
+
+
+def _is_pipe_table_line(line: str) -> bool:
+    stripped = line.strip()
+    return stripped.startswith("|") and stripped.endswith("|") and stripped.count("|") >= 2
+
+
+def _is_separator_row(line: str) -> bool:
+    stripped = line.strip().strip("|")
+    if not stripped:
+        return False
+    cells = [cell.strip() for cell in stripped.split("|")]
+    return all(cell and re.fullmatch(r":?-+:?", cell) for cell in cells)
+
+
+def _split_pipe_row(line: str) -> list[str]:
+    stripped = line.strip()
+    if stripped.startswith("|"):
+        stripped = stripped[1:]
+    if stripped.endswith("|"):
+        stripped = stripped[:-1]
+
+    cells: list[str] = []
+    current: list[str] = []
+    code_delimiter_length = 0
+    i = 0
+    while i < len(stripped):
+        char = stripped[i]
+        if char == "\\" and i + 1 < len(stripped):
+            current.extend((char, stripped[i + 1]))
+            i += 2
+            continue
+        if char == "`":
+            end = i + 1
+            while end < len(stripped) and stripped[end] == "`":
+                end += 1
+            delimiter_length = end - i
+            if code_delimiter_length == 0:
+                code_delimiter_length = delimiter_length
+            elif code_delimiter_length == delimiter_length:
+                code_delimiter_length = 0
+            current.extend(stripped[i:end])
+            i = end
+            continue
+        if char == "|" and code_delimiter_length == 0:
+            cells.append("".join(current).strip())
+            current = []
+        else:
+            current.append(char)
+        i += 1
+
+    cells.append("".join(current).strip())
+    return cells
+
+
+def _render_cell_inline(cell: str) -> str:
+    if cell.startswith("**") and not cell.endswith("**"):
+        cell = cell[2:]
+    if cell.endswith("**") and not cell.startswith("**"):
+        cell = cell[:-2]
+    # PyMuPDF4LLM uses HTML line breaks inside Markdown table cells. Preserve
+    # only that structural tag while keeping arbitrary raw HTML disabled.
+    protected_cell = _BR_TAG_RE.sub(_BR_PLACEHOLDER, cell)
+    rendered = _MD.renderInline(protected_cell).strip().replace(_BR_PLACEHOLDER, "<br>")
+    return rendered if rendered else html.escape(cell)
+
+
+def _render_html_table(
+    rows: list[list[str]],
+    *,
+    header_rows: int = 1,
+    alignments: list[str | None] | None = None,
+) -> str:
+    if not rows:
+        return ""
+
+    max_cols = max(len(row) for row in rows)
+    normalized_rows = [row + [""] * (max_cols - len(row)) for row in rows]
+    normalized_alignments = (alignments or []) + [None] * max_cols
+
+    def render_cell(tag: str, cell: str, column_index: int) -> str:
+        alignment = normalized_alignments[column_index]
+        style = f' style="text-align:{alignment}"' if alignment else ""
+        return f"<{tag}{style}>{_render_cell_inline(cell)}</{tag}>"
+
+    parts = ["<table>"]
+    if header_rows > 0:
+        parts.append("<thead>")
+        for row in normalized_rows[:header_rows]:
+            cells = "".join(render_cell("th", cell, index) for index, cell in enumerate(row))
+            parts.append(f"<tr>{cells}</tr>")
+        parts.append("</thead>")
+
+    body_rows = normalized_rows[header_rows:]
+    if body_rows:
+        parts.append("<tbody>")
+        for row in body_rows:
+            cells = "".join(render_cell("td", cell, index) for index, cell in enumerate(row))
+            parts.append(f"<tr>{cells}</tr>")
+        parts.append("</tbody>")
+
+    parts.append("</table>")
+    return "\n".join(parts)
+
+
+def _render_forgiving_pipe_table(block: list[str], *, min_columns: int = 2) -> str | None:
+    if len(block) < 2:
+        return None
+    separator_idx = next((idx for idx, line in enumerate(block) if _is_separator_row(line)), None)
+    if separator_idx is None:
+        return None
+
+    alignments: list[str | None] = []
+    for cell in _split_pipe_row(block[separator_idx]):
+        stripped = cell.strip()
+        if stripped.startswith(":") and stripped.endswith(":"):
+            alignments.append("center")
+        elif stripped.startswith(":"):
+            alignments.append("left")
+        elif stripped.endswith(":"):
+            alignments.append("right")
+        else:
+            alignments.append(None)
+
+    header = [_split_pipe_row(line) for line in block[:separator_idx]]
+    body = [_split_pipe_row(line) for line in block[separator_idx + 1 :]]
+    while header and not any(cell.strip() for cell in header[0]):
+        header.pop(0)
+
+    rows = [*header, *body]
+    non_empty_rows = [row for row in rows if any(cell.strip() for cell in row)]
+    if len(non_empty_rows) < 2 or max(len(row) for row in non_empty_rows) < min_columns:
+        return None
+    return _render_html_table(rows, header_rows=len(header), alignments=alignments)
+
+
+def _protected_block_lines(text: str) -> set[int]:
+    protected: set[int] = set()
+    for token in _BLOCK_MD.parse(text):
+        if token.type in {"fence", "code_block", "html_block"} and token.map:
+            start, end = token.map
+            protected.update(range(start, end))
+    return protected
+
+
+def _render_strict_pipe_tables(text: str) -> str:
+    tokens = _MD.parse(text)
+    lines = text.split("\n")
+    protected = _protected_block_lines(text)
+    spans: list[tuple[int, int, str]] = []
+    i = 0
+    while i < len(tokens):
+        token = tokens[i]
+        if token.type != "table_open" or not token.map:
+            i += 1
+            continue
+        start, end = token.map
+        j = i
+        while j < len(tokens) and tokens[j].type != "table_close":
+            j += 1
+        if not any(line_number in protected for line_number in range(start, end)):
+            # Markdown-it has already established that this is a structural
+            # table, so valid one-column tables are safe to render here.
+            rendered = _render_forgiving_pipe_table(lines[start:end], min_columns=1)
+            if rendered is not None:
+                spans.append((start, end, rendered))
+        i = j + 1
+
+    for start, end, rendered in sorted(spans, reverse=True):
+        lines[start:end] = [rendered]
+    return "\n".join(lines)
+
+
+def _render_forgiving_pipe_tables(text: str) -> str:
+    lines = text.split("\n")
+    protected = _protected_block_lines(text)
+    result: list[str] = []
+    i = 0
+    while i < len(lines):
+        if i in protected or not _is_pipe_table_line(lines[i]):
+            result.append(lines[i])
+            i += 1
+            continue
+        start = i
+        while i < len(lines) and i not in protected and _is_pipe_table_line(lines[i]):
+            i += 1
+        block = lines[start:i]
+        rendered = _render_forgiving_pipe_table(block)
+        result.extend(block if rendered is None else [rendered])
+    return "\n".join(result)
+
+
+def convert_pipe_tables_to_html(text: str) -> str:
+    """Convert structural GFM pipe tables without touching protected blocks."""
+    converted = _render_strict_pipe_tables(text) if "|" in text else text
+    return _render_forgiving_pipe_tables(converted) if "|" in converted else converted
 
 
 @register_provider("pymupdf4llm")
@@ -27,31 +248,134 @@ class PyMuPDF4LLMProvider(Provider):
     def __init__(self, provider_name: str, base_config: dict[str, Any] | None = None):
         super().__init__(provider_name, base_config)
 
+    def _markdown_options(self) -> dict[str, Any]:
+        options: dict[str, Any] = {
+            "page_chunks": True,
+            "show_progress": False,
+        }
+
+        use_ocr = self.base_config.get("use_ocr")
+        if use_ocr is not None:
+            if not isinstance(use_ocr, bool):
+                raise ProviderConfigError("PyMuPDF4LLM 'use_ocr' must be a boolean")
+            options["use_ocr"] = use_ocr
+
+        force_ocr = self.base_config.get("force_ocr")
+        if force_ocr is not None:
+            if not isinstance(force_ocr, bool):
+                raise ProviderConfigError("PyMuPDF4LLM 'force_ocr' must be a boolean")
+            options["force_ocr"] = force_ocr
+
+        if use_ocr is False and force_ocr is True:
+            raise ProviderConfigError("PyMuPDF4LLM cannot set force_ocr=True when use_ocr=False")
+
+        ocr_dpi = self.base_config.get("ocr_dpi")
+        if ocr_dpi is not None:
+            if isinstance(ocr_dpi, bool) or not isinstance(ocr_dpi, int) or ocr_dpi <= 0:
+                raise ProviderConfigError("PyMuPDF4LLM 'ocr_dpi' must be a positive integer")
+            options["ocr_dpi"] = ocr_dpi
+
+        ocr_language = self.base_config.get("ocr_language")
+        if ocr_language is not None:
+            if not isinstance(ocr_language, str) or not ocr_language.strip():
+                raise ProviderConfigError("PyMuPDF4LLM 'ocr_language' must be a non-empty string")
+            options["ocr_language"] = ocr_language
+
+        raw_backend = self.base_config.get("ocr_backend")
+        if raw_backend is None:
+            return options
+        if not isinstance(raw_backend, str):
+            raise ProviderConfigError("PyMuPDF4LLM 'ocr_backend' must be a string")
+        backend = raw_backend.strip().lower()
+        if backend not in _OCR_BACKEND_MODULES:
+            supported = ", ".join(_OCR_BACKEND_MODULES)
+            raise ProviderConfigError(
+                f"Unsupported PyMuPDF4LLM OCR backend '{raw_backend}'. Supported backends: {supported}"
+            )
+        return options
+
+    def _resolve_ocr_function(self) -> Callable[..., Any] | None:
+        """Resolve the configured bundled OCR engine immediately before use."""
+        raw_backend = self.base_config.get("ocr_backend")
+        if not isinstance(raw_backend, str):
+            return None
+        module_name = _OCR_BACKEND_MODULES.get(raw_backend.strip().lower())
+        if module_name is None:
+            return None
+        try:
+            ocr_module = importlib.import_module(module_name)
+        except (ImportError, RuntimeError) as e:
+            raise ProviderConfigError(f"PyMuPDF4LLM OCR backend '{raw_backend}' is unavailable: {e}") from e
+        ocr_function = getattr(ocr_module, "exec_ocr", None)
+        if not callable(ocr_function):
+            raise ProviderConfigError(f"PyMuPDF4LLM OCR backend '{raw_backend}' does not expose exec_ocr")
+        if getattr(ocr_module, "TESSDATA", True) is None:
+            raise ProviderConfigError(
+                f"PyMuPDF4LLM OCR backend '{raw_backend}' is unavailable: Tesseract language data was not found"
+            )
+        return cast(Callable[..., Any], ocr_function)
+
     def _extract(self, pdf_path: str) -> dict[str, Any]:
         try:
-            import pymupdf4llm
+            import pymupdf
+            import pymupdf4llm  # type: ignore[import-untyped]
         except ImportError as e:
             raise ProviderConfigError("pymupdf4llm not installed. Run: pip install pymupdf4llm") from e
 
         try:
-            page_chunks = pymupdf4llm.to_markdown(
-                pdf_path, page_chunks=True, show_progress=False, use_ocr=False
-            )
+            markdown_options = self._markdown_options()
+            ocr_function = self._resolve_ocr_function()
+            if ocr_function is None:
+                page_chunks = pymupdf4llm.to_markdown(pdf_path, **markdown_options)
+            else:
+                page_chunks = pymupdf4llm.to_markdown(pdf_path, ocr_function=ocr_function, **markdown_options)
+            with pymupdf.open(pdf_path) as document:
+                page_dimensions = [(float(page.rect.width), float(page.rect.height)) for page in document]
+        except ProviderConfigError:
+            raise
         except Exception as e:
             raise ProviderPermanentError(f"PyMuPDF4LLM error: {e}") from e
 
         pages = []
         for i, chunk in enumerate(page_chunks):
             text = chunk.get("text", "") if isinstance(chunk, dict) else str(chunk)
-            pages.append({"page_index": i, "text": text})
+            metadata = chunk.get("metadata", {}) if isinstance(chunk, dict) else {}
+            raw_page_number = metadata.get("page_number") if isinstance(metadata, dict) else None
+            if isinstance(raw_page_number, (int, float, str)):
+                try:
+                    page_number = int(raw_page_number)
+                except ValueError:
+                    page_number = i + 1
+            else:
+                page_number = i + 1
+
+            dimension_index = page_number - 1
+            if not 0 <= dimension_index < len(page_dimensions):
+                dimension_index = i
+            if 0 <= dimension_index < len(page_dimensions):
+                width, height = page_dimensions[dimension_index]
+            else:
+                width, height = 0.0, 0.0
+
+            page_boxes = chunk.get("page_boxes", []) if isinstance(chunk, dict) else []
+            if not isinstance(page_boxes, list):
+                page_boxes = []
+            pages.append(
+                {
+                    "page_index": i,
+                    "page_number": page_number,
+                    "text": text,
+                    "width": width,
+                    "height": height,
+                    "page_boxes": page_boxes,
+                }
+            )
 
         return {"pages": pages, "num_pages": len(pages)}
 
     def run_inference(self, pipeline: PipelineSpec, request: InferenceRequest) -> RawInferenceResult:
         if request.product_type != ProductType.PARSE:
-            raise ProviderPermanentError(
-                f"PyMuPDF4LLMProvider only supports PARSE, got {request.product_type}"
-            )
+            raise ProviderPermanentError(f"PyMuPDF4LLMProvider only supports PARSE, got {request.product_type}")
 
         pdf_path = Path(request.source_file_path)
         if not pdf_path.exists():
@@ -78,44 +402,157 @@ class PyMuPDF4LLMProvider(Provider):
 
     @staticmethod
     def _convert_md_tables_to_html(content: str) -> str:
-        import markdown2
+        return convert_pipe_tables_to_html(content)
 
-        lines = content.split("\n")
-        result_parts: list[str] = []
-        table_lines: list[str] = []
-        in_table = False
+    @staticmethod
+    def _coerce_bbox(
+        raw_bbox: Any,
+        *,
+        page_width: float,
+        page_height: float,
+    ) -> tuple[float, float, float, float] | None:
+        if not isinstance(raw_bbox, (list, tuple)) or len(raw_bbox) != 4:
+            return None
+        try:
+            x0, y0, x1, y1 = (float(value) for value in raw_bbox)
+        except (TypeError, ValueError):
+            return None
+        if not all(math.isfinite(value) for value in (x0, y0, x1, y1)):
+            return None
+        if page_width <= 0 or page_height <= 0:
+            return None
+        x0 = min(max(x0, 0.0), page_width)
+        x1 = min(max(x1, 0.0), page_width)
+        y0 = min(max(y0, 0.0), page_height)
+        y1 = min(max(y1, 0.0), page_height)
+        if x1 <= x0 or y1 <= y0:
+            return None
+        return (
+            x0 / page_width,
+            y0 / page_height,
+            (x1 - x0) / page_width,
+            (y1 - y0) / page_height,
+        )
 
-        def _flush() -> None:
-            nonlocal table_lines
-            if len(table_lines) >= 2:
-                html = markdown2.markdown("\n".join(table_lines), extras=["tables"]).strip()
-                if "<table>" in html.lower():
-                    result_parts.append(html)
-                else:
-                    result_parts.extend(table_lines)
+    @staticmethod
+    def _coerce_text_range(raw_pos: Any, text_length: int) -> tuple[int, int] | None:
+        if not isinstance(raw_pos, (list, tuple)) or len(raw_pos) != 2:
+            return None
+        start, stop = raw_pos
+        if isinstance(start, bool) or isinstance(stop, bool):
+            return None
+        try:
+            start = int(start)
+            stop = int(stop)
+        except (TypeError, ValueError):
+            return None
+        start = min(max(start, 0), text_length)
+        stop = min(max(stop, 0), text_length)
+        if stop < start:
+            return None
+        return start, stop
+
+    @classmethod
+    def _build_layout_page(
+        cls,
+        page_data: dict[str, Any],
+        *,
+        raw_markdown: str,
+    ) -> ParseLayoutPageIR | None:
+        try:
+            page_number = int(page_data.get("page_number", 0))
+            page_width = float(page_data.get("width", 0.0))
+            page_height = float(page_data.get("height", 0.0))
+        except (TypeError, ValueError):
+            return None
+        if page_number < 1 or page_width <= 0 or page_height <= 0:
+            return None
+
+        items: list[LayoutItemIR] = []
+        for page_box in page_data.get("page_boxes", []):
+            if not isinstance(page_box, dict):
+                continue
+            raw_label = str(page_box.get("class", "")).strip()
+            if not raw_label:
+                continue
+            normalized_class = raw_label.lower().replace("_", "-")
+
+            bbox = cls._coerce_bbox(
+                page_box.get("bbox"),
+                page_width=page_width,
+                page_height=page_height,
+            )
+            if bbox is None:
+                continue
+            text_range = cls._coerce_text_range(page_box.get("pos"), len(raw_markdown))
+            if text_range is None:
+                start_index = None
+                end_index = None
+                content = ""
             else:
-                result_parts.extend(table_lines)
-            table_lines = []
+                start_index, end_index = text_range
+                content = raw_markdown[start_index:end_index]
 
-        for line in lines:
-            if "|" in line and line.strip().startswith("|"):
-                in_table = True
-                table_lines.append(line)
+            confidence: float | None = None
+            raw_confidence = page_box.get("confidence")
+            if raw_confidence is not None:
+                try:
+                    parsed_confidence = float(raw_confidence)
+                except (TypeError, ValueError):
+                    parsed_confidence = math.nan
+                if math.isfinite(parsed_confidence) and 0.0 <= parsed_confidence <= 1.0:
+                    confidence = parsed_confidence
+
+            segment = LayoutSegmentIR(
+                x=bbox[0],
+                y=bbox[1],
+                w=bbox[2],
+                h=bbox[3],
+                confidence=confidence,
+                label=raw_label,
+                start_index=start_index,
+                end_index=end_index,
+            )
+            if normalized_class == "table":
+                item_type = "table"
+                item_html = cls._convert_md_tables_to_html(content)
+            elif normalized_class == "picture":
+                item_type = "image"
+                item_html = ""
             else:
-                if in_table:
-                    _flush()
-                    in_table = False
-                result_parts.append(line)
-        if in_table:
-            _flush()
-        return "\n".join(result_parts)
+                item_type = "text"
+                item_html = ""
+            items.append(
+                LayoutItemIR(
+                    type=item_type,
+                    md=content,
+                    html=item_html,
+                    value=content,
+                    bbox=segment,
+                    layout_segments=[segment],
+                )
+            )
+
+        return ParseLayoutPageIR(
+            page_number=page_number,
+            width=page_width,
+            height=page_height,
+            md=raw_markdown,
+            text=raw_markdown,
+            items=items,
+        )
 
     def normalize(self, raw_result: RawInferenceResult) -> InferenceResult:
         pages: list[PageIR] = []
+        layout_pages: list[ParseLayoutPageIR] = []
         page_texts: list[str] = []
         for page_data in raw_result.raw_output.get("pages", []):
             page_index = page_data.get("page_index", 0)
-            text = self._convert_md_tables_to_html(page_data.get("text", "") or "")
+            raw_markdown = page_data.get("text", "") or ""
+            layout_page = self._build_layout_page(page_data, raw_markdown=raw_markdown)
+            if layout_page is not None:
+                layout_pages.append(layout_page)
+            text = self._convert_md_tables_to_html(raw_markdown)
             pages.append(PageIR(page_index=page_index, markdown=text))
             page_texts.append(text)
 
@@ -125,6 +562,7 @@ class PyMuPDF4LLMProvider(Provider):
             example_id=raw_result.request.example_id,
             pipeline_name=raw_result.pipeline_name,
             pages=pages,
+            layout_pages=layout_pages,
             markdown=full_text,
         )
         return InferenceResult(

--- a/src/parse_bench/inference/providers/parse/pymupdf4llm.py
+++ b/src/parse_bench/inference/providers/parse/pymupdf4llm.py
@@ -74,14 +74,10 @@ class PyMuPDF4LLMProvider(Provider):
                 raise ProviderConfigError("PyMuPDF4LLM 'ocr_language' must be a non-empty string")
             options["ocr_language"] = ocr_language
 
-        table_output = self.base_config.get("table_output")
-        if table_output is not None:
-            if not isinstance(table_output, str):
-                raise ProviderConfigError("PyMuPDF4LLM 'table_output' must be a string")
-            normalized_table_output = table_output.strip().lower()
-            if normalized_table_output not in ("markdown", "html"):
-                raise ProviderConfigError("PyMuPDF4LLM 'table_output' must be 'markdown' or 'html'")
-            options["table_output"] = normalized_table_output
+        table_output = self.base_config.get("table_output", "html")
+        if not isinstance(table_output, str) or table_output.strip().lower() != "html":
+            raise ProviderConfigError("PyMuPDF4LLM only supports table_output='html'")
+        options["table_output"] = "html"
 
         raw_backend = self.base_config.get("ocr_backend")
         if raw_backend is None:
@@ -288,22 +284,11 @@ class PyMuPDF4LLMProvider(Provider):
                 start_index, end_index = text_range
                 content = raw_markdown[start_index:end_index]
 
-            confidence: float | None = None
-            raw_confidence = page_box.get("confidence")
-            if raw_confidence is not None:
-                try:
-                    parsed_confidence = float(raw_confidence)
-                except (TypeError, ValueError):
-                    parsed_confidence = math.nan
-                if math.isfinite(parsed_confidence) and 0.0 <= parsed_confidence <= 1.0:
-                    confidence = parsed_confidence
-
             segment = LayoutSegmentIR(
                 x=bbox[0],
                 y=bbox[1],
                 w=bbox[2],
                 h=bbox[3],
-                confidence=confidence,
                 label=raw_label,
                 start_index=start_index,
                 end_index=end_index,

--- a/src/parse_bench/schemas/layout_detection_output.py
+++ b/src/parse_bench/schemas/layout_detection_output.py
@@ -316,6 +316,7 @@ class LayoutDetectionModel(StrEnum):
     DATABRICKS_LAYOUT = "databricks_layout"
     INFINITY_PARSER2_LAYOUT = "infinity_parser2_layout"
     OI_PARSER_LAYOUT = "oi_parser_layout"
+    PYMUPDF4LLM_LAYOUT = "pymupdf4llm_layout"
 
 
 LAYOUT_MODEL_INFO: dict[LayoutDetectionModel, dict[str, str]] = {
@@ -438,6 +439,10 @@ LAYOUT_MODEL_INFO: dict[LayoutDetectionModel, dict[str, str]] = {
     LayoutDetectionModel.INFINITY_PARSER2_LAYOUT: {
         "name": "Infinity-Parser2 Layout",
         "hf_url": "https://huggingface.co/collections/infly/infinity-parser2",
+    },
+    LayoutDetectionModel.PYMUPDF4LLM_LAYOUT: {
+        "name": "PyMuPDF4LLM Layout",
+        "hf_url": "https://pymupdf.readthedocs.io/en/latest/pymupdf4llm/",
     },
 }
 

--- a/tests/parse_bench/evaluation/layout_label_mappers/test_pymupdf4llm_label_mapper.py
+++ b/tests/parse_bench/evaluation/layout_label_mappers/test_pymupdf4llm_label_mapper.py
@@ -1,0 +1,62 @@
+"""Tests for the PyMuPDF4LLM layout label mapper."""
+
+import pytest
+
+from parse_bench.evaluation.layout_label_mappers.base import MappingContext
+from parse_bench.evaluation.layout_label_mappers.mappers import PyMuPDF4LLMLabelMapper
+from parse_bench.evaluation.layout_label_mappers.registry import (
+    list_layout_label_mappers,
+    resolve_layout_label_mapper,
+)
+from parse_bench.layout_label_mapping import UnknownRawLayoutLabelError
+from parse_bench.schemas.layout_detection_output import LayoutDetectionModel, LayoutOutput
+from parse_bench.schemas.layout_ontology import CanonicalLabel
+
+
+def _context(*, provider_name: str | None) -> MappingContext:
+    layout_output = LayoutOutput(
+        example_id="ex",
+        pipeline_name="pymupdf4llm_markdown",
+        model=LayoutDetectionModel.PYMUPDF4LLM_LAYOUT,
+        image_width=100,
+        image_height=100,
+        predictions=[],
+    )
+    return MappingContext(
+        provider_name=provider_name,
+        pipeline_name="pymupdf4llm_markdown",
+        model=LayoutDetectionModel.PYMUPDF4LLM_LAYOUT,
+        raw_output={},
+        layout_output=layout_output,
+    )
+
+
+def test_mapper_registered_for_provider_and_model() -> None:
+    keys = list_layout_label_mappers()
+    assert "pymupdf4llm" in keys
+    assert "model:pymupdf4llm_layout" in keys
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("table", CanonicalLabel.TABLE),
+        ("text", CanonicalLabel.TEXT),
+        ("Section_Header", CanonicalLabel.SECTION_HEADER),
+        ("list_item", CanonicalLabel.LIST_ITEM),
+        ("picture", CanonicalLabel.PICTURE),
+        ("caption", CanonicalLabel.CAPTION),
+    ],
+)
+def test_maps_known_raw_labels(raw: str, expected: CanonicalLabel) -> None:
+    assert PyMuPDF4LLMLabelMapper().to_canonical(raw, None, None) == expected  # type: ignore[arg-type]
+
+
+def test_unknown_label_raises() -> None:
+    with pytest.raises(UnknownRawLayoutLabelError):
+        PyMuPDF4LLMLabelMapper().to_canonical("unknown", None, None)  # type: ignore[arg-type]
+
+
+def test_resolver_selects_mapper_by_provider_or_model() -> None:
+    assert isinstance(resolve_layout_label_mapper(_context(provider_name="pymupdf4llm")), PyMuPDF4LLMLabelMapper)
+    assert isinstance(resolve_layout_label_mapper(_context(provider_name=None)), PyMuPDF4LLMLabelMapper)

--- a/tests/parse_bench/inference/providers/parse/test_pymupdf4llm.py
+++ b/tests/parse_bench/inference/providers/parse/test_pymupdf4llm.py
@@ -1,8 +1,6 @@
 """Tests for the PyMuPDF4LLM native-HTML provider."""
 
-import tomllib
 from datetime import datetime
-from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -18,8 +16,6 @@ from parse_bench.schemas.pipeline import PipelineSpec
 from parse_bench.schemas.pipeline_io import InferenceRequest, RawInferenceResult
 from parse_bench.schemas.product import ProductType
 
-REPO_ROOT = Path(__file__).resolve().parents[5]
-
 
 def test_only_one_pymupdf4llm_pipeline_is_registered() -> None:
     assert [name for name in list_pipelines() if name.startswith("pymupdf4llm")] == [
@@ -27,7 +23,7 @@ def test_only_one_pymupdf4llm_pipeline_is_registered() -> None:
     ]
 
 
-def test_pipeline_uses_modern_rapidocr_and_native_html() -> None:
+def test_pipeline_uses_rapidocr_and_native_html() -> None:
     pipeline = get_pipeline("pymupdf4llm_markdown")
 
     assert pipeline.provider_name == "pymupdf4llm"
@@ -37,20 +33,6 @@ def test_pipeline_uses_modern_rapidocr_and_native_html() -> None:
         "ocr_dpi": 150,
         "table_output": "html",
     }
-
-
-def test_pymupdf4llm_extra_pins_modern_rapidocr_runtime() -> None:
-    pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
-    lock = tomllib.loads((REPO_ROOT / "uv.lock").read_text())
-    extras = pyproject["project"]["optional-dependencies"]
-
-    assert extras["pymupdf4llm"] == ["pymupdf4llm==1.28.2", "rapidocr==3.9.2"]
-    assert not any(dependency.startswith("rapidocr-onnxruntime") for dependency in extras["pymupdf4llm"])
-    assert {package["version"] for package in lock["package"] if package["name"] == "rapidocr"} == {"3.9.2"}
-    assert not any(
-        package["name"] == "rapidocr-onnxruntime" and package["version"] == "1.2.3"
-        for package in lock["package"]
-    )
 
 
 def test_markdown_options_are_declarative() -> None:
@@ -73,7 +55,7 @@ def test_markdown_options_are_declarative() -> None:
     }
 
 
-def test_resolve_rapidocr_uses_modern_bundled_module(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_resolve_rapidocr_uses_bundled_module(monkeypatch: pytest.MonkeyPatch) -> None:
     def exec_ocr() -> None:
         return None
 
@@ -92,7 +74,7 @@ def test_resolve_rapidocr_uses_modern_bundled_module(monkeypatch: pytest.MonkeyP
 
 
 @pytest.mark.parametrize("backend", ["rapidtess", "tesseract", "rapidocr_onnxruntime"])
-def test_markdown_options_reject_legacy_ocr_backends(backend: str) -> None:
+def test_markdown_options_rejects_unsupported_ocr_backends(backend: str) -> None:
     provider = PyMuPDF4LLMProvider("pymupdf4llm", {"ocr_backend": backend})
 
     with pytest.raises(ProviderConfigError, match="Unsupported.*OCR backend"):
@@ -107,17 +89,6 @@ def test_markdown_options_reject_invalid_ocr_dpi(ocr_dpi: object) -> None:
         provider._markdown_options()
 
 
-@pytest.mark.parametrize("table_output", [None, 1, "xml"])
-def test_markdown_options_reject_invalid_table_output(table_output: object) -> None:
-    provider = PyMuPDF4LLMProvider("pymupdf4llm", {"table_output": table_output})
-
-    if table_output is None:
-        assert "table_output" not in provider._markdown_options()
-    else:
-        with pytest.raises(ProviderConfigError, match="table_output"):
-            provider._markdown_options()
-
-
 def test_build_layout_page_preserves_native_html_raw_labels_and_bbox() -> None:
     native_html = "<table><tr><td>value</td></tr></table>"
     page = PyMuPDF4LLMProvider._build_layout_page(
@@ -130,7 +101,6 @@ def test_build_layout_page_preserves_native_html_raw_labels_and_bbox() -> None:
                     "class": "table",
                     "bbox": [20, 10, 180, 90],
                     "pos": [0, len(native_html)],
-                    "confidence": 0.8,
                 }
             ],
         },

--- a/tests/parse_bench/inference/providers/parse/test_pymupdf4llm.py
+++ b/tests/parse_bench/inference/providers/parse/test_pymupdf4llm.py
@@ -1,0 +1,296 @@
+"""Tests for the PyMuPDF4LLM provider and table normalization."""
+
+import tomllib
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import parse_bench.inference.providers.parse.pymupdf4llm as provider_module
+from parse_bench.evaluation.layout_adapters.adapters import PyMuPDF4LLMLayoutAdapter
+from parse_bench.inference.pipelines import get_pipeline, list_pipelines
+from parse_bench.inference.providers.base import ProviderConfigError
+from parse_bench.inference.providers.parse.pymupdf4llm import (
+    PyMuPDF4LLMProvider,
+    convert_pipe_tables_to_html,
+)
+from parse_bench.schemas.layout_detection_output import LayoutDetectionModel
+from parse_bench.schemas.parse_output import ParseOutput
+from parse_bench.schemas.pipeline import PipelineSpec
+from parse_bench.schemas.pipeline_io import InferenceRequest, RawInferenceResult
+from parse_bench.schemas.product import ProductType
+
+REPO_ROOT = Path(__file__).resolve().parents[5]
+
+
+def test_only_one_pymupdf4llm_pipeline_is_registered() -> None:
+    assert [name for name in list_pipelines() if name.startswith("pymupdf4llm")] == ["pymupdf4llm_markdown"]
+
+
+def test_pipeline_uses_rapidtess_at_150_dpi() -> None:
+    pipeline = get_pipeline("pymupdf4llm_markdown")
+
+    assert pipeline.provider_name == "pymupdf4llm"
+    assert pipeline.config == {
+        "use_ocr": True,
+        "ocr_backend": "rapidtess",
+        "ocr_dpi": 150,
+    }
+
+
+def test_pymupdf4llm_extra_pins_compatible_rapidocr_runtime() -> None:
+    pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+    lock = tomllib.loads((REPO_ROOT / "uv.lock").read_text())
+    extras = pyproject["project"]["optional-dependencies"]
+
+    assert "pymupdf4llm==1.28.0" in extras["pymupdf4llm"]
+    assert "rapidocr-onnxruntime==1.2.3" in extras["pymupdf4llm"]
+    assert not any(dependency.startswith("rapidocr-onnxruntime") for dependency in extras["runners"])
+    assert {package["version"] for package in lock["package"] if package["name"] == "rapidocr-onnxruntime"} == {
+        "1.2.3",
+        "1.4.4",
+    }
+
+
+def test_markdown_options_are_declarative() -> None:
+    provider = PyMuPDF4LLMProvider(
+        "pymupdf4llm",
+        {"use_ocr": True, "ocr_backend": "rapidtess", "ocr_dpi": 150},
+    )
+
+    assert provider._markdown_options() == {
+        "page_chunks": True,
+        "show_progress": False,
+        "use_ocr": True,
+        "ocr_dpi": 150,
+    }
+
+
+def test_resolve_rapidtess_uses_bundled_module(monkeypatch: pytest.MonkeyPatch) -> None:
+    def exec_ocr() -> None:
+        return None
+
+    requested: list[str] = []
+
+    def import_module(name: str) -> SimpleNamespace:
+        requested.append(name)
+        return SimpleNamespace(TESSDATA="/usr/share/tessdata", exec_ocr=exec_ocr)
+
+    monkeypatch.setattr(provider_module.importlib, "import_module", import_module)
+
+    provider = PyMuPDF4LLMProvider("pymupdf4llm", {"ocr_backend": "rapidtess"})
+
+    assert provider._resolve_ocr_function() is exec_ocr
+    assert requested == ["pymupdf4llm.ocr.rapidtess_api"]
+
+
+def test_resolve_rapidtess_requires_tesseract_language_data(monkeypatch: pytest.MonkeyPatch) -> None:
+    engine = SimpleNamespace(text_detector=lambda: None)
+    ocr_module = SimpleNamespace(ENGINE=engine, TESSDATA=None, exec_ocr=lambda: None)
+    monkeypatch.setattr(provider_module.importlib, "import_module", lambda _name: ocr_module)
+
+    provider = PyMuPDF4LLMProvider("pymupdf4llm", {"ocr_backend": "rapidtess"})
+
+    with pytest.raises(ProviderConfigError, match="Tesseract language data was not found"):
+        provider._resolve_ocr_function()
+
+
+@pytest.mark.parametrize("ocr_dpi", [True, 0, -1, 150.0, "150"])
+def test_markdown_options_reject_invalid_ocr_dpi(ocr_dpi: object) -> None:
+    provider = PyMuPDF4LLMProvider("pymupdf4llm", {"ocr_dpi": ocr_dpi})
+
+    with pytest.raises(ProviderConfigError, match="positive integer"):
+        provider._markdown_options()
+
+
+def test_build_layout_page_preserves_raw_labels_and_normalizes_bbox() -> None:
+    markdown = "table content"
+    page = PyMuPDF4LLMProvider._build_layout_page(
+        {
+            "page_number": 1,
+            "width": 200,
+            "height": 100,
+            "page_boxes": [
+                {
+                    "class": "table",
+                    "bbox": [20, 10, 180, 90],
+                    "pos": [0, len(markdown)],
+                    "confidence": 0.8,
+                }
+            ],
+        },
+        raw_markdown=markdown,
+    )
+
+    assert page is not None
+    assert page.items[0].layout_segments[0].label == "table"
+    assert page.items[0].layout_segments[0].model_dump(include={"x", "y", "w", "h"}) == {
+        "x": 0.1,
+        "y": 0.1,
+        "w": 0.8,
+        "h": 0.8,
+    }
+
+
+def test_convert_pipe_tables_preserves_alignment_and_uneven_rows() -> None:
+    markdown = "| Name | Q1 |\n| :--- | ---: |\n| Alpha | 10 | extra |\n| Beta |"
+
+    converted = convert_pipe_tables_to_html(markdown)
+
+    assert '<th style="text-align:left">Name</th>' in converted
+    assert '<th style="text-align:right">Q1</th>' in converted
+    assert "<td>extra</td>" in converted
+    assert converted.count("<td") == 6
+
+
+def test_convert_pipe_tables_preserves_interior_blank_rows() -> None:
+    markdown = "| A | B |\n| --- | --- |\n| 1 | 2 |\n| | |\n| 3 | 4 |"
+
+    converted = convert_pipe_tables_to_html(markdown)
+
+    assert "<tr><td></td><td></td></tr>" in converted
+    assert converted.count("<tr>") == 4
+
+
+def test_convert_pipe_tables_does_not_count_blank_rows_toward_minimum_width() -> None:
+    markdown = "| Header |\n| --- | --- |\n| Value |\n| | |"
+
+    assert convert_pipe_tables_to_html(markdown) == markdown
+
+
+@pytest.mark.parametrize("separator", ["|-|-|", "|:--|--:|"])
+def test_convert_pipe_tables_accepts_short_gfm_separators(separator: str) -> None:
+    markdown = f"| A | B |\n{separator}\n| 1 | 2 |"
+
+    converted = convert_pipe_tables_to_html(markdown)
+
+    assert "<table>" in converted
+    assert ">A</th>" in converted
+    assert ">B</th>" in converted
+    assert ">1</td>" in converted
+    assert ">2</td>" in converted
+
+
+def test_convert_pipe_tables_drops_empty_fallback_header_without_promoting_body() -> None:
+    markdown = "| | |\n| --- | --- |\n| 1 | 2 |\n| 3 | 4 |"
+
+    converted = convert_pipe_tables_to_html(markdown)
+
+    assert "<thead>" not in converted
+    assert "<th" not in converted
+    assert converted.count("<tr>") == 2
+    assert "<td>1</td><td>2</td>" in converted
+
+
+def test_convert_pipe_tables_preserves_escaped_and_code_pipes() -> None:
+    markdown = "| Expression | Meaning |\n| --- | --- |\n| left \\| right | `a|b` |"
+
+    converted = convert_pipe_tables_to_html(markdown)
+
+    assert "left | right" in converted
+    assert "<code>a|b</code>" in converted
+
+
+def test_convert_pipe_tables_escapes_raw_html() -> None:
+    markdown = "| Name | Value |\n| --- | --- |\n| <script>alert(1)</script> | safe |"
+
+    converted = convert_pipe_tables_to_html(markdown)
+
+    assert "<script>" not in converted
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in converted
+
+
+def test_convert_pipe_tables_preserves_line_breaks_in_cells() -> None:
+    markdown = "| Header<br>Detail |\n| --- |\n| Value<br/>More |"
+
+    converted = convert_pipe_tables_to_html(markdown)
+
+    assert "<th>Header<br>Detail</th>" in converted
+    assert "<td>Value<br>More</td>" in converted
+    assert "&lt;br" not in converted
+
+
+def test_convert_pipe_tables_supports_valid_one_column_tables() -> None:
+    markdown = "| Charge |\n| --- |\n| 0% to 15% |"
+
+    converted = convert_pipe_tables_to_html(markdown)
+
+    assert "<table>" in converted
+    assert "<th>Charge</th>" in converted
+    assert "<td>0% to 15%</td>" in converted
+
+
+@pytest.mark.parametrize(
+    "markdown",
+    [
+        "Use `left | right` as an example.\n| This is not a table |",
+        "```markdown\n| A | B |\n| --- | --- |\n| 1 | 2 |\n```",
+        "<div>\n| A | B |\n| --- | --- |\n| 1 | 2 |\n</div>",
+        "<table><tbody><tr><td>existing</td></tr></tbody></table>",
+    ],
+)
+def test_convert_pipe_tables_preserves_non_table_or_protected_content(markdown: str) -> None:
+    assert convert_pipe_tables_to_html(markdown) == markdown
+
+
+def test_convert_pipe_tables_is_idempotent() -> None:
+    markdown = "| A | B |\n| --- | --- |\n| 1 | 2 |"
+    converted = convert_pipe_tables_to_html(markdown)
+
+    assert convert_pipe_tables_to_html(converted) == converted
+
+
+def test_normalize_builds_layout_before_table_conversion() -> None:
+    markdown = "| A | B |\n| --- | --- |\n| 1 | 2 |"
+    raw_output = {
+        "pages": [
+            {
+                "page_index": 0,
+                "page_number": 1,
+                "text": markdown,
+                "width": 100,
+                "height": 100,
+                "page_boxes": [{"class": "table", "bbox": [0, 0, 100, 100], "pos": [0, len(markdown)]}],
+            }
+        ],
+        "num_pages": 1,
+    }
+    pipeline = PipelineSpec(
+        pipeline_name="pymupdf4llm_markdown",
+        provider_name="pymupdf4llm",
+        product_type=ProductType.PARSE,
+        config={"use_ocr": True, "ocr_backend": "rapidtess", "ocr_dpi": 150},
+    )
+    request = InferenceRequest(
+        example_id="example-1",
+        source_file_path="/tmp/example.pdf",
+        product_type=ProductType.PARSE,
+    )
+    now = datetime.now()
+    raw_result = RawInferenceResult(
+        request=request,
+        pipeline=pipeline,
+        pipeline_name=pipeline.pipeline_name,
+        product_type=ProductType.PARSE,
+        raw_output=raw_output,
+        started_at=now,
+        completed_at=now,
+        latency_in_ms=0,
+    )
+
+    result = PyMuPDF4LLMProvider("pymupdf4llm", pipeline.config).normalize(raw_result)
+
+    assert isinstance(result.output, ParseOutput)
+    assert result.output.layout_pages[0].items[0].md == markdown
+    assert "<table>" in result.output.layout_pages[0].items[0].html
+    assert "<table>" in result.output.markdown
+    assert result.raw_output == raw_output
+
+    adapter = PyMuPDF4LLMLayoutAdapter()
+    assert adapter.matches(result)
+    layout_output = adapter.to_layout_output(result)
+    assert layout_output.model == LayoutDetectionModel.PYMUPDF4LLM_LAYOUT
+    assert layout_output.image_width == 100
+    assert layout_output.image_height == 100
+    assert layout_output.predictions[0].bbox == [0.0, 0.0, 100.0, 100.0]

--- a/tests/parse_bench/inference/providers/parse/test_pymupdf4llm.py
+++ b/tests/parse_bench/inference/providers/parse/test_pymupdf4llm.py
@@ -1,4 +1,4 @@
-"""Tests for the PyMuPDF4LLM provider and table normalization."""
+"""Tests for the PyMuPDF4LLM native-HTML provider."""
 
 import tomllib
 from datetime import datetime
@@ -11,10 +11,7 @@ import parse_bench.inference.providers.parse.pymupdf4llm as provider_module
 from parse_bench.evaluation.layout_adapters.adapters import PyMuPDF4LLMLayoutAdapter
 from parse_bench.inference.pipelines import get_pipeline, list_pipelines
 from parse_bench.inference.providers.base import ProviderConfigError
-from parse_bench.inference.providers.parse.pymupdf4llm import (
-    PyMuPDF4LLMProvider,
-    convert_pipe_tables_to_html,
-)
+from parse_bench.inference.providers.parse.pymupdf4llm import PyMuPDF4LLMProvider
 from parse_bench.schemas.layout_detection_output import LayoutDetectionModel
 from parse_bench.schemas.parse_output import ParseOutput
 from parse_bench.schemas.pipeline import PipelineSpec
@@ -25,38 +22,46 @@ REPO_ROOT = Path(__file__).resolve().parents[5]
 
 
 def test_only_one_pymupdf4llm_pipeline_is_registered() -> None:
-    assert [name for name in list_pipelines() if name.startswith("pymupdf4llm")] == ["pymupdf4llm_markdown"]
+    assert [name for name in list_pipelines() if name.startswith("pymupdf4llm")] == [
+        "pymupdf4llm_markdown"
+    ]
 
 
-def test_pipeline_uses_rapidtess_at_150_dpi() -> None:
+def test_pipeline_uses_modern_rapidocr_and_native_html() -> None:
     pipeline = get_pipeline("pymupdf4llm_markdown")
 
     assert pipeline.provider_name == "pymupdf4llm"
     assert pipeline.config == {
         "use_ocr": True,
-        "ocr_backend": "rapidtess",
+        "ocr_backend": "rapidocr",
         "ocr_dpi": 150,
+        "table_output": "html",
     }
 
 
-def test_pymupdf4llm_extra_pins_compatible_rapidocr_runtime() -> None:
+def test_pymupdf4llm_extra_pins_modern_rapidocr_runtime() -> None:
     pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
     lock = tomllib.loads((REPO_ROOT / "uv.lock").read_text())
     extras = pyproject["project"]["optional-dependencies"]
 
-    assert "pymupdf4llm==1.28.0" in extras["pymupdf4llm"]
-    assert "rapidocr-onnxruntime==1.2.3" in extras["pymupdf4llm"]
-    assert not any(dependency.startswith("rapidocr-onnxruntime") for dependency in extras["runners"])
-    assert {package["version"] for package in lock["package"] if package["name"] == "rapidocr-onnxruntime"} == {
-        "1.2.3",
-        "1.4.4",
-    }
+    assert extras["pymupdf4llm"] == ["pymupdf4llm==1.28.2", "rapidocr==3.9.2"]
+    assert not any(dependency.startswith("rapidocr-onnxruntime") for dependency in extras["pymupdf4llm"])
+    assert {package["version"] for package in lock["package"] if package["name"] == "rapidocr"} == {"3.9.2"}
+    assert not any(
+        package["name"] == "rapidocr-onnxruntime" and package["version"] == "1.2.3"
+        for package in lock["package"]
+    )
 
 
 def test_markdown_options_are_declarative() -> None:
     provider = PyMuPDF4LLMProvider(
         "pymupdf4llm",
-        {"use_ocr": True, "ocr_backend": "rapidtess", "ocr_dpi": 150},
+        {
+            "use_ocr": True,
+            "ocr_backend": "rapidocr",
+            "ocr_dpi": 150,
+            "table_output": "html",
+        },
     )
 
     assert provider._markdown_options() == {
@@ -64,10 +69,11 @@ def test_markdown_options_are_declarative() -> None:
         "show_progress": False,
         "use_ocr": True,
         "ocr_dpi": 150,
+        "table_output": "html",
     }
 
 
-def test_resolve_rapidtess_uses_bundled_module(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_resolve_rapidocr_uses_modern_bundled_module(monkeypatch: pytest.MonkeyPatch) -> None:
     def exec_ocr() -> None:
         return None
 
@@ -75,25 +81,22 @@ def test_resolve_rapidtess_uses_bundled_module(monkeypatch: pytest.MonkeyPatch) 
 
     def import_module(name: str) -> SimpleNamespace:
         requested.append(name)
-        return SimpleNamespace(TESSDATA="/usr/share/tessdata", exec_ocr=exec_ocr)
+        return SimpleNamespace(exec_ocr=exec_ocr)
 
     monkeypatch.setattr(provider_module.importlib, "import_module", import_module)
 
-    provider = PyMuPDF4LLMProvider("pymupdf4llm", {"ocr_backend": "rapidtess"})
+    provider = PyMuPDF4LLMProvider("pymupdf4llm", {"ocr_backend": "rapidocr"})
 
     assert provider._resolve_ocr_function() is exec_ocr
-    assert requested == ["pymupdf4llm.ocr.rapidtess_api"]
+    assert requested == ["pymupdf4llm.ocr.rapidocr_api"]
 
 
-def test_resolve_rapidtess_requires_tesseract_language_data(monkeypatch: pytest.MonkeyPatch) -> None:
-    engine = SimpleNamespace(text_detector=lambda: None)
-    ocr_module = SimpleNamespace(ENGINE=engine, TESSDATA=None, exec_ocr=lambda: None)
-    monkeypatch.setattr(provider_module.importlib, "import_module", lambda _name: ocr_module)
+@pytest.mark.parametrize("backend", ["rapidtess", "tesseract", "rapidocr_onnxruntime"])
+def test_markdown_options_reject_legacy_ocr_backends(backend: str) -> None:
+    provider = PyMuPDF4LLMProvider("pymupdf4llm", {"ocr_backend": backend})
 
-    provider = PyMuPDF4LLMProvider("pymupdf4llm", {"ocr_backend": "rapidtess"})
-
-    with pytest.raises(ProviderConfigError, match="Tesseract language data was not found"):
-        provider._resolve_ocr_function()
+    with pytest.raises(ProviderConfigError, match="Unsupported.*OCR backend"):
+        provider._markdown_options()
 
 
 @pytest.mark.parametrize("ocr_dpi", [True, 0, -1, 150.0, "150"])
@@ -104,8 +107,19 @@ def test_markdown_options_reject_invalid_ocr_dpi(ocr_dpi: object) -> None:
         provider._markdown_options()
 
 
-def test_build_layout_page_preserves_raw_labels_and_normalizes_bbox() -> None:
-    markdown = "table content"
+@pytest.mark.parametrize("table_output", [None, 1, "xml"])
+def test_markdown_options_reject_invalid_table_output(table_output: object) -> None:
+    provider = PyMuPDF4LLMProvider("pymupdf4llm", {"table_output": table_output})
+
+    if table_output is None:
+        assert "table_output" not in provider._markdown_options()
+    else:
+        with pytest.raises(ProviderConfigError, match="table_output"):
+            provider._markdown_options()
+
+
+def test_build_layout_page_preserves_native_html_raw_labels_and_bbox() -> None:
+    native_html = "<table><tr><td>value</td></tr></table>"
     page = PyMuPDF4LLMProvider._build_layout_page(
         {
             "page_number": 1,
@@ -115,17 +129,20 @@ def test_build_layout_page_preserves_raw_labels_and_normalizes_bbox() -> None:
                 {
                     "class": "table",
                     "bbox": [20, 10, 180, 90],
-                    "pos": [0, len(markdown)],
+                    "pos": [0, len(native_html)],
                     "confidence": 0.8,
                 }
             ],
         },
-        raw_markdown=markdown,
+        raw_markdown=native_html,
     )
 
     assert page is not None
-    assert page.items[0].layout_segments[0].label == "table"
-    assert page.items[0].layout_segments[0].model_dump(include={"x", "y", "w", "h"}) == {
+    item = page.items[0]
+    assert item.md == native_html
+    assert item.html == native_html
+    assert item.layout_segments[0].label == "table"
+    assert item.layout_segments[0].model_dump(include={"x", "y", "w", "h"}) == {
         "x": 0.1,
         "y": 0.1,
         "w": 0.8,
@@ -133,125 +150,19 @@ def test_build_layout_page_preserves_raw_labels_and_normalizes_bbox() -> None:
     }
 
 
-def test_convert_pipe_tables_preserves_alignment_and_uneven_rows() -> None:
-    markdown = "| Name | Q1 |\n| :--- | ---: |\n| Alpha | 10 | extra |\n| Beta |"
-
-    converted = convert_pipe_tables_to_html(markdown)
-
-    assert '<th style="text-align:left">Name</th>' in converted
-    assert '<th style="text-align:right">Q1</th>' in converted
-    assert "<td>extra</td>" in converted
-    assert converted.count("<td") == 6
-
-
-def test_convert_pipe_tables_preserves_interior_blank_rows() -> None:
-    markdown = "| A | B |\n| --- | --- |\n| 1 | 2 |\n| | |\n| 3 | 4 |"
-
-    converted = convert_pipe_tables_to_html(markdown)
-
-    assert "<tr><td></td><td></td></tr>" in converted
-    assert converted.count("<tr>") == 4
-
-
-def test_convert_pipe_tables_does_not_count_blank_rows_toward_minimum_width() -> None:
-    markdown = "| Header |\n| --- | --- |\n| Value |\n| | |"
-
-    assert convert_pipe_tables_to_html(markdown) == markdown
-
-
-@pytest.mark.parametrize("separator", ["|-|-|", "|:--|--:|"])
-def test_convert_pipe_tables_accepts_short_gfm_separators(separator: str) -> None:
-    markdown = f"| A | B |\n{separator}\n| 1 | 2 |"
-
-    converted = convert_pipe_tables_to_html(markdown)
-
-    assert "<table>" in converted
-    assert ">A</th>" in converted
-    assert ">B</th>" in converted
-    assert ">1</td>" in converted
-    assert ">2</td>" in converted
-
-
-def test_convert_pipe_tables_drops_empty_fallback_header_without_promoting_body() -> None:
-    markdown = "| | |\n| --- | --- |\n| 1 | 2 |\n| 3 | 4 |"
-
-    converted = convert_pipe_tables_to_html(markdown)
-
-    assert "<thead>" not in converted
-    assert "<th" not in converted
-    assert converted.count("<tr>") == 2
-    assert "<td>1</td><td>2</td>" in converted
-
-
-def test_convert_pipe_tables_preserves_escaped_and_code_pipes() -> None:
-    markdown = "| Expression | Meaning |\n| --- | --- |\n| left \\| right | `a|b` |"
-
-    converted = convert_pipe_tables_to_html(markdown)
-
-    assert "left | right" in converted
-    assert "<code>a|b</code>" in converted
-
-
-def test_convert_pipe_tables_escapes_raw_html() -> None:
-    markdown = "| Name | Value |\n| --- | --- |\n| <script>alert(1)</script> | safe |"
-
-    converted = convert_pipe_tables_to_html(markdown)
-
-    assert "<script>" not in converted
-    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in converted
-
-
-def test_convert_pipe_tables_preserves_line_breaks_in_cells() -> None:
-    markdown = "| Header<br>Detail |\n| --- |\n| Value<br/>More |"
-
-    converted = convert_pipe_tables_to_html(markdown)
-
-    assert "<th>Header<br>Detail</th>" in converted
-    assert "<td>Value<br>More</td>" in converted
-    assert "&lt;br" not in converted
-
-
-def test_convert_pipe_tables_supports_valid_one_column_tables() -> None:
-    markdown = "| Charge |\n| --- |\n| 0% to 15% |"
-
-    converted = convert_pipe_tables_to_html(markdown)
-
-    assert "<table>" in converted
-    assert "<th>Charge</th>" in converted
-    assert "<td>0% to 15%</td>" in converted
-
-
-@pytest.mark.parametrize(
-    "markdown",
-    [
-        "Use `left | right` as an example.\n| This is not a table |",
-        "```markdown\n| A | B |\n| --- | --- |\n| 1 | 2 |\n```",
-        "<div>\n| A | B |\n| --- | --- |\n| 1 | 2 |\n</div>",
-        "<table><tbody><tr><td>existing</td></tr></tbody></table>",
-    ],
-)
-def test_convert_pipe_tables_preserves_non_table_or_protected_content(markdown: str) -> None:
-    assert convert_pipe_tables_to_html(markdown) == markdown
-
-
-def test_convert_pipe_tables_is_idempotent() -> None:
-    markdown = "| A | B |\n| --- | --- |\n| 1 | 2 |"
-    converted = convert_pipe_tables_to_html(markdown)
-
-    assert convert_pipe_tables_to_html(converted) == converted
-
-
-def test_normalize_builds_layout_before_table_conversion() -> None:
-    markdown = "| A | B |\n| --- | --- |\n| 1 | 2 |"
+def test_normalize_preserves_native_html_and_layout_grounding() -> None:
+    native_html = "<table><tr><td>value</td></tr></table>"
     raw_output = {
         "pages": [
             {
                 "page_index": 0,
                 "page_number": 1,
-                "text": markdown,
+                "text": native_html,
                 "width": 100,
                 "height": 100,
-                "page_boxes": [{"class": "table", "bbox": [0, 0, 100, 100], "pos": [0, len(markdown)]}],
+                "page_boxes": [
+                    {"class": "table", "bbox": [0, 0, 100, 100], "pos": [0, len(native_html)]}
+                ],
             }
         ],
         "num_pages": 1,
@@ -260,7 +171,12 @@ def test_normalize_builds_layout_before_table_conversion() -> None:
         pipeline_name="pymupdf4llm_markdown",
         provider_name="pymupdf4llm",
         product_type=ProductType.PARSE,
-        config={"use_ocr": True, "ocr_backend": "rapidtess", "ocr_dpi": 150},
+        config={
+            "use_ocr": True,
+            "ocr_backend": "rapidocr",
+            "ocr_dpi": 150,
+            "table_output": "html",
+        },
     )
     request = InferenceRequest(
         example_id="example-1",
@@ -282,9 +198,9 @@ def test_normalize_builds_layout_before_table_conversion() -> None:
     result = PyMuPDF4LLMProvider("pymupdf4llm", pipeline.config).normalize(raw_result)
 
     assert isinstance(result.output, ParseOutput)
-    assert result.output.layout_pages[0].items[0].md == markdown
-    assert "<table>" in result.output.layout_pages[0].items[0].html
-    assert "<table>" in result.output.markdown
+    assert result.output.layout_pages[0].items[0].md == native_html
+    assert result.output.layout_pages[0].items[0].html == native_html
+    assert result.output.markdown == native_html
     assert result.raw_output == raw_output
 
     adapter = PyMuPDF4LLMLayoutAdapter()

--- a/uv.lock
+++ b/uv.lock
@@ -238,6 +238,12 @@ wheels = [
 ]
 
 [[package]]
+name = "antlr4-python3-runtime"
+version = "4.9.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/38/7859ff46355f76f8d19459005ca000b6e7012f2f1ca597746cbcd1fbfe5e/antlr4-python3-runtime-4.9.3.tar.gz", hash = "sha256:f224469b4168294902bb1efa80a8bf7855f24c99aef99cbefc1bcd3cce77881b", size = 117034, upload-time = "2021-11-06T17:52:23.524Z" }
+
+[[package]]
 name = "anyio"
 version = "4.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -617,6 +623,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "colorlog"
+version = "6.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8c/55/ba79756cb90c8d69d599d57785398ac87bba7b19c80e87f4e8a562197c93/colorlog-6.12.0.tar.gz", hash = "sha256:2a7924c1dadf18b22a0eb8b06d1c7b01d5341707ec1641eb6fcc4fde0c3e8e5f", size = 18151, upload-time = "2026-07-23T13:40:40.71Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/19/0b6647bf5e331521e55d2b63bfbdc210bd9cd605189273f03614a05f702d/colorlog-6.12.0-py3-none-any.whl", hash = "sha256:30d392604e9110045a2c2aeefc27d7a017abbab63f3a8aee594eac0801df784e", size = 12239, upload-time = "2026-07-23T13:40:39.562Z" },
 ]
 
 [[package]]
@@ -1329,7 +1347,7 @@ dependencies = [
     { name = "pillow" },
     { name = "py-cpuinfo" },
     { name = "pybase64" },
-    { name = "pymupdf" },
+    { name = "pymupdf", version = "1.28.0", source = { registry = "https://pypi.org/simple" } },
     { name = "pypdf" },
     { name = "qwen-vl-utils" },
     { name = "scikit-learn" },
@@ -2411,6 +2429,19 @@ wheels = [
 ]
 
 [[package]]
+name = "omegaconf"
+version = "2.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "antlr4-python3-runtime" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/3d/e4b57b8d9008c6ebe0d5eff901f91d5700cf7bdb8c8863df817463a7fd5e/omegaconf-2.3.1.tar.gz", hash = "sha256:e5e7de64aeebeddaf8e6d3f7a783b32ac2a01c0fbd9c878012caecb891a1f42a", size = 3298472, upload-time = "2026-06-11T05:05:12.885Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/0e/152509871bf30df6fc38569f52a2db9b55dd41aae957adae50a053ac7778/omegaconf-2.3.1-py3-none-any.whl", hash = "sha256:3d701d14e9a8828f1edd28bb70b725908b34277cdd72cf7d6a83f94dadc6b6a0", size = 79502, upload-time = "2026-06-11T05:05:09.954Z" },
+]
+
+[[package]]
 name = "onnxruntime"
 version = "1.27.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2599,7 +2630,6 @@ dependencies = [
     { name = "huggingface-hub" },
     { name = "lxml" },
     { name = "markdown" },
-    { name = "markdown-it-py" },
     { name = "markdown2" },
     { name = "numpy" },
     { name = "pandas" },
@@ -2627,7 +2657,7 @@ fast = [
 ]
 pymupdf4llm = [
     { name = "pymupdf4llm" },
-    { name = "rapidocr-onnxruntime", version = "1.2.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "rapidocr" },
 ]
 runners = [
     { name = "amazon-textract-textractor" },
@@ -2647,7 +2677,7 @@ runners = [
     { name = "openai" },
     { name = "pdf2image" },
     { name = "pillow" },
-    { name = "pymupdf" },
+    { name = "pymupdf", version = "1.28.0", source = { registry = "https://pypi.org/simple" } },
     { name = "pypdf" },
     { name = "pytesseract" },
     { name = "reductoai" },
@@ -2682,7 +2712,6 @@ requires-dist = [
     { name = "llama-cloud", marker = "extra == 'runners'", specifier = ">=1.4.1" },
     { name = "lxml", specifier = ">=5.0.0" },
     { name = "markdown", specifier = ">=3.0" },
-    { name = "markdown-it-py", specifier = ">=3.0" },
     { name = "markdown2", specifier = ">=2.4.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.18.2" },
     { name = "numba", marker = "extra == 'dev'", specifier = ">=0.59.0" },
@@ -2694,7 +2723,7 @@ requires-dist = [
     { name = "pillow", marker = "extra == 'runners'", specifier = ">=10.0.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pymupdf", marker = "extra == 'runners'", specifier = ">=1.24.0" },
-    { name = "pymupdf4llm", marker = "extra == 'pymupdf4llm'", specifier = "==1.28.0" },
+    { name = "pymupdf4llm", marker = "extra == 'pymupdf4llm'", specifier = "==1.28.2" },
     { name = "pypdf", marker = "extra == 'runners'", specifier = ">=6.4.0" },
     { name = "pytesseract", marker = "extra == 'runners'", specifier = ">=0.3.10" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
@@ -2702,7 +2731,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "python-levenshtein", specifier = ">=0.25.0" },
     { name = "rapidfuzz", specifier = ">=3.0.0" },
-    { name = "rapidocr-onnxruntime", marker = "extra == 'pymupdf4llm'", specifier = "==1.2.3" },
+    { name = "rapidocr", marker = "extra == 'pymupdf4llm'", specifier = "==3.9.2" },
     { name = "reductoai", marker = "extra == 'runners'", specifier = ">=0.13.0" },
     { name = "rich", specifier = ">=13.7.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.14.5" },
@@ -2972,6 +3001,34 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c5/f5/65d838092fd01c44d16037953fd4c2cc851e783de9b8f02b27ec4ffd906f/protobuf-6.33.5-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:8afa18e1d6d20af15b417e728e9f60f3aa108ee76f23c3b2c07a2c3b546d3afd", size = 339411, upload-time = "2026-01-29T21:51:27.446Z" },
     { url = "https://files.pythonhosted.org/packages/9b/53/a9443aa3ca9ba8724fdfa02dd1887c1bcd8e89556b715cfbacca6b63dbec/protobuf-6.33.5-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:cbf16ba3350fb7b889fca858fb215967792dc125b35c7976ca4818bee3521cf0", size = 323465, upload-time = "2026-01-29T21:51:28.925Z" },
     { url = "https://files.pythonhosted.org/packages/57/bf/2086963c69bdac3d7cff1cc7ff79b8ce5ea0bec6797a017e1be338a46248/protobuf-6.33.5-py3-none-any.whl", hash = "sha256:69915a973dd0f60f31a08b8318b73eab2bd6a392c79184b3612226b0a3f8ec02", size = 170687, upload-time = "2026-01-29T21:51:32.557Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
 ]
 
 [[package]]
@@ -3317,6 +3374,17 @@ wheels = [
 name = "pymupdf"
 version = "1.28.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version < '3.13' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
 sdist = { url = "https://files.pythonhosted.org/packages/8e/e9/6d6c5d6c0a3551bffd47681a6240caf941727f195b45593cf20ab36f018f/pymupdf-1.28.0.tar.gz", hash = "sha256:e53f3567403a92da15caa9e7ae0164327fff48817e9f40175367fb9de524258d", size = 87637751, upload-time = "2026-06-29T09:08:47.547Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/b7/88043e38cc7529de070f0c9bd267fa258035cca0b4ad5260536b994594a7/pymupdf-1.28.0-cp310-abi3-macosx_10_15_x86_64.whl", hash = "sha256:892b89ba88e8f98b53133b62877a9dc9b5e7dc6a4aeb837b612db56a8d2e03ac", size = 24597385, upload-time = "2026-06-29T09:03:30.608Z" },
@@ -3331,36 +3399,63 @@ wheels = [
 ]
 
 [[package]]
+name = "pymupdf"
+version = "1.28.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/fb/b6761fa2d5266f2cdb24c3b91f4023070ab7848381417678e7a289a1d52a/pymupdf-1.28.2.tar.gz", hash = "sha256:5e0be7908a715aa20333caddd73f1d6f01e4cd0c26e869fa2dd0b7f344da2249", size = 87903557, upload-time = "2026-08-06T21:43:23.321Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/51/550c9a75c4ff3245cb4ecb7bb95cbe2ab7374230b8e2b7a1f7259444150b/pymupdf-1.28.2-cp310-abi3-macosx_10_15_x86_64.whl", hash = "sha256:5fc315b425ff1f7afdd1ea2f348205cb19b806767daae7ce4d64115799c2bae1", size = 24645079, upload-time = "2026-08-06T21:37:25.001Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/01/3591f781b417b382a8487a2356e927acfe858b1043bab0ec47f6805bb109/pymupdf-1.28.2-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:7113846b35dbf0a033f088e4f4fb543dabeb4b0b12c112966a1ca1ee2d5eacae", size = 23875605, upload-time = "2026-08-06T21:37:40.369Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/86/4a68f080b71b46802178346af46486e1697508e760855ff5f3b218a6dff7/pymupdf-1.28.2-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:3050a233dde1211efe89ada74e2add6238436434159f46097a1423aad2842545", size = 25095554, upload-time = "2026-08-06T21:37:58.485Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/06/dace3e27af26690cb20bead80dbac42941b0841eb689b8aabbd67dde16f0/pymupdf-1.28.2-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:397d6715c1f0df7548a92d0afd8ce370fc48fa47aeefac16be2bc04a16a8227f", size = 25762500, upload-time = "2026-08-06T21:38:17.438Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/61/4146dfa1d8172a1ce8d59f0eed94896ddefb8deb2274534d0522fbb8abf5/pymupdf-1.28.2-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f89fb2d86d07d643a269f17a093105057e20c79c1d06c103b53600067b6d2b01", size = 25986309, upload-time = "2026-08-06T21:38:35.472Z" },
+    { url = "https://files.pythonhosted.org/packages/52/60/1fb6e64676f7500ebe89054b9e5bbbe14d3101c92d5f1a40ac9a35227673/pymupdf-1.28.2-cp310-abi3-win32.whl", hash = "sha256:530ef543a3885b3b81cb72a854e7c5a625a9233201221132bb6c31698c6a2bdb", size = 18525353, upload-time = "2026-08-06T21:38:47.697Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/61/d563bbccba262f9dd6d2d35ccb72593648184d886188efb12d9ce8f34dd6/pymupdf-1.28.2-cp310-abi3-win_amd64.whl", hash = "sha256:ebd244918798502d7b4504c90410d1711a4d7675a32584ca30f1bab419ecbffe", size = 19826532, upload-time = "2026-08-06T21:39:00.213Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/93/08f404a1f0155fe24137cf2d3aabd3e2b4b08c62053ed89c60f2611be3e9/pymupdf-1.28.2-cp310-abi3-win_arm64.whl", hash = "sha256:ffe91a24edc75c80da2a4b62f50fc0f54632d34fc8fe4cbc48e5c7ff07cf8fb4", size = 19759252, upload-time = "2026-08-06T21:39:12.937Z" },
+    { url = "https://files.pythonhosted.org/packages/58/8c/d897dcd32a25b58186c968b15ce4324ca029e9d96460de12325314e390be/pymupdf-1.28.2-cp313-abi3-pyemscripten_2025_0_wasm32.whl", hash = "sha256:2e1b574c0fd2cb238021033fd3c0f9c4388816638df064e4bfb56d9d81736dc8", size = 18399403, upload-time = "2026-08-06T21:39:25.008Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/f1/de34a1c53fe2bf8c6e71db84b0ced782d408970c9810d2b456a2ae96814c/pymupdf-1.28.2-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:fd481ed48bef56305c41fb7e05a055c03345c899c7b101dad086258b438f8168", size = 25802333, upload-time = "2026-08-06T21:39:41.426Z" },
+]
+
+[[package]]
 name = "pymupdf-layout"
-version = "1.28.0"
+version = "1.28.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "networkx" },
     { name = "numpy" },
     { name = "onnxruntime" },
-    { name = "pymupdf" },
+    { name = "pymupdf", version = "1.28.2", source = { registry = "https://pypi.org/simple" } },
     { name = "pyyaml" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/fe/eb3c960cbc6e5be5acffbd6811f281ba6e176a841b592858e25e28ac0a97/pymupdf_layout-1.28.0-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:dc4e2f4b48951633607020d80de0bed00b2450eafd56ecda224f611c19e5f9e8", size = 41567727, upload-time = "2026-06-29T09:05:35.532Z" },
-    { url = "https://files.pythonhosted.org/packages/60/14/9a330a7d77cbe05fa9e97d9f2aa11d627a556eec795eee08bcbeedc16ac6/pymupdf_layout-1.28.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:911aa80b3ddcca2ddbc1df5fc59f652935b392052251397e75963d3de9559dbc", size = 41566722, upload-time = "2026-06-29T09:06:01.73Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/58/2607c539540ce261d05d2677c0d839b78a4191d328accc1d0e9385a06799/pymupdf_layout-1.28.0-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:35b98e1ce9382709622e03c34b57d1b51a155ceb3d9122f11f8e9b2aa4f1ee55", size = 41576718, upload-time = "2026-06-29T09:06:29.258Z" },
-    { url = "https://files.pythonhosted.org/packages/56/3a/dc5ab8573300b0f1b7fb996aa33ce4683c27b190a8e8be6f18d80714183d/pymupdf_layout-1.28.0-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a6bd191301570a0863d6e04418324e823d0fd7f18b4fe1db2b9e53e715d2f8ff", size = 41578107, upload-time = "2026-06-29T09:06:54.224Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/73/79af357b1cacb02ea9e054b5b368dee5a0ccd7168c6229e54e1a70e74c53/pymupdf_layout-1.28.0-cp310-abi3-win_amd64.whl", hash = "sha256:07195ec4ad6317dd70bf1d4eca44d9dd93231d8db3648ab9f4b771557a59ea48", size = 41577085, upload-time = "2026-06-29T09:07:20.443Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/84/cf9030e29adbfa9fb555d925af1e0f212d54810e50711bd059e6e71c7cb1/pymupdf_layout-1.28.2-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2a7368b5b0d75acb0835fae40a4d6e6c30ba457b388fedc75f06619a581ba17f", size = 42928696, upload-time = "2026-08-06T21:40:10.372Z" },
+    { url = "https://files.pythonhosted.org/packages/16/1f/f03250cb18d4942d16f335d90a7eef2411b29097ba52531e0062edf16186/pymupdf_layout-1.28.2-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:d55e9b9150e1e9f182063b93092f0ba2c2475b51ea6da656e9d6edad0dd4054d", size = 42927631, upload-time = "2026-08-06T21:40:38.474Z" },
+    { url = "https://files.pythonhosted.org/packages/75/82/6cbf0331e148db48bf609c165dbe900cf3c1158546c5d09d4ad7fd4d6b17/pymupdf_layout-1.28.2-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:fc7716682bfde26c002a7309cda0c520f3d2466dce368054d4fc2b653a74e8bc", size = 42937884, upload-time = "2026-08-06T21:41:03.992Z" },
+    { url = "https://files.pythonhosted.org/packages/03/65/6b92d25678c64839fb2066ee98d6d1f164d820ba045d83c77e79021cda98/pymupdf_layout-1.28.2-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:4b44a1d8ebf897b0e862ee2d73e7df73099f1c047fc024d2dd24ef0632d2cb5f", size = 42939266, upload-time = "2026-08-06T21:41:31.835Z" },
+    { url = "https://files.pythonhosted.org/packages/db/a0/f429e4c398db6f88071e305434d67f8c6455498f4c7ebb372b730553f073/pymupdf_layout-1.28.2-cp310-abi3-win_amd64.whl", hash = "sha256:a765d3ba0b1622e8d5794772ad4303d824386f04b382a5d31c999a828ed4a089", size = 42938028, upload-time = "2026-08-06T21:41:59.15Z" },
 ]
 
 [[package]]
 name = "pymupdf4llm"
-version = "1.28.0"
+version = "1.28.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pymupdf" },
+    { name = "psutil" },
+    { name = "pymupdf", version = "1.28.2", source = { registry = "https://pypi.org/simple" } },
     { name = "pymupdf-layout" },
     { name = "tabulate" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cb/15/36ff769451f5e62cbca89c3b59739e625565df7140778bd6dd11db32caea/pymupdf4llm-1.28.0.tar.gz", hash = "sha256:713595be867f7cb52893e57aa1b058d5721d017b2ba7b6a3d185a05e15978852", size = 2072657, upload-time = "2026-06-29T09:08:52.23Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/be/6f78a076947529c13bd0660cbe9e61f0155c903aa0c17fd9751733dccc36/pymupdf4llm-1.28.2.tar.gz", hash = "sha256:02681698ef67bda9a2acd5d9e1115d4e88be0eb9c5d68926e5e3cd98cd351874", size = 2091728, upload-time = "2026-08-06T21:43:27.654Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e8/1a/8b997bbeeaf63286d7179fe4cdc29dcc328105f2558f01394370dc0fcaa9/pymupdf4llm-1.28.0-py3-none-any.whl", hash = "sha256:6e74e8666806cc6040d9159053130f0761d21ef17e2a9c938df8108f15160cb3", size = 164656, upload-time = "2026-06-29T09:05:11.914Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/93/0ec4c33150f127d19b306d876b969755f02ed721f3a9337fd1f4fe4a1c85/pymupdf4llm-1.28.2-py3-none-any.whl", hash = "sha256:55c06c07d128f94c4d9271bd427d16ee219779e7d796a7b9da4e110be3004d96", size = 176403, upload-time = "2026-08-06T21:39:44.118Z" },
 ]
 
 [[package]]
@@ -3588,46 +3683,30 @@ wheels = [
 ]
 
 [[package]]
-name = "rapidocr-onnxruntime"
-version = "1.2.3"
+name = "rapidocr"
+version = "3.9.2"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version < '3.14' and sys_platform == 'emscripten'",
-    "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-]
 dependencies = [
+    { name = "colorlog" },
     { name = "numpy" },
-    { name = "onnxruntime" },
+    { name = "omegaconf" },
     { name = "opencv-python" },
     { name = "pillow" },
     { name = "pyclipper" },
     { name = "pyyaml" },
+    { name = "requests" },
     { name = "shapely" },
     { name = "six" },
+    { name = "tqdm" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/ef/0df9a58310895ab357f85df67935af6a8fb98f0965c7476cee6fcb966a7e/rapidocr_onnxruntime-1.2.3-py3-none-any.whl", hash = "sha256:c707d3a6eb72d13119afe9602d3cc36d8b2a4a4d74e9575cf1b0e67ed6a27819", size = 12326259, upload-time = "2023-03-11T06:25:37.618Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ed/0ee9b9281986974be9d2406ae0134c8d7c91d2fc613f16ffda9701eeda6f/rapidocr-3.9.2-py3-none-any.whl", hash = "sha256:04d6b8d151f823d930bd91910555f57bea897c0c44fa6794267b94cf9c1ef9a0", size = 27275208, upload-time = "2026-07-21T10:59:01.599Z" },
 ]
 
 [[package]]
 name = "rapidocr-onnxruntime"
 version = "1.4.4"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version < '3.13' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version < '3.13' and sys_platform == 'emscripten'",
-    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-]
 dependencies = [
     { name = "numpy" },
     { name = "onnxruntime" },
@@ -4426,7 +4505,7 @@ ocr = [
     { name = "opencv-python-headless" },
     { name = "pyclipper" },
     { name = "pyyaml" },
-    { name = "rapidocr-onnxruntime", version = "1.4.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "rapidocr-onnxruntime" },
     { name = "shapely" },
     { name = "six" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -2,16 +2,32 @@ version = 1
 revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
-    "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version < '3.13' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version < '3.13' and sys_platform == 'emscripten'",
-    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-11-parse-bench-pymupdf4llm' and extra == 'extra-11-parse-bench-runners'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-11-parse-bench-pymupdf4llm' and extra == 'extra-11-parse-bench-runners'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-11-parse-bench-pymupdf4llm' and extra == 'extra-11-parse-bench-runners'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-11-parse-bench-pymupdf4llm' and extra == 'extra-11-parse-bench-runners'",
+    "python_full_version < '3.13' and sys_platform == 'win32' and extra != 'extra-11-parse-bench-pymupdf4llm' and extra == 'extra-11-parse-bench-runners'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten' and extra != 'extra-11-parse-bench-pymupdf4llm' and extra == 'extra-11-parse-bench-runners'",
+    "python_full_version < '3.13' and sys_platform == 'emscripten' and extra != 'extra-11-parse-bench-pymupdf4llm' and extra == 'extra-11-parse-bench-runners'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-11-parse-bench-pymupdf4llm' and extra == 'extra-11-parse-bench-runners'",
+    "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-11-parse-bench-pymupdf4llm' and extra == 'extra-11-parse-bench-runners'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra == 'extra-11-parse-bench-pymupdf4llm' and extra != 'extra-11-parse-bench-runners'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra == 'extra-11-parse-bench-pymupdf4llm' and extra != 'extra-11-parse-bench-runners'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-11-parse-bench-pymupdf4llm' and extra != 'extra-11-parse-bench-runners'",
+    "python_full_version < '3.14' and sys_platform == 'win32' and extra == 'extra-11-parse-bench-pymupdf4llm' and extra != 'extra-11-parse-bench-runners'",
+    "python_full_version < '3.14' and sys_platform == 'emscripten' and extra == 'extra-11-parse-bench-pymupdf4llm' and extra != 'extra-11-parse-bench-runners'",
+    "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-11-parse-bench-pymupdf4llm' and extra != 'extra-11-parse-bench-runners'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-11-parse-bench-pymupdf4llm' and extra != 'extra-11-parse-bench-runners'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-11-parse-bench-pymupdf4llm' and extra != 'extra-11-parse-bench-runners'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-11-parse-bench-pymupdf4llm' and extra != 'extra-11-parse-bench-runners'",
+    "python_full_version < '3.14' and sys_platform == 'win32' and extra != 'extra-11-parse-bench-pymupdf4llm' and extra != 'extra-11-parse-bench-runners'",
+    "python_full_version < '3.14' and sys_platform == 'emscripten' and extra != 'extra-11-parse-bench-pymupdf4llm' and extra != 'extra-11-parse-bench-runners'",
+    "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-11-parse-bench-pymupdf4llm' and extra != 'extra-11-parse-bench-runners'",
 ]
+conflicts = [[
+    { package = "parse-bench", extra = "pymupdf4llm" },
+    { package = "parse-bench", extra = "runners" },
+]]
 
 [[package]]
 name = "aiofiles"
@@ -122,7 +138,7 @@ version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "frozenlist" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-11-parse-bench-pymupdf4llm' and extra == 'extra-11-parse-bench-runners')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
 wheels = [
@@ -227,7 +243,7 @@ version = "4.12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-11-parse-bench-pymupdf4llm' and extra == 'extra-11-parse-bench-runners')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
 wheels = [
@@ -587,7 +603,7 @@ name = "click"
 version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-11-parse-bench-pymupdf4llm' and extra == 'extra-11-parse-bench-runners')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
 wheels = [
@@ -666,12 +682,16 @@ dependencies = [
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/67/5e7dba1ba576dd73da5dee894ca076ca5e959450dfff66d6d510a255d1f7/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7855c4868aabc0cfae28abbe83d56734bdfbd08f08fc234ac1912a12858bf49", size = 6025351, upload-time = "2026-05-29T23:11:49.685Z" },
     { url = "https://files.pythonhosted.org/packages/39/2a/6d2e9047d1fb243dbaa364b01e0297534b9ed7fd27dba1c9f361519cf69b/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e32d08f71ebcdf00f0f41eab2eb37e8da94c8ed411cc9f7f7a019ce6b34abe3a", size = 6657965, upload-time = "2026-05-29T23:11:52.227Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/95/872a0392122f1fb43fcb06869790ef3171f37beee9f7db8f441739113570/cuda_bindings-13.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:b134dd8c5c66ae4c4ad814f7aee88fd215353c077010cbc47e3b55ed35ec9eff", size = 5875099, upload-time = "2026-05-29T23:11:54.635Z" },
     { url = "https://files.pythonhosted.org/packages/cc/6e/2394f8163360f8391f8f1b7e72d300a82724edb81a7b7084c799fbd4c91f/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9efb21c1ee64981e184b9e0ba5eb3179e5ba3d4b51665a6cb52b8ef3d01a7cbf", size = 5920504, upload-time = "2026-05-29T23:11:56.883Z" },
     { url = "https://files.pythonhosted.org/packages/34/c2/ef9b6a63f7dc432712a462c816662e662e00d38caa9b861c8c2588195d03/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2732904099e0a4d4db774a5fc6d91ee95fae065b4d2ecabb4968c5fe2406c9d7", size = 6476660, upload-time = "2026-05-29T23:11:59.188Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/2f/6a0dd496550c6fafbf6aeb1bf40242eeabb2fd138a43892aabb4be8224c2/cuda_bindings-13.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:18c8c167c8907b8f02531ca810534315c458dabef31f7965095619bf647b9202", size = 5830027, upload-time = "2026-05-29T23:12:01.205Z" },
     { url = "https://files.pythonhosted.org/packages/b1/81/bff68ce829999c1e4209c761bbf903b1c06ec570416ddb25020864ad5907/cuda_bindings-13.3.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ab2f74ed65bfef4163ba07a8db16f1085e0729291db12a2423aff84ee8278b8", size = 6013639, upload-time = "2026-05-29T23:12:03.509Z" },
     { url = "https://files.pythonhosted.org/packages/d4/e0/c8a1f0c8f9ffdea4f5fe6dbab89b326cef4d85caf489dad39e209da89416/cuda_bindings-13.3.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd4c814d311ec08c981f6dded1dbe7d4b371067ee4f6c14cccec4bde9590f80", size = 6534419, upload-time = "2026-05-29T23:12:05.633Z" },
+    { url = "https://files.pythonhosted.org/packages/48/45/2734be44dbc80ac082ec23a86b41c8294992dcb90033645ed1bc50aafe4c/cuda_bindings-13.3.1-cp314-cp314-win_amd64.whl", hash = "sha256:8de12ef60bf40756852cb62bbb40460609269f6ece522903d1cc93d73a3ececb", size = 5961055, upload-time = "2026-05-29T23:12:07.971Z" },
     { url = "https://files.pythonhosted.org/packages/52/b8/83b1f563925b290f2d11a01a77a84013ba56052fe3653a5bef3ccfbb43d6/cuda_bindings-13.3.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c3c772dfff49681541d59630c90f858e173ac926b9c593a2b7123f2a1043cc76", size = 5809771, upload-time = "2026-05-29T23:12:10.422Z" },
     { url = "https://files.pythonhosted.org/packages/12/20/e79b4bfe98f075195afb6343d41c498f9dbd2d161d7021d4d28bceb83581/cuda_bindings-13.3.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:36febb7c1079d68a981dbbd8d5a67235b399802b82075c9388624719607e52b9", size = 6358584, upload-time = "2026-05-29T23:12:12.767Z" },
+    { url = "https://files.pythonhosted.org/packages/27/2a/b59bcac016ab9985d6b48a5d05b0d698461a159ca03ee11c4abd54da2ac4/cuda_bindings-13.3.1-cp314-cp314t-win_amd64.whl", hash = "sha256:61120b5e4f4a63f67efd7e7396914cb9ef871bb1f0021e990fb70277be240a4d", size = 6740329, upload-time = "2026-05-29T23:12:15.153Z" },
 ]
 
 [[package]]
@@ -1092,7 +1112,7 @@ name = "google-cloud-documentai"
 version = "3.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "google-api-core", extra = ["grpc"] },
+    { name = "google-api-core", extra = ["grpc"], marker = "extra == 'extra-11-parse-bench-runners'" },
     { name = "google-auth" },
     { name = "grpcio" },
     { name = "proto-plus" },
@@ -1110,7 +1130,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "distro" },
-    { name = "google-auth", extra = ["requests"] },
+    { name = "google-auth", extra = ["requests"], marker = "extra == 'extra-11-parse-bench-runners'" },
     { name = "httpx" },
     { name = "pydantic" },
     { name = "requests" },
@@ -1267,7 +1287,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "fsspec" },
-    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64' or (extra == 'extra-11-parse-bench-pymupdf4llm' and extra == 'extra-11-parse-bench-runners')" },
     { name = "httpx" },
     { name = "packaging" },
     { name = "pyyaml" },
@@ -2066,7 +2086,7 @@ name = "mypy"
 version = "1.19.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy' or (extra == 'extra-11-parse-bench-pymupdf4llm' and extra == 'extra-11-parse-bench-runners')" },
     { name = "mypy-extensions" },
     { name = "pathspec" },
     { name = "typing-extensions" },
@@ -2236,6 +2256,7 @@ dependencies = [
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
     { url = "https://files.pythonhosted.org/packages/3b/cd/154ca20c38269e05eff77c1464e6c1da89f50a6390b565e9d82e06bc11e1/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:37936a16db8fe4ac1f065c2139360608a543a09275cb1a1af612e08cfa065436", size = 423138758, upload-time = "2026-04-08T18:46:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/45/9e/2f562daf80eb8f7a685fb7bea4fda71f6048e4f359d6fdd1b6e70206cb2f/nvidia_cublas-13.1.1.3-py3-none-win_amd64.whl", hash = "sha256:b6cdce694e47ff6aadf0a69df1cab6628d696f5ff56e8d16af50309d855fa20f", size = 404358158, upload-time = "2026-04-08T18:47:26.987Z" },
 ]
 
 [[package]]
@@ -2245,6 +2266,7 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/2a/80353b103fc20ce05ef51e928daed4b6015db4aaa9162ed0997090fe2250/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_aarch64.whl", hash = "sha256:796bd679890ee55fb14a94629b698b6db54bcfd833d391d5e94017dd9d7d3151", size = 10310827, upload-time = "2025-09-04T08:26:42.012Z" },
     { url = "https://files.pythonhosted.org/packages/33/6d/737d164b4837a9bbd202f5ae3078975f0525a55730fe871d8ed4e3b952b0/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_x86_64.whl", hash = "sha256:4eb01c08e859bf924d222250d2e8f8b8ff6d3db4721288cf35d14252a4d933c8", size = 10715597, upload-time = "2025-09-04T08:26:51.312Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/df/b74b10025c1205695c5676373f2edd3e87a7202cc62ead0dfbc373b0f6ea/nvidia_cuda_cupti-13.0.85-py3-none-win_amd64.whl", hash = "sha256:683f58d301548deeefcb8f6fac1b8d907691b9d8b18eccab417f51e362102f00", size = 7736776, upload-time = "2025-09-04T08:38:08.38Z" },
 ]
 
 [[package]]
@@ -2254,6 +2276,7 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c3/68/483a78f5e8f31b08fb1bb671559968c0ca3a065ac7acabfc7cee55214fd6/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:ad9b6d2ead2435f11cbb6868809d2adeeee302e9bb94bcf0539c7a40d80e8575", size = 90215200, upload-time = "2025-09-04T08:28:44.204Z" },
     { url = "https://files.pythonhosted.org/packages/b7/dc/6bb80850e0b7edd6588d560758f17e0550893a1feaf436807d64d2da040f/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d27f20a0ca67a4bb34268a5e951033496c5b74870b868bacd046b1b8e0c3267b", size = 43015449, upload-time = "2025-09-04T08:28:20.239Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/af/345fedb9f4c76c84ab4fa445b36bd4048a4d9db60e6bc76b4f913ff4b852/nvidia_cuda_nvrtc-13.0.88-py3-none-win_amd64.whl", hash = "sha256:6bcd4e7f8e205cbe644f5a98f2f799bef9556fefc89dd786e79a16312ce49872", size = 76807835, upload-time = "2025-09-04T08:39:15.274Z" },
 ]
 
 [[package]]
@@ -2263,6 +2286,7 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/87/4f/17d7b9b8e285199c58ce28e31b5c5bbaa4d8271af06a89b6405258245de2/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ef9bcbe90493a2b9d810e43d249adb3d02e98dd30200d86607d8d02687c43f55", size = 2261060, upload-time = "2025-10-09T08:55:15.78Z" },
     { url = "https://files.pythonhosted.org/packages/2e/24/d1558f3b68b1d26e706813b1d10aa1d785e4698c425af8db8edc3dced472/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f82250d7782aa23b6cfe765ecc7db554bd3c2870c43f3d1821f1d18aebf0548", size = 2243632, upload-time = "2025-10-09T08:55:36.117Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/94/6b867483bec07da24ffa32736c79fabb94ef3a7af4d787a9d4a974868576/nvidia_cuda_runtime-13.0.96-py3-none-win_amd64.whl", hash = "sha256:f79298c8a098cec150a597c8eba58ecdab96e3bdc4b9bc4f9983635031740492", size = 2927037, upload-time = "2025-10-09T09:04:23.782Z" },
 ]
 
 [[package]]
@@ -2275,6 +2299,7 @@ dependencies = [
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
     { url = "https://files.pythonhosted.org/packages/6e/5e/edb9c0ae051602c3ccaffe424256463636d639e27d7f302dde9975ef9e7a/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0c45dd8eeb50b603f07995b1b300c62ffe6a1980482b82b3bcf94a4ca9d49304", size = 366173588, upload-time = "2026-03-09T19:29:34.474Z" },
+    { url = "https://files.pythonhosted.org/packages/78/39/21507455b1bca8b5702a9e9fc6ce73735f216f558dac2c9ede58e4d456b8/nvidia_cudnn_cu13-9.20.0.48-py3-none-win_amd64.whl", hash = "sha256:af8139732b99c0118be65ea5aac97f0d46018f8c552889e49d2fb0c6261a4a24", size = 350712614, upload-time = "2026-03-09T19:31:11.398Z" },
 ]
 
 [[package]]
@@ -2287,6 +2312,7 @@ dependencies = [
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
     { url = "https://files.pythonhosted.org/packages/a8/2f/7b57e29836ea8714f81e9898409196f47d772d5ddedddf1592eadb8ab743/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6c44f692dce8fd5ffd3e3df134b6cdb9c2f72d99cf40b62c32dde45eea9ddad3", size = 214085489, upload-time = "2025-09-04T08:31:56.044Z" },
+    { url = "https://files.pythonhosted.org/packages/85/b2/f8af21a2ed1beed337a6a02c5a28aeb85441f4d578ec3d529543c775ea4b/nvidia_cufft-12.0.0.61-py3-none-win_amd64.whl", hash = "sha256:2abce5b39d2f5ae12730fb7e5db6696533e36c26e2d3e8fd1750bdd2853364eb", size = 213342123, upload-time = "2025-09-04T08:40:51.145Z" },
 ]
 
 [[package]]
@@ -2305,6 +2331,7 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/72/7c2ae24fb6b63a32e6ae5d241cc65263ea18d08802aaae087d9f013335a2/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:133df5a7509c3e292aaa2b477afd0194f06ce4ea24d714d616ff36439cee349a", size = 61962106, upload-time = "2025-08-04T10:21:41.128Z" },
     { url = "https://files.pythonhosted.org/packages/a5/9f/be0a41ca4a4917abf5cb9ae0daff1a6060cc5de950aec0396de9f3b52bc5/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:1aee33a5da6e1db083fe2b90082def8915f30f3248d5896bcec36a579d941bfc", size = 59544258, upload-time = "2025-08-04T10:22:03.992Z" },
+    { url = "https://files.pythonhosted.org/packages/99/27/72103153b1ffc00e09fdc40ac970235343dcd1ea8bd762e84d2d73219ffa/nvidia_curand-10.4.0.35-py3-none-win_amd64.whl", hash = "sha256:65b1710aa6961d326b411e314b374290904c5ddf41dc3f766ebc3f1d7d4ca69f", size = 55242481, upload-time = "2025-08-04T10:30:41.831Z" },
 ]
 
 [[package]]
@@ -2319,6 +2346,7 @@ dependencies = [
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
     { url = "https://files.pythonhosted.org/packages/5f/67/cba3777620cdacb99102da4042883709c41c709f4b6323c10781a9c3aa34/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0a759da5dea5c0ea10fd307de75cdeb59e7ea4fcb8add0924859b944babf1112", size = 200941980, upload-time = "2025-09-04T08:33:22.767Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ef/332a0101260ca78a1daef046bf0b06199e8ed4dac1d2aa698289c358169c/nvidia_cusolver-12.0.4.66-py3-none-win_amd64.whl", hash = "sha256:16515bd33a8e76bb54d024cfa068fa68d30e80fc34b9e1090813ea9362e0cb65", size = 193551444, upload-time = "2025-09-04T08:41:46.813Z" },
 ]
 
 [[package]]
@@ -2331,6 +2359,7 @@ dependencies = [
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
     { url = "https://files.pythonhosted.org/packages/fa/18/623c77619c31d62efd55302939756966f3ecc8d724a14dab2b75f1508850/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b3c89c88d01ee0e477cb7f82ef60a11a4bcd57b6b87c33f789350b59759360b", size = 145942937, upload-time = "2025-09-04T08:33:58.029Z" },
+    { url = "https://files.pythonhosted.org/packages/02/b0/b043d6f3480f102f885cf87fc3ffd3edcb5e23b855025a50e2ef4d059185/nvidia_cusparse-12.6.3.3-py3-none-win_amd64.whl", hash = "sha256:cbcf42feb737bd7ec15b4c0a63e62351886bd3f975027b8815d7f720a2b5ea79", size = 143783033, upload-time = "2025-09-04T08:42:12.391Z" },
 ]
 
 [[package]]
@@ -2340,6 +2369,7 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/46/e1/cdc1797eadf82d3a9a575a19b33fdc871a97edbec42c00b5b5e914f4aff4/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:4dca476c50bf4780d46cd0bfbd82e2bc10a08e4fef7950917ce8d7578d22a23f", size = 221051344, upload-time = "2025-09-05T18:49:51.289Z" },
     { url = "https://files.pythonhosted.org/packages/34/7d/2661f2fb3ac4302f3a246f5fc030213ac60c1fe0bce84f9783dbd831dbb7/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:786ce87568c303fadb5afcc7102d454cd3040d75f6f8626f5db460d1871f4dd0", size = 170148586, upload-time = "2025-09-05T18:50:50.248Z" },
+    { url = "https://files.pythonhosted.org/packages/31/83/f3647ce26916c94a6ca4ff1810623e2c405cff2dea6e78d29516b2514df9/nvidia_cusparselt_cu13-0.8.1-py3-none-win_amd64.whl", hash = "sha256:dccbd362f91a7b9024d1f55ee9f548ac065027ff15d8c8b0db889ab3a8f31215", size = 156885108, upload-time = "2025-09-05T18:51:35.958Z" },
 ]
 
 [[package]]
@@ -2358,6 +2388,7 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/7a/123e033aaff487c77107195fa5a2b8686795ca537935a24efae476c41f05/nvidia_nvjitlink-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:13a74f429e23b921c1109976abefacc69835f2f433ebd323d3946e11d804e47b", size = 40713933, upload-time = "2025-09-04T08:35:43.553Z" },
     { url = "https://files.pythonhosted.org/packages/ab/2c/93c5250e64df4f894f1cbb397c6fd71f79813f9fd79d7cd61de3f97b3c2d/nvidia_nvjitlink-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e931536ccc7d467a98ba1d8b89ff7fa7f1fa3b13f2b0069118cd7f47bff07d0c", size = 38768748, upload-time = "2025-09-04T08:35:20.008Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/01/07530b0e37546231052e30234540289c42eaffa486f1a34a87fed340157b/nvidia_nvjitlink-13.0.88-py3-none-win_amd64.whl", hash = "sha256:634e96e3da9ef845ae744097a1f289238ecf946ce0b82e93cdce14b9782e682f", size = 36035115, upload-time = "2025-09-04T08:43:03.001Z" },
 ]
 
 [[package]]
@@ -2376,6 +2407,7 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f3/d86c845465a2723ad7e1e5c36dcd75ddb82898b3f53be47ebd429fb2fa5d/nvidia_nvtx-13.0.85-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4936d1d6780fbe68db454f5e72a42ff64d1fd6397df9f363ae786930fd5c1cd4", size = 148047, upload-time = "2025-09-04T08:29:01.761Z" },
     { url = "https://files.pythonhosted.org/packages/a8/64/3708a90d1ebe202ffdeb7185f878a3c84d15c2b2c31858da2ce0583e2def/nvidia_nvtx-13.0.85-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb7780edb6b14107373c835bf8b72e7a178bac7367e23da7acb108f973f157a6", size = 148878, upload-time = "2025-09-04T08:28:53.627Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/50/0e2220f8620a177de994211186ffc5bfa9f2ce1e1282797f8f90096f9f88/nvidia_nvtx-13.0.85-py3-none-win_amd64.whl", hash = "sha256:d66ea44254dd3c6eacc300047af6e1288d2269dd072b417e0adffbf479e18519", size = 137066, upload-time = "2025-09-04T08:39:25.649Z" },
 ]
 
 [[package]]
@@ -2506,7 +2538,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
     { name = "python-dateutil" },
-    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32' or (extra == 'extra-11-parse-bench-pymupdf4llm' and extra == 'extra-11-parse-bench-runners')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2e/0c/b28ed414f080ee0ad153f848586d61d1878f91689950f037f976ce15f6c8/pandas-3.0.1.tar.gz", hash = "sha256:4186a699674af418f655dbd420ed87f50d56b4cd6603784279d9eef6627823c8", size = 4641901, upload-time = "2026-02-17T22:20:16.434Z" }
 wheels = [
@@ -2567,6 +2599,7 @@ dependencies = [
     { name = "huggingface-hub" },
     { name = "lxml" },
     { name = "markdown" },
+    { name = "markdown-it-py" },
     { name = "markdown2" },
     { name = "numpy" },
     { name = "pandas" },
@@ -2592,6 +2625,10 @@ dev = [
 fast = [
     { name = "numba" },
 ]
+pymupdf4llm = [
+    { name = "pymupdf4llm" },
+    { name = "rapidocr-onnxruntime", version = "1.2.3", source = { registry = "https://pypi.org/simple" } },
+]
 runners = [
     { name = "amazon-textract-textractor" },
     { name = "anthropic" },
@@ -2615,7 +2652,7 @@ runners = [
     { name = "pytesseract" },
     { name = "reductoai" },
     { name = "unstructured-client" },
-    { name = "warp-ingest", extra = ["ocr"] },
+    { name = "warp-ingest", extra = ["ocr"], marker = "extra == 'extra-11-parse-bench-runners'" },
 ]
 
 [package.metadata]
@@ -2645,6 +2682,7 @@ requires-dist = [
     { name = "llama-cloud", marker = "extra == 'runners'", specifier = ">=1.4.1" },
     { name = "lxml", specifier = ">=5.0.0" },
     { name = "markdown", specifier = ">=3.0" },
+    { name = "markdown-it-py", specifier = ">=3.0" },
     { name = "markdown2", specifier = ">=2.4.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.18.2" },
     { name = "numba", marker = "extra == 'dev'", specifier = ">=0.59.0" },
@@ -2656,6 +2694,7 @@ requires-dist = [
     { name = "pillow", marker = "extra == 'runners'", specifier = ">=10.0.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pymupdf", marker = "extra == 'runners'", specifier = ">=1.24.0" },
+    { name = "pymupdf4llm", marker = "extra == 'pymupdf4llm'", specifier = "==1.28.0" },
     { name = "pypdf", marker = "extra == 'runners'", specifier = ">=6.4.0" },
     { name = "pytesseract", marker = "extra == 'runners'", specifier = ">=0.3.10" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
@@ -2663,6 +2702,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "python-levenshtein", specifier = ">=0.25.0" },
     { name = "rapidfuzz", specifier = ">=3.0.0" },
+    { name = "rapidocr-onnxruntime", marker = "extra == 'pymupdf4llm'", specifier = "==1.2.3" },
     { name = "reductoai", marker = "extra == 'runners'", specifier = ">=0.13.0" },
     { name = "rich", specifier = ">=13.7.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.14.5" },
@@ -2673,7 +2713,7 @@ requires-dist = [
     { name = "unstructured-client", marker = "extra == 'runners'", specifier = ">=0.26.0" },
     { name = "warp-ingest", extras = ["ocr"], marker = "extra == 'runners'", specifier = ">=2.0.1" },
 ]
-provides-extras = ["runners", "fast", "dev"]
+provides-extras = ["runners", "pymupdf4llm", "fast", "dev"]
 
 [[package]]
 name = "partial-json-parser"
@@ -3275,17 +3315,52 @@ wheels = [
 
 [[package]]
 name = "pymupdf"
-version = "1.26.7"
+version = "1.28.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/48/d6/09b28f027b510838559f7748807192149c419b30cb90e6d5f0cf916dc9dc/pymupdf-1.26.7.tar.gz", hash = "sha256:71add8bdc8eb1aaa207c69a13400693f06ad9b927bea976f5d5ab9df0bb489c3", size = 84327033, upload-time = "2025-12-11T21:48:50.694Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/e9/6d6c5d6c0a3551bffd47681a6240caf941727f195b45593cf20ab36f018f/pymupdf-1.28.0.tar.gz", hash = "sha256:e53f3567403a92da15caa9e7ae0164327fff48817e9f40175367fb9de524258d", size = 87637751, upload-time = "2026-06-29T09:08:47.547Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/35/cd74cea1787b2247702ef8522186bdef32e9cb30a099e6bb864627ef6045/pymupdf-1.26.7-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:07085718dfdae5ab83b05eb5eb397f863bcc538fe05135318a01ea353e7a1353", size = 23179369, upload-time = "2025-12-11T21:47:21.587Z" },
-    { url = "https://files.pythonhosted.org/packages/72/74/448b6172927c829c6a3fba80078d7b0a016ebbe2c9ee528821f5ea21677a/pymupdf-1.26.7-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:31aa9c8377ea1eea02934b92f4dcf79fb2abba0bf41f8a46d64c3e31546a3c02", size = 22470101, upload-time = "2025-12-11T21:47:37.105Z" },
-    { url = "https://files.pythonhosted.org/packages/65/e7/47af26f3ac76be7ac3dd4d6cc7ee105948a8355d774e5ca39857bf91c11c/pymupdf-1.26.7-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e419b609996434a14a80fa060adec72c434a1cca6a511ec54db9841bc5d51b3c", size = 23502486, upload-time = "2025-12-12T09:51:25.824Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/6b/3de1714d734ff949be1e90a22375d0598d3540b22ae73eb85c2d7d1f36a9/pymupdf-1.26.7-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:69dfc78f206a96e5b3ac22741263ebab945fdf51f0dbe7c5757c3511b23d9d72", size = 24115727, upload-time = "2025-12-11T21:47:51.274Z" },
-    { url = "https://files.pythonhosted.org/packages/62/9b/f86224847949577a523be2207315ae0fd3155b5d909cd66c274d095349a3/pymupdf-1.26.7-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1d5106f46e1ca0d64d46bd51892372a4f82076bdc14a9678d33d630702abca36", size = 24324386, upload-time = "2025-12-12T14:58:45.483Z" },
-    { url = "https://files.pythonhosted.org/packages/85/8e/a117d39092ca645fde8b903f4a941d9aa75b370a67b4f1f435f56393dc5a/pymupdf-1.26.7-cp310-abi3-win32.whl", hash = "sha256:7c9645b6f5452629c747690190350213d3e5bbdb6b2eca227d82702b327f6eee", size = 17203888, upload-time = "2025-12-12T13:59:57.613Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/c3/d0047678146c294469c33bae167c8ace337deafb736b0bf97b9bc481aa65/pymupdf-1.26.7-cp310-abi3-win_amd64.whl", hash = "sha256:425b1befe40d41b72eb0fe211711c7ae334db5eb60307e9dd09066ed060cceba", size = 18405952, upload-time = "2025-12-11T21:48:02.947Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/b7/88043e38cc7529de070f0c9bd267fa258035cca0b4ad5260536b994594a7/pymupdf-1.28.0-cp310-abi3-macosx_10_15_x86_64.whl", hash = "sha256:892b89ba88e8f98b53133b62877a9dc9b5e7dc6a4aeb837b612db56a8d2e03ac", size = 24597385, upload-time = "2026-06-29T09:03:30.608Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f4/23775bbda0781b61fc398cc75079a2b0e64696d8fcf93271748883e9627e/pymupdf-1.28.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:4d692dcf44d3566ae96bc6f6346c6ad432274a29ba617bf7a9fe18009e24adb4", size = 23828292, upload-time = "2026-06-29T09:03:46.129Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/f5/bf75fc7a415722f8b33662054f82d88520c0cbfd4c36d0e08aeaec605e49/pymupdf-1.28.0-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:47a5c29ed4eb0744de9c4e37bb49b1259b18d4d75fcc8a7c130f7c9fa15956f6", size = 25045507, upload-time = "2026-06-29T09:04:03.86Z" },
+    { url = "https://files.pythonhosted.org/packages/58/69/5d12c9f1f2d76f28383d6110a069c79fbfced5a4f97bb1ee6e8354f52bb7/pymupdf-1.28.0-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:44f0973f5e5edbaec95bc34b64e71d1959d4ee90b1328de1b4f4f5b4fa78673f", size = 25716599, upload-time = "2026-06-29T09:04:19.367Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/b4/ec0e017bc42857cc86bd651441dbc41cc18be48d4698ecd27aac491e0c9a/pymupdf-1.28.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4d61ec323a706e153a12e262e51febfb43eeaa20977785ace135d18d48bcdc83", size = 25940489, upload-time = "2026-06-29T09:04:36.624Z" },
+    { url = "https://files.pythonhosted.org/packages/06/86/f831fef09013f33b3c9c09fb3923f2ff53e1e437f6ace14b8ae46392f558/pymupdf-1.28.0-cp310-abi3-win32.whl", hash = "sha256:caea2b3b67347fd79e5d15ed7929b0e886aac594ea228073b6d39de0078189da", size = 18489703, upload-time = "2026-06-29T20:50:30.599Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/5d/1a03f53eb0449900469335fcfc742ca28e3ba159b7d650e0921d50b8b308/pymupdf-1.28.0-cp310-abi3-win_amd64.whl", hash = "sha256:e01e90fd86abfeb37ceb921eddb951f988a11d45ff6ce6b7664f2039849068ec", size = 19773102, upload-time = "2026-06-29T09:04:49.773Z" },
+    { url = "https://files.pythonhosted.org/packages/72/f6/1e52ce243ca792254f6223b4017c5667194c146ce9b88baf37bc5eb3d1c9/pymupdf-1.28.0-cp313-abi3-pyemscripten_2025_0_wasm32.whl", hash = "sha256:74c6d00ba2a9aad3a635db73b07c15db462b480741d831a34a75a56535ebc22b", size = 18357011, upload-time = "2026-06-29T20:50:50.353Z" },
+    { url = "https://files.pythonhosted.org/packages/62/b1/46b5b3d8ef3cc71114667cf10c4d8b33f39af97253af32e9a0986775b638/pymupdf-1.28.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:b3e1399c7a64c6914239116a369efcdaac4cfb9e838bde2656d7accc4a85c72d", size = 25753599, upload-time = "2026-06-29T09:05:09.398Z" },
+]
+
+[[package]]
+name = "pymupdf-layout"
+version = "1.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "networkx" },
+    { name = "numpy" },
+    { name = "onnxruntime" },
+    { name = "pymupdf" },
+    { name = "pyyaml" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/fe/eb3c960cbc6e5be5acffbd6811f281ba6e176a841b592858e25e28ac0a97/pymupdf_layout-1.28.0-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:dc4e2f4b48951633607020d80de0bed00b2450eafd56ecda224f611c19e5f9e8", size = 41567727, upload-time = "2026-06-29T09:05:35.532Z" },
+    { url = "https://files.pythonhosted.org/packages/60/14/9a330a7d77cbe05fa9e97d9f2aa11d627a556eec795eee08bcbeedc16ac6/pymupdf_layout-1.28.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:911aa80b3ddcca2ddbc1df5fc59f652935b392052251397e75963d3de9559dbc", size = 41566722, upload-time = "2026-06-29T09:06:01.73Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/58/2607c539540ce261d05d2677c0d839b78a4191d328accc1d0e9385a06799/pymupdf_layout-1.28.0-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:35b98e1ce9382709622e03c34b57d1b51a155ceb3d9122f11f8e9b2aa4f1ee55", size = 41576718, upload-time = "2026-06-29T09:06:29.258Z" },
+    { url = "https://files.pythonhosted.org/packages/56/3a/dc5ab8573300b0f1b7fb996aa33ce4683c27b190a8e8be6f18d80714183d/pymupdf_layout-1.28.0-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a6bd191301570a0863d6e04418324e823d0fd7f18b4fe1db2b9e53e715d2f8ff", size = 41578107, upload-time = "2026-06-29T09:06:54.224Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/73/79af357b1cacb02ea9e054b5b368dee5a0ccd7168c6229e54e1a70e74c53/pymupdf_layout-1.28.0-cp310-abi3-win_amd64.whl", hash = "sha256:07195ec4ad6317dd70bf1d4eca44d9dd93231d8db3648ab9f4b771557a59ea48", size = 41577085, upload-time = "2026-06-29T09:07:20.443Z" },
+]
+
+[[package]]
+name = "pymupdf4llm"
+version = "1.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pymupdf" },
+    { name = "pymupdf-layout" },
+    { name = "tabulate" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cb/15/36ff769451f5e62cbca89c3b59739e625565df7140778bd6dd11db32caea/pymupdf4llm-1.28.0.tar.gz", hash = "sha256:713595be867f7cb52893e57aa1b058d5721d017b2ba7b6a3d185a05e15978852", size = 2072657, upload-time = "2026-06-29T09:08:52.23Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/1a/8b997bbeeaf63286d7179fe4cdc29dcc328105f2558f01394370dc0fcaa9/pymupdf4llm-1.28.0-py3-none-any.whl", hash = "sha256:6e74e8666806cc6040d9159053130f0761d21ef17e2a9c938df8108f15160cb3", size = 164656, upload-time = "2026-06-29T09:05:11.914Z" },
 ]
 
 [[package]]
@@ -3344,7 +3419,7 @@ name = "pytest"
 version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-11-parse-bench-pymupdf4llm' and extra == 'extra-11-parse-bench-runners')" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
@@ -3514,8 +3589,45 @@ wheels = [
 
 [[package]]
 name = "rapidocr-onnxruntime"
+version = "1.2.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "numpy" },
+    { name = "onnxruntime" },
+    { name = "opencv-python" },
+    { name = "pillow" },
+    { name = "pyclipper" },
+    { name = "pyyaml" },
+    { name = "shapely" },
+    { name = "six" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ef/0df9a58310895ab357f85df67935af6a8fb98f0965c7476cee6fcb966a7e/rapidocr_onnxruntime-1.2.3-py3-none-any.whl", hash = "sha256:c707d3a6eb72d13119afe9602d3cc36d8b2a4a4d74e9575cf1b0e67ed6a27819", size = 12326259, upload-time = "2023-03-11T06:25:37.618Z" },
+]
+
+[[package]]
+name = "rapidocr-onnxruntime"
 version = "1.4.4"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version < '3.13' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
 dependencies = [
     { name = "numpy" },
     { name = "onnxruntime" },
@@ -3555,7 +3667,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "rpds-py" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-11-parse-bench-pymupdf4llm' and extra == 'extra-11-parse-bench-runners')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
@@ -4124,7 +4236,7 @@ version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cuda-bindings", marker = "sys_platform == 'linux'" },
-    { name = "cuda-toolkit", extra = ["cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
+    { name = "cuda-toolkit", extra = ["cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "(sys_platform == 'linux' and extra == 'extra-11-parse-bench-runners') or (extra == 'extra-11-parse-bench-pymupdf4llm' and extra == 'extra-11-parse-bench-runners')" },
     { name = "filelock" },
     { name = "fsspec" },
     { name = "jinja2" },
@@ -4167,7 +4279,7 @@ name = "tqdm"
 version = "4.67.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-11-parse-bench-pymupdf4llm' and extra == 'extra-11-parse-bench-runners')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
@@ -4314,7 +4426,7 @@ ocr = [
     { name = "opencv-python-headless" },
     { name = "pyclipper" },
     { name = "pyyaml" },
-    { name = "rapidocr-onnxruntime" },
+    { name = "rapidocr-onnxruntime", version = "1.4.4", source = { registry = "https://pypi.org/simple" } },
     { name = "shapely" },
     { name = "six" },
 ]


### PR DESCRIPTION
## Summary

Modernizes the existing `pymupdf4llm_markdown` pipeline using PyMuPDF4LLM 1.28.2 and its supported modern RapidOCR integration.


The implementation does the following:

- Pins `pymupdf4llm==1.28.2` and `rapidocr==3.9.2`
- Uses PyMuPDF4LLM's native HTML tables directly
- Exposes PyMuPDF4LLM layout predictions for visual-grounding evaluation
- Updates the documentation, tests, lockfile, and leaderboard results

## Benchmark Results


| Metric | Score |
|---|---:|
| Overall | 53.49 |
| Tables | 72.00 |
| Charts | 2.19 |
| Content Faithfulness | 79.34 |
| Semantic Formatting | 52.04 |
| Visual Grounding | 61.89 |

The leaderboard has been updated with these results.

## Revision Context

Since this PR was opened, PyMuPDF4LLM 1.28.2 was released with modern RapidOCR support and native HTML table output. The implementation has been updated to use these capabilities directly, replacing the original 1.28.0-based approach and its Markdown-to-HTML conversion step.

The earlier review feedback applied to the previous converter implementation, but that code has now been removed from the final diff.

## Reproducing the Results

The submitted results were produced with:

- Python 3.12
- Ubuntu 26.04 LTS
- 8 Intel Haswell-class vCPUs
- 24 GiB RAM
- Maximum concurrency: 1
- Approximately one hour per full run

Install the dedicated pipeline dependencies:

```bash
uv sync --python 3.12 --extra pymupdf4llm
```

Run the small test benchmark:

```bash
uv run --python 3.12 --extra pymupdf4llm \
  parse-bench run pymupdf4llm_markdown --test --max_concurrent 1
```

Run the full benchmark:

```bash
uv run --python 3.12 --extra pymupdf4llm \
  parse-bench run pymupdf4llm_markdown --max_concurrent 1
```