### PR TITLE
Make LLM normalization off by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,13 +233,14 @@ ANTHROPIC_API_KEY=...
 GOOGLE_API_KEY=...
 ```
 
-ParseBench does **not** use LLM-as-a-judge — all evaluation is deterministic and rule-based. API keys are only used to call the parsing tool being evaluated.
+ParseBench does **not** use LLM-as-a-judge — all evaluation is deterministic and rule-based. API keys are only used to call the parsing tool being evaluated. (An opt-in chart normalization mode exists but is off by default — see [`LLAMACLOUD_BENCH_LLM_NORMALIZATION`](#environment-variables).)
 
 ### Environment Variables
 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `PARSEBENCH_FAST_TEDS` | `1` | Fast Zhang-Shasha TEDS table metric (uses the `numba` JIT when the [`fast` extra](#quick-start) is installed, otherwise an exact pure-Python fallback). Set to `0` to force the original APTED implementation — scores are identical either way, so this is only needed for debugging or benchmarking. |
+| `LLAMACLOUD_BENCH_LLM_NORMALIZATION` | `off` | Set to `judge` to opt into LLM-as-judge chart normalization (non-deterministic, needs `ANTHROPIC_API_KEY`). |
 
 ### CLI Reference
 

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ ANTHROPIC_API_KEY=...
 GOOGLE_API_KEY=...
 ```
 
-ParseBench does **not** use LLM-as-a-judge — all evaluation is deterministic and rule-based. API keys are only used to call the parsing tool being evaluated. (An opt-in chart normalization mode exists but is off by default — see [`LLAMACLOUD_BENCH_LLM_NORMALIZATION`](#environment-variables).)
+By default ParseBench does **not** use LLM-as-a-judge — all evaluation is deterministic and rule-based, and API keys are only used to call the parsing tool being evaluated. (An opt-in chart normalization mode exists but is off by default — see [`LLAMACLOUD_BENCH_LLM_NORMALIZATION`](#environment-variables).)
 
 ### Environment Variables
 

--- a/src/parse_bench/evaluation/evaluators/parse.py
+++ b/src/parse_bench/evaluation/evaluators/parse.py
@@ -18,6 +18,9 @@ from parse_bench.evaluation.metrics.parse.header_accuracy_metric import (
     HeaderAccuracyMetric,
     HeaderAccuracyMetricGenerous,
 )
+from parse_bench.evaluation.metrics.parse.llm_normalization.config import (
+    get_normalization_mode,
+)
 from parse_bench.evaluation.metrics.parse.rule_based_judge_metric import (
     RuleBasedJudgeMetric as RuleBasedMetric,
 )
@@ -152,6 +155,7 @@ class ParseEvaluator(BaseEvaluator):
         self._enable_table_record_match = enable_table_record_match
         self._enable_table_composite = enable_table_composite
         self._rule_metric = RuleBasedMetric()
+        logger.info("Chart LLM normalization mode: %s", get_normalization_mode().value)
         self._text_similarity_metric = TextSimilarityMetric()
         self._teds_metric = TEDSMetric(variants=teds_variants if teds_variants is not None else {TEDS_CONTENT})
         self._grits_metric = GriTSMetric()

--- a/src/parse_bench/evaluation/metrics/parse/llm_normalization/__init__.py
+++ b/src/parse_bench/evaluation/metrics/parse/llm_normalization/__init__.py
@@ -3,9 +3,9 @@
 Uses Claude LLM-as-judge to improve chart benchmark accuracy by handling
 semantic equivalence that deterministic fuzzy matching misses.
 
-Controlled by env var ``LLAMACLOUD_BENCH_LLM_NORMALIZATION``:
-  - ``"judge"`` -- Claude LLM-as-judge normalization (default)
-  - ``"off"``   -- no LLM normalization
+Off by default. Controlled by env var ``LLAMACLOUD_BENCH_LLM_NORMALIZATION``:
+  - unset / ``"off"`` -- no LLM normalization (default; fully deterministic)
+  - ``"judge"``       -- opt-in Claude LLM-as-judge normalization
 """
 
 from parse_bench.evaluation.metrics.parse.llm_normalization.base import (

--- a/src/parse_bench/evaluation/metrics/parse/llm_normalization/config.py
+++ b/src/parse_bench/evaluation/metrics/parse/llm_normalization/config.py
@@ -7,7 +7,7 @@ from enum import StrEnum
 
 
 class NormalizationMode(StrEnum):
-    """LLM normalization mode, controlled by LLAMACLOUD_BENCH_LLM_NORMALIZATION env var."""
+    """LLM normalization mode (off by default; ``judge`` opts in)."""
 
     OFF = "off"
     JUDGE = "judge"
@@ -32,15 +32,11 @@ MAX_API_CALLS_PER_NORMALIZER = 500
 
 
 def get_normalization_mode() -> NormalizationMode:
-    """Read LLAMACLOUD_BENCH_LLM_NORMALIZATION env var and return the mode.
-
-    Returns NormalizationMode.JUDGE if unset or unrecognized.
-    """
-    raw = os.environ.get("LLAMACLOUD_BENCH_LLM_NORMALIZATION", "judge").strip().lower()
-    try:
-        return NormalizationMode(raw)
-    except ValueError:
+    """Read LLAMACLOUD_BENCH_LLM_NORMALIZATION; OFF unless set to ``judge``."""
+    raw = os.environ.get("LLAMACLOUD_BENCH_LLM_NORMALIZATION", "").strip().lower()
+    if raw == NormalizationMode.JUDGE.value:
         return NormalizationMode.JUDGE
+    return NormalizationMode.OFF
 
 
 def get_anthropic_api_key() -> str | None:

--- a/src/parse_bench/evaluation/metrics/parse/llm_normalization/postprocess.py
+++ b/src/parse_bench/evaluation/metrics/parse/llm_normalization/postprocess.py
@@ -6,7 +6,7 @@ an LLM normalizer. This approach requires ZERO modifications to existing
 test rules — it works entirely on the rule_results dicts produced by the
 standard evaluation pipeline.
 
-Controlled by env var ``LLAMACLOUD_BENCH_LLM_NORMALIZATION`` (off by default).
+Off by default; opt in with ``LLAMACLOUD_BENCH_LLM_NORMALIZATION=judge``.
 """
 
 from __future__ import annotations

--- a/src/parse_bench/evaluation/metrics/parse/rule_based_judge_metric.py
+++ b/src/parse_bench/evaluation/metrics/parse/rule_based_judge_metric.py
@@ -6,8 +6,8 @@ returned metadata so the evaluator's per-type loop auto-generates
 ``rule_*_judge_pass_rate`` metrics. Also stores ``judge_pass_rate`` in
 metadata so the evaluator can emit ``rule_pass_rate_judge``.
 
-Controlled by env var ``LLAMACLOUD_BENCH_LLM_NORMALIZATION`` (off by default).
-When OFF this class is identical in behaviour to its parent.
+Off by default; opt in with ``LLAMACLOUD_BENCH_LLM_NORMALIZATION=judge``.
+When OFF (the default) this class is identical in behaviour to its parent.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## What
`LLAMACLOUD_BENCH_LLM_NORMALIZATION` now defaults to `off`. LLM-as-judge normalization of chart metrics is strictly opt-in via `=judge`.

## Why
The env var previously defaulted to `judge`, so an **unset** environment silently ran LLM normalization on chart metrics — directly contradicting the "off by default" docstrings and the README's claim that all evaluation is deterministic and rule-based. This is the root of the reproducibility gap in #106: default (and leaderboard) runs used `judge` while local runs used `off`, producing ~18-point chart differences.

## How
`get_normalization_mode()` now returns `OFF` unless the var is set to exactly `judge`. Unset, empty, `off`, or any unrecognized value all map to `OFF` (fails safe). Docstrings and README updated to match reality.

## Changes
- `llm_normalization/config.py` — default OFF; only `judge` opts in
- `llm_normalization/__init__.py`, `postprocess.py`, `rule_based_judge_metric.py` — corrected the contradictory docstrings
- `README.md` — clarified the deterministic-by-default claim and documented the env var

## Testing
- Verified mode resolution across unset / `judge` / `JUDGE` / `off` / typos / empty — only `judge` enables it
- `ruff check` and `mypy` pass on the changed files

## Notes
- Behavioral change: default chart scores are now lower (deterministic) than judge-normalized runs. Leaderboard numbers generated with judge-on should be regenerated deterministically or annotated, otherwise #106 recurs in reverse.
- The `llm_normalization` module itself is unchanged and still available via `LLAMACLOUD_BENCH_LLM_NORMALIZATION=judge`.

Relates to #106.