### PR TITLE
Keep formatting-rule matches within a single span

### DIFF
--- a/src/parse_bench/evaluation/metrics/parse/rules_formatting.py
+++ b/src/parse_bench/evaluation/metrics/parse/rules_formatting.py
@@ -101,8 +101,11 @@ def _strip_other_formatting(text: str, keep_kind: str) -> str:
             continue
         for pattern, repl in replacements:
             result = pattern.sub(repl, result)
-    # Collapse whitespace and fix stray spaces before punctuation
-    result = re.sub(r"\s+", " ", result)
+    # Collapse whitespace (preserving line structure — the heading arm of
+    # the bold patterns is line-anchored) and fix stray spaces before
+    # punctuation
+    result = re.sub(r"[^\S\n]+", " ", result)
+    result = re.sub(r" ?\n ?", "\n", result)
     result = re.sub(r" ([,;:!?.\)\]\}])", r"\1", result)
     return result
 
@@ -172,21 +175,32 @@ class FormattingRule(ParseTestRule):
 
         The query may be a substring of the bold span (e.g. query
         ``Population`` matches ``**Population:**``).
+
+        The ``**`` delimiters follow CommonMark flanking (an opener is not
+        followed by whitespace, a closer is not preceded by it) and the
+        ``<b>`` filler cannot cross a closing tag — otherwise the closer of
+        one span pairs with the opener of the next and the unformatted text
+        between two bold spans (``**Name:** John **Age:**``) tests as bold.
+        The heading arm's fillers stay on the heading's own line for the
+        same reason. (The whitespace joiners inside a multi-word query can
+        still cross these boundaries; only the fillers are constrained.)
         """
         # Tempered greedy token: match any char that doesn't start a new **
         _not_bold_close = r"(?:(?!\*\*).)*?"
+        # Same idea for the HTML arm: don't cross a closing </b>
+        _not_b_close_tag = r"(?:(?!</b>).)*?"
         return [
             re.compile(
-                r"\*\*" + _not_bold_close + escaped_query + _not_bold_close + r"\*\*",
+                r"\*\*(?!\s)" + _not_bold_close + escaped_query + _not_bold_close + r"(?<!\s)\*\*",
                 re.IGNORECASE | re.DOTALL,
             ),
             re.compile(
-                r"<b>.*?" + escaped_query + r".*?</b>",
+                r"<b>" + _not_b_close_tag + escaped_query + _not_b_close_tag + r"</b>",
                 re.IGNORECASE | re.DOTALL,
             ),
             re.compile(
-                r"^\s*#{1,6}\s+.*?" + escaped_query + r".*?\s*(?:#+\s*)?$",
-                re.IGNORECASE | re.MULTILINE | re.DOTALL,
+                r"^[ \t]*#{1,6}[ \t]+[^\n]*?" + escaped_query + r"[^\n]*?[ \t]*(?:#+[ \t]*)?$",
+                re.IGNORECASE | re.MULTILINE,
             ),
         ]
 
@@ -201,6 +215,10 @@ class FormattingRule(ParseTestRule):
         _not_italic_close_star = r"(?:(?!\*(?!\*)).)*?"
         # Same idea for _
         _not_italic_close_under = r"(?:(?!_(?!_)).)*?"
+        # And for the HTML arms: the fillers must not cross a closing tag,
+        # or adjacent spans (<i>A</i> x <i>B</i>) merge into one match.
+        _not_i_close_tag = r"(?:(?!</i>).)*?"
+        _not_em_close_tag = r"(?:(?!</em>).)*?"
         return [
             # *text* but NOT **text** – use negative lookbehind/lookahead
             re.compile(
@@ -212,11 +230,11 @@ class FormattingRule(ParseTestRule):
                 re.IGNORECASE | re.DOTALL,
             ),
             re.compile(
-                r"<i>.*?" + escaped_query + r".*?</i>",
+                r"<i>" + _not_i_close_tag + escaped_query + _not_i_close_tag + r"</i>",
                 re.IGNORECASE | re.DOTALL,
             ),
             re.compile(
-                r"<em>.*?" + escaped_query + r".*?</em>",
+                r"<em>" + _not_em_close_tag + escaped_query + _not_em_close_tag + r"</em>",
                 re.IGNORECASE | re.DOTALL,
             ),
         ]

--- a/tests/parse_bench/evaluation/metrics/parse/test_formatting_rule_adjacent_spans.py
+++ b/tests/parse_bench/evaluation/metrics/parse/test_formatting_rule_adjacent_spans.py
@@ -1,0 +1,83 @@
+"""Tests for FormattingRule span boundaries.
+
+Three ways unformatted text used to test as formatted:
+
+* markdown ``**`` spans: the closer of one span paired with the opener of
+  the next, so the plain text between two bold spans matched
+  (``**Name:** John **Age:**`` -> ``** John **``),
+* HTML spans: the greedy fillers in ``<b>.*?query.*?</b>`` crossed closing
+  tags, merging adjacent elements, and
+* the heading arm: its DOTALL fillers crossed newlines, so any text
+  anywhere after any heading in the document tested as bold.
+"""
+
+from __future__ import annotations
+
+from parse_bench.evaluation.metrics.parse.rules_base import create_test_rule
+
+KV_MD = "**Name:** John **Age:** 42"
+KV_HTML = "<b>Name:</b> John <b>Age:</b> 42"
+
+
+def _run(rule_type: str, text: str, md: str) -> bool:
+    passed, _ = create_test_rule({"type": rule_type, "text": text}).run(md)
+    return passed
+
+
+class TestAdjacentMarkdownSpans:
+    def test_text_between_bold_spans_is_not_bold(self):
+        assert not _run("is_bold", "John", KV_MD)
+        assert _run("is_not_bold", "John", KV_MD)
+
+    def test_bold_span_content_still_detected(self):
+        assert _run("is_bold", "Name:", KV_MD)
+        assert _run("is_bold", "Age:", KV_MD)
+
+    def test_substring_of_bold_span_still_detected(self):
+        assert _run("is_bold", "Population", "**Population:** 5,000")
+
+    def test_multiline_bold_span_still_detected(self):
+        assert _run("is_bold", "multi line", "**multi\nline**")
+
+    def test_bold_italic_still_detected(self):
+        assert _run("is_bold", "tri", "some ***tri*** here")
+
+
+class TestAdjacentHtmlSpans:
+    def test_text_between_b_tags_is_not_bold(self):
+        assert not _run("is_bold", "John", KV_HTML)
+        assert _run("is_not_bold", "John", KV_HTML)
+
+    def test_b_tag_content_still_detected(self):
+        assert _run("is_bold", "Name:", KV_HTML)
+
+    def test_text_between_i_tags_is_not_italic(self):
+        assert not _run("is_italic", "John", "<i>Name:</i> John <i>Age:</i> 42")
+
+    def test_text_between_em_tags_is_not_italic(self):
+        assert not _run("is_italic", "John", "<em>Name:</em> John <em>Age:</em> 42")
+
+    def test_i_tag_content_still_detected(self):
+        assert _run("is_italic", "Name:", "<i>Name:</i> John")
+
+    def test_nested_markup_inside_element_still_detected(self):
+        assert _run("is_bold", "A B", "<b>A <mark>B</mark></b>")
+
+
+class TestHeadingArmStaysOnItsLine:
+    def test_body_text_after_heading_is_not_bold(self):
+        md = "# Some Heading\n\nparagraph with later text here"
+        assert not _run("is_bold", "later text here", md)
+        assert _run("is_not_bold", "later text here", md)
+
+    def test_heading_text_still_detected(self):
+        assert _run("is_bold", "Actual Heading", "# Actual Heading\n\nbody")
+
+    def test_heading_substring_still_detected(self):
+        assert _run("is_bold", "Heading", "## Longer Actual Heading Line\nbody")
+
+    def test_closed_atx_heading_still_detected(self):
+        assert _run("is_bold", "Title", "## Title ##\nbody")
+
+    def test_indented_heading_still_detected(self):
+        assert _run("is_bold", "Indented", "   # Indented\nbody")


### PR DESCRIPTION

### Problem

Text that sits *between* two formatted spans passes formatting rules. Three
separate cases, all in the `FormattingRule` patterns in
`src/parse_bench/evaluation/metrics/parse/rules_formatting.py`:

```python
is_bold("John")   on "**Name:** John **Age:** 42"        → True  (wrong)
is_bold("John")   on "<b>Name:</b> John <b>Age:</b> 42"  → True  (wrong)
is_bold("later text") on "# Heading\n\nsome later text"  → True  (wrong)
```

1. **`**` spans**: nothing stops a match from starting at the *closing* `**`
   of one span and ending at the *opening* `**` of the next, so the plain
   text between two bold spans matches (`** John **` above).
2. **HTML tags**: the `<b>.*?query.*?</b>` patterns use fillers that run
   straight through closing tags, merging adjacent elements.
3. **Headings**: the heading pattern's fillers can cross newlines, so any
   text appearing anywhere *after* a heading matches. Since most parsed
   documents contain a heading, `is_bold` rules pass close to automatically.

Case 3 matters most. `is_bold` is the most common rule type in the dataset
(2,066 of the 5,997 text-formatting rules), and it feeds the text-styling
component of the Semantic Formatting score — so a large share of that score
is currently handed out for free.

### Fix

Constrain each pattern to a single span:

- a `**` opener doesn't count if it's followed by whitespace, and a closer
  doesn't count if it's preceded by whitespace — which is exactly the shape
  of the closer/opener pair in `**Name:** John **Age:**`
- the `<b>` / `<i>` / `<em>` fillers can no longer cross a closing tag
- the heading pattern only matches text on the heading's own line
- `_strip_other_formatting` now preserves newlines when collapsing
  whitespace (it previously flattened the whole document onto one line,
  which re-broke the heading fix on the fallback path)

Known trade-offs, all verified against CommonMark rendering:

- nested same-tag HTML (`<b>a <b>b</b> c</b>`) no longer matches the outer
  span's trailing text — rare in parser output
- space-padded bold (`** padded **`) no longer matches — CommonMark renders
  it as literal text, not bold
- a multi-word rule text that itself straddles a span boundary can still
  match, since only the fillers are constrained

### Impact

`is_bold` scores drop wherever they were passing for free — on any page with
a heading, and on key/value layouts like `**Name:** John`. This makes the
text-styling component actually measure bold formatting, but leaderboard
numbers from before and after aren't directly comparable.

### Testing

New `tests/parse_bench/evaluation/metrics/parse/test_formatting_rule_adjacent_spans.py`
(16 cases: adjacent markdown/HTML spans, span contents and substrings still
detected, multiline bold, `***bold-italic***`, closed/indented headings,
body-after-heading negatives). Full suite passes; `ruff check` /
`ruff format --check` clean.

