### PR TITLE
Add bbox_scale config for absolute-pixel layout coordinates

### DIFF
--- a/src/parse_bench/inference/providers/parse/_layout_utils.py
+++ b/src/parse_bench/inference/providers/parse/_layout_utils.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import re
 from typing import Any
 
@@ -91,6 +92,122 @@ USER_PROMPT_LAYOUT_GEMINI = USER_PROMPT_LAYOUT.replace(
     "[x1,y1,x2,y2]",
     "[y_min,x_min,y_max,x_max]",
 )
+
+
+# ---------------------------------------------------------------------------
+# Absolute-pixel prompt variants (bbox_scale=None in the provider config).
+# Some models ground well but are unreliable at re-normalizing their bboxes
+# into the 0-1000 range, which conflates grounding quality with coordinate
+# compliance. These variants ask for the model's native pixel frame instead;
+# build_layout_pages(bbox_scale=None) then normalizes by the image
+# dimensions. Built by string replacement so the variants can never drift
+# from the base prompts on anything except the coordinate bullet.
+# ---------------------------------------------------------------------------
+
+_DATA_BBOX_BULLET_NORM = (
+    '"[x1, y1, x2, y2]" — bounding box in normalized 0-1000 '
+    "coordinates where x is horizontal (left edge = 0, right edge = 1000) "
+    "and y is vertical (top = 0, bottom = 1000). "
+    "x1,y1 is the top-left corner and x2,y2 is the bottom-right corner."
+)
+_DATA_BBOX_BULLET_ABS = (
+    '"[x1, y1, x2, y2]" — bounding box in ABSOLUTE PIXEL coordinates '
+    "of the image, where x is horizontal (left edge = 0) and y is "
+    "vertical (top = 0). "
+    "x1,y1 is the top-left corner and x2,y2 is the bottom-right corner."
+)
+
+SYSTEM_PROMPT_LAYOUT_ABS = SYSTEM_PROMPT_LAYOUT.replace(_DATA_BBOX_BULLET_NORM, _DATA_BBOX_BULLET_ABS)
+assert SYSTEM_PROMPT_LAYOUT_ABS != SYSTEM_PROMPT_LAYOUT, (
+    "data-bbox bullet replacement did not match SYSTEM_PROMPT_LAYOUT"
+)
+
+USER_PROMPT_LAYOUT_ABS = USER_PROMPT_LAYOUT.replace(
+    'data-label="Category"> tag. ',
+    'data-label="Category"> tag (data-bbox in absolute pixel coordinates). ',
+)
+assert USER_PROMPT_LAYOUT_ABS != USER_PROMPT_LAYOUT, "user-prompt replacement did not match USER_PROMPT_LAYOUT"
+
+_DATA_BBOX_BULLET_GEMINI_NORM = (
+    '"[y_min, x_min, y_max, x_max]" — bounding box in normalized 0-1000 '
+    "coordinates where x is horizontal (left edge = 0, right edge = 1000) "
+    "and y is vertical (top = 0, bottom = 1000). "
+    "The order is [y_min, x_min, y_max, x_max]."
+)
+_DATA_BBOX_BULLET_GEMINI_ABS = (
+    '"[y_min, x_min, y_max, x_max]" — bounding box in ABSOLUTE PIXEL '
+    "coordinates of the image, where x is horizontal (left edge = 0) "
+    "and y is vertical (top = 0). "
+    "The order is [y_min, x_min, y_max, x_max]."
+)
+
+SYSTEM_PROMPT_LAYOUT_GEMINI_ABS = SYSTEM_PROMPT_LAYOUT_GEMINI.replace(
+    _DATA_BBOX_BULLET_GEMINI_NORM, _DATA_BBOX_BULLET_GEMINI_ABS
+)
+assert SYSTEM_PROMPT_LAYOUT_GEMINI_ABS != SYSTEM_PROMPT_LAYOUT_GEMINI, (
+    "data-bbox bullet replacement did not match SYSTEM_PROMPT_LAYOUT_GEMINI"
+)
+
+USER_PROMPT_LAYOUT_GEMINI_ABS = USER_PROMPT_LAYOUT_GEMINI.replace(
+    'data-label="Category"> tag. ',
+    'data-label="Category"> tag (data-bbox in absolute pixel coordinates). ',
+)
+assert USER_PROMPT_LAYOUT_GEMINI_ABS != USER_PROMPT_LAYOUT_GEMINI, (
+    "user-prompt replacement did not match USER_PROMPT_LAYOUT_GEMINI"
+)
+
+
+def resolve_layout_prompts(
+    bbox_scale: float | None,
+    mode: str | None,
+    *,
+    gemini: bool = False,
+    pixel_disallowed_modes: tuple[str, ...] = ("parse_with_layout_file",),
+) -> tuple[str, str]:
+    """Validate *bbox_scale* and return the (system, user) layout prompts.
+
+    ``bbox_scale`` follows the same convention as the layoutdet providers:
+    a number means the model's coordinates are on that grid (only 1000 is
+    supported here, since the prompt text hardcodes the range), and ``None``
+    means absolute pixel coordinates, normalized by the image dimensions.
+
+    Shared by the div-layout providers so the scale validation, the
+    scale/mode constraint, and the prompt-pair selection cannot drift
+    between them.
+
+    The pixel frame is normalized by the recorded page dimensions, so it
+    assumes the model perceives the image at the sent resolution. Provider
+    APIs downscale images past their native limits — keep the render
+    ``dpi`` low enough that pages stay within them, or pre-resize per the
+    provider's documented resize rule.
+
+    Raises:
+        ProviderConfigError: for an unsupported scale, or for
+            ``bbox_scale=None`` combined with a mode in
+            *pixel_disallowed_modes* (absolute pixel coordinates are
+            undefined when the model is sent the PDF file rather than a
+            rendered image).
+    """
+    from parse_bench.inference.providers.base import ProviderConfigError
+
+    if bbox_scale is not None and bbox_scale != 1000:
+        raise ProviderConfigError(
+            f"Unsupported bbox_scale {bbox_scale!r}. Use 1000 (normalized 0-1000, "
+            "the default) or None (absolute pixel coordinates)."
+        )
+    if bbox_scale is None and mode in pixel_disallowed_modes:
+        raise ProviderConfigError(
+            f"bbox_scale=None (pixel coordinates) is not supported with mode "
+            f"'{mode}'; absolute pixel coordinates are undefined when the model "
+            "is sent the PDF file."
+        )
+    if bbox_scale is None:
+        if gemini:
+            return SYSTEM_PROMPT_LAYOUT_GEMINI_ABS, USER_PROMPT_LAYOUT_GEMINI_ABS
+        return SYSTEM_PROMPT_LAYOUT_ABS, USER_PROMPT_LAYOUT_ABS
+    if gemini:
+        return SYSTEM_PROMPT_LAYOUT_GEMINI, USER_PROMPT_LAYOUT_GEMINI
+    return SYSTEM_PROMPT_LAYOUT, USER_PROMPT_LAYOUT
 
 
 def swap_gemini_bbox(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -213,12 +330,28 @@ def items_to_markdown(items: list[dict[str, Any]]) -> str:
     return "\n\n".join(parts)
 
 
+# Coordinates may overshoot their grid by rounding noise; values beyond
+# scale * this tolerance indicate the model did not follow the coordinate
+# instruction (see the compliance warning in ``build_layout_pages``).
+_BBOX_ROUNDING_TOLERANCE = 1.05
+
+
+def _is_finite_bbox(bbox: Any) -> bool:
+    """True when *bbox* is four finite numeric (non-bool) values."""
+    return (
+        isinstance(bbox, list)
+        and len(bbox) == 4
+        and all(isinstance(v, (int, float)) and not isinstance(v, bool) and math.isfinite(v) for v in bbox)
+    )
+
+
 def build_layout_pages(
     items: list[dict[str, Any]],
     image_width: int,
     image_height: int,
     markdown: str,
     page_number: int = 1,
+    bbox_scale: float | None = 1000.0,
 ) -> list[ParseLayoutPageIR]:
     """Convert parsed layout blocks to ParseLayoutPageIR.
 
@@ -228,26 +361,62 @@ def build_layout_pages(
         image_height: Page image height in pixels.
         markdown: Page markdown content.
         page_number: 1-indexed page number.
+        bbox_scale: The grid the bboxes are on (same convention as the
+            layoutdet providers): a number divides coordinates by that
+            scale; ``None`` means absolute pixel coordinates (the
+            ``bbox_scale=None`` pipelines, prompted with the ``*_ABS``
+            variants), normalized by the image dimensions.
     """
     if not items or not image_width or not image_height:
         return []
 
+    if bbox_scale is None:
+        scale_x = float(image_width)
+        scale_y = float(image_height)
+    else:
+        scale_x = scale_y = float(bbox_scale)
+
+    compliance_warned = False
     layout_items: list[LayoutItemIR] = []
     for item in items:
         bbox = item.get("bbox", [])
         label_raw = item.get("label", "text")
         text = item.get("text", "")
 
-        if len(bbox) != 4:
+        # Clamping a non-finite value would silently place it at the page
+        # edge (min(scale, nan) returns scale), so skip boxes the clamp
+        # cannot handle honestly.
+        if not _is_finite_bbox(bbox):
+            if len(bbox) == 4:
+                logger.warning(f"Skipping layout item with non-numeric bbox: {bbox!r}")
             continue
+
+        if (
+            bbox_scale is not None
+            and not compliance_warned
+            and any(v > bbox_scale * _BBOX_ROUNDING_TOLERANCE for v in bbox)
+        ):
+            logger.warning(
+                f"Page {page_number}: bbox coordinates exceed the 0-{bbox_scale:g} "
+                "range; the model may be emitting absolute pixels (consider "
+                "bbox_scale=None)"
+            )
+            compliance_warned = True
 
         x1, y1, x2, y2 = bbox
 
-        # Convert from 0-1000 [x1,y1,x2,y2] to normalized [0,1] COCO [x,y,w,h]
-        nx = x1 / 1000.0
-        ny = y1 / 1000.0
-        nw = (x2 - x1) / 1000.0
-        nh = (y2 - y1) / 1000.0
+        # Clamp to the page so out-of-range values cannot produce segments
+        # outside the unit square.
+        x1 = max(0.0, min(scale_x, x1))
+        x2 = max(0.0, min(scale_x, x2))
+        y1 = max(0.0, min(scale_y, y1))
+        y2 = max(0.0, min(scale_y, y2))
+
+        # Convert [x1,y1,x2,y2] to normalized [0,1] COCO [x,y,w,h]
+        nx = x1 / scale_x
+        ny = y1 / scale_y
+        nw = (x2 - x1) / scale_x
+        nh = (y2 - y1) / scale_y
 
         label = LABEL_MAP.get(label_raw.lower(), "Text")
         seg = LayoutSegmentIR(x=nx, y=ny, w=nw, h=nh, confidence=1.0, label=label)

--- a/src/parse_bench/inference/providers/parse/anthropic.py
+++ b/src/parse_bench/inference/providers/parse/anthropic.py
@@ -2,6 +2,7 @@
 
 import base64
 import io
+import math
 import os
 from datetime import date, datetime
 from pathlib import Path
@@ -17,11 +18,10 @@ from parse_bench.inference.providers.base import (
     ProviderTransientError,
 )
 from parse_bench.inference.providers.parse._layout_utils import (
-    SYSTEM_PROMPT_LAYOUT,
-    USER_PROMPT_LAYOUT,
     build_layout_pages,
     items_to_markdown,
     parse_layout_blocks,
+    resolve_layout_prompts,
     split_pdf_to_pages,
 )
 from parse_bench.inference.providers.registry import register_provider
@@ -90,6 +90,45 @@ _ANTHROPIC_PRICING_PER_M: dict[str, tuple[float, float]] = {
 }
 
 
+def _count_image_tokens(width: int, height: int) -> int:
+    """Visual tokens consumed by an image: one token per 28x28 pixel patch."""
+    return math.ceil(width / 28) * math.ceil(height / 28)
+
+
+def _resized_size(width: int, height: int, max_edge: int, max_tokens: int) -> tuple[int, int]:
+    """The size the Claude API resizes an image to before padding.
+
+    Reference implementation from the vision docs (see
+    ``_resize_to_perceived_size``); images already within the limits are
+    returned unchanged.
+    """
+
+    def fits(w: int, h: int) -> bool:
+        return (
+            math.ceil(w / 28) * 28 <= max_edge
+            and math.ceil(h / 28) * 28 <= max_edge
+            and _count_image_tokens(w, h) <= max_tokens
+        )
+
+    if fits(width, height):
+        return (width, height)
+    if height > width:
+        resized_h, resized_w = _resized_size(height, width, max_edge, max_tokens)
+        return (resized_w, resized_h)
+
+    # Binary search along the long edge for the largest aspect-preserving
+    # size that fits.
+    aspect_ratio = width / height
+    lo, hi = 1, width  # lo always fits; hi never fits
+    while lo + 1 < hi:
+        mid = (lo + hi) // 2
+        if fits(mid, max(round(mid / aspect_ratio), 1)):
+            lo = mid
+        else:
+            hi = mid
+    return (lo, max(round(lo / aspect_ratio), 1))
+
+
 @register_provider("anthropic")
 class AnthropicProvider(Provider):
     """
@@ -136,6 +175,19 @@ class AnthropicProvider(Provider):
                 f"Invalid mode '{self._mode}'. "
                 "Must be 'image', 'file', 'parse_with_layout', or 'parse_with_layout_file'."
             )
+
+        # Grid the layout-mode bboxes are on: 1000 (the 0-1000 prompt, the
+        # default) or None (absolute pixels of the sent image, for models
+        # that ground well but re-normalize unreliably).
+        self._bbox_scale = self.base_config.get("bbox_scale", 1000)
+        self._layout_system_prompt, self._layout_user_prompt = resolve_layout_prompts(self._bbox_scale, self._mode)
+        # Image limits used to pre-resize pages in pixel-coordinate mode.
+        # Defaults are the standard resolution tier, which is safe for every
+        # model (an image within standard limits is never downscaled
+        # server-side on any tier); high-resolution-tier models can pass
+        # vision_max_edge=2576, vision_max_tokens=4784 to keep fidelity.
+        self._vision_max_edge = int(self.base_config.get("vision_max_edge", 1568))
+        self._vision_max_tokens = int(self.base_config.get("vision_max_tokens", 1568))
 
         # Initialize Anthropic client
         try:
@@ -192,6 +244,21 @@ class AnthropicProvider(Provider):
             "thinking_tokens": thinking_tok,
             "total_tokens": total_tok,
         }
+
+    def _resize_to_perceived_size(self, image: Image.Image) -> Image.Image:
+        """Pre-resize so the image Claude perceives is the image we recorded.
+
+        The API downscales images that exceed the model's native limits, and
+        with ``bbox_scale=None`` the model's pixel coordinates are in that
+        downscaled frame — while normalize() divides by the recorded dims.
+        Resizing up front (per the published resize rule) keeps the two
+        identical, as the vision docs recommend:
+        https://platform.claude.com/docs/en/docs/build-with-claude/vision-coordinates
+        """
+        target = _resized_size(image.width, image.height, self._vision_max_edge, self._vision_max_tokens)
+        if target == (image.width, image.height):
+            return image
+        return image.resize(target, Image.Resampling.LANCZOS)
 
     def _prepare_image_for_api(self, image: Image.Image) -> Image.Image:
         """
@@ -364,7 +431,7 @@ class AnthropicProvider(Provider):
             response = self._client.messages.create(
                 model=self._model,
                 max_tokens=self._max_tokens,
-                system=SYSTEM_PROMPT_LAYOUT,
+                system=self._layout_system_prompt,
                 timeout=httpx.Timeout(3600.0, connect=5.0),
                 messages=[
                     {
@@ -380,7 +447,7 @@ class AnthropicProvider(Provider):
                             },
                             {
                                 "type": "text",
-                                "text": USER_PROMPT_LAYOUT,
+                                "text": self._layout_user_prompt,
                             },
                         ],
                     }
@@ -489,7 +556,7 @@ class AnthropicProvider(Provider):
                 model=self._model,
                 max_tokens=self._max_tokens,
                 betas=["pdfs-2024-09-25"],
-                system=SYSTEM_PROMPT_LAYOUT,
+                system=self._layout_system_prompt,
                 timeout=httpx.Timeout(3600.0, connect=5.0),
                 messages=[
                     {
@@ -505,7 +572,7 @@ class AnthropicProvider(Provider):
                             },
                             {
                                 "type": "text",
-                                "text": USER_PROMPT_LAYOUT,
+                                "text": self._layout_user_prompt,
                             },
                         ],
                     }
@@ -629,15 +696,18 @@ class AnthropicProvider(Provider):
                 pages = []
                 for page_index, image in enumerate(images):  # type: ignore[assignment]
                     if self._mode == "parse_with_layout":
-                        items, raw_content, usage = self._parse_image_with_layout(image)
+                        # In pixel mode, send the pre-resized image so the recorded
+                        # dims are exactly what the model perceives.
+                        page = self._resize_to_perceived_size(image) if self._bbox_scale is None else image
+                        items, raw_content, usage = self._parse_image_with_layout(page)
                         page_usages.append(usage)
                         pages.append(
                             {
                                 "page_index": page_index,
                                 "items": items,
                                 "raw_content": raw_content,
-                                "width": image.width,
-                                "height": image.height,
+                                "width": page.width,
+                                "height": page.height,
                             }
                         )
                     else:
@@ -671,6 +741,7 @@ class AnthropicProvider(Provider):
                 "num_pages": num_pages,
                 "model": self._model,
                 "mode": self._mode,
+                "bbox_scale": self._bbox_scale,
                 "config": {
                     "dpi": self._dpi,
                     "max_tokens": self._max_tokens,
@@ -736,6 +807,7 @@ class AnthropicProvider(Provider):
                         image_height,
                         markdown,
                         page_number=page_index + 1,
+                        bbox_scale=raw_result.raw_output.get("bbox_scale", 1000),
                     )
                 )
             else:

--- a/src/parse_bench/inference/providers/parse/gemma4.py
+++ b/src/parse_bench/inference/providers/parse/gemma4.py
@@ -33,11 +33,10 @@ from parse_bench.inference.providers.base import (
     ProviderTransientError,
 )
 from parse_bench.inference.providers.parse._layout_utils import (
-    SYSTEM_PROMPT_LAYOUT,
-    USER_PROMPT_LAYOUT,
     build_layout_pages,
     items_to_markdown,
     parse_layout_blocks,
+    resolve_layout_prompts,
 )
 from parse_bench.inference.providers.registry import register_provider
 from parse_bench.schemas.parse_output import ParseOutput
@@ -97,6 +96,8 @@ class Gemma4Provider(Provider):
         - server_url (str, required): Modal server URL
         - model (str, default="gemma-4-26b-a4b"): Served model name
         - prompt_mode (str, default="parse"): "parse" or "layout"
+        - bbox_scale: 1000 (default, 0-1000 bboxes) or None
+          (absolute pixel bboxes, layout prompt only)
         - timeout (int, default=600): Request timeout in seconds
         - dpi (int, default=150): DPI for PDF to image conversion
         - max_tokens (int, default=16384): Max tokens per response
@@ -124,9 +125,14 @@ class Gemma4Provider(Provider):
         api_key_env = self.base_config.get("api_key_env", "VLLM_API_KEY")
         self._api_key = os.environ.get(api_key_env, "")
 
+        # Grid the layout-prompt bboxes are on: 1000 (the 0-1000 prompt,
+        # the default) or None (absolute pixels of the sent image).
+        self._bbox_scale = self.base_config.get("bbox_scale", 1000)
+        layout_system, layout_user = resolve_layout_prompts(self._bbox_scale, None)
+
         if self._prompt_mode == "layout":
-            self._system_prompt = SYSTEM_PROMPT_LAYOUT
-            self._user_prompt = USER_PROMPT_LAYOUT
+            self._system_prompt = layout_system
+            self._user_prompt = layout_user
         else:
             self._system_prompt = SYSTEM_PROMPT_PARSE
             self._user_prompt = USER_PROMPT_PARSE
@@ -228,6 +234,7 @@ class Gemma4Provider(Provider):
 
         result: dict[str, Any] = {
             "prompt_mode": self._prompt_mode,
+            "bbox_scale": self._bbox_scale,
             "_config": {
                 "server_url": self._server_url,
                 "model": self._model,
@@ -407,6 +414,7 @@ class Gemma4Provider(Provider):
                 image_height=img_h,
                 markdown=markdown,
                 page_number=1,
+                bbox_scale=raw_result.raw_output.get("bbox_scale", 1000),
             )
 
             output = ParseOutput(

--- a/src/parse_bench/inference/providers/parse/google.py
+++ b/src/parse_bench/inference/providers/parse/google.py
@@ -16,11 +16,10 @@ from parse_bench.inference.providers.base import (
     ProviderTransientError,
 )
 from parse_bench.inference.providers.parse._layout_utils import (
-    SYSTEM_PROMPT_LAYOUT_GEMINI,
-    USER_PROMPT_LAYOUT_GEMINI,
     build_layout_pages,
     items_to_markdown,
     parse_layout_blocks,
+    resolve_layout_prompts,
     split_pdf_to_pages,
     swap_gemini_bbox,
 )
@@ -159,6 +158,17 @@ class GoogleProvider(Provider):
                 "Must be 'image', 'file', 'parse_with_layout', 'parse_with_layout_file', "
                 "or 'parse_with_layout_agentic_vision'."
             )
+
+        # Grid the layout-mode bboxes are on: 1000 (the 0-1000 prompt, the
+        # default) or None (absolute pixels of the sent image, for models
+        # that ground well but re-normalize unreliably).
+        self._bbox_scale = self.base_config.get("bbox_scale", 1000)
+        self._layout_system_prompt, self._layout_user_prompt = resolve_layout_prompts(
+            self._bbox_scale,
+            self._mode,
+            gemini=True,
+            pixel_disallowed_modes=("parse_with_layout_file", "parse_with_layout_agentic_vision"),
+        )
 
         # Initialize Gemini client
         try:
@@ -534,12 +544,12 @@ class GoogleProvider(Provider):
 
         try:
             image_part = types.Part.from_bytes(data=img_bytes, mime_type="image/jpeg")
-            text_part = types.Part.from_text(text=USER_PROMPT_LAYOUT_GEMINI)
+            text_part = types.Part.from_text(text=self._layout_user_prompt)
 
             gen_config = types.GenerateContentConfig(
                 temperature=0,
                 max_output_tokens=self._max_tokens,
-                system_instruction=SYSTEM_PROMPT_LAYOUT_GEMINI,
+                system_instruction=self._layout_system_prompt,
             )
             if self._thinking_level is not None:
                 gen_config.thinking_config = types.ThinkingConfig(
@@ -667,12 +677,12 @@ class GoogleProvider(Provider):
 
         try:
             pdf_part = types.Part.from_bytes(data=pdf_bytes, mime_type="application/pdf")
-            text_part = types.Part.from_text(text=USER_PROMPT_LAYOUT_GEMINI)
+            text_part = types.Part.from_text(text=self._layout_user_prompt)
 
             gen_config = types.GenerateContentConfig(
                 temperature=0,
                 max_output_tokens=self._max_tokens,
-                system_instruction=SYSTEM_PROMPT_LAYOUT_GEMINI,
+                system_instruction=self._layout_system_prompt,
             )
             if self._thinking_level is not None:
                 gen_config.thinking_config = types.ThinkingConfig(
@@ -939,6 +949,7 @@ class GoogleProvider(Provider):
                 "num_pages": num_pages,
                 "model": self._model,
                 "mode": self._mode,
+                "bbox_scale": self._bbox_scale,
                 "config": config_info,
                 **usage_summary,
             }
@@ -1008,6 +1019,7 @@ class GoogleProvider(Provider):
                         image_height,
                         markdown,
                         page_number=page_index + 1,
+                        bbox_scale=raw_result.raw_output.get("bbox_scale", 1000),
                     )
                 )
             elif mode == "parse_with_layout_agentic_vision":

--- a/src/parse_bench/inference/providers/parse/openai.py
+++ b/src/parse_bench/inference/providers/parse/openai.py
@@ -16,11 +16,10 @@ from parse_bench.inference.providers.base import (
     ProviderTransientError,
 )
 from parse_bench.inference.providers.parse._layout_utils import (
-    SYSTEM_PROMPT_LAYOUT,
-    USER_PROMPT_LAYOUT,
     build_layout_pages,
     items_to_markdown,
     parse_layout_blocks,
+    resolve_layout_prompts,
     split_pdf_to_pages,
 )
 from parse_bench.inference.providers.registry import register_provider
@@ -133,6 +132,12 @@ class OpenAIProvider(Provider):
                 f"Invalid mode '{self._mode}'. "
                 "Must be 'image', 'file', 'parse_with_layout', or 'parse_with_layout_file'."
             )
+
+        # Grid the layout-mode bboxes are on: 1000 (the 0-1000 prompt, the
+        # default) or None (absolute pixels of the sent image, for models
+        # that ground well but re-normalize unreliably).
+        self._bbox_scale = self.base_config.get("bbox_scale", 1000)
+        self._layout_system_prompt, self._layout_user_prompt = resolve_layout_prompts(self._bbox_scale, self._mode)
 
         # Initialize OpenAI client
         try:
@@ -332,7 +337,7 @@ class OpenAIProvider(Provider):
                 "model": self._model,
                 "max_completion_tokens": self._max_tokens,
                 "messages": [
-                    {"role": "system", "content": SYSTEM_PROMPT_LAYOUT},
+                    {"role": "system", "content": self._layout_system_prompt},
                     {
                         "role": "user",
                         "content": [
@@ -344,7 +349,7 @@ class OpenAIProvider(Provider):
                             },
                             {
                                 "type": "text",
-                                "text": USER_PROMPT_LAYOUT,
+                                "text": self._layout_user_prompt,
                             },
                         ],
                     },
@@ -440,7 +445,7 @@ class OpenAIProvider(Provider):
                 "model": self._model,
                 "max_completion_tokens": self._max_tokens,
                 "messages": [
-                    {"role": "system", "content": SYSTEM_PROMPT_LAYOUT},
+                    {"role": "system", "content": self._layout_system_prompt},
                     {
                         "role": "user",
                         "content": [
@@ -453,7 +458,7 @@ class OpenAIProvider(Provider):
                             },
                             {
                                 "type": "text",
-                                "text": USER_PROMPT_LAYOUT,
+                                "text": self._layout_user_prompt,
                             },
                         ],
                     },
@@ -479,8 +484,7 @@ class OpenAIProvider(Provider):
             # GPT-5.6 intermittently returns a 401 "insufficient permissions"
             # that clears on retry; treat it as transient so the runner retries.
             is_gpt56_401_blip = (
-                self._model.startswith("gpt-5.6-")
-                and "insufficient permissions for this operation" in error_str
+                self._model.startswith("gpt-5.6-") and "insufficient permissions for this operation" in error_str
             )
             if is_gpt56_401_blip:
                 raise ProviderTransientError(f"Transient OpenAI 401 (retryable): {e}") from e
@@ -636,6 +640,7 @@ class OpenAIProvider(Provider):
                 "num_pages": num_pages,
                 "model": self._model,
                 "mode": self._mode,
+                "bbox_scale": self._bbox_scale,
                 "config": config_info,
                 "input_tokens": total_input,
                 "output_tokens": total_output,
@@ -697,6 +702,7 @@ class OpenAIProvider(Provider):
                         image_height,
                         markdown,
                         page_number=page_index + 1,
+                        bbox_scale=raw_result.raw_output.get("bbox_scale", 1000),
                     )
                 )
             else:

--- a/tests/parse_bench/inference/providers/parse/test_layout_coordinate_frames.py
+++ b/tests/parse_bench/inference/providers/parse/test_layout_coordinate_frames.py
@@ -1,0 +1,210 @@
+"""Tests for the ``bbox_scale`` config: absolute-pixel layout coordinates.
+
+Some models ground well but are unreliable at re-normalizing bboxes into the
+prompt's 0-1000 range, which conflates grounding quality with coordinate
+compliance. Pipelines can now set ``bbox_scale=None`` (a number is the
+coordinate grid, ``None`` means native pixels) to prompt for the pixel frame (the ``*_ABS`` prompt variants) and have
+``build_layout_pages`` normalize by the image dimensions instead of 1000.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+
+from parse_bench.inference.providers.parse._layout_utils import (
+    SYSTEM_PROMPT_LAYOUT,
+    SYSTEM_PROMPT_LAYOUT_ABS,
+    SYSTEM_PROMPT_LAYOUT_GEMINI,
+    SYSTEM_PROMPT_LAYOUT_GEMINI_ABS,
+    USER_PROMPT_LAYOUT,
+    USER_PROMPT_LAYOUT_ABS,
+    USER_PROMPT_LAYOUT_GEMINI,
+    USER_PROMPT_LAYOUT_GEMINI_ABS,
+    build_layout_pages,
+)
+
+
+def _item(bbox: list, label: str = "Text", text: str = "t") -> dict:
+    return {"bbox": bbox, "label": label, "text": text}
+
+
+def _segs(items: list[dict], width: int = 850, height: int = 1100, scale: float | None = 1000):
+    pages = build_layout_pages(items, width, height, "md", bbox_scale=scale)
+    assert len(pages) == 1
+    segs = []
+    for it in pages[0].items:
+        assert it.bbox is not None
+        segs.append(it.bbox)
+    return segs
+
+
+class TestAbsPromptVariants(unittest.TestCase):
+    def test_system_prompts_diverge_only_on_coordinate_frame(self) -> None:
+        self.assertNotEqual(SYSTEM_PROMPT_LAYOUT_ABS, SYSTEM_PROMPT_LAYOUT)
+        self.assertIn("ABSOLUTE PIXEL", SYSTEM_PROMPT_LAYOUT_ABS)
+        self.assertNotIn("normalized 0-1000", SYSTEM_PROMPT_LAYOUT_ABS)
+        # Everything except the coordinate bullet is retained.
+        for token in ("Caption, Footnote, Formula", "reading order", "<div>"):
+            self.assertIn(token, SYSTEM_PROMPT_LAYOUT_ABS)
+
+    def test_gemini_system_prompts_diverge_only_on_coordinate_frame(self) -> None:
+        self.assertNotEqual(SYSTEM_PROMPT_LAYOUT_GEMINI_ABS, SYSTEM_PROMPT_LAYOUT_GEMINI)
+        self.assertIn("ABSOLUTE PIXEL", SYSTEM_PROMPT_LAYOUT_GEMINI_ABS)
+        self.assertNotIn("normalized 0-1000", SYSTEM_PROMPT_LAYOUT_GEMINI_ABS)
+        # Gemini's native coordinate order is preserved in the abs variant.
+        self.assertIn("[y_min, x_min, y_max, x_max]", SYSTEM_PROMPT_LAYOUT_GEMINI_ABS)
+
+    def test_user_prompts_mention_pixel_frame(self) -> None:
+        self.assertIn("absolute pixel coordinates", USER_PROMPT_LAYOUT_ABS)
+        self.assertNotIn("absolute pixel coordinates", USER_PROMPT_LAYOUT)
+        self.assertIn("absolute pixel coordinates", USER_PROMPT_LAYOUT_GEMINI_ABS)
+        self.assertNotIn("absolute pixel coordinates", USER_PROMPT_LAYOUT_GEMINI)
+
+
+class TestNormalizedFrame(unittest.TestCase):
+    def test_in_range_coords_unchanged(self) -> None:
+        (seg,) = _segs([_item([100, 200, 600, 700])])
+        self.assertAlmostEqual(seg.x, 0.1)
+        self.assertAlmostEqual(seg.y, 0.2)
+        self.assertAlmostEqual(seg.w, 0.5)
+        self.assertAlmostEqual(seg.h, 0.5)
+
+    def test_overshoot_clamped_into_unit_square(self) -> None:
+        (seg,) = _segs([_item([0, 0, 1003, 998])])
+        self.assertAlmostEqual(seg.w, 1.0)  # 1003 -> 1000
+        self.assertAlmostEqual(seg.h, 0.998)
+
+    def test_negative_coords_clamped(self) -> None:
+        (seg,) = _segs([_item([-50, 0, 500, 500])])
+        self.assertAlmostEqual(seg.x, 0.0)
+        self.assertAlmostEqual(seg.w, 0.5)
+
+    def test_pixel_output_warns_but_is_not_rescaled(self) -> None:
+        # A model that emitted pixels under the normalized prompt gets a
+        # compliance warning pointing at bbox_scale=None — the frame is
+        # config-driven, never guessed from the values.
+        with self.assertLogs("parse_bench.inference.providers.parse._layout_utils", "WARNING") as logs:
+            (seg,) = _segs([_item([0, 990, 850, 1100])])
+        self.assertTrue(any("bbox_scale" in m for m in logs.output))
+        self.assertAlmostEqual(seg.y, 0.990)  # still the 0-1000 frame
+        self.assertAlmostEqual(seg.h, 0.010)  # 1100 clamped to 1000
+
+
+class TestPixelFrame(unittest.TestCase):
+    def test_pixel_coords_normalized_by_image_dims(self) -> None:
+        segs = _segs(
+            [
+                _item([85, 110, 425, 550]),
+                _item([0, 990, 850, 1100]),
+            ],
+            scale=None,
+        )
+        body, footer = segs
+        self.assertAlmostEqual(body.x, 0.1)
+        self.assertAlmostEqual(body.y, 0.1)
+        self.assertAlmostEqual(body.w, 0.4)
+        self.assertAlmostEqual(body.h, 0.4)
+        self.assertAlmostEqual(footer.y, 0.9)
+        self.assertAlmostEqual(footer.h, 0.1)
+
+    def test_pixel_overshoot_clamped_to_image(self) -> None:
+        (seg,) = _segs([_item([0, 0, 900, 1120])], scale=None)
+        self.assertAlmostEqual(seg.w, 1.0)  # 900 -> 850
+        self.assertAlmostEqual(seg.h, 1.0)  # 1120 -> 1100
+
+
+class TestRobustness(unittest.TestCase):
+    def test_nan_bbox_skipped(self) -> None:
+        segs = _segs([_item([float("nan"), 100, 500, 600]), _item([100, 200, 600, 700])])
+        self.assertEqual(len(segs), 1)
+        self.assertAlmostEqual(segs[0].x, 0.1)
+
+    def test_string_bbox_skipped(self) -> None:
+        segs = _segs([_item(["100", "200", "600", "700"]), _item([100, 200, 600, 700])])
+        self.assertEqual(len(segs), 1)
+
+    def test_short_bbox_skipped(self) -> None:
+        segs = _segs([_item([1, 2, 3]), _item([100, 200, 600, 700])])
+        self.assertEqual(len(segs), 1)
+
+
+class TestPerceivedSizeResize(unittest.TestCase):
+    """Pin the resize rule against the vision docs' published examples."""
+
+    def test_docs_reference_vectors(self) -> None:
+        from parse_bench.inference.providers.parse.anthropic import _resized_size
+
+        # Worked examples from the vision-coordinates docs page.
+        self.assertEqual(_resized_size(1075, 1520, 1568, 1568), (924, 1307))
+        self.assertEqual(_resized_size(1920, 1080, 1568, 1568), (1456, 819))
+        # Fits within limits: unchanged.
+        self.assertEqual(_resized_size(800, 600, 1568, 1568), (800, 600))
+        # Same scan on high-resolution-tier limits: no resize needed.
+        self.assertEqual(_resized_size(1075, 1520, 2576, 4784), (1075, 1520))
+
+    def test_pixel_mode_resizes_page_image(self) -> None:
+        from PIL import Image
+
+        from parse_bench.inference.providers.parse.anthropic import AnthropicProvider
+
+        prev = os.environ.get("ANTHROPIC_API_KEY")
+        os.environ["ANTHROPIC_API_KEY"] = "test-key"
+        try:
+            provider = AnthropicProvider("anthropic", {"mode": "parse_with_layout", "bbox_scale": None})
+            resized = provider._resize_to_perceived_size(Image.new("RGB", (1075, 1520)))
+            self.assertEqual(resized.size, (924, 1307))
+            small = Image.new("RGB", (800, 600))
+            self.assertIs(provider._resize_to_perceived_size(small), small)
+        finally:
+            if prev is None:
+                os.environ.pop("ANTHROPIC_API_KEY", None)
+            else:
+                os.environ["ANTHROPIC_API_KEY"] = prev
+
+
+class TestProviderConfig(unittest.TestCase):
+    def setUp(self) -> None:
+        self._prev_key = os.environ.get("ANTHROPIC_API_KEY")
+        os.environ["ANTHROPIC_API_KEY"] = "test-key"
+
+    def tearDown(self) -> None:
+        if self._prev_key is None:
+            os.environ.pop("ANTHROPIC_API_KEY", None)
+        else:
+            os.environ["ANTHROPIC_API_KEY"] = self._prev_key
+
+    def _provider(self, **config):
+        from parse_bench.inference.providers.parse.anthropic import AnthropicProvider
+
+        return AnthropicProvider("anthropic", {"mode": "parse_with_layout", **config})
+
+    def test_default_frame_uses_normalized_prompts(self) -> None:
+        provider = self._provider()
+        self.assertEqual(provider._layout_system_prompt, SYSTEM_PROMPT_LAYOUT)
+        self.assertEqual(provider._layout_user_prompt, USER_PROMPT_LAYOUT)
+
+    def test_pixel_frame_uses_abs_prompts(self) -> None:
+        provider = self._provider(bbox_scale=None)
+        self.assertEqual(provider._layout_system_prompt, SYSTEM_PROMPT_LAYOUT_ABS)
+        self.assertEqual(provider._layout_user_prompt, USER_PROMPT_LAYOUT_ABS)
+
+    def test_unsupported_scale_rejected(self) -> None:
+        from parse_bench.inference.providers.base import ProviderConfigError
+
+        with self.assertRaises(ProviderConfigError):
+            self._provider(bbox_scale=500)
+
+    def test_pixel_frame_rejected_for_file_mode(self) -> None:
+        from parse_bench.inference.providers.base import ProviderConfigError
+        from parse_bench.inference.providers.parse.anthropic import AnthropicProvider
+
+        with self.assertRaises(ProviderConfigError):
+            AnthropicProvider(
+                "anthropic",
+                {"mode": "parse_with_layout_file", "bbox_scale": None},
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION

### Problem

The layout prompts ask for bboxes in the normalized 0-1000 range, but some
models ground well and re-normalize unreliably — they emit absolute pixels.
`build_layout_pages` divides by 1000 regardless, so every box is shifted and
rescaled and Visual Grounding collapses for reasons unrelated to grounding
quality (the same frame-error class #52 fixed for `databricks_ai_parse`).

For Claude specifically this is documented behavior, not a quirk:
[Anthropic's vision docs](https://platform.claude.com/docs/en/docs/build-with-claude/vision-coordinates)
state that Claude "works best with absolute pixel coordinates" and "does not
work well when you ask for normalized coordinates, for example: *Return
bounding box coordinates between 0 and 1000*" — the exact instruction in the
current prompt. Their recommendation is to ask for pixels and normalize in
your own code, which is what this PR wires up.

### Fix

A `bbox_scale` option in the provider config, reusing the layoutdet
providers' existing convention (a number is the coordinate grid, `None`
means native pixels). The parse prompts hardcode the range text, so only
`1000` (default) and `None` are accepted.

With `bbox_scale=None`, the model is prompted for absolute pixel
coordinates (new `*_ABS` prompt variants, string-replaced from the base
prompts on only the coordinate bullet, with drift asserts) and
`build_layout_pages` normalizes by the image dimensions. The frame is
config-driven, never guessed: the default mode still measures coordinate
compliance, and pixel-looking output under it gets a log warning, not a
silent rescue. Wired through the four div-layout providers via a shared
`resolve_layout_prompts` helper; `bbox_scale=None` is rejected for the
PDF-file modes (per the same docs, server-side PDF rasterization dimensions
aren't knowable, so pixel coordinates are undefined there).

Independent of the frame: coordinates are clamped before conversion
(rounding overshoot like `1003` currently escapes the unit square) and
non-numeric/NaN boxes are skipped with a warning instead of crashing or
clamping to a fabricated edge coordinate.

### Testing

New `test_layout_coordinate_frames.py` (18 cases: prompt variants, both
frames, clamping, compliance warning without rescale, NaN/string/short
bboxes, config validation, file-mode rejection, and resize-rule vectors
from the docs' worked examples). Full suite passes;
ruff clean.

