### PR TITLE
Gate bbox_scale=None to providers that pin the image frame

### DIFF
--- a/src/parse_bench/inference/providers/parse/_layout_utils.py
+++ b/src/parse_bench/inference/providers/parse/_layout_utils.py
@@ -163,6 +163,7 @@ def resolve_layout_prompts(
     *,
     gemini: bool = False,
     pixel_disallowed_modes: tuple[str, ...] = ("parse_with_layout_file",),
+    pixel_frame_supported: bool = False,
 ) -> tuple[str, str]:
     """Validate *bbox_scale* and return the (system, user) layout prompts.
 
@@ -177,12 +178,17 @@ def resolve_layout_prompts(
 
     The pixel frame is normalized by the recorded page dimensions, so it
     assumes the model perceives the image at the sent resolution. Provider
-    APIs downscale images past their native limits — keep the render
-    ``dpi`` low enough that pages stay within them, or pre-resize per the
-    provider's documented resize rule.
+    APIs downscale images past their native limits, and the model then
+    reports pixels in that downscaled frame while ``normalize()`` divides by
+    the dimensions we recorded — so a provider may only opt in
+    (``pixel_frame_supported=True``) once it pre-resizes each page to the
+    size the model actually perceives. Anthropic does this in
+    ``_resize_to_perceived_size``; the other div-layout providers do not,
+    and are rejected rather than allowed to report a silently shifted frame.
 
     Raises:
-        ProviderConfigError: for an unsupported scale, or for
+        ProviderConfigError: for an unsupported scale; for ``bbox_scale=None``
+            on a provider that cannot pin the perceived frame; or for
             ``bbox_scale=None`` combined with a mode in
             *pixel_disallowed_modes* (absolute pixel coordinates are
             undefined when the model is sent the PDF file rather than a
@@ -194,6 +200,14 @@ def resolve_layout_prompts(
         raise ProviderConfigError(
             f"Unsupported bbox_scale {bbox_scale!r}. Use 1000 (normalized 0-1000, "
             "the default) or None (absolute pixel coordinates)."
+        )
+    if bbox_scale is None and not pixel_frame_supported:
+        raise ProviderConfigError(
+            "bbox_scale=None (pixel coordinates) is not supported by this provider. "
+            "The provider API may downscale the page before the model sees it, so "
+            "the model's pixel coordinates would be in a different frame than the "
+            "recorded page dimensions. Use bbox_scale=1000 (the default), or add a "
+            "perceived-size pre-resize to the provider first."
         )
     if bbox_scale is None and mode in pixel_disallowed_modes:
         raise ProviderConfigError(

--- a/src/parse_bench/inference/providers/parse/anthropic.py
+++ b/src/parse_bench/inference/providers/parse/anthropic.py
@@ -180,7 +180,12 @@ class AnthropicProvider(Provider):
         # default) or None (absolute pixels of the sent image, for models
         # that ground well but re-normalize unreliably).
         self._bbox_scale = self.base_config.get("bbox_scale", 1000)
-        self._layout_system_prompt, self._layout_user_prompt = resolve_layout_prompts(self._bbox_scale, self._mode)
+        # Pixel mode is safe here because _resize_to_perceived_size() pins the
+        # sent image to the size the model perceives, so the recorded page
+        # dimensions and the model's coordinate frame are the same.
+        self._layout_system_prompt, self._layout_user_prompt = resolve_layout_prompts(
+            self._bbox_scale, self._mode, pixel_frame_supported=True
+        )
         # Image limits used to pre-resize pages in pixel-coordinate mode.
         # Defaults are the standard resolution tier, which is safe for every
         # model (an image within standard limits is never downscaled

--- a/tests/parse_bench/inference/providers/parse/test_layout_coordinate_frames.py
+++ b/tests/parse_bench/inference/providers/parse/test_layout_coordinate_frames.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import os
 import unittest
+from unittest import mock
 
 from parse_bench.inference.providers.parse._layout_utils import (
     SYSTEM_PROMPT_LAYOUT,
@@ -22,6 +23,7 @@ from parse_bench.inference.providers.parse._layout_utils import (
     USER_PROMPT_LAYOUT_GEMINI,
     USER_PROMPT_LAYOUT_GEMINI_ABS,
     build_layout_pages,
+    resolve_layout_prompts,
 )
 
 
@@ -204,6 +206,96 @@ class TestProviderConfig(unittest.TestCase):
                 "anthropic",
                 {"mode": "parse_with_layout_file", "bbox_scale": None},
             )
+
+
+class TestPixelFrameProviderGate(unittest.TestCase):
+    """Pixel mode is only offered by providers that pin the perceived frame.
+
+    ``build_layout_pages(bbox_scale=None)`` normalizes by the page dimensions
+    recorded at inference time. That is only the model's coordinate frame if
+    the sent image is never downscaled on the way in — which holds for
+    Anthropic because ``_resize_to_perceived_size`` pre-resizes per the
+    published rule, and does not hold for the other div-layout providers.
+    Without the gate they would accept ``bbox_scale=None`` and report a
+    silently shifted frame.
+    """
+
+    def test_gate_defaults_closed(self) -> None:
+        from parse_bench.inference.providers.base import ProviderConfigError
+
+        with self.assertRaises(ProviderConfigError) as ctx:
+            resolve_layout_prompts(None, "parse_with_layout")
+        self.assertIn("not supported by this provider", str(ctx.exception))
+
+    def test_gate_open_returns_abs_prompts(self) -> None:
+        self.assertEqual(
+            resolve_layout_prompts(None, "parse_with_layout", pixel_frame_supported=True),
+            (SYSTEM_PROMPT_LAYOUT_ABS, USER_PROMPT_LAYOUT_ABS),
+        )
+
+    def test_gate_does_not_affect_default_frame(self) -> None:
+        # The 0-1000 frame is unchanged for every provider, gated or not.
+        for supported in (False, True):
+            self.assertEqual(
+                resolve_layout_prompts(1000, "parse_with_layout", pixel_frame_supported=supported),
+                (SYSTEM_PROMPT_LAYOUT, USER_PROMPT_LAYOUT),
+            )
+
+    def test_unsupported_scale_still_rejected_when_gate_open(self) -> None:
+        from parse_bench.inference.providers.base import ProviderConfigError
+
+        with self.assertRaises(ProviderConfigError):
+            resolve_layout_prompts(500, "parse_with_layout", pixel_frame_supported=True)
+
+    def _env(self, **kv: str) -> None:
+        """Set provider API keys for the duration of one test."""
+        patcher = mock.patch.dict(os.environ, kv)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_anthropic_opts_in(self) -> None:
+        from parse_bench.inference.providers.parse.anthropic import AnthropicProvider
+
+        self._env(ANTHROPIC_API_KEY="test-key")
+        provider = AnthropicProvider("anthropic", {"mode": "parse_with_layout", "bbox_scale": None})
+        self.assertEqual(provider._layout_system_prompt, SYSTEM_PROMPT_LAYOUT_ABS)
+
+    def test_openai_rejects_pixel_frame(self) -> None:
+        from parse_bench.inference.providers.base import ProviderConfigError
+        from parse_bench.inference.providers.parse.openai import OpenAIProvider
+
+        self._env(OPENAI_API_KEY="test-key")
+        with self.assertRaises(ProviderConfigError):
+            OpenAIProvider("openai", {"mode": "parse_with_layout", "bbox_scale": None})
+
+    def test_google_rejects_pixel_frame(self) -> None:
+        from parse_bench.inference.providers.base import ProviderConfigError
+        from parse_bench.inference.providers.parse.google import GoogleProvider
+
+        self._env(GEMINI_API_KEY="test-key", GOOGLE_API_KEY="test-key")
+        with self.assertRaises(ProviderConfigError):
+            GoogleProvider("google", {"mode": "parse_with_layout", "bbox_scale": None})
+
+    def test_gemma4_rejects_pixel_frame(self) -> None:
+        from parse_bench.inference.providers.base import ProviderConfigError
+        from parse_bench.inference.providers.parse.gemma4 import Gemma4Provider
+
+        with self.assertRaises(ProviderConfigError):
+            Gemma4Provider("gemma4", {"server_url": "http://x", "prompt_mode": "layout", "bbox_scale": None})
+
+    def test_gated_providers_still_accept_default_frame(self) -> None:
+        from parse_bench.inference.providers.parse.gemma4 import Gemma4Provider
+        from parse_bench.inference.providers.parse.openai import OpenAIProvider
+
+        self._env(OPENAI_API_KEY="test-key")
+        self.assertEqual(
+            OpenAIProvider("openai", {"mode": "parse_with_layout"})._layout_system_prompt,
+            SYSTEM_PROMPT_LAYOUT,
+        )
+        self.assertEqual(
+            Gemma4Provider("gemma4", {"server_url": "http://x", "prompt_mode": "layout"})._system_prompt,
+            SYSTEM_PROMPT_LAYOUT,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What

Adds a `pixel_frame_supported` gate to `resolve_layout_prompts()` so that
`bbox_scale=None` (absolute-pixel layout coordinates, added in #91) is only
accepted by providers that can guarantee the model sees the page at the
resolution we recorded. Anthropic opts in; `openai`, `google` and `gemma4`
are rejected at construction.

The default `bbox_scale=1000` path is unchanged for every provider, so no
existing pipeline or leaderboard number is affected.

### Why

`build_layout_pages(bbox_scale=None)` normalizes the model's pixel
coordinates by the page dimensions recorded at inference time. That is only
the model's coordinate frame if the image is never downscaled on the way in.

Provider APIs do downscale: they resize or re-tile images past their native
limits before the model ever sees them. When that happens the model reports
pixels in the *downscaled* frame while `normalize()` divides by the original
dimensions, and every box comes back systematically shifted and rescaled —
the exact failure mode `bbox_scale=None` was introduced to fix.

`anthropic.py` already handles this: `_resize_to_perceived_size()` pre-resizes
each page per the published resize rule, so the recorded dimensions and the
model's frame are identical. No equivalent exists in the other three
div-layout providers, but #91 wired the option into all four. As it stands,
adding a pixel-mode pipeline on `openai`, `google` or `gemma4` would produce
plausible-looking but silently wrong grounding, with nothing to catch it.

### How

`resolve_layout_prompts()` takes a new keyword-only `pixel_frame_supported`
defaulting to `False`, and raises `ProviderConfigError` for
`bbox_scale=None` unless the caller opts in. The error names the cause and
the two ways out (use the default frame, or add a perceived-size pre-resize).

`AnthropicProvider` passes `pixel_frame_supported=True`. The other three call
sites are untouched, so the gate closes for them by default — a provider has
to demonstrate it pins the frame in order to open it.

Defaulting closed rather than open means any div-layout provider added later
inherits the safe behaviour without the author having to know this
constraint exists.

### Changes

- `src/parse_bench/inference/providers/parse/_layout_utils.py` — new
  `pixel_frame_supported` parameter, validation, and docstring explaining
  the frame constraint.
- `src/parse_bench/inference/providers/parse/anthropic.py` — opts in, with a
  comment pointing at `_resize_to_perceived_size()`.
- `tests/parse_bench/inference/providers/parse/test_layout_coordinate_frames.py`
  — new `TestPixelFrameProviderGate` (9 cases).

### Testing

New tests cover: the gate defaulting closed; the gate open returning the
`*_ABS` prompts; the default 0-1000 frame being identical with the gate open
or closed; unsupported scales still rejected when the gate is open; Anthropic
accepting pixel mode; `openai` / `google` / `gemma4` each rejecting it; and
the gated providers still accepting the default frame.

Full suite: 327 passed. `ruff check`, `ruff format --check` and `mypy` clean
on the changed files.

### Notes

- No behaviour change on the default frame, so this does not move any
  existing score. It only constrains an option that no pipeline sets yet.
- Lifting the restriction for another provider is a two-part change: add the
  provider's documented resize rule, then flip its call site to
  `pixel_frame_supported=True`.
- `parse_with_layout_file` remains rejected for pixel mode via the existing
  `pixel_disallowed_modes` check; the two constraints are independent and
  both still apply.
