### PR TITLE
Fix multipage PDF inference across parse providers

### DIFF
--- a/.github/workflows/static-quality-delta.yml
+++ b/.github/workflows/static-quality-delta.yml
@@ -1,0 +1,35 @@
+name: Static quality delta
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  static-quality-delta:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out full history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Install Python
+        run: uv python install 3.12
+
+      - name: Install quality tooling and provider dependencies
+        run: uv sync --extra dev --extra runners
+
+      - name: Fetch baseline
+        run: git fetch --no-tags origin main:refs/remotes/origin/main
+
+      - name: Enforce static quality delta
+        run: uv run python scripts/check_static_quality_delta.py --baseline origin/main

--- a/scripts/check_static_quality_delta.py
+++ b/scripts/check_static_quality_delta.py
@@ -18,6 +18,14 @@ from typing import Any
 
 _HUNK_RE = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
 _MYPY_ERROR_RE = re.compile(r"^(.*?):(\d+): error: (.*?)(?:  \[([^]]+)\])?$")
+_MYPY_NOTE_RE = re.compile(r"^.*?: note: .*$")
+_MYPY_SUMMARY_RE = re.compile(
+    r"^(?:Success: no issues found in \d+ source files?|Found \d+ errors? in \d+ files? \(checked \d+ source files?\))$"
+)
+
+
+class StaticQualityError(RuntimeError):
+    """The checker could not establish a trustworthy tool result."""
 
 
 @dataclass(frozen=True, order=True)
@@ -25,7 +33,7 @@ class Diagnostic:
     path: str
     code: str
     message: str
-    source: str = field(compare=False)
+    source: str
     row: int = field(compare=False)
 
 
@@ -33,36 +41,67 @@ def _run(
     command: list[str],
     *,
     cwd: Path,
-    check: bool = False,
 ) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         command,
         cwd=cwd,
-        check=check,
+        check=False,
         text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
+        capture_output=True,
     )
 
 
-def _changed_python_files(root: Path, baseline: str) -> list[str]:
-    result = _run(
-        ["git", "diff", "--name-only", "--diff-filter=ACMR", baseline, "--"],
-        cwd=root,
-        check=True,
+def _require_command(
+    result: subprocess.CompletedProcess[str],
+    *,
+    description: str,
+    allowed_returncodes: tuple[int, ...] = (0,),
+) -> subprocess.CompletedProcess[str]:
+    if result.returncode not in allowed_returncodes:
+        detail = result.stderr.strip() or result.stdout.strip() or "no output"
+        raise StaticQualityError(f"{description} failed with exit code {result.returncode}: {detail}")
+    if result.stderr.strip():
+        raise StaticQualityError(f"{description} wrote to stderr: {result.stderr.strip()}")
+    return result
+
+
+def _merge_base(root: Path, baseline: str) -> str:
+    result = _require_command(
+        _run(["git", "merge-base", baseline, "HEAD"], cwd=root),
+        description=f"git merge-base {baseline} HEAD",
+    )
+    merge_base = result.stdout.strip()
+    if not re.fullmatch(r"[0-9a-fA-F]{7,64}", merge_base):
+        raise StaticQualityError(f"git merge-base returned malformed revision: {merge_base!r}")
+    return merge_base
+
+
+def _changed_python_files(root: Path, merge_base: str) -> list[str]:
+    result = _require_command(
+        _run(
+            ["git", "diff", "--name-only", "--diff-filter=ACMR", merge_base, "--"],
+            cwd=root,
+        ),
+        description="git changed-file discovery",
     )
     return sorted(path for path in result.stdout.splitlines() if path.endswith(".py") and (root / path).is_file())
 
 
-def _extract_baseline(root: Path, baseline: str, destination: Path) -> None:
+def _extract_baseline(root: Path, merge_base: str, destination: Path) -> None:
     archive = subprocess.run(
-        ["git", "archive", baseline],
+        ["git", "archive", merge_base],
         cwd=root,
-        check=True,
-        stdout=subprocess.PIPE,
-    ).stdout
-    with tarfile.open(fileobj=io.BytesIO(archive), mode="r:") as tar:
-        tar.extractall(destination, filter="data")
+        check=False,
+        capture_output=True,
+    )
+    if archive.returncode != 0 or archive.stderr:
+        detail = archive.stderr.decode(errors="replace").strip() or "no output"
+        raise StaticQualityError(f"git archive failed with exit code {archive.returncode}: {detail}")
+    try:
+        with tarfile.open(fileobj=io.BytesIO(archive.stdout), mode="r:") as tar:
+            tar.extractall(destination, filter="data")
+    except (tarfile.TarError, OSError) as exc:
+        raise StaticQualityError(f"git archive produced an invalid baseline archive: {exc}") from exc
 
 
 def _source_line(root: Path, relative_path: str, row: int) -> str:
@@ -90,33 +129,67 @@ def _normalized_message(message: str) -> str:
 def _ruff_diagnostics(root: Path, files: list[str], ruff: str) -> list[Diagnostic]:
     if not files:
         return []
-    result = _run([ruff, "check", "--output-format=json", *files], cwd=root)
-    payload: list[dict[str, Any]] = json.loads(result.stdout or "[]")
+    result = _require_command(
+        _run([ruff, "check", "--output-format=json", *files], cwd=root),
+        description="Ruff check",
+        allowed_returncodes=(0, 1),
+    )
+    try:
+        payload: Any = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise StaticQualityError(f"Ruff emitted malformed JSON: {exc}") from exc
+    if not isinstance(payload, list):
+        raise StaticQualityError("Ruff JSON output is not a list")
     diagnostics: list[Diagnostic] = []
-    for item in payload:
-        path = _relative_path(str(item["filename"]), root)
-        row = int(item["location"]["row"])
+    for index, item in enumerate(payload):
+        if not isinstance(item, dict):
+            raise StaticQualityError(f"Ruff diagnostic {index} is not an object")
+        try:
+            filename = item["filename"]
+            location = item["location"]
+            code = item["code"]
+            message = item["message"]
+            if not isinstance(filename, str) or not isinstance(location, dict):
+                raise TypeError
+            row = location["row"]
+            if not isinstance(row, int) or isinstance(row, bool) or row < 1:
+                raise TypeError
+            if not isinstance(code, str) or not code or not isinstance(message, str):
+                raise TypeError
+        except (KeyError, TypeError) as exc:
+            raise StaticQualityError(f"Ruff diagnostic {index} has an invalid schema") from exc
+        path = _relative_path(filename, root)
         diagnostics.append(
             Diagnostic(
                 path=path,
-                code=str(item["code"]),
-                message=_normalized_message(str(item["message"])),
+                code=code,
+                message=_normalized_message(message),
                 source=_source_line(root, path, row),
                 row=row,
             )
         )
+    if result.returncode == 0 and diagnostics:
+        raise StaticQualityError("Ruff returned success while reporting diagnostics")
+    if result.returncode == 1 and not diagnostics:
+        raise StaticQualityError("Ruff returned a diagnostic exit code without diagnostics")
     return diagnostics
 
 
 def _mypy_diagnostics(root: Path, files: list[str], mypy: str) -> list[Diagnostic]:
     if not files:
         return []
-    result = _run([mypy, "--follow-imports=skip", *files], cwd=root)
+    result = _require_command(
+        _run([mypy, "--follow-imports=skip", *files], cwd=root),
+        description="mypy",
+        allowed_returncodes=(0, 1),
+    )
     diagnostics: list[Diagnostic] = []
     for line in result.stdout.splitlines():
         match = _MYPY_ERROR_RE.match(line)
         if match is None:
-            continue
+            if _MYPY_NOTE_RE.match(line) or _MYPY_SUMMARY_RE.match(line):
+                continue
+            raise StaticQualityError(f"mypy emitted unrecognized output: {line!r}")
         filename, row_text, message, code = match.groups()
         path = _relative_path(filename, root)
         row = int(row_text)
@@ -129,11 +202,18 @@ def _mypy_diagnostics(root: Path, files: list[str], mypy: str) -> list[Diagnosti
                 row=row,
             )
         )
+    if result.returncode == 0 and diagnostics:
+        raise StaticQualityError("mypy returned success while reporting errors")
+    if result.returncode == 1 and not diagnostics:
+        raise StaticQualityError("mypy returned an error exit code without parseable errors")
     return diagnostics
 
 
-def _added_line_ranges(root: Path, baseline: str, files: list[str]) -> dict[str, list[range]]:
-    result = _run(["git", "diff", "--unified=0", baseline, "--", *files], cwd=root, check=True)
+def _added_line_ranges(root: Path, merge_base: str, files: list[str]) -> dict[str, list[range]]:
+    result = _require_command(
+        _run(["git", "diff", "--unified=0", merge_base, "--", *files], cwd=root),
+        description="git changed-line discovery",
+    )
     ranges: dict[str, list[range]] = {}
     current_path: str | None = None
     for line in result.stdout.splitlines():
@@ -153,19 +233,33 @@ def _added_line_ranges(root: Path, baseline: str, files: list[str]) -> dict[str,
 def _format_hunks(root: Path, files: list[str], ruff: str) -> list[tuple[str, range]]:
     if not files:
         return []
-    result = _run([ruff, "format", "--diff", *files], cwd=root)
+    result = _require_command(
+        _run([ruff, "format", "--diff", "--quiet", *files], cwd=root),
+        description="Ruff formatter",
+    )
     hunks: list[tuple[str, range]] = []
     current_path: str | None = None
+    saw_diff_header = False
     for line in result.stdout.splitlines():
         if line.startswith("--- "):
+            saw_diff_header = True
+            current_path = None
+            continue
+        if line.startswith("+++ "):
+            if not saw_diff_header:
+                raise StaticQualityError("Ruff formatter emitted an unmatched current-file header")
             current_path = _relative_path(line[4:].split("\t", 1)[0], root)
             continue
         match = _HUNK_RE.match(line)
-        if match is None or current_path is None:
+        if match is None:
             continue
-        start = int(match.group(1))
-        count = int(match.group(2) or "1")
+        if current_path is None:
+            raise StaticQualityError("Ruff formatter emitted a hunk without a file header")
+        start = int(match.group(3))
+        count = int(match.group(4) or "1")
         hunks.append((current_path, range(start, start + max(count, 1))))
+    if result.stdout.strip() and (not saw_diff_header or not hunks):
+        raise StaticQualityError("Ruff formatter emitted malformed diff output")
     return hunks
 
 
@@ -201,52 +295,68 @@ def _existing_files(root: Path, files: Iterable[str]) -> list[str]:
     return [path for path in files if (root / path).is_file()]
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--baseline", default="origin/main")
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
-    root = Path(_run(["git", "rev-parse", "--show-toplevel"], cwd=Path.cwd(), check=True).stdout.strip())
+    try:
+        root_result = _require_command(
+            _run(["git", "rev-parse", "--show-toplevel"], cwd=Path.cwd()),
+            description="git repository discovery",
+        )
+        root = Path(root_result.stdout.strip())
+        if not root.is_dir():
+            raise StaticQualityError(f"git returned an invalid repository root: {root}")
+        merge_base = _merge_base(root, args.baseline)
+    except StaticQualityError as exc:
+        parser.error(str(exc))
     ruff = shutil.which("ruff")
     mypy = shutil.which("mypy")
     if ruff is None or mypy is None:
         parser.error("ruff and mypy must be available on PATH")
 
-    files = _changed_python_files(root, args.baseline)
+    try:
+        files = _changed_python_files(root, merge_base)
+    except StaticQualityError as exc:
+        parser.error(str(exc))
     source_files = [path for path in files if path.startswith("src/")]
     if not files:
         print("No changed Python files.")
         return 0
 
-    with tempfile.TemporaryDirectory(prefix="parse-bench-static-baseline-") as temp_dir:
-        baseline_root = Path(temp_dir)
-        _extract_baseline(root, args.baseline, baseline_root)
-        baseline_files = _existing_files(baseline_root, files)
-        baseline_source_files = _existing_files(baseline_root, source_files)
+    try:
+        with tempfile.TemporaryDirectory(prefix="parse-bench-static-baseline-") as temp_dir:
+            baseline_root = Path(temp_dir)
+            _extract_baseline(root, merge_base, baseline_root)
+            baseline_files = _existing_files(baseline_root, files)
+            baseline_source_files = _existing_files(baseline_root, source_files)
 
-        baseline_ruff_list = _ruff_diagnostics(baseline_root, baseline_files, ruff)
-        current_ruff_list = _ruff_diagnostics(root, files, ruff)
-        baseline_ruff = Counter(baseline_ruff_list)
-        current_ruff = Counter(current_ruff_list)
-        new_ruff = _new_diagnostics(current_ruff, baseline_ruff)
+            baseline_ruff_list = _ruff_diagnostics(baseline_root, baseline_files, ruff)
+            current_ruff_list = _ruff_diagnostics(root, files, ruff)
+            baseline_ruff = Counter(baseline_ruff_list)
+            current_ruff = Counter(current_ruff_list)
+            new_ruff = _new_diagnostics(current_ruff, baseline_ruff)
 
-        baseline_mypy_list = _mypy_diagnostics(baseline_root, baseline_source_files, mypy)
-        current_mypy_list = _mypy_diagnostics(root, source_files, mypy)
-        baseline_mypy = Counter(baseline_mypy_list)
-        current_mypy = Counter(current_mypy_list)
-        new_mypy = _new_diagnostics(current_mypy, baseline_mypy)
+            baseline_mypy_list = _mypy_diagnostics(baseline_root, baseline_source_files, mypy)
+            current_mypy_list = _mypy_diagnostics(root, source_files, mypy)
+            baseline_mypy = Counter(baseline_mypy_list)
+            current_mypy = Counter(current_mypy_list)
+            new_mypy = _new_diagnostics(current_mypy, baseline_mypy)
 
-    changed_ranges = _added_line_ranges(root, args.baseline, files)
-    touched_ruff = _on_changed_lines(current_ruff_list, changed_ranges)
-    touched_mypy = _on_changed_lines(current_mypy_list, changed_ranges)
-    format_failures = [
-        (path, formatter_range)
-        for path, formatter_range in _format_hunks(root, files, ruff)
-        if any(_ranges_overlap(formatter_range, changed) for changed in changed_ranges.get(path, []))
-    ]
+        changed_ranges = _added_line_ranges(root, merge_base, files)
+        touched_ruff = _on_changed_lines(current_ruff_list, changed_ranges)
+        touched_mypy = _on_changed_lines(current_mypy_list, changed_ranges)
+        format_failures = [
+            (path, formatter_range)
+            for path, formatter_range in _format_hunks(root, files, ruff)
+            if any(_ranges_overlap(formatter_range, changed) for changed in changed_ranges.get(path, []))
+        ]
+    except StaticQualityError as exc:
+        parser.error(str(exc))
 
     print(
-        f"Checked {len(files)} changed Python files against {args.baseline}: "
+        f"Checked {len(files)} changed Python files against merge-base {merge_base} ({args.baseline}): "
         f"Ruff {sum(current_ruff.values())} current/{sum(baseline_ruff.values())} baseline, "
         f"mypy {sum(current_mypy.values())} current/{sum(baseline_mypy.values())} baseline."
     )

--- a/scripts/check_static_quality_delta.py
+++ b/scripts/check_static_quality_delta.py
@@ -1,0 +1,271 @@
+"""Fail when a branch adds Ruff or mypy debt relative to a git baseline."""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import re
+import shutil
+import subprocess
+import tarfile
+import tempfile
+from collections import Counter
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+_HUNK_RE = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
+_MYPY_ERROR_RE = re.compile(r"^(.*?):(\d+): error: (.*?)(?:  \[([^]]+)\])?$")
+
+
+@dataclass(frozen=True, order=True)
+class Diagnostic:
+    path: str
+    code: str
+    message: str
+    source: str = field(compare=False)
+    row: int = field(compare=False)
+
+
+def _run(
+    command: list[str],
+    *,
+    cwd: Path,
+    check: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=cwd,
+        check=check,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+
+
+def _changed_python_files(root: Path, baseline: str) -> list[str]:
+    result = _run(
+        ["git", "diff", "--name-only", "--diff-filter=ACMR", baseline, "--"],
+        cwd=root,
+        check=True,
+    )
+    return sorted(path for path in result.stdout.splitlines() if path.endswith(".py") and (root / path).is_file())
+
+
+def _extract_baseline(root: Path, baseline: str, destination: Path) -> None:
+    archive = subprocess.run(
+        ["git", "archive", baseline],
+        cwd=root,
+        check=True,
+        stdout=subprocess.PIPE,
+    ).stdout
+    with tarfile.open(fileobj=io.BytesIO(archive), mode="r:") as tar:
+        tar.extractall(destination, filter="data")
+
+
+def _source_line(root: Path, relative_path: str, row: int) -> str:
+    try:
+        lines = (root / relative_path).read_text().splitlines()
+    except (OSError, UnicodeError):
+        return ""
+    return lines[row - 1].strip() if 0 < row <= len(lines) else ""
+
+
+def _relative_path(filename: str, root: Path) -> str:
+    path = Path(filename)
+    if path.is_absolute():
+        try:
+            return path.resolve().relative_to(root.resolve()).as_posix()
+        except ValueError:
+            return path.as_posix()
+    return path.as_posix()
+
+
+def _normalized_message(message: str) -> str:
+    return re.sub(r"\bfrom line \d+\b", "from prior line", message)
+
+
+def _ruff_diagnostics(root: Path, files: list[str], ruff: str) -> list[Diagnostic]:
+    if not files:
+        return []
+    result = _run([ruff, "check", "--output-format=json", *files], cwd=root)
+    payload: list[dict[str, Any]] = json.loads(result.stdout or "[]")
+    diagnostics: list[Diagnostic] = []
+    for item in payload:
+        path = _relative_path(str(item["filename"]), root)
+        row = int(item["location"]["row"])
+        diagnostics.append(
+            Diagnostic(
+                path=path,
+                code=str(item["code"]),
+                message=_normalized_message(str(item["message"])),
+                source=_source_line(root, path, row),
+                row=row,
+            )
+        )
+    return diagnostics
+
+
+def _mypy_diagnostics(root: Path, files: list[str], mypy: str) -> list[Diagnostic]:
+    if not files:
+        return []
+    result = _run([mypy, "--follow-imports=skip", *files], cwd=root)
+    diagnostics: list[Diagnostic] = []
+    for line in result.stdout.splitlines():
+        match = _MYPY_ERROR_RE.match(line)
+        if match is None:
+            continue
+        filename, row_text, message, code = match.groups()
+        path = _relative_path(filename, root)
+        row = int(row_text)
+        diagnostics.append(
+            Diagnostic(
+                path=path,
+                code=code or "mypy",
+                message=_normalized_message(message),
+                source=_source_line(root, path, row),
+                row=row,
+            )
+        )
+    return diagnostics
+
+
+def _added_line_ranges(root: Path, baseline: str, files: list[str]) -> dict[str, list[range]]:
+    result = _run(["git", "diff", "--unified=0", baseline, "--", *files], cwd=root, check=True)
+    ranges: dict[str, list[range]] = {}
+    current_path: str | None = None
+    for line in result.stdout.splitlines():
+        if line.startswith("+++ b/"):
+            current_path = line[6:]
+            continue
+        match = _HUNK_RE.match(line)
+        if match is None or current_path is None:
+            continue
+        start = int(match.group(3))
+        count = int(match.group(4) or "1")
+        if count:
+            ranges.setdefault(current_path, []).append(range(start, start + count))
+    return ranges
+
+
+def _format_hunks(root: Path, files: list[str], ruff: str) -> list[tuple[str, range]]:
+    if not files:
+        return []
+    result = _run([ruff, "format", "--diff", *files], cwd=root)
+    hunks: list[tuple[str, range]] = []
+    current_path: str | None = None
+    for line in result.stdout.splitlines():
+        if line.startswith("--- "):
+            current_path = _relative_path(line[4:].split("\t", 1)[0], root)
+            continue
+        match = _HUNK_RE.match(line)
+        if match is None or current_path is None:
+            continue
+        start = int(match.group(1))
+        count = int(match.group(2) or "1")
+        hunks.append((current_path, range(start, start + max(count, 1))))
+    return hunks
+
+
+def _ranges_overlap(left: range, right: range) -> bool:
+    return left.start < right.stop and right.start < left.stop
+
+
+def _new_diagnostics(
+    current: Counter[Diagnostic],
+    baseline: Counter[Diagnostic],
+) -> Counter[Diagnostic]:
+    return current - baseline
+
+
+def _on_changed_lines(
+    diagnostics: Iterable[Diagnostic],
+    changed_ranges: dict[str, list[range]],
+) -> Counter[Diagnostic]:
+    return Counter(
+        diagnostic
+        for diagnostic in diagnostics
+        if any(diagnostic.row in changed for changed in changed_ranges.get(diagnostic.path, []))
+    )
+
+
+def _print_diagnostics(label: str, diagnostics: Counter[Diagnostic]) -> None:
+    for diagnostic, count in sorted(diagnostics.items()):
+        suffix = f" (x{count})" if count > 1 else ""
+        print(f"{label}: {diagnostic.path}: {diagnostic.code}: {diagnostic.message} :: {diagnostic.source}{suffix}")
+
+
+def _existing_files(root: Path, files: Iterable[str]) -> list[str]:
+    return [path for path in files if (root / path).is_file()]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--baseline", default="origin/main")
+    args = parser.parse_args()
+
+    root = Path(_run(["git", "rev-parse", "--show-toplevel"], cwd=Path.cwd(), check=True).stdout.strip())
+    ruff = shutil.which("ruff")
+    mypy = shutil.which("mypy")
+    if ruff is None or mypy is None:
+        parser.error("ruff and mypy must be available on PATH")
+
+    files = _changed_python_files(root, args.baseline)
+    source_files = [path for path in files if path.startswith("src/")]
+    if not files:
+        print("No changed Python files.")
+        return 0
+
+    with tempfile.TemporaryDirectory(prefix="parse-bench-static-baseline-") as temp_dir:
+        baseline_root = Path(temp_dir)
+        _extract_baseline(root, args.baseline, baseline_root)
+        baseline_files = _existing_files(baseline_root, files)
+        baseline_source_files = _existing_files(baseline_root, source_files)
+
+        baseline_ruff_list = _ruff_diagnostics(baseline_root, baseline_files, ruff)
+        current_ruff_list = _ruff_diagnostics(root, files, ruff)
+        baseline_ruff = Counter(baseline_ruff_list)
+        current_ruff = Counter(current_ruff_list)
+        new_ruff = _new_diagnostics(current_ruff, baseline_ruff)
+
+        baseline_mypy_list = _mypy_diagnostics(baseline_root, baseline_source_files, mypy)
+        current_mypy_list = _mypy_diagnostics(root, source_files, mypy)
+        baseline_mypy = Counter(baseline_mypy_list)
+        current_mypy = Counter(current_mypy_list)
+        new_mypy = _new_diagnostics(current_mypy, baseline_mypy)
+
+    changed_ranges = _added_line_ranges(root, args.baseline, files)
+    touched_ruff = _on_changed_lines(current_ruff_list, changed_ranges)
+    touched_mypy = _on_changed_lines(current_mypy_list, changed_ranges)
+    format_failures = [
+        (path, formatter_range)
+        for path, formatter_range in _format_hunks(root, files, ruff)
+        if any(_ranges_overlap(formatter_range, changed) for changed in changed_ranges.get(path, []))
+    ]
+
+    print(
+        f"Checked {len(files)} changed Python files against {args.baseline}: "
+        f"Ruff {sum(current_ruff.values())} current/{sum(baseline_ruff.values())} baseline, "
+        f"mypy {sum(current_mypy.values())} current/{sum(baseline_mypy.values())} baseline."
+    )
+    if new_ruff:
+        _print_diagnostics("new Ruff diagnostic", new_ruff)
+    if new_mypy:
+        _print_diagnostics("new mypy diagnostic", new_mypy)
+    if touched_ruff:
+        _print_diagnostics("Ruff diagnostic on branch-touched line", touched_ruff)
+    if touched_mypy:
+        _print_diagnostics("mypy diagnostic on branch-touched line", touched_mypy)
+    for path, formatter_range in format_failures:
+        print(f"Ruff format changes branch-touched lines: {path}:{formatter_range.start}-{formatter_range.stop - 1}")
+
+    if new_ruff or new_mypy or touched_ruff or touched_mypy or format_failures:
+        return 1
+    print("Static quality delta passed: no new Ruff, Ruff-format, or mypy issues.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/parse_bench/inference/__init__.py
+++ b/src/parse_bench/inference/__init__.py
@@ -11,6 +11,7 @@ from parse_bench.inference.providers.base import (
     ProviderError,
     ProviderPermanentError,
     ProviderRateLimitError,
+    ProviderRetryExhaustedError,
     ProviderTransientError,
 )
 from parse_bench.inference.providers.registry import create_provider, register_provider
@@ -22,6 +23,7 @@ __all__ = [
     "ProviderError",
     "ProviderPermanentError",
     "ProviderRateLimitError",
+    "ProviderRetryExhaustedError",
     "ProviderTransientError",
     "create_provider",
     "register_provider",

--- a/src/parse_bench/inference/__init__.py
+++ b/src/parse_bench/inference/__init__.py
@@ -14,7 +14,7 @@ from parse_bench.inference.providers.base import (
     ProviderRetryExhaustedError,
     ProviderTransientError,
 )
-from parse_bench.inference.providers.registry import create_provider, register_provider
+from parse_bench.inference.providers.registry import create_provider, register_provider, registered_providers
 from parse_bench.inference.runner import InferenceRunner, RunSummary
 
 __all__ = [
@@ -27,6 +27,7 @@ __all__ = [
     "ProviderTransientError",
     "create_provider",
     "register_provider",
+    "registered_providers",
     "InferenceRunner",
     "RunSummary",
     "get_pipeline",

--- a/src/parse_bench/inference/providers/__init__.py
+++ b/src/parse_bench/inference/providers/__init__.py
@@ -15,7 +15,7 @@ from parse_bench.inference.providers.base import (
     ProviderRetryExhaustedError,
     ProviderTransientError,
 )
-from parse_bench.inference.providers.registry import create_provider, register_provider
+from parse_bench.inference.providers.registry import create_provider, register_provider, registered_providers
 
 __all__ = [
     "Provider",
@@ -27,4 +27,5 @@ __all__ = [
     "ProviderTransientError",
     "create_provider",
     "register_provider",
+    "registered_providers",
 ]

--- a/src/parse_bench/inference/providers/__init__.py
+++ b/src/parse_bench/inference/providers/__init__.py
@@ -12,6 +12,7 @@ from parse_bench.inference.providers.base import (
     ProviderError,
     ProviderPermanentError,
     ProviderRateLimitError,
+    ProviderRetryExhaustedError,
     ProviderTransientError,
 )
 from parse_bench.inference.providers.registry import create_provider, register_provider
@@ -22,6 +23,7 @@ __all__ = [
     "ProviderError",
     "ProviderPermanentError",
     "ProviderRateLimitError",
+    "ProviderRetryExhaustedError",
     "ProviderTransientError",
     "create_provider",
     "register_provider",

--- a/src/parse_bench/inference/providers/base.py
+++ b/src/parse_bench/inference/providers/base.py
@@ -42,6 +42,15 @@ class ProviderPermanentError(ProviderError):
     """
 
 
+class ProviderRetryExhaustedError(ProviderPermanentError):
+    """Terminal failure after a provider-owned retry budget is exhausted.
+
+    Providers that retry at a finer-grained boundary raise this error so the
+    document runner does not start a second retry cycle and replay completed
+    work.
+    """
+
+
 class Provider(ABC):
     """Abstract base class for document parsing providers."""
 

--- a/src/parse_bench/inference/providers/base.py
+++ b/src/parse_bench/inference/providers/base.py
@@ -1,7 +1,7 @@
 import asyncio
 import concurrent.futures
 from abc import ABC, abstractmethod
-from collections.abc import Coroutine
+from collections.abc import Coroutine, Mapping
 from typing import Any
 
 from parse_bench.schemas.pipeline import PipelineSpec
@@ -15,9 +15,16 @@ from parse_bench.schemas.pipeline_io import (
 class ProviderError(Exception):
     """Base exception for provider-related failures."""
 
-    def __init__(self, message: str, *, debug_payload: dict[str, Any] | None = None):
+    def __init__(
+        self,
+        message: str,
+        *,
+        debug_payload: dict[str, Any] | None = None,
+        attempt_stats: Mapping[str, int | float] | None = None,
+    ):
         super().__init__(message)
         self.debug_payload = debug_payload
+        self.attempt_stats = attempt_stats
 
 
 class ProviderConfigError(ProviderError):

--- a/src/parse_bench/inference/providers/parse/__init__.py
+++ b/src/parse_bench/inference/providers/parse/__init__.py
@@ -5,7 +5,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-_PROVIDER_MODULES = [
+PARSE_PROVIDER_MODULES = (
     "amazon_nova",
     "anthropic",
     "azure_document_intelligence",
@@ -32,7 +32,6 @@ _PROVIDER_MODULES = [
     "pdf_inspector",
     "pymupdf4llm",
     "llamaparse",
-    "llamaparse_v2_normalization",
     "mineru25",
     "mineru2605pro",
     "mineru_diffusion",
@@ -52,9 +51,9 @@ _PROVIDER_MODULES = [
     "unstructured",
     "warp_ingest",
     "oi_parser",
-]
+)
 
-for _mod in _PROVIDER_MODULES:
+for _mod in PARSE_PROVIDER_MODULES:
     try:
         importlib.import_module(f"parse_bench.inference.providers.parse.{_mod}")
     except ImportError:

--- a/src/parse_bench/inference/providers/parse/_layout_utils.py
+++ b/src/parse_bench/inference/providers/parse/_layout_utils.py
@@ -13,6 +13,7 @@ import math
 import re
 from typing import Any
 
+from parse_bench.inference.providers.base import ProviderPermanentError
 from parse_bench.schemas.parse_output import (
     LayoutItemIR,
     LayoutSegmentIR,
@@ -453,6 +454,26 @@ def parse_layout_response(content: str) -> list[dict[str, Any]]:
     return blocks
 
 
+def validated_sorted_page_records(raw_pages: object) -> list[dict[str, Any]]:
+    """Validate zero-based page records once, then return document order."""
+    if not isinstance(raw_pages, list):
+        raise ProviderPermanentError("Invalid raw output: 'pages' must be a list")
+
+    records: list[dict[str, Any]] = []
+    for position, record in enumerate(raw_pages):
+        if not isinstance(record, dict):
+            raise ProviderPermanentError(f"Invalid raw output: page record {position} must be an object")
+        page_index = record.get("page_index")
+        if not isinstance(page_index, int) or isinstance(page_index, bool) or page_index < 0:
+            raise ProviderPermanentError(f"Invalid raw output: page record {position} has invalid page_index")
+        records.append(record)
+
+    records.sort(key=lambda record: record["page_index"])
+    if [record["page_index"] for record in records] != list(range(len(records))):
+        raise ProviderPermanentError("Invalid raw output: pages must be unique, contiguous, and zero-based")
+    return records
+
+
 # A markdown ATX heading marker: optional indent, 1-6 hashes, then whitespace.
 # The trailing whitespace is required (as in CommonMark), so literal text like
 # "#1 Best Seller" is not mistaken for a marker.
@@ -549,7 +570,7 @@ def build_layout_pages(
             ``bbox_scale=None`` pipelines, prompted with the ``*_ABS``
             variants), normalized by the image dimensions.
     """
-    if not items or not image_width or not image_height:
+    if not image_width or not image_height:
         return []
 
     if bbox_scale is None:
@@ -612,9 +633,6 @@ def build_layout_pages(
             item_type = "text"
 
         layout_items.append(LayoutItemIR(type=item_type, value=text, bbox=seg, layout_segments=[seg]))
-
-    if not layout_items:
-        return []
 
     return [
         ParseLayoutPageIR(

--- a/src/parse_bench/inference/providers/parse/_layout_utils.py
+++ b/src/parse_bench/inference/providers/parse/_layout_utils.py
@@ -68,7 +68,7 @@ USER_PROMPT_LAYOUT = (
     "Use HTML tables for any tabular data. "
     "For charts/graphs, use flat combined column headers. "
     "Output ONLY the parsed content with div wrappers, "
-    "no explanations."
+    "no explanations. If the page is genuinely blank, output exactly []."
 )
 
 # ---------------------------------------------------------------------------
@@ -434,6 +434,22 @@ def parse_layout_blocks(content: str) -> list[dict[str, Any]]:
         except json.JSONDecodeError:
             logger.warning(f"Failed to parse bbox: {bbox_str}")
 
+    return blocks
+
+
+def parse_layout_response(content: str) -> list[dict[str, Any]]:
+    """Parse a complete layout response and reject malformed output.
+
+    An explicit empty JSON array is the only empty representation accepted by
+    the layout protocol. It proves that the model returned a structured blank
+    page rather than no output. Any other response must contain at least one
+    valid layout wrapper.
+    """
+    if content.strip() == "[]":
+        return []
+    blocks = parse_layout_blocks(content)
+    if not blocks:
+        raise ValueError("layout response contains no valid layout elements")
     return blocks
 
 

--- a/src/parse_bench/inference/providers/parse/_multipage_image.py
+++ b/src/parse_bench/inference/providers/parse/_multipage_image.py
@@ -55,10 +55,9 @@ class ParseProviderPdfClassification:
 
 # Authoritative inventory for every registered parse provider. A provider is
 # either locally page-rasterized (and must declare its bounded execution path)
-# or explicitly classified as not locally page-rasterized. Coverage tests walk
-# registration decorators structurally, including imported aliases, so adding
-# any provider requires a deliberate entry here regardless of the raster API it
-# chooses.
+# or explicitly classified as not locally page-rasterized. Coverage tests compare
+# this inventory with both the authoritative parse-module manifest and the runtime
+# registry, independent of decorator source syntax.
 PARSE_PROVIDER_PDF_CLASSIFICATIONS = (
     ParseProviderPdfClassification(
         "amazon_nova", "amazon_nova", "AmazonNovaProvider", "local-page-raster", 150, "direct"

--- a/src/parse_bench/inference/providers/parse/_multipage_image.py
+++ b/src/parse_bench/inference/providers/parse/_multipage_image.py
@@ -1,0 +1,157 @@
+"""Page-wise execution adapter for image-backed parse providers.
+
+Many vision providers accept exactly one raster image per request.  This module
+lets those providers keep their existing single-image implementation while
+giving PDF inputs document semantics: every page is rendered, submitted in
+order, and normalized into one :class:`ParseOutput`.
+
+The adapter is deliberately opt-in.  Providers that natively accept PDFs or
+already implement page-wise inference should not use it.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from collections.abc import Callable
+from datetime import datetime
+from pathlib import Path
+
+from PIL import Image
+
+from parse_bench.inference.providers.base import ProviderConfigError, ProviderPermanentError
+from parse_bench.schemas.parse_output import PageIR, ParseLayoutPageIR, ParseOutput
+from parse_bench.schemas.pipeline import PipelineSpec
+from parse_bench.schemas.pipeline_io import InferenceRequest, InferenceResult, RawInferenceResult
+from parse_bench.schemas.product import ProductType
+
+_MULTIPAGE_KEY = "_parse_bench_multipage"
+
+
+def run_pdf_pages(
+    pipeline: PipelineSpec,
+    request: InferenceRequest,
+    *,
+    dpi: int,
+    run_single_image: Callable[[PipelineSpec, InferenceRequest], RawInferenceResult],
+) -> RawInferenceResult | None:
+    """Run a single-image provider once per PDF page.
+
+    ``None`` means the source is not a PDF and the provider should continue down
+    its normal single-image path.  Page results remain JSON-serializable so raw
+    benchmark artifacts can be checkpointed and normalized again later.
+    """
+
+    source_path = Path(request.source_file_path)
+    if request.product_type != ProductType.PARSE or source_path.suffix.lower() != ".pdf":
+        return None
+
+    try:
+        from pdf2image import convert_from_path
+    except ImportError as exc:
+        raise ProviderConfigError("pdf2image is required to process PDF inputs") from exc
+
+    started_at = datetime.now()
+    try:
+        images = convert_from_path(source_path, dpi=dpi)
+    except Exception as exc:
+        raise ProviderPermanentError(f"Failed to convert PDF to images: {exc}") from exc
+
+    if not images:
+        raise ProviderPermanentError(f"No pages found in PDF: {source_path}")
+
+    page_results: list[dict[str, object]] = []
+    with tempfile.TemporaryDirectory(prefix="parse-bench-pages-") as temp_dir:
+        for page_index, image in enumerate(images):
+            page_path = Path(temp_dir) / f"page-{page_index + 1:06d}.png"
+            _save_png(image, page_path)
+            page_request = request.model_copy(update={"source_file_path": str(page_path)})
+            page_result = run_single_image(pipeline, page_request)
+            page_results.append(
+                {
+                    "page_index": page_index,
+                    "raw_output": page_result.raw_output,
+                    "latency_in_ms": page_result.latency_in_ms,
+                }
+            )
+
+    completed_at = datetime.now()
+    return RawInferenceResult(
+        request=request,
+        pipeline=pipeline,
+        pipeline_name=pipeline.pipeline_name,
+        product_type=request.product_type,
+        raw_output={
+            _MULTIPAGE_KEY: {
+                "version": 1,
+                "num_pages": len(page_results),
+                "pages": page_results,
+            }
+        },
+        started_at=started_at,
+        completed_at=completed_at,
+        latency_in_ms=int((completed_at - started_at).total_seconds() * 1000),
+    )
+
+
+def normalize_pdf_pages(
+    raw_result: RawInferenceResult,
+    *,
+    normalize_single_image: Callable[[RawInferenceResult], InferenceResult],
+) -> InferenceResult | None:
+    """Normalize and combine a result produced by :func:`run_pdf_pages`."""
+
+    envelope = raw_result.raw_output.get(_MULTIPAGE_KEY)
+    if not isinstance(envelope, dict):
+        return None
+
+    page_records = envelope.get("pages")
+    if not isinstance(page_records, list):
+        raise ProviderPermanentError("Invalid multipage raw output: 'pages' must be a list")
+
+    pages: list[PageIR] = []
+    layout_pages: list[ParseLayoutPageIR] = []
+    for expected_index, record in enumerate(page_records):
+        if not isinstance(record, dict) or not isinstance(record.get("raw_output"), dict):
+            raise ProviderPermanentError(f"Invalid multipage raw output for page {expected_index + 1}")
+
+        page_index = record.get("page_index")
+        if page_index != expected_index:
+            raise ProviderPermanentError("Invalid multipage raw output: pages must be contiguous and in document order")
+
+        single_raw = raw_result.model_copy(update={"raw_output": record["raw_output"]})
+        single_result = normalize_single_image(single_raw)
+        single_output = single_result.output
+        if not isinstance(single_output, ParseOutput):
+            raise ProviderPermanentError("Multipage image adapter only supports parse outputs")
+
+        pages.append(PageIR(page_index=expected_index, markdown=single_output.markdown))
+        layout_pages.extend(
+            page.model_copy(update={"page_number": expected_index + 1}) for page in single_output.layout_pages
+        )
+
+    markdown = "\n\n".join(page.markdown for page in pages)
+    output = ParseOutput(
+        example_id=raw_result.request.example_id,
+        pipeline_name=raw_result.pipeline_name,
+        pages=pages,
+        layout_pages=layout_pages,
+        markdown=markdown,
+    )
+    return InferenceResult(
+        request=raw_result.request,
+        pipeline_name=raw_result.pipeline_name,
+        product_type=raw_result.product_type,
+        raw_output=raw_result.raw_output,
+        output=output,
+        started_at=raw_result.started_at,
+        completed_at=raw_result.completed_at,
+        latency_in_ms=raw_result.latency_in_ms,
+    )
+
+
+def _save_png(image: Image.Image, destination: Path) -> None:
+    """Persist a rendered page without leaking an open PDF image handle."""
+
+    if image.mode not in ("RGB", "RGBA"):
+        image = image.convert("RGB")
+    image.save(destination, format="PNG")

--- a/src/parse_bench/inference/providers/parse/_multipage_image.py
+++ b/src/parse_bench/inference/providers/parse/_multipage_image.py
@@ -46,33 +46,53 @@ def run_pdf_pages(
         return None
 
     try:
-        from pdf2image import convert_from_path
+        from pdf2image import convert_from_path, pdfinfo_from_path
     except ImportError as exc:
         raise ProviderConfigError("pdf2image is required to process PDF inputs") from exc
 
     started_at = datetime.now()
     try:
-        images = convert_from_path(source_path, dpi=dpi)
+        page_count = pdfinfo_from_path(str(source_path)).get("Pages")
     except Exception as exc:
-        raise ProviderPermanentError(f"Failed to convert PDF to images: {exc}") from exc
+        raise ProviderPermanentError(f"Failed to inspect PDF: {exc}") from exc
 
-    if not images:
+    if not isinstance(page_count, int) or isinstance(page_count, bool) or page_count < 1:
         raise ProviderPermanentError(f"No pages found in PDF: {source_path}")
 
     page_results: list[dict[str, object]] = []
     with tempfile.TemporaryDirectory(prefix="parse-bench-pages-") as temp_dir:
-        for page_index, image in enumerate(images):
+        for page_index in range(page_count):
+            page_number = page_index + 1
+            try:
+                images = convert_from_path(
+                    str(source_path),
+                    dpi=dpi,
+                    first_page=page_number,
+                    last_page=page_number,
+                )
+            except Exception as exc:
+                raise ProviderPermanentError(f"Failed to render PDF page {page_number}: {exc}") from exc
+
+            if len(images) != 1:
+                for image in images:
+                    image.close()
+                raise ProviderPermanentError(f"Expected one image for PDF page {page_number}, got {len(images)}")
+
+            image = images[0]
             page_path = Path(temp_dir) / f"page-{page_index + 1:06d}.png"
-            _save_png(image, page_path)
-            page_request = request.model_copy(update={"source_file_path": str(page_path)})
-            page_result = run_single_image(pipeline, page_request)
-            page_results.append(
-                {
-                    "page_index": page_index,
-                    "raw_output": page_result.raw_output,
-                    "latency_in_ms": page_result.latency_in_ms,
-                }
-            )
+            try:
+                _save_png(image, page_path)
+                page_request = request.model_copy(update={"source_file_path": str(page_path)})
+                page_result = run_single_image(pipeline, page_request)
+                page_results.append(
+                    {
+                        "page_index": page_index,
+                        "raw_output": page_result.raw_output,
+                        "latency_in_ms": page_result.latency_in_ms,
+                    }
+                )
+            finally:
+                image.close()
 
     completed_at = datetime.now()
     return RawInferenceResult(
@@ -152,6 +172,9 @@ def normalize_pdf_pages(
 def _save_png(image: Image.Image, destination: Path) -> None:
     """Persist a rendered page without leaking an open PDF image handle."""
 
-    if image.mode not in ("RGB", "RGBA"):
-        image = image.convert("RGB")
-    image.save(destination, format="PNG")
+    if image.mode in ("RGB", "RGBA"):
+        image.save(destination, format="PNG")
+        return
+
+    with image.convert("RGB") as converted:
+        converted.save(destination, format="PNG")

--- a/src/parse_bench/inference/providers/parse/_multipage_image.py
+++ b/src/parse_bench/inference/providers/parse/_multipage_image.py
@@ -47,6 +47,7 @@ def run_page_with_retries[PageResultT](
     provider_name: str,
     page_number: int,
     attempt_ledger: list[dict[str, object]] | None = None,
+    prior_attempt_ledger: list[dict[str, object]] | None = None,
 ) -> PageResultT:
     """Run one billable page and record every physical provider attempt."""
 
@@ -66,9 +67,12 @@ def run_page_with_retries[PageResultT](
                     }
                 )
             if attempt == _PAGE_MAX_ATTEMPTS - 1:
+                debug_attempts = list(attempt_ledger or [])
+                if prior_attempt_ledger is not None and prior_attempt_ledger is not attempt_ledger:
+                    debug_attempts = [*prior_attempt_ledger, *debug_attempts]
                 raise ProviderRetryExhaustedError(
                     f"{provider_name} page {page_number} failed after {_PAGE_MAX_ATTEMPTS} attempts: {exc}",
-                    debug_payload={"attempts": list(attempt_ledger or [])},
+                    debug_payload={"attempts": debug_attempts},
                 ) from exc
             time.sleep(_PAGE_INITIAL_BACKOFF_S * (2**attempt))
         else:
@@ -119,9 +123,33 @@ def append_attempt_usages(
                 and not isinstance(value, bool)
                 and math.isfinite(value)
             }
+            required = {"input_tokens", "output_tokens", "total_tokens"}
+            usage_known = required.issubset(usage)
             for key in ("input_tokens", "output_tokens", "thinking_tokens", "total_tokens"):
                 usage.setdefault(key, 0)
+            if not usage_known:
+                usage["_usage_known"] = 0
             usages.append(usage)
+
+
+def attempt_usages_complete(usages: list[dict[str, int]]) -> bool:
+    """Whether every physical attempt supplied a usable token accounting record."""
+    required = {"input_tokens", "output_tokens", "total_tokens"}
+    return bool(usages) and all(usage.get("_usage_known", 1) == 1 and required.issubset(usage) for usage in usages)
+
+
+def include_prior_attempts(
+    error: ProviderRetryExhaustedError,
+    prior_attempts: list[dict[str, object]],
+) -> None:
+    """Prepend completed-page attempts to a terminal retry payload."""
+    payload = dict(error.debug_payload or {})
+    current_attempts = payload.get("attempts")
+    payload["attempts"] = [
+        *prior_attempts,
+        *(current_attempts if isinstance(current_attempts, list) else []),
+    ]
+    error.debug_payload = payload
 
 
 def annotate_attempt_costs(
@@ -135,8 +163,10 @@ def annotate_attempt_costs(
         stats = attempt.get("stats")
         if not isinstance(stats, dict):
             continue
-        input_tokens = stats.get("input_tokens", 0)
-        output_tokens = stats.get("output_tokens", 0)
+        if "input_tokens" not in stats or "output_tokens" not in stats:
+            continue
+        input_tokens = stats["input_tokens"]
+        output_tokens = stats["output_tokens"]
         thinking_tokens = stats.get("thinking_tokens", 0)
         if not all(
             isinstance(value, (int, float)) and not isinstance(value, bool)
@@ -445,12 +475,23 @@ def run_pdf_pages(
                 _save_png(image, page_path)
                 page_request = request.model_copy(update={"source_file_path": str(page_path)})
                 attempts: list[dict[str, object]] = []
-                page_result = run_page_with_retries(
-                    partial(run_single_image, pipeline, page_request),
-                    provider_name=pipeline.provider_name,
-                    page_number=page_index + 1,
-                    attempt_ledger=attempts,
-                )
+                try:
+                    page_result = run_page_with_retries(
+                        partial(run_single_image, pipeline, page_request),
+                        provider_name=pipeline.provider_name,
+                        page_number=page_index + 1,
+                        attempt_ledger=attempts,
+                    )
+                except ProviderRetryExhaustedError as error:
+                    completed_attempts: list[dict[str, object]] = []
+                    for record in page_results:
+                        record_attempts = record.get("attempts")
+                        if isinstance(record_attempts, list):
+                            completed_attempts.extend(
+                                attempt for attempt in record_attempts if isinstance(attempt, dict)
+                            )
+                    include_prior_attempts(error, completed_attempts)
+                    raise
                 page_results.append(
                     {
                         "page_index": page_index,

--- a/src/parse_bench/inference/providers/parse/_multipage_image.py
+++ b/src/parse_bench/inference/providers/parse/_multipage_image.py
@@ -11,6 +11,7 @@ already implement page-wise inference should not use it.
 
 from __future__ import annotations
 
+import importlib
 import math
 import tempfile
 import time
@@ -68,8 +69,17 @@ class ImageBackedPdfProviderSpec:
     provider_name: str
     module_name: str
     class_name: str
-    dpi: int
     execution: str
+
+    @property
+    def dpi(self) -> int:
+        """Read the provider's actual declared render default lazily."""
+        module = importlib.import_module(f"parse_bench.inference.providers.parse.{self.module_name}")
+        provider_class = getattr(module, self.class_name)
+        dpi = getattr(provider_class, "PDF_RENDER_DPI", None)
+        if not isinstance(dpi, int) or isinstance(dpi, bool) or dpi <= 0:
+            raise ValueError(f"{self.class_name}.PDF_RENDER_DPI must be a positive integer")
+        return dpi
 
 
 @dataclass(frozen=True)
@@ -80,7 +90,6 @@ class ParseProviderPdfClassification:
     module_name: str
     class_name: str
     pdf_handling: str
-    dpi: int | None = None
     execution: str | None = None
 
 
@@ -90,77 +99,73 @@ class ParseProviderPdfClassification:
 # this inventory with both the authoritative parse-module manifest and the runtime
 # registry, independent of decorator source syntax.
 PARSE_PROVIDER_PDF_CLASSIFICATIONS = (
-    ParseProviderPdfClassification(
-        "amazon_nova", "amazon_nova", "AmazonNovaProvider", "local-page-raster", 150, "direct"
-    ),
-    ParseProviderPdfClassification("anthropic", "anthropic", "AnthropicProvider", "local-page-raster", 144, "direct"),
+    ParseProviderPdfClassification("amazon_nova", "amazon_nova", "AmazonNovaProvider", "local-page-raster", "direct"),
+    ParseProviderPdfClassification("anthropic", "anthropic", "AnthropicProvider", "local-page-raster", "direct"),
     ParseProviderPdfClassification(
         "azure_document_intelligence",
         "azure_document_intelligence",
         "AzureDocumentIntelligenceProvider",
         "no-local-page-raster",
     ),
-    ParseProviderPdfClassification("chandra2", "chandra2", "Chandra2Provider", "local-page-raster", 144, "adapter"),
+    ParseProviderPdfClassification("chandra2", "chandra2", "Chandra2Provider", "local-page-raster", "adapter"),
     ParseProviderPdfClassification("chunkr", "chunkr", "ChunkrProvider", "no-local-page-raster"),
     ParseProviderPdfClassification(
         "databricks_ai_parse", "databricks_ai_parse", "DatabricksAiParseProvider", "no-local-page-raster"
     ),
     ParseProviderPdfClassification("datalab", "datalab", "DatalabProvider", "no-local-page-raster"),
     ParseProviderPdfClassification(
-        "deepseekocr2", "deepseekocr2", "DeepSeekOCR2Provider", "local-page-raster", 144, "adapter"
+        "deepseekocr2", "deepseekocr2", "DeepSeekOCR2Provider", "local-page-raster", "adapter"
     ),
     ParseProviderPdfClassification("docling_parse", "docling", "DoclingParseProvider", "no-local-page-raster"),
     ParseProviderPdfClassification("docling_serve", "docling_serve", "DoclingServeProvider", "no-local-page-raster"),
-    ParseProviderPdfClassification(
-        "dots_ocr_parse", "dots_ocr", "DotsOcrParseProvider", "local-page-raster", 144, "direct"
-    ),
+    ParseProviderPdfClassification("dots_ocr_parse", "dots_ocr", "DotsOcrParseProvider", "local-page-raster", "direct"),
     ParseProviderPdfClassification("extend_parse", "extend_parse", "ExtendParseProvider", "no-local-page-raster"),
-    ParseProviderPdfClassification("falconocr", "falconocr", "FalconOcrProvider", "local-page-raster", 144, "adapter"),
-    ParseProviderPdfClassification("gemma4", "gemma4", "Gemma4Provider", "local-page-raster", 144, "adapter"),
-    ParseProviderPdfClassification("google", "google", "GoogleProvider", "local-page-raster", 144, "direct"),
+    ParseProviderPdfClassification("falconocr", "falconocr", "FalconOcrProvider", "local-page-raster", "adapter"),
+    ParseProviderPdfClassification("gemma4", "gemma4", "Gemma4Provider", "local-page-raster", "adapter"),
+    ParseProviderPdfClassification("google", "google", "GoogleProvider", "local-page-raster", "direct"),
     ParseProviderPdfClassification("google_docai", "google_docai", "GoogleDocAIProvider", "no-local-page-raster"),
     ParseProviderPdfClassification(
-        "granite_vision", "granite_vision", "GraniteVisionProvider", "local-page-raster", 144, "adapter"
+        "granite_vision", "granite_vision", "GraniteVisionProvider", "local-page-raster", "adapter"
     ),
     ParseProviderPdfClassification(
-        "infinity_parser2", "infinity_parser2", "InfinityParser2Provider", "local-page-raster", 300, "adapter"
+        "infinity_parser2", "infinity_parser2", "InfinityParser2Provider", "local-page-raster", "adapter"
     ),
     ParseProviderPdfClassification(
-        "kdl_frontier_nano", "kdl_frontier_nano", "KdlFrontierNanoProvider", "local-page-raster", 144, "kdl"
+        "kdl_frontier_nano", "kdl_frontier_nano", "KdlFrontierNanoProvider", "local-page-raster", "kdl"
     ),
     ParseProviderPdfClassification("landingai", "landingai", "LandingAIParseProvider", "no-local-page-raster"),
     ParseProviderPdfClassification("liteparse", "liteparse", "LiteParseProvider", "no-local-page-raster"),
     ParseProviderPdfClassification("llamaparse", "llamaparse", "LlamaParseProvider", "no-local-page-raster"),
     ParseProviderPdfClassification("markitdown", "markitdown", "MarkItDownProvider", "no-local-page-raster"),
-    ParseProviderPdfClassification("mineru25", "mineru25", "MinerU25Provider", "local-page-raster", 144, "adapter"),
+    ParseProviderPdfClassification("mineru25", "mineru25", "MinerU25Provider", "local-page-raster", "adapter"),
     ParseProviderPdfClassification(
-        "mineru2605pro", "mineru2605pro", "MinerU2605ProProvider", "local-page-raster", 144, "adapter"
+        "mineru2605pro", "mineru2605pro", "MinerU2605ProProvider", "local-page-raster", "adapter"
     ),
     ParseProviderPdfClassification(
-        "mineru_diffusion", "mineru_diffusion", "MinerUDiffusionProvider", "local-page-raster", 144, "adapter"
+        "mineru_diffusion", "mineru_diffusion", "MinerUDiffusionProvider", "local-page-raster", "adapter"
     ),
     ParseProviderPdfClassification("mistral_ocr", "mistral_ocr", "MistralOCRProvider", "no-local-page-raster"),
     ParseProviderPdfClassification(
-        "nemotron_omni", "nemotron_omni", "NemotronOmniProvider", "local-page-raster", 144, "adapter"
+        "nemotron_omni", "nemotron_omni", "NemotronOmniProvider", "local-page-raster", "adapter"
     ),
     ParseProviderPdfClassification("oi_parser", "oi_parser", "OIParserProvider", "no-local-page-raster"),
-    ParseProviderPdfClassification("openai", "openai", "OpenAIProvider", "local-page-raster", 144, "direct"),
+    ParseProviderPdfClassification("openai", "openai", "OpenAIProvider", "local-page-raster", "direct"),
     ParseProviderPdfClassification(
         "opendataloader", "opendataloader", "OpenDataLoaderProvider", "no-local-page-raster"
     ),
-    ParseProviderPdfClassification("paddleocr", "paddleocr", "PaddleOCRProvider", "local-page-raster", 144, "adapter"),
+    ParseProviderPdfClassification("paddleocr", "paddleocr", "PaddleOCRProvider", "local-page-raster", "adapter"),
     ParseProviderPdfClassification("pdf_inspector", "pdf_inspector", "PdfInspectorProvider", "no-local-page-raster"),
     ParseProviderPdfClassification("pulse", "pulse", "PulseProvider", "no-local-page-raster"),
     ParseProviderPdfClassification("pymupdf", "pymupdf", "PyMuPDFProvider", "no-local-page-raster"),
     ParseProviderPdfClassification("pymupdf4llm", "pymupdf4llm", "PyMuPDF4LLMProvider", "no-local-page-raster"),
     ParseProviderPdfClassification("pypdf", "pypdf", "PyPDFProvider", "no-local-page-raster"),
-    ParseProviderPdfClassification("qwen3_5", "qwen3_5", "Qwen35Provider", "local-page-raster", 144, "adapter"),
+    ParseProviderPdfClassification("qwen3_5", "qwen3_5", "Qwen35Provider", "local-page-raster", "adapter"),
     ParseProviderPdfClassification("reducto", "reducto", "ReductoProvider", "no-local-page-raster"),
-    ParseProviderPdfClassification("surya2", "surya2", "Surya2Provider", "local-page-raster", 144, "adapter"),
-    ParseProviderPdfClassification("tesseract", "tesseract", "TesseractProvider", "local-page-raster", 144, "direct"),
-    ParseProviderPdfClassification("textract", "textract", "TextractProvider", "local-page-raster", 300, "direct"),
+    ParseProviderPdfClassification("surya2", "surya2", "Surya2Provider", "local-page-raster", "adapter"),
+    ParseProviderPdfClassification("tesseract", "tesseract", "TesseractProvider", "local-page-raster", "direct"),
+    ParseProviderPdfClassification("textract", "textract", "TextractProvider", "local-page-raster", "direct"),
     ParseProviderPdfClassification(
-        "unlimitedocr", "unlimitedocr", "UnlimitedOCRProvider", "local-page-raster", 144, "adapter"
+        "unlimitedocr", "unlimitedocr", "UnlimitedOCRProvider", "local-page-raster", "adapter"
     ),
     ParseProviderPdfClassification("unstructured", "unstructured", "UnstructuredProvider", "no-local-page-raster"),
     ParseProviderPdfClassification("warp_ingest", "warp_ingest", "WarpIngestProvider", "no-local-page-raster"),
@@ -172,14 +177,13 @@ def _image_backed_provider_specs() -> tuple[ImageBackedPdfProviderSpec, ...]:
     for classification in PARSE_PROVIDER_PDF_CLASSIFICATIONS:
         if classification.pdf_handling != "local-page-raster":
             continue
-        if classification.dpi is None or classification.execution is None:
+        if classification.execution is None:
             raise ValueError(f"Incomplete local raster classification for {classification.provider_name}")
         specs.append(
             ImageBackedPdfProviderSpec(
                 classification.provider_name,
                 classification.module_name,
                 classification.class_name,
-                classification.dpi,
                 classification.execution,
             )
         )

--- a/src/parse_bench/inference/providers/parse/_multipage_image.py
+++ b/src/parse_bench/inference/providers/parse/_multipage_image.py
@@ -13,21 +13,52 @@ from __future__ import annotations
 
 import math
 import tempfile
+import time
 from collections.abc import Callable, Generator, Iterator
 from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
 from datetime import datetime
+from functools import partial
 from pathlib import Path
 
 from PIL import Image
 
-from parse_bench.inference.providers.base import ProviderConfigError, ProviderPermanentError
+from parse_bench.inference.providers.base import (
+    ProviderConfigError,
+    ProviderPermanentError,
+    ProviderRateLimitError,
+    ProviderRetryExhaustedError,
+    ProviderTransientError,
+)
 from parse_bench.schemas.parse_output import PageIR, ParseLayoutPageIR, ParseOutput
 from parse_bench.schemas.pipeline import PipelineSpec
 from parse_bench.schemas.pipeline_io import InferenceRequest, InferenceResult, RawInferenceResult
 from parse_bench.schemas.product import ProductType
 
 _MULTIPAGE_KEY = "_parse_bench_multipage"
+_PAGE_MAX_ATTEMPTS = 3
+_PAGE_INITIAL_BACKOFF_S = 2.0
+
+
+def run_page_with_retries[PageResultT](
+    call: Callable[[], PageResultT],
+    *,
+    provider_name: str,
+    page_number: int,
+) -> PageResultT:
+    """Run one billable page with the sole retry budget for that page."""
+
+    for attempt in range(_PAGE_MAX_ATTEMPTS):
+        try:
+            return call()
+        except (ProviderTransientError, ProviderRateLimitError) as exc:
+            if attempt == _PAGE_MAX_ATTEMPTS - 1:
+                raise ProviderRetryExhaustedError(
+                    f"{provider_name} page {page_number} failed after {_PAGE_MAX_ATTEMPTS} attempts: {exc}"
+                ) from exc
+            time.sleep(_PAGE_INITIAL_BACKOFF_S * (2**attempt))
+
+    raise AssertionError("unreachable")
 
 
 @dataclass(frozen=True)
@@ -316,7 +347,11 @@ def run_pdf_pages(
                 page_path = Path(temp_dir) / f"page-{page_index + 1:06d}.png"
                 _save_png(image, page_path)
                 page_request = request.model_copy(update={"source_file_path": str(page_path)})
-                page_result = run_single_image(pipeline, page_request)
+                page_result = run_page_with_retries(
+                    partial(run_single_image, pipeline, page_request),
+                    provider_name=pipeline.provider_name,
+                    page_number=page_index + 1,
+                )
                 page_results.append(
                     {
                         "page_index": page_index,

--- a/src/parse_bench/inference/providers/parse/_multipage_image.py
+++ b/src/parse_bench/inference/providers/parse/_multipage_image.py
@@ -53,19 +53,14 @@ def run_page_with_retries[PageResultT](
 
     for attempt in range(_PAGE_MAX_ATTEMPTS):
         try:
-            result = call()
+            result = run_page_once(
+                call,
+                page_number=page_number,
+                attempt=attempt + 1,
+                attempt_ledger=attempt_ledger,
+                prior_attempt_ledger=prior_attempt_ledger,
+            )
         except (ProviderTransientError, ProviderRateLimitError) as exc:
-            if attempt_ledger is not None:
-                attempt_ledger.append(
-                    {
-                        "page_number": page_number,
-                        "attempt": attempt + 1,
-                        "status": "failed",
-                        "stats": dict(exc.attempt_stats or {}),
-                        "error_type": type(exc).__name__,
-                        "error": str(exc),
-                    }
-                )
             if attempt == _PAGE_MAX_ATTEMPTS - 1:
                 debug_attempts = list(attempt_ledger or [])
                 if prior_attempt_ledger is not None and prior_attempt_ledger is not attempt_ledger:
@@ -76,18 +71,54 @@ def run_page_with_retries[PageResultT](
                 ) from exc
             time.sleep(_PAGE_INITIAL_BACKOFF_S * (2**attempt))
         else:
-            if attempt_ledger is not None:
-                attempt_ledger.append(
-                    {
-                        "page_number": page_number,
-                        "attempt": attempt + 1,
-                        "status": "succeeded",
-                        "stats": _result_attempt_stats(result),
-                    }
-                )
             return result
 
     raise AssertionError("unreachable")
+
+
+def run_page_once[PageResultT](
+    call: Callable[[], PageResultT],
+    *,
+    page_number: int,
+    attempt: int = 1,
+    attempt_ledger: list[dict[str, object]] | None = None,
+    prior_attempt_ledger: list[dict[str, object]] | None = None,
+) -> PageResultT:
+    """Run one physical provider call, preserving its original error semantics."""
+    try:
+        result = call()
+    except (ProviderPermanentError, ProviderTransientError, ProviderRateLimitError) as exc:
+        if attempt_ledger is not None:
+            attempt_ledger.append(
+                {
+                    "page_number": page_number,
+                    "attempt": attempt,
+                    "status": "failed",
+                    "stats": dict(exc.attempt_stats or {}),
+                    "error_type": type(exc).__name__,
+                    "error": str(exc),
+                }
+            )
+        payload = dict(exc.debug_payload or {})
+        current_attempts = payload.get("attempts")
+        recorded_attempts = list(attempt_ledger or [])
+        if prior_attempt_ledger is not None and prior_attempt_ledger is not attempt_ledger:
+            recorded_attempts = [*prior_attempt_ledger, *recorded_attempts]
+        if isinstance(current_attempts, list) and current_attempts != recorded_attempts:
+            recorded_attempts.extend(current_attempts)
+        payload["attempts"] = recorded_attempts
+        exc.debug_payload = payload
+        raise
+    if attempt_ledger is not None:
+        attempt_ledger.append(
+            {
+                "page_number": page_number,
+                "attempt": attempt,
+                "status": "succeeded",
+                "stats": _result_attempt_stats(result),
+            }
+        )
+    return result
 
 
 def _result_attempt_stats(result: object) -> dict[str, int | float]:
@@ -125,8 +156,6 @@ def append_attempt_usages(
             }
             required = {"input_tokens", "output_tokens", "total_tokens"}
             usage_known = required.issubset(usage)
-            for key in ("input_tokens", "output_tokens", "thinking_tokens", "total_tokens"):
-                usage.setdefault(key, 0)
             if not usage_known:
                 usage["_usage_known"] = 0
             usages.append(usage)
@@ -157,6 +186,8 @@ def annotate_attempt_costs(
     *,
     input_rate_per_million: float,
     output_rate_per_million: float,
+    output_tokens_include_thinking: bool = False,
+    cached_input_rate_per_million: float | None = None,
 ) -> None:
     """Add the same token-derived cost used by document summaries to each attempt."""
     for attempt in attempts:
@@ -168,13 +199,22 @@ def annotate_attempt_costs(
         input_tokens = stats["input_tokens"]
         output_tokens = stats["output_tokens"]
         thinking_tokens = stats.get("thinking_tokens", 0)
+        cached_content_tokens = stats.get("cached_content_tokens", 0)
         if not all(
             isinstance(value, (int, float)) and not isinstance(value, bool)
-            for value in (input_tokens, output_tokens, thinking_tokens)
+            for value in (input_tokens, output_tokens, thinking_tokens, cached_content_tokens)
         ):
             continue
+        if cached_content_tokens and cached_input_rate_per_million is None:
+            continue
+        cached_tokens = min(input_tokens, cached_content_tokens)
+        output_and_thinking_tokens = (
+            output_tokens if output_tokens_include_thinking else output_tokens + thinking_tokens
+        )
         stats["cost_usd"] = (
-            input_tokens * input_rate_per_million + (output_tokens + thinking_tokens) * output_rate_per_million
+            (input_tokens - cached_tokens) * input_rate_per_million
+            + cached_tokens * (cached_input_rate_per_million or 0.0)
+            + output_and_thinking_tokens * output_rate_per_million
         ) / 1_000_000
 
 

--- a/src/parse_bench/inference/providers/parse/_multipage_image.py
+++ b/src/parse_bench/inference/providers/parse/_multipage_image.py
@@ -11,9 +11,10 @@ already implement page-wise inference should not use it.
 
 from __future__ import annotations
 
+import math
 import tempfile
 from collections.abc import Callable, Generator, Iterator
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from datetime import datetime
 from pathlib import Path
 
@@ -26,6 +27,56 @@ from parse_bench.schemas.pipeline_io import InferenceRequest, InferenceResult, R
 from parse_bench.schemas.product import ProductType
 
 _MULTIPAGE_KEY = "_parse_bench_multipage"
+
+# Public operational-stat fields consumed by evaluation/stats.py. Totals are
+# additive across requests; per-page values are arithmetic means.
+_ADDITIVE_STAT_FIELDS = (
+    "credits_used",
+    "cost_usd",
+    "input_cost_usd",
+    "tool_use_prompt_cost_usd",
+    "cached_input_cost_usd",
+    "output_and_thinking_cost_usd",
+    "cache_storage_cost_usd",
+    "input_tokens",
+    "tool_use_prompt_tokens",
+    "cached_content_tokens",
+    "output_tokens",
+    "total_tokens",
+    "thinking_tokens",
+    "num_api_calls",
+)
+_PER_PAGE_STAT_FIELDS = (
+    "cost_per_page_usd",
+    "input_tokens_per_page",
+    "tool_use_prompt_tokens_per_page",
+    "cached_content_tokens_per_page",
+    "output_tokens_per_page",
+)
+
+
+@contextmanager
+def close_derived_images(
+    original: Image.Image,
+) -> Iterator[Callable[[Image.Image], Image.Image]]:
+    """Track and close PIL images derived from a caller-owned image.
+
+    Providers may resize or convert a page several times before encoding it.
+    Every tracked derivative is closed on success and failure, while the
+    original page remains owned by the caller.
+    """
+
+    with ExitStack() as stack:
+        tracked: set[int] = set()
+
+        def track(image: Image.Image) -> Image.Image:
+            image_id = id(image)
+            if image is not original and image_id not in tracked:
+                stack.callback(image.close)
+                tracked.add(image_id)
+            return image
+
+        yield track
 
 
 class PageImages:
@@ -146,22 +197,61 @@ def run_pdf_pages(
                 )
 
     completed_at = datetime.now()
+    aggregate = _aggregate_page_raw_outputs(page_results)
     return RawInferenceResult(
         request=request,
         pipeline=pipeline,
         pipeline_name=pipeline.pipeline_name,
         product_type=request.product_type,
         raw_output={
+            **aggregate,
             _MULTIPAGE_KEY: {
                 "version": 1,
                 "num_pages": len(page_results),
                 "pages": page_results,
-            }
+            },
         },
         started_at=started_at,
         completed_at=completed_at,
         latency_in_ms=int((completed_at - started_at).total_seconds() * 1000),
     )
+
+
+def _aggregate_page_raw_outputs(page_results: list[dict[str, object]]) -> dict[str, int | float]:
+    """Project complete page-level operational metadata to the top level.
+
+    A field is omitted when any page is missing it, uses a non-numeric value,
+    or contains NaN/infinity. This avoids presenting partial totals as accurate
+    document totals while preserving heterogeneous provider payloads verbatim
+    inside the multipage envelope.
+    """
+
+    aggregate: dict[str, int | float] = {"num_pages": len(page_results)}
+    raw_outputs = [record.get("raw_output") for record in page_results]
+
+    for field in _ADDITIVE_STAT_FIELDS:
+        values = _complete_numeric_values(raw_outputs, field)
+        if values is not None:
+            aggregate[field] = sum(values)
+
+    for field in _PER_PAGE_STAT_FIELDS:
+        values = _complete_numeric_values(raw_outputs, field)
+        if values is not None:
+            aggregate[field] = sum(values) / len(values)
+
+    return aggregate
+
+
+def _complete_numeric_values(raw_outputs: list[object], field: str) -> list[int | float] | None:
+    values: list[int | float] = []
+    for raw_output in raw_outputs:
+        if not isinstance(raw_output, dict):
+            return None
+        value = raw_output.get(field)
+        if not isinstance(value, (int, float)) or isinstance(value, bool) or not math.isfinite(value):
+            return None
+        values.append(value)
+    return values or None
 
 
 def normalize_pdf_pages(

--- a/src/parse_bench/inference/providers/parse/_multipage_image.py
+++ b/src/parse_bench/inference/providers/parse/_multipage_image.py
@@ -41,33 +41,122 @@ class ImageBackedPdfProviderSpec:
     execution: str
 
 
-# Authoritative inventory for local PDF-to-image parse providers. Tests derive
-# their provider matrices from this manifest and verify it against registered
-# provider decorators plus the page-rendering calls in provider source.
-IMAGE_BACKED_PDF_PROVIDERS = (
-    ImageBackedPdfProviderSpec("amazon_nova", "amazon_nova", "AmazonNovaProvider", 150, "direct"),
-    ImageBackedPdfProviderSpec("anthropic", "anthropic", "AnthropicProvider", 144, "direct"),
-    ImageBackedPdfProviderSpec("chandra2", "chandra2", "Chandra2Provider", 144, "adapter"),
-    ImageBackedPdfProviderSpec("deepseekocr2", "deepseekocr2", "DeepSeekOCR2Provider", 144, "adapter"),
-    ImageBackedPdfProviderSpec("dots_ocr_parse", "dots_ocr", "DotsOcrParseProvider", 144, "direct"),
-    ImageBackedPdfProviderSpec("falconocr", "falconocr", "FalconOcrProvider", 144, "adapter"),
-    ImageBackedPdfProviderSpec("gemma4", "gemma4", "Gemma4Provider", 144, "adapter"),
-    ImageBackedPdfProviderSpec("google", "google", "GoogleProvider", 144, "direct"),
-    ImageBackedPdfProviderSpec("granite_vision", "granite_vision", "GraniteVisionProvider", 144, "adapter"),
-    ImageBackedPdfProviderSpec("infinity_parser2", "infinity_parser2", "InfinityParser2Provider", 300, "adapter"),
-    ImageBackedPdfProviderSpec("kdl_frontier_nano", "kdl_frontier_nano", "KdlFrontierNanoProvider", 144, "kdl"),
-    ImageBackedPdfProviderSpec("mineru25", "mineru25", "MinerU25Provider", 144, "adapter"),
-    ImageBackedPdfProviderSpec("mineru2605pro", "mineru2605pro", "MinerU2605ProProvider", 144, "adapter"),
-    ImageBackedPdfProviderSpec("mineru_diffusion", "mineru_diffusion", "MinerUDiffusionProvider", 144, "adapter"),
-    ImageBackedPdfProviderSpec("nemotron_omni", "nemotron_omni", "NemotronOmniProvider", 144, "adapter"),
-    ImageBackedPdfProviderSpec("openai", "openai", "OpenAIProvider", 144, "direct"),
-    ImageBackedPdfProviderSpec("paddleocr", "paddleocr", "PaddleOCRProvider", 144, "adapter"),
-    ImageBackedPdfProviderSpec("qwen3_5", "qwen3_5", "Qwen35Provider", 144, "adapter"),
-    ImageBackedPdfProviderSpec("surya2", "surya2", "Surya2Provider", 144, "adapter"),
-    ImageBackedPdfProviderSpec("tesseract", "tesseract", "TesseractProvider", 144, "direct"),
-    ImageBackedPdfProviderSpec("textract", "textract", "TextractProvider", 300, "direct"),
-    ImageBackedPdfProviderSpec("unlimitedocr", "unlimitedocr", "UnlimitedOCRProvider", 144, "adapter"),
+@dataclass(frozen=True)
+class ParseProviderPdfClassification:
+    """Explicit PDF execution classification for one registered parse provider."""
+
+    provider_name: str
+    module_name: str
+    class_name: str
+    pdf_handling: str
+    dpi: int | None = None
+    execution: str | None = None
+
+
+# Authoritative inventory for every registered parse provider. A provider is
+# either locally page-rasterized (and must declare its bounded execution path)
+# or explicitly classified as not locally page-rasterized. Coverage tests walk
+# registration decorators structurally, including imported aliases, so adding
+# any provider requires a deliberate entry here regardless of the raster API it
+# chooses.
+PARSE_PROVIDER_PDF_CLASSIFICATIONS = (
+    ParseProviderPdfClassification(
+        "amazon_nova", "amazon_nova", "AmazonNovaProvider", "local-page-raster", 150, "direct"
+    ),
+    ParseProviderPdfClassification("anthropic", "anthropic", "AnthropicProvider", "local-page-raster", 144, "direct"),
+    ParseProviderPdfClassification(
+        "azure_document_intelligence",
+        "azure_document_intelligence",
+        "AzureDocumentIntelligenceProvider",
+        "no-local-page-raster",
+    ),
+    ParseProviderPdfClassification("chandra2", "chandra2", "Chandra2Provider", "local-page-raster", 144, "adapter"),
+    ParseProviderPdfClassification("chunkr", "chunkr", "ChunkrProvider", "no-local-page-raster"),
+    ParseProviderPdfClassification(
+        "databricks_ai_parse", "databricks_ai_parse", "DatabricksAiParseProvider", "no-local-page-raster"
+    ),
+    ParseProviderPdfClassification("datalab", "datalab", "DatalabProvider", "no-local-page-raster"),
+    ParseProviderPdfClassification(
+        "deepseekocr2", "deepseekocr2", "DeepSeekOCR2Provider", "local-page-raster", 144, "adapter"
+    ),
+    ParseProviderPdfClassification("docling_parse", "docling", "DoclingParseProvider", "no-local-page-raster"),
+    ParseProviderPdfClassification("docling_serve", "docling_serve", "DoclingServeProvider", "no-local-page-raster"),
+    ParseProviderPdfClassification(
+        "dots_ocr_parse", "dots_ocr", "DotsOcrParseProvider", "local-page-raster", 144, "direct"
+    ),
+    ParseProviderPdfClassification("extend_parse", "extend_parse", "ExtendParseProvider", "no-local-page-raster"),
+    ParseProviderPdfClassification("falconocr", "falconocr", "FalconOcrProvider", "local-page-raster", 144, "adapter"),
+    ParseProviderPdfClassification("gemma4", "gemma4", "Gemma4Provider", "local-page-raster", 144, "adapter"),
+    ParseProviderPdfClassification("google", "google", "GoogleProvider", "local-page-raster", 144, "direct"),
+    ParseProviderPdfClassification("google_docai", "google_docai", "GoogleDocAIProvider", "no-local-page-raster"),
+    ParseProviderPdfClassification(
+        "granite_vision", "granite_vision", "GraniteVisionProvider", "local-page-raster", 144, "adapter"
+    ),
+    ParseProviderPdfClassification(
+        "infinity_parser2", "infinity_parser2", "InfinityParser2Provider", "local-page-raster", 300, "adapter"
+    ),
+    ParseProviderPdfClassification(
+        "kdl_frontier_nano", "kdl_frontier_nano", "KdlFrontierNanoProvider", "local-page-raster", 144, "kdl"
+    ),
+    ParseProviderPdfClassification("landingai", "landingai", "LandingAIParseProvider", "no-local-page-raster"),
+    ParseProviderPdfClassification("liteparse", "liteparse", "LiteParseProvider", "no-local-page-raster"),
+    ParseProviderPdfClassification("llamaparse", "llamaparse", "LlamaParseProvider", "no-local-page-raster"),
+    ParseProviderPdfClassification("markitdown", "markitdown", "MarkItDownProvider", "no-local-page-raster"),
+    ParseProviderPdfClassification("mineru25", "mineru25", "MinerU25Provider", "local-page-raster", 144, "adapter"),
+    ParseProviderPdfClassification(
+        "mineru2605pro", "mineru2605pro", "MinerU2605ProProvider", "local-page-raster", 144, "adapter"
+    ),
+    ParseProviderPdfClassification(
+        "mineru_diffusion", "mineru_diffusion", "MinerUDiffusionProvider", "local-page-raster", 144, "adapter"
+    ),
+    ParseProviderPdfClassification("mistral_ocr", "mistral_ocr", "MistralOCRProvider", "no-local-page-raster"),
+    ParseProviderPdfClassification(
+        "nemotron_omni", "nemotron_omni", "NemotronOmniProvider", "local-page-raster", 144, "adapter"
+    ),
+    ParseProviderPdfClassification("oi_parser", "oi_parser", "OIParserProvider", "no-local-page-raster"),
+    ParseProviderPdfClassification("openai", "openai", "OpenAIProvider", "local-page-raster", 144, "direct"),
+    ParseProviderPdfClassification(
+        "opendataloader", "opendataloader", "OpenDataLoaderProvider", "no-local-page-raster"
+    ),
+    ParseProviderPdfClassification("paddleocr", "paddleocr", "PaddleOCRProvider", "local-page-raster", 144, "adapter"),
+    ParseProviderPdfClassification("pdf_inspector", "pdf_inspector", "PdfInspectorProvider", "no-local-page-raster"),
+    ParseProviderPdfClassification("pulse", "pulse", "PulseProvider", "no-local-page-raster"),
+    ParseProviderPdfClassification("pymupdf", "pymupdf", "PyMuPDFProvider", "no-local-page-raster"),
+    ParseProviderPdfClassification("pymupdf4llm", "pymupdf4llm", "PyMuPDF4LLMProvider", "no-local-page-raster"),
+    ParseProviderPdfClassification("pypdf", "pypdf", "PyPDFProvider", "no-local-page-raster"),
+    ParseProviderPdfClassification("qwen3_5", "qwen3_5", "Qwen35Provider", "local-page-raster", 144, "adapter"),
+    ParseProviderPdfClassification("reducto", "reducto", "ReductoProvider", "no-local-page-raster"),
+    ParseProviderPdfClassification("surya2", "surya2", "Surya2Provider", "local-page-raster", 144, "adapter"),
+    ParseProviderPdfClassification("tesseract", "tesseract", "TesseractProvider", "local-page-raster", 144, "direct"),
+    ParseProviderPdfClassification("textract", "textract", "TextractProvider", "local-page-raster", 300, "direct"),
+    ParseProviderPdfClassification(
+        "unlimitedocr", "unlimitedocr", "UnlimitedOCRProvider", "local-page-raster", 144, "adapter"
+    ),
+    ParseProviderPdfClassification("unstructured", "unstructured", "UnstructuredProvider", "no-local-page-raster"),
+    ParseProviderPdfClassification("warp_ingest", "warp_ingest", "WarpIngestProvider", "no-local-page-raster"),
 )
+
+
+def _image_backed_provider_specs() -> tuple[ImageBackedPdfProviderSpec, ...]:
+    specs: list[ImageBackedPdfProviderSpec] = []
+    for classification in PARSE_PROVIDER_PDF_CLASSIFICATIONS:
+        if classification.pdf_handling != "local-page-raster":
+            continue
+        if classification.dpi is None or classification.execution is None:
+            raise ValueError(f"Incomplete local raster classification for {classification.provider_name}")
+        specs.append(
+            ImageBackedPdfProviderSpec(
+                classification.provider_name,
+                classification.module_name,
+                classification.class_name,
+                classification.dpi,
+                classification.execution,
+            )
+        )
+    return tuple(specs)
+
+
+IMAGE_BACKED_PDF_PROVIDERS = _image_backed_provider_specs()
 
 # Public operational-stat fields consumed by evaluation/stats.py. Totals are
 # additive across requests; per-page values are arithmetic means.

--- a/src/parse_bench/inference/providers/parse/_multipage_image.py
+++ b/src/parse_bench/inference/providers/parse/_multipage_image.py
@@ -15,6 +15,7 @@ import math
 import tempfile
 from collections.abc import Callable, Generator, Iterator
 from contextlib import ExitStack, contextmanager
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 
@@ -27,6 +28,46 @@ from parse_bench.schemas.pipeline_io import InferenceRequest, InferenceResult, R
 from parse_bench.schemas.product import ProductType
 
 _MULTIPAGE_KEY = "_parse_bench_multipage"
+
+
+@dataclass(frozen=True)
+class ImageBackedPdfProviderSpec:
+    """Registered parse provider whose PDF path rasterizes pages locally."""
+
+    provider_name: str
+    module_name: str
+    class_name: str
+    dpi: int
+    execution: str
+
+
+# Authoritative inventory for local PDF-to-image parse providers. Tests derive
+# their provider matrices from this manifest and verify it against registered
+# provider decorators plus the page-rendering calls in provider source.
+IMAGE_BACKED_PDF_PROVIDERS = (
+    ImageBackedPdfProviderSpec("amazon_nova", "amazon_nova", "AmazonNovaProvider", 150, "direct"),
+    ImageBackedPdfProviderSpec("anthropic", "anthropic", "AnthropicProvider", 144, "direct"),
+    ImageBackedPdfProviderSpec("chandra2", "chandra2", "Chandra2Provider", 144, "adapter"),
+    ImageBackedPdfProviderSpec("deepseekocr2", "deepseekocr2", "DeepSeekOCR2Provider", 144, "adapter"),
+    ImageBackedPdfProviderSpec("dots_ocr_parse", "dots_ocr", "DotsOcrParseProvider", 144, "direct"),
+    ImageBackedPdfProviderSpec("falconocr", "falconocr", "FalconOcrProvider", 144, "adapter"),
+    ImageBackedPdfProviderSpec("gemma4", "gemma4", "Gemma4Provider", 144, "adapter"),
+    ImageBackedPdfProviderSpec("google", "google", "GoogleProvider", 144, "direct"),
+    ImageBackedPdfProviderSpec("granite_vision", "granite_vision", "GraniteVisionProvider", 144, "adapter"),
+    ImageBackedPdfProviderSpec("infinity_parser2", "infinity_parser2", "InfinityParser2Provider", 300, "adapter"),
+    ImageBackedPdfProviderSpec("kdl_frontier_nano", "kdl_frontier_nano", "KdlFrontierNanoProvider", 144, "kdl"),
+    ImageBackedPdfProviderSpec("mineru25", "mineru25", "MinerU25Provider", 144, "adapter"),
+    ImageBackedPdfProviderSpec("mineru2605pro", "mineru2605pro", "MinerU2605ProProvider", 144, "adapter"),
+    ImageBackedPdfProviderSpec("mineru_diffusion", "mineru_diffusion", "MinerUDiffusionProvider", 144, "adapter"),
+    ImageBackedPdfProviderSpec("nemotron_omni", "nemotron_omni", "NemotronOmniProvider", 144, "adapter"),
+    ImageBackedPdfProviderSpec("openai", "openai", "OpenAIProvider", 144, "direct"),
+    ImageBackedPdfProviderSpec("paddleocr", "paddleocr", "PaddleOCRProvider", 144, "adapter"),
+    ImageBackedPdfProviderSpec("qwen3_5", "qwen3_5", "Qwen35Provider", 144, "adapter"),
+    ImageBackedPdfProviderSpec("surya2", "surya2", "Surya2Provider", 144, "adapter"),
+    ImageBackedPdfProviderSpec("tesseract", "tesseract", "TesseractProvider", 144, "direct"),
+    ImageBackedPdfProviderSpec("textract", "textract", "TextractProvider", 300, "direct"),
+    ImageBackedPdfProviderSpec("unlimitedocr", "unlimitedocr", "UnlimitedOCRProvider", 144, "adapter"),
+)
 
 # Public operational-stat fields consumed by evaluation/stats.py. Totals are
 # additive across requests; per-page values are arithmetic means.

--- a/src/parse_bench/inference/providers/parse/_multipage_image.py
+++ b/src/parse_bench/inference/providers/parse/_multipage_image.py
@@ -12,7 +12,8 @@ already implement page-wise inference should not use it.
 from __future__ import annotations
 
 import tempfile
-from collections.abc import Callable
+from collections.abc import Callable, Generator, Iterator
+from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
 
@@ -25,6 +26,88 @@ from parse_bench.schemas.pipeline_io import InferenceRequest, InferenceResult, R
 from parse_bench.schemas.product import ProductType
 
 _MULTIPAGE_KEY = "_parse_bench_multipage"
+
+
+class PageImages:
+    """One-shot, bounded-memory collection of document page images."""
+
+    def __init__(self, page_count: int, images: Iterator[Image.Image]) -> None:
+        self._page_count = page_count
+        self._images = images
+
+    def __len__(self) -> int:
+        return self._page_count
+
+    def __iter__(self) -> Iterator[Image.Image]:
+        return self._images
+
+
+@contextmanager
+def open_document_page_images(source_path: str | Path, *, dpi: int) -> Iterator[PageImages]:
+    """Open an image document or incrementally rasterize a PDF.
+
+    PDF pages are inspected up front but rendered one at a time.  The current
+    image is closed before the next page is rendered and also when inference
+    exits early with an exception.
+    """
+
+    path = Path(source_path)
+    if path.suffix.lower() != ".pdf":
+        with Image.open(path) as image:
+            yield PageImages(1, iter((image,)))
+        return
+
+    page_count = _pdf_page_count(path)
+    images = _iter_pdf_page_images(path, dpi=dpi, page_count=page_count)
+    try:
+        yield PageImages(page_count, images)
+    finally:
+        images.close()
+
+
+def _pdf_page_count(source_path: Path) -> int:
+    try:
+        from pdf2image import pdfinfo_from_path
+    except ImportError as exc:
+        raise ProviderConfigError("pdf2image is required to process PDF inputs") from exc
+
+    try:
+        page_count = pdfinfo_from_path(str(source_path)).get("Pages")
+    except Exception as exc:
+        raise ProviderPermanentError(f"Failed to inspect PDF: {exc}") from exc
+
+    if not isinstance(page_count, int) or isinstance(page_count, bool) or page_count < 1:
+        raise ProviderPermanentError(f"No pages found in PDF: {source_path}")
+    return page_count
+
+
+def _iter_pdf_page_images(source_path: Path, *, dpi: int, page_count: int) -> Generator[Image.Image]:
+    try:
+        from pdf2image import convert_from_path
+    except ImportError as exc:
+        raise ProviderConfigError("pdf2image is required to process PDF inputs") from exc
+
+    for page_number in range(1, page_count + 1):
+        try:
+            rendered = convert_from_path(
+                str(source_path),
+                dpi=dpi,
+                first_page=page_number,
+                last_page=page_number,
+            )
+        except Exception as exc:
+            raise ProviderPermanentError(f"Failed to render PDF page {page_number}: {exc}") from exc
+
+        if len(rendered) != 1:
+            for image in rendered:
+                image.close()
+            raise ProviderPermanentError(f"Expected one image for PDF page {page_number}, got {len(rendered)}")
+
+        image = rendered[0]
+        try:
+            yield image
+        finally:
+            image.close()
 
 
 def run_pdf_pages(
@@ -45,42 +128,12 @@ def run_pdf_pages(
     if request.product_type != ProductType.PARSE or source_path.suffix.lower() != ".pdf":
         return None
 
-    try:
-        from pdf2image import convert_from_path, pdfinfo_from_path
-    except ImportError as exc:
-        raise ProviderConfigError("pdf2image is required to process PDF inputs") from exc
-
     started_at = datetime.now()
-    try:
-        page_count = pdfinfo_from_path(str(source_path)).get("Pages")
-    except Exception as exc:
-        raise ProviderPermanentError(f"Failed to inspect PDF: {exc}") from exc
-
-    if not isinstance(page_count, int) or isinstance(page_count, bool) or page_count < 1:
-        raise ProviderPermanentError(f"No pages found in PDF: {source_path}")
-
     page_results: list[dict[str, object]] = []
     with tempfile.TemporaryDirectory(prefix="parse-bench-pages-") as temp_dir:
-        for page_index in range(page_count):
-            page_number = page_index + 1
-            try:
-                images = convert_from_path(
-                    str(source_path),
-                    dpi=dpi,
-                    first_page=page_number,
-                    last_page=page_number,
-                )
-            except Exception as exc:
-                raise ProviderPermanentError(f"Failed to render PDF page {page_number}: {exc}") from exc
-
-            if len(images) != 1:
-                for image in images:
-                    image.close()
-                raise ProviderPermanentError(f"Expected one image for PDF page {page_number}, got {len(images)}")
-
-            image = images[0]
-            page_path = Path(temp_dir) / f"page-{page_index + 1:06d}.png"
-            try:
+        with open_document_page_images(source_path, dpi=dpi) as images:
+            for page_index, image in enumerate(images):
+                page_path = Path(temp_dir) / f"page-{page_index + 1:06d}.png"
                 _save_png(image, page_path)
                 page_request = request.model_copy(update={"source_file_path": str(page_path)})
                 page_result = run_single_image(pipeline, page_request)
@@ -91,8 +144,6 @@ def run_pdf_pages(
                         "latency_in_ms": page_result.latency_in_ms,
                     }
                 )
-            finally:
-                image.close()
 
     completed_at = datetime.now()
     return RawInferenceResult(
@@ -124,9 +175,18 @@ def normalize_pdf_pages(
     if not isinstance(envelope, dict):
         return None
 
+    if envelope.get("version") != 1:
+        raise ProviderPermanentError("Invalid multipage raw output: unsupported version")
+
+    num_pages = envelope.get("num_pages")
+    if not isinstance(num_pages, int) or isinstance(num_pages, bool) or num_pages < 1:
+        raise ProviderPermanentError("Invalid multipage raw output: 'num_pages' must be a positive integer")
+
     page_records = envelope.get("pages")
     if not isinstance(page_records, list):
         raise ProviderPermanentError("Invalid multipage raw output: 'pages' must be a list")
+    if len(page_records) != num_pages:
+        raise ProviderPermanentError("Invalid multipage raw output: 'num_pages' does not match 'pages'")
 
     pages: list[PageIR] = []
     layout_pages: list[ParseLayoutPageIR] = []
@@ -135,7 +195,7 @@ def normalize_pdf_pages(
             raise ProviderPermanentError(f"Invalid multipage raw output for page {expected_index + 1}")
 
         page_index = record.get("page_index")
-        if page_index != expected_index:
+        if not isinstance(page_index, int) or isinstance(page_index, bool) or page_index != expected_index:
             raise ProviderPermanentError("Invalid multipage raw output: pages must be contiguous and in document order")
 
         single_raw = raw_result.model_copy(update={"raw_output": record["raw_output"]})

--- a/src/parse_bench/inference/providers/parse/_multipage_image.py
+++ b/src/parse_bench/inference/providers/parse/_multipage_image.py
@@ -46,20 +46,106 @@ def run_page_with_retries[PageResultT](
     *,
     provider_name: str,
     page_number: int,
+    attempt_ledger: list[dict[str, object]] | None = None,
 ) -> PageResultT:
-    """Run one billable page with the sole retry budget for that page."""
+    """Run one billable page and record every physical provider attempt."""
 
     for attempt in range(_PAGE_MAX_ATTEMPTS):
         try:
-            return call()
+            result = call()
         except (ProviderTransientError, ProviderRateLimitError) as exc:
+            if attempt_ledger is not None:
+                attempt_ledger.append(
+                    {
+                        "page_number": page_number,
+                        "attempt": attempt + 1,
+                        "status": "failed",
+                        "stats": dict(exc.attempt_stats or {}),
+                        "error_type": type(exc).__name__,
+                        "error": str(exc),
+                    }
+                )
             if attempt == _PAGE_MAX_ATTEMPTS - 1:
                 raise ProviderRetryExhaustedError(
-                    f"{provider_name} page {page_number} failed after {_PAGE_MAX_ATTEMPTS} attempts: {exc}"
+                    f"{provider_name} page {page_number} failed after {_PAGE_MAX_ATTEMPTS} attempts: {exc}",
+                    debug_payload={"attempts": list(attempt_ledger or [])},
                 ) from exc
             time.sleep(_PAGE_INITIAL_BACKOFF_S * (2**attempt))
+        else:
+            if attempt_ledger is not None:
+                attempt_ledger.append(
+                    {
+                        "page_number": page_number,
+                        "attempt": attempt + 1,
+                        "status": "succeeded",
+                        "stats": _result_attempt_stats(result),
+                    }
+                )
+            return result
 
     raise AssertionError("unreachable")
+
+
+def _result_attempt_stats(result: object) -> dict[str, int | float]:
+    """Extract public operational fields from a successful physical attempt."""
+    source: object = result.raw_output if isinstance(result, RawInferenceResult) else None
+    if source is None and isinstance(result, tuple):
+        source = next((item for item in reversed(result) if isinstance(item, dict)), None)
+    if not isinstance(source, dict):
+        return {}
+    return {
+        field: value
+        for field, value in source.items()
+        if field in {*_ADDITIVE_STAT_FIELDS, *_PER_PAGE_STAT_FIELDS}
+        and isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(value)
+    }
+
+
+def append_attempt_usages(
+    usages: list[dict[str, int]],
+    attempts: list[dict[str, object]],
+) -> None:
+    """Append token buckets from every recorded attempt to document usage."""
+    for attempt in attempts:
+        stats = attempt.get("stats")
+        if isinstance(stats, dict):
+            usage = {
+                key: int(value)
+                for key, value in stats.items()
+                if key.endswith("tokens")
+                and isinstance(value, (int, float))
+                and not isinstance(value, bool)
+                and math.isfinite(value)
+            }
+            for key in ("input_tokens", "output_tokens", "thinking_tokens", "total_tokens"):
+                usage.setdefault(key, 0)
+            usages.append(usage)
+
+
+def annotate_attempt_costs(
+    attempts: list[dict[str, object]],
+    *,
+    input_rate_per_million: float,
+    output_rate_per_million: float,
+) -> None:
+    """Add the same token-derived cost used by document summaries to each attempt."""
+    for attempt in attempts:
+        stats = attempt.get("stats")
+        if not isinstance(stats, dict):
+            continue
+        input_tokens = stats.get("input_tokens", 0)
+        output_tokens = stats.get("output_tokens", 0)
+        thinking_tokens = stats.get("thinking_tokens", 0)
+        if not all(
+            isinstance(value, (int, float)) and not isinstance(value, bool)
+            for value in (input_tokens, output_tokens, thinking_tokens)
+        ):
+            continue
+        stats["cost_usd"] = (
+            input_tokens * input_rate_per_million + (output_tokens + thinking_tokens) * output_rate_per_million
+        ) / 1_000_000
 
 
 @dataclass(frozen=True)
@@ -217,6 +303,13 @@ _PER_PAGE_STAT_FIELDS = (
     "cached_content_tokens_per_page",
     "output_tokens_per_page",
 )
+_PER_PAGE_ADDITIVE_FIELDS = {
+    "cost_per_page_usd": "cost_usd",
+    "input_tokens_per_page": "input_tokens",
+    "tool_use_prompt_tokens_per_page": "tool_use_prompt_tokens",
+    "cached_content_tokens_per_page": "cached_content_tokens",
+    "output_tokens_per_page": "output_tokens",
+}
 
 
 @contextmanager
@@ -351,16 +444,19 @@ def run_pdf_pages(
                 page_path = Path(temp_dir) / f"page-{page_index + 1:06d}.png"
                 _save_png(image, page_path)
                 page_request = request.model_copy(update={"source_file_path": str(page_path)})
+                attempts: list[dict[str, object]] = []
                 page_result = run_page_with_retries(
                     partial(run_single_image, pipeline, page_request),
                     provider_name=pipeline.provider_name,
                     page_number=page_index + 1,
+                    attempt_ledger=attempts,
                 )
                 page_results.append(
                     {
                         "page_index": page_index,
                         "raw_output": page_result.raw_output,
                         "latency_in_ms": page_result.latency_in_ms,
+                        "attempts": attempts,
                     }
                 )
 
@@ -395,17 +491,29 @@ def _aggregate_page_raw_outputs(page_results: list[dict[str, object]]) -> dict[s
     """
 
     aggregate: dict[str, int | float] = {"num_pages": len(page_results)}
-    raw_outputs = [record.get("raw_output") for record in page_results]
+    attempts: list[dict[str, object]] = []
+    for record in page_results:
+        record_attempts = record.get("attempts")
+        if isinstance(record_attempts, list):
+            attempts.extend(attempt for attempt in record_attempts if isinstance(attempt, dict))
+    attempt_stats = [attempt.get("stats") for attempt in attempts]
 
     for field in _ADDITIVE_STAT_FIELDS:
-        values = _complete_numeric_values(raw_outputs, field)
+        if field == "num_api_calls":
+            aggregate[field] = len(attempts)
+            continue
+        values = _complete_numeric_values(attempt_stats, field)
         if values is not None:
             aggregate[field] = sum(values)
 
     for field in _PER_PAGE_STAT_FIELDS:
-        values = _complete_numeric_values(raw_outputs, field)
+        additive_field = _PER_PAGE_ADDITIVE_FIELDS[field]
+        if additive_field in aggregate:
+            aggregate[field] = aggregate[additive_field] / len(page_results)
+            continue
+        values = _complete_numeric_values(attempt_stats, field)
         if values is not None:
-            aggregate[field] = sum(values) / len(values)
+            aggregate[field] = sum(values) / len(page_results)
 
     return aggregate
 

--- a/src/parse_bench/inference/providers/parse/amazon_nova.py
+++ b/src/parse_bench/inference/providers/parse/amazon_nova.py
@@ -36,6 +36,7 @@ from parse_bench.inference.providers.parse._layout_utils import (
     items_to_markdown,
     parse_layout_blocks,
 )
+from parse_bench.inference.providers.parse._multipage_image import open_document_page_images
 from parse_bench.inference.providers.registry import register_provider
 from parse_bench.schemas.parse_output import PageIR, ParseLayoutPageIR, ParseOutput
 from parse_bench.schemas.pipeline import PipelineSpec
@@ -280,21 +281,7 @@ class AmazonNovaProvider(Provider):
         image.save(buffer, format="JPEG", quality=min_quality)
         return buffer.getvalue()
 
-    def _pdf_to_images(self, pdf_path: str) -> list[Image.Image]:
-        """Convert PDF pages to images."""
-        try:
-            from pdf2image import convert_from_path
-        except ImportError as e:
-            raise ProviderConfigError("pdf2image package not installed. Run: pip install pdf2image") from e
-
-        try:
-            return convert_from_path(pdf_path, dpi=self._dpi)
-        except Exception as e:
-            raise ProviderPermanentError(f"Failed to convert PDF to images: {e}") from e
-
-    def _converse(
-        self, image: Image.Image, system_prompt: str, user_prompt: str
-    ) -> tuple[str, dict[str, int], str]:
+    def _converse(self, image: Image.Image, system_prompt: str, user_prompt: str) -> tuple[str, dict[str, int], str]:
         """Send one page image to Bedrock Converse and return (text, usage, stop_reason)."""
         image_bytes = self._image_to_jpeg_bytes(image)
 
@@ -345,9 +332,7 @@ class AmazonNovaProvider(Provider):
 
         return text, self._extract_usage(response), stop_reason
 
-    def _parse_image_with_layout(
-        self, image: Image.Image
-    ) -> tuple[list[dict[str, Any]], str, dict[str, int], str]:
+    def _parse_image_with_layout(self, image: Image.Image) -> tuple[list[dict[str, Any]], str, dict[str, int], str]:
         """Parse a page image to layout-annotated markdown blocks."""
         text, usage, stop_reason = self._converse(image, SYSTEM_PROMPT_LAYOUT, USER_PROMPT_LAYOUT)
         # Prefer the lenient reader (Nova uses <TABLE>/<p> wrappers and leaves
@@ -384,26 +369,22 @@ class AmazonNovaProvider(Provider):
         try:
             page_usages: list[dict[str, int]] = []
 
-            if source_path.suffix.lower() == ".pdf":
-                images = self._pdf_to_images(str(source_path))
-            else:
-                images = [Image.open(source_path)]
-
             pages: list[dict[str, Any]] = []
-            for page_index, image in enumerate(images):
-                items, raw_content, usage, stop_reason = self._parse_image_with_layout(image)
-                page_usages.append(usage)
-                pages.append(
-                    {
-                        "page_index": page_index,
-                        "items": items,
-                        "raw_content": raw_content,
-                        "stop_reason": stop_reason,
-                        "width": image.width,
-                        "height": image.height,
-                    }
-                )
-            num_pages = len(images)
+            with open_document_page_images(source_path, dpi=self._dpi) as images:
+                for page_index, image in enumerate(images):
+                    items, raw_content, usage, stop_reason = self._parse_image_with_layout(image)
+                    page_usages.append(usage)
+                    pages.append(
+                        {
+                            "page_index": page_index,
+                            "items": items,
+                            "raw_content": raw_content,
+                            "stop_reason": stop_reason,
+                            "width": image.width,
+                            "height": image.height,
+                        }
+                    )
+                num_pages = len(images)
 
             completed_at = datetime.now()
             latency_ms = int((completed_at - started_at).total_seconds() * 1000)

--- a/src/parse_bench/inference/providers/parse/amazon_nova.py
+++ b/src/parse_bench/inference/providers/parse/amazon_nova.py
@@ -36,7 +36,10 @@ from parse_bench.inference.providers.parse._layout_utils import (
     items_to_markdown,
     parse_layout_blocks,
 )
-from parse_bench.inference.providers.parse._multipage_image import open_document_page_images
+from parse_bench.inference.providers.parse._multipage_image import (
+    close_derived_images,
+    open_document_page_images,
+)
 from parse_bench.inference.providers.registry import register_provider
 from parse_bench.schemas.parse_output import PageIR, ParseLayoutPageIR, ParseOutput
 from parse_bench.schemas.pipeline import PipelineSpec
@@ -248,38 +251,39 @@ class AmazonNovaProvider(Provider):
 
     def _image_to_jpeg_bytes(self, image: Image.Image) -> bytes:
         """Encode a PIL image as JPEG bytes within Nova's payload budget."""
-        image = self._prepare_image_for_api(image)
+        with close_derived_images(image) as track:
+            image = track(self._prepare_image_for_api(image))
 
-        if image.mode in ("RGBA", "P"):
-            image = image.convert("RGB")
+            if image.mode in ("RGBA", "P"):
+                image = track(image.convert("RGB"))
 
-        quality = 85
-        min_quality = 20
+            quality = 85
+            min_quality = 20
 
-        while quality >= min_quality:
-            buffer = io.BytesIO()
-            image.save(buffer, format="JPEG", quality=quality)
-            data = buffer.getvalue()
-            if len(data) <= self.MAX_IMAGE_SIZE_BYTES:
-                return data
-            quality -= 10
+            while quality >= min_quality:
+                buffer = io.BytesIO()
+                image.save(buffer, format="JPEG", quality=quality)
+                data = buffer.getvalue()
+                if len(data) <= self.MAX_IMAGE_SIZE_BYTES:
+                    return data
+                quality -= 10
 
-        while True:
-            width, height = image.size
-            new_width, new_height = int(width * 0.8), int(height * 0.8)
-            if new_width < 100 or new_height < 100:
-                break
+            while True:
+                width, height = image.size
+                new_width, new_height = int(width * 0.8), int(height * 0.8)
+                if new_width < 100 or new_height < 100:
+                    break
 
-            image = image.resize((new_width, new_height), Image.Resampling.LANCZOS)
+                image = track(image.resize((new_width, new_height), Image.Resampling.LANCZOS))
+                buffer = io.BytesIO()
+                image.save(buffer, format="JPEG", quality=min_quality)
+                data = buffer.getvalue()
+                if len(data) <= self.MAX_IMAGE_SIZE_BYTES:
+                    return data
+
             buffer = io.BytesIO()
             image.save(buffer, format="JPEG", quality=min_quality)
-            data = buffer.getvalue()
-            if len(data) <= self.MAX_IMAGE_SIZE_BYTES:
-                return data
-
-        buffer = io.BytesIO()
-        image.save(buffer, format="JPEG", quality=min_quality)
-        return buffer.getvalue()
+            return buffer.getvalue()
 
     def _converse(self, image: Image.Image, system_prompt: str, user_prompt: str) -> tuple[str, dict[str, int], str]:
         """Send one page image to Bedrock Converse and return (text, usage, stop_reason)."""

--- a/src/parse_bench/inference/providers/parse/amazon_nova.py
+++ b/src/parse_bench/inference/providers/parse/amazon_nova.py
@@ -41,6 +41,7 @@ from parse_bench.inference.providers.parse._layout_utils import (
 from parse_bench.inference.providers.parse._multipage_image import (
     annotate_attempt_costs,
     append_attempt_usages,
+    attempt_usages_complete,
     close_derived_images,
     open_document_page_images,
     run_page_with_retries,
@@ -399,6 +400,7 @@ class AmazonNovaProvider(Provider):
                         provider_name=pipeline.provider_name,
                         page_number=page_index + 1,
                         attempt_ledger=attempts,
+                        prior_attempt_ledger=api_attempts,
                     )
                     api_attempts.extend(attempts)
                     append_attempt_usages(page_usages, attempts)
@@ -429,6 +431,20 @@ class AmazonNovaProvider(Provider):
                 output_rate_per_million=output_rate,
             )
             cost = (total_input * input_rate + (total_output + total_thinking) * output_rate) / 1_000_000
+            usage_summary = (
+                {
+                    "input_tokens": total_input,
+                    "output_tokens": total_output,
+                    "thinking_tokens": total_thinking,
+                    "total_tokens": total_all,
+                    "cost_usd": cost,
+                    "cost_per_page_usd": cost / num_pages if num_pages > 0 else 0.0,
+                    "input_tokens_per_page": total_input / num_pages if num_pages > 0 else 0.0,
+                    "output_tokens_per_page": total_output / num_pages if num_pages > 0 else 0.0,
+                }
+                if attempt_usages_complete(page_usages)
+                else {}
+            )
 
             config_info: dict[str, Any] = {
                 "dpi": self._dpi,
@@ -447,14 +463,7 @@ class AmazonNovaProvider(Provider):
                 "num_pages": num_pages,
                 "model": self._model,
                 "config": config_info,
-                "input_tokens": total_input,
-                "output_tokens": total_output,
-                "thinking_tokens": total_thinking,
-                "total_tokens": total_all,
-                "cost_usd": cost,
-                "cost_per_page_usd": cost / num_pages if num_pages > 0 else 0.0,
-                "input_tokens_per_page": total_input / num_pages if num_pages > 0 else 0.0,
-                "output_tokens_per_page": total_output / num_pages if num_pages > 0 else 0.0,
+                **usage_summary,
                 "num_api_calls": len(api_attempts),
                 "api_attempts": api_attempts,
             }

--- a/src/parse_bench/inference/providers/parse/amazon_nova.py
+++ b/src/parse_bench/inference/providers/parse/amazon_nova.py
@@ -363,7 +363,15 @@ class AmazonNovaProvider(Provider):
         # Prefer the lenient reader (Nova uses <TABLE>/<p> wrappers and leaves
         # them unclosed); fall back to the strict shared parser if it finds
         # nothing, so this can never score worse than the default path.
-        items = extract_layout_blocks_lenient(text) or parse_layout_blocks(text)
+        if text.strip() == "[]":
+            items: list[dict[str, Any]] = []
+        else:
+            items = extract_layout_blocks_lenient(text) or parse_layout_blocks(text)
+            if not items:
+                raise ProviderTransientError(
+                    "Bedrock Converse returned malformed non-empty layout output",
+                    attempt_stats=usage,
+                )
         return close_open_ended_bands(items), text, usage, stop_reason
 
     def run_inference(self, pipeline: PipelineSpec, request: InferenceRequest) -> RawInferenceResult:
@@ -423,23 +431,22 @@ class AmazonNovaProvider(Provider):
             completed_at = datetime.now()
             latency_ms = int((completed_at - started_at).total_seconds() * 1000)
 
-            total_input = sum(u["input_tokens"] for u in page_usages)
-            total_output = sum(u["output_tokens"] for u in page_usages)
-            total_thinking = sum(u["thinking_tokens"] for u in page_usages)
-            total_all = sum(u["total_tokens"] for u in page_usages)
-
-            usage_summary = (
-                {
-                    "input_tokens": total_input,
-                    "output_tokens": total_output,
-                    "thinking_tokens": total_thinking,
-                    "total_tokens": total_all,
-                    "input_tokens_per_page": total_input / num_pages if num_pages > 0 else 0.0,
-                    "output_tokens_per_page": total_output / num_pages if num_pages > 0 else 0.0,
-                }
-                if attempt_usages_complete(page_usages)
-                else {}
-            )
+            usage_summary: dict[str, int | float] = {}
+            if attempt_usages_complete(page_usages):
+                total_input = sum(u["input_tokens"] for u in page_usages)
+                total_output = sum(u["output_tokens"] for u in page_usages)
+                total_thinking = sum(u["thinking_tokens"] for u in page_usages)
+                total_all = sum(u["total_tokens"] for u in page_usages)
+                usage_summary.update(
+                    {
+                        "input_tokens": total_input,
+                        "output_tokens": total_output,
+                        "thinking_tokens": total_thinking,
+                        "total_tokens": total_all,
+                        "input_tokens_per_page": total_input / num_pages if num_pages > 0 else 0.0,
+                        "output_tokens_per_page": total_output / num_pages if num_pages > 0 else 0.0,
+                    }
+                )
             pricing = self._get_pricing()
             if pricing is not None and attempt_usages_complete(page_usages):
                 input_rate, output_rate = pricing

--- a/src/parse_bench/inference/providers/parse/amazon_nova.py
+++ b/src/parse_bench/inference/providers/parse/amazon_nova.py
@@ -196,10 +196,10 @@ class AmazonNovaProvider(Provider):
                 return self._model[len(prefix) :]
         return self._model
 
-    def _get_pricing(self) -> tuple[float, float]:
-        """Return (input_rate, output_rate) in USD per million tokens."""
+    def _get_pricing(self) -> tuple[float, float] | None:
+        """Return known (input_rate, output_rate) in USD per million tokens."""
         table = _NOVA_GLOBAL_PRICING_PER_M if self._model.startswith("global.") else _NOVA_PRICING_PER_M
-        return table.get(self._base_model_id(), (0.0, 0.0))
+        return table.get(self._base_model_id())
 
     def _raise_bedrock_error(self, e: Exception) -> NoReturn:
         """Classify a Bedrock/botocore exception as transient, rate-limited or permanent."""
@@ -227,16 +227,20 @@ class AmazonNovaProvider(Provider):
         separately, so ``thinking_tokens`` is always 0 — the spend is already
         inside ``output_tokens``.
         """
-        usage = response.get("usage") or {}
-        input_tok = int(usage.get("inputTokens", 0) or 0)
-        output_tok = int(usage.get("outputTokens", 0) or 0)
-        total_tok = int(usage.get("totalTokens", 0) or 0) or (input_tok + output_tok)
-        return {
-            "input_tokens": input_tok,
-            "output_tokens": output_tok,
-            "thinking_tokens": 0,
-            "total_tokens": total_tok,
-        }
+        usage = response.get("usage")
+        if not isinstance(usage, dict):
+            return {}
+        result = {"thinking_tokens": 0}
+        for key, source_key in (("input_tokens", "inputTokens"), ("output_tokens", "outputTokens")):
+            value = usage.get(source_key)
+            if value is not None:
+                result[key] = int(value)
+        total_value = usage.get("totalTokens")
+        if total_value is not None:
+            result["total_tokens"] = int(total_value)
+        elif "input_tokens" in result and "output_tokens" in result:
+            result["total_tokens"] = result["input_tokens"] + result["output_tokens"]
+        return result
 
     @staticmethod
     def _extract_text(response: dict[str, Any]) -> str:
@@ -424,27 +428,33 @@ class AmazonNovaProvider(Provider):
             total_thinking = sum(u["thinking_tokens"] for u in page_usages)
             total_all = sum(u["total_tokens"] for u in page_usages)
 
-            input_rate, output_rate = self._get_pricing()
-            annotate_attempt_costs(
-                api_attempts,
-                input_rate_per_million=input_rate,
-                output_rate_per_million=output_rate,
-            )
-            cost = (total_input * input_rate + (total_output + total_thinking) * output_rate) / 1_000_000
             usage_summary = (
                 {
                     "input_tokens": total_input,
                     "output_tokens": total_output,
                     "thinking_tokens": total_thinking,
                     "total_tokens": total_all,
-                    "cost_usd": cost,
-                    "cost_per_page_usd": cost / num_pages if num_pages > 0 else 0.0,
                     "input_tokens_per_page": total_input / num_pages if num_pages > 0 else 0.0,
                     "output_tokens_per_page": total_output / num_pages if num_pages > 0 else 0.0,
                 }
                 if attempt_usages_complete(page_usages)
                 else {}
             )
+            pricing = self._get_pricing()
+            if pricing is not None and attempt_usages_complete(page_usages):
+                input_rate, output_rate = pricing
+                annotate_attempt_costs(
+                    api_attempts,
+                    input_rate_per_million=input_rate,
+                    output_rate_per_million=output_rate,
+                )
+                cost = (total_input * input_rate + (total_output + total_thinking) * output_rate) / 1_000_000
+                usage_summary.update(
+                    {
+                        "cost_usd": cost,
+                        "cost_per_page_usd": cost / num_pages if num_pages > 0 else 0.0,
+                    }
+                )
 
             config_info: dict[str, Any] = {
                 "dpi": self._dpi,

--- a/src/parse_bench/inference/providers/parse/amazon_nova.py
+++ b/src/parse_bench/inference/providers/parse/amazon_nova.py
@@ -15,6 +15,7 @@ https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-amazon-nova-2-li
 import io
 import os
 from datetime import datetime
+from functools import partial
 from pathlib import Path
 from typing import Any, NoReturn
 
@@ -39,6 +40,7 @@ from parse_bench.inference.providers.parse._layout_utils import (
 from parse_bench.inference.providers.parse._multipage_image import (
     close_derived_images,
     open_document_page_images,
+    run_page_with_retries,
 )
 from parse_bench.inference.providers.registry import register_provider
 from parse_bench.schemas.parse_output import PageIR, ParseLayoutPageIR, ParseOutput
@@ -376,7 +378,11 @@ class AmazonNovaProvider(Provider):
             pages: list[dict[str, Any]] = []
             with open_document_page_images(source_path, dpi=self._dpi) as images:
                 for page_index, image in enumerate(images):
-                    items, raw_content, usage, stop_reason = self._parse_image_with_layout(image)
+                    items, raw_content, usage, stop_reason = run_page_with_retries(
+                        partial(self._parse_image_with_layout, image),
+                        provider_name=pipeline.provider_name,
+                        page_number=page_index + 1,
+                    )
                     page_usages.append(usage)
                     pages.append(
                         {

--- a/src/parse_bench/inference/providers/parse/amazon_nova.py
+++ b/src/parse_bench/inference/providers/parse/amazon_nova.py
@@ -106,6 +106,8 @@ class AmazonNovaProvider(Provider):
     the markdown and the per-element bounding boxes.
     """
 
+    PDF_RENDER_DPI = 150
+
     # Nova image-understanding limits: 8,000 x 8,000 px, 25 MB total request
     # payload. Images are base64-encoded on the wire, so the raw byte budget is
     # 3/4 of the payload cap.
@@ -137,7 +139,7 @@ class AmazonNovaProvider(Provider):
 
         self._model: str = self.base_config.get("model", "us.amazon.nova-2-lite-v1:0")
         self._region: str = self.base_config.get("region") or os.environ.get("AWS_REGION") or "us-east-1"
-        self._dpi = self.base_config.get("dpi", 150)
+        self._dpi = self.base_config.get("dpi", self.PDF_RENDER_DPI)
         self._max_tokens = self.base_config.get("max_tokens", 8192)
         self._timeout = self.base_config.get("timeout", 300)
         self._reasoning_effort = self.base_config.get("reasoning_effort", None)
@@ -175,7 +177,9 @@ class AmazonNovaProvider(Provider):
                 config=Config(
                     read_timeout=self._timeout,
                     connect_timeout=30,
-                    retries={"max_attempts": 3, "mode": "standard"},
+                    # run_page_with_retries owns the complete retry budget for
+                    # each billable page; botocore performs one HTTP attempt.
+                    retries={"total_max_attempts": 1, "mode": "standard"},
                 ),
             )
         except ImportError as e:

--- a/src/parse_bench/inference/providers/parse/amazon_nova.py
+++ b/src/parse_bench/inference/providers/parse/amazon_nova.py
@@ -36,8 +36,11 @@ from parse_bench.inference.providers.parse._layout_utils import (
     extract_layout_blocks_lenient,
     items_to_markdown,
     parse_layout_blocks,
+    validated_sorted_page_records,
 )
 from parse_bench.inference.providers.parse._multipage_image import (
+    annotate_attempt_costs,
+    append_attempt_usages,
     close_derived_images,
     open_document_page_images,
     run_page_with_retries,
@@ -327,6 +330,7 @@ class AmazonNovaProvider(Provider):
 
         stop_reason = str(response.get("stopReason", ""))
         text = self._extract_text(response)
+        usage = self._extract_usage(response)
 
         # Bedrock's built-in content filter returns HTTP 200 with a canned
         # notice in the text block ("The generated text has been blocked by our
@@ -336,11 +340,17 @@ class AmazonNovaProvider(Provider):
         # responses — and a page that stays blocked surfaces as a failed doc
         # rather than as an empty parse.
         if stop_reason == "content_filtered":
-            raise ProviderTransientError(f"Bedrock content filter blocked the response (stopReason={stop_reason})")
+            raise ProviderTransientError(
+                f"Bedrock content filter blocked the response (stopReason={stop_reason})",
+                attempt_stats=usage,
+            )
         if not text.strip():
-            raise ProviderTransientError(f"Bedrock Converse returned no text (stopReason={stop_reason or 'unknown'})")
+            raise ProviderTransientError(
+                f"Bedrock Converse returned no text (stopReason={stop_reason or 'unknown'})",
+                attempt_stats=usage,
+            )
 
-        return text, self._extract_usage(response), stop_reason
+        return text, usage, stop_reason
 
     def _parse_image_with_layout(self, image: Image.Image) -> tuple[list[dict[str, Any]], str, dict[str, int], str]:
         """Parse a page image to layout-annotated markdown blocks."""
@@ -378,16 +388,20 @@ class AmazonNovaProvider(Provider):
 
         try:
             page_usages: list[dict[str, int]] = []
+            api_attempts: list[dict[str, object]] = []
 
             pages: list[dict[str, Any]] = []
             with open_document_page_images(source_path, dpi=self._dpi) as images:
                 for page_index, image in enumerate(images):
+                    attempts: list[dict[str, object]] = []
                     items, raw_content, usage, stop_reason = run_page_with_retries(
                         partial(self._parse_image_with_layout, image),
                         provider_name=pipeline.provider_name,
                         page_number=page_index + 1,
+                        attempt_ledger=attempts,
                     )
-                    page_usages.append(usage)
+                    api_attempts.extend(attempts)
+                    append_attempt_usages(page_usages, attempts)
                     pages.append(
                         {
                             "page_index": page_index,
@@ -409,6 +423,11 @@ class AmazonNovaProvider(Provider):
             total_all = sum(u["total_tokens"] for u in page_usages)
 
             input_rate, output_rate = self._get_pricing()
+            annotate_attempt_costs(
+                api_attempts,
+                input_rate_per_million=input_rate,
+                output_rate_per_million=output_rate,
+            )
             cost = (total_input * input_rate + (total_output + total_thinking) * output_rate) / 1_000_000
 
             config_info: dict[str, Any] = {
@@ -436,6 +455,8 @@ class AmazonNovaProvider(Provider):
                 "cost_per_page_usd": cost / num_pages if num_pages > 0 else 0.0,
                 "input_tokens_per_page": total_input / num_pages if num_pages > 0 else 0.0,
                 "output_tokens_per_page": total_output / num_pages if num_pages > 0 else 0.0,
+                "num_api_calls": len(api_attempts),
+                "api_attempts": api_attempts,
             }
 
             return RawInferenceResult(
@@ -470,7 +491,7 @@ class AmazonNovaProvider(Provider):
         page_markdowns: list[str] = []
         layout_pages: list[ParseLayoutPageIR] = []
 
-        for page_data in raw_result.raw_output.get("pages", []):
+        for page_data in validated_sorted_page_records(raw_result.raw_output.get("pages", [])):
             page_index = page_data.get("page_index", 0)
 
             items = page_data.get("items", [])
@@ -490,7 +511,6 @@ class AmazonNovaProvider(Provider):
             pages.append(PageIR(page_index=page_index, markdown=markdown))
             page_markdowns.append(markdown)
 
-        pages.sort(key=lambda p: p.page_index)
         full_markdown = "\n\n".join(page_markdowns)
 
         output = ParseOutput(

--- a/src/parse_bench/inference/providers/parse/anthropic.py
+++ b/src/parse_bench/inference/providers/parse/anthropic.py
@@ -32,6 +32,7 @@ from parse_bench.inference.providers.parse._multipage_image import (
     attempt_usages_complete,
     close_derived_images,
     open_document_page_images,
+    run_page_once,
     run_page_with_retries,
 )
 from parse_bench.inference.providers.registry import register_provider
@@ -662,12 +663,19 @@ class AnthropicProvider(Provider):
         try:
             page_usages: list[dict[str, int]] = []
             api_attempts: list[dict[str, object]] = []
+            attempts: list[dict[str, object]]
 
             if self._mode == "file":
                 if source_path.suffix.lower() == ".pdf":
                     # File mode: send raw PDF to API
-                    markdown, usage = self._parse_pdf_file(str(source_path))
-                    page_usages.append(usage)
+                    attempts = []
+                    markdown, usage = run_page_once(
+                        partial(self._parse_pdf_file, str(source_path)),
+                        page_number=1,
+                        attempt_ledger=attempts,
+                    )
+                    api_attempts.extend(attempts)
+                    append_attempt_usages(page_usages, attempts)
                     # In file mode, we get one response for the entire document
                     # We don't have page-level info, so we treat it as a single "page"
                     pages = [
@@ -682,8 +690,14 @@ class AnthropicProvider(Provider):
                 else:
                     # Non-PDF: fall back to image-based parsing
                     with Image.open(source_path) as image:
-                        markdown, usage = self._parse_image(image)
-                        page_usages.append(usage)
+                        attempts = []
+                        markdown, usage = run_page_once(
+                            partial(self._parse_image, image),
+                            page_number=1,
+                            attempt_ledger=attempts,
+                        )
+                        api_attempts.extend(attempts)
+                        append_attempt_usages(page_usages, attempts)
                         pages = [
                             {
                                 "page_index": 0,
@@ -699,7 +713,7 @@ class AnthropicProvider(Provider):
                     pdf_pages = split_pdf_to_pages(str(source_path))
                     pages = []
                     for page_index, (pdf_bytes, w, h) in enumerate(pdf_pages):
-                        attempts: list[dict[str, object]] = []
+                        attempts = []
                         items, raw_content, usage = run_page_with_retries(
                             partial(self._parse_pdf_page_with_layout, pdf_bytes),
                             provider_name=pipeline.provider_name,
@@ -798,24 +812,23 @@ class AnthropicProvider(Provider):
             completed_at = datetime.now()
             latency_ms = int((completed_at - started_at).total_seconds() * 1000)
 
-            # Aggregate token usage across pages
-            total_input = sum(u["input_tokens"] for u in page_usages)
-            total_output = sum(u["output_tokens"] for u in page_usages)
-            total_thinking = sum(u["thinking_tokens"] for u in page_usages)
-            total_all = sum(u["total_tokens"] for u in page_usages)
-
-            usage_summary = (
-                {
-                    "input_tokens": total_input,
-                    "output_tokens": total_output,
-                    "thinking_tokens": total_thinking,
-                    "total_tokens": total_all,
-                    "input_tokens_per_page": total_input / num_pages if num_pages > 0 else 0.0,
-                    "output_tokens_per_page": total_output / num_pages if num_pages > 0 else 0.0,
-                }
-                if attempt_usages_complete(page_usages)
-                else {}
-            )
+            # Aggregate token usage only when every physical call reported it.
+            usage_summary: dict[str, int | float] = {}
+            if attempt_usages_complete(page_usages):
+                total_input = sum(u["input_tokens"] for u in page_usages)
+                total_output = sum(u["output_tokens"] for u in page_usages)
+                total_thinking = sum(u["thinking_tokens"] for u in page_usages)
+                total_all = sum(u["total_tokens"] for u in page_usages)
+                usage_summary.update(
+                    {
+                        "input_tokens": total_input,
+                        "output_tokens": total_output,
+                        "thinking_tokens": total_thinking,
+                        "total_tokens": total_all,
+                        "input_tokens_per_page": total_input / num_pages if num_pages > 0 else 0.0,
+                        "output_tokens_per_page": total_output / num_pages if num_pages > 0 else 0.0,
+                    }
+                )
             pricing = self._get_pricing()
             if pricing is not None and attempt_usages_complete(page_usages):
                 input_rate, output_rate = pricing

--- a/src/parse_bench/inference/providers/parse/anthropic.py
+++ b/src/parse_bench/inference/providers/parse/anthropic.py
@@ -5,6 +5,7 @@ import io
 import math
 import os
 from datetime import date, datetime
+from functools import partial
 from pathlib import Path
 from typing import Any
 
@@ -27,6 +28,7 @@ from parse_bench.inference.providers.parse._layout_utils import (
 from parse_bench.inference.providers.parse._multipage_image import (
     close_derived_images,
     open_document_page_images,
+    run_page_with_retries,
 )
 from parse_bench.inference.providers.registry import register_provider
 from parse_bench.schemas.parse_output import PageIR, ParseLayoutPageIR, ParseOutput
@@ -687,7 +689,11 @@ class AnthropicProvider(Provider):
                             # dims are exactly what the model perceives.
                             page = self._resize_to_perceived_size(image) if self._bbox_scale is None else image
                             try:
-                                items, raw_content, usage = self._parse_image_with_layout(page)
+                                items, raw_content, usage = run_page_with_retries(
+                                    partial(self._parse_image_with_layout, page),
+                                    provider_name=pipeline.provider_name,
+                                    page_number=page_index + 1,
+                                )
                                 page_usages.append(usage)
                                 pages.append(
                                     {
@@ -702,7 +708,11 @@ class AnthropicProvider(Provider):
                                 if page is not image:
                                     page.close()
                         else:
-                            markdown, usage = self._parse_image(image)
+                            markdown, usage = run_page_with_retries(
+                                partial(self._parse_image, image),
+                                provider_name=pipeline.provider_name,
+                                page_number=page_index + 1,
+                            )
                             page_usages.append(usage)
                             pages.append(
                                 {

--- a/src/parse_bench/inference/providers/parse/anthropic.py
+++ b/src/parse_bench/inference/providers/parse/anthropic.py
@@ -24,7 +24,10 @@ from parse_bench.inference.providers.parse._layout_utils import (
     resolve_layout_prompts,
     split_pdf_to_pages,
 )
-from parse_bench.inference.providers.parse._multipage_image import open_document_page_images
+from parse_bench.inference.providers.parse._multipage_image import (
+    close_derived_images,
+    open_document_page_images,
+)
 from parse_bench.inference.providers.registry import register_provider
 from parse_bench.schemas.parse_output import PageIR, ParseLayoutPageIR, ParseOutput
 from parse_bench.schemas.pipeline import PipelineSpec
@@ -295,52 +298,53 @@ class AnthropicProvider(Provider):
         - Images exceeding 5MB after encoding (reduces quality iteratively)
         """
         # Resize if dimensions exceed limit
-        image = self._prepare_image_for_api(image)
+        with close_derived_images(image) as track:
+            image = track(self._prepare_image_for_api(image))
 
-        # Convert to RGB if necessary (e.g., RGBA images)
-        if image.mode in ("RGBA", "P"):
-            image = image.convert("RGB")
+            # Convert to RGB if necessary (e.g., RGBA images)
+            if image.mode in ("RGBA", "P"):
+                image = track(image.convert("RGB"))
 
-        # Try encoding with decreasing quality until under size limit
-        quality = 85
-        min_quality = 20
+            # Try encoding with decreasing quality until under size limit
+            quality = 85
+            min_quality = 20
 
-        while quality >= min_quality:
-            buffer = io.BytesIO()
-            image.save(buffer, format="JPEG", quality=quality)
-            buffer.seek(0)
-            data = buffer.getvalue()
+            while quality >= min_quality:
+                buffer = io.BytesIO()
+                image.save(buffer, format="JPEG", quality=quality)
+                buffer.seek(0)
+                data = buffer.getvalue()
 
-            if len(data) <= self.MAX_IMAGE_SIZE_BYTES:
-                return base64.standard_b64encode(data).decode("utf-8")
+                if len(data) <= self.MAX_IMAGE_SIZE_BYTES:
+                    return base64.standard_b64encode(data).decode("utf-8")
 
-            quality -= 10
+                quality -= 10
 
-        # If still too large after quality reduction, resize the image
-        while True:
-            width, height = image.size
-            new_width = int(width * 0.8)
-            new_height = int(height * 0.8)
+            # If still too large after quality reduction, resize the image
+            while True:
+                width, height = image.size
+                new_width = int(width * 0.8)
+                new_height = int(height * 0.8)
 
-            if new_width < 100 or new_height < 100:
-                # Give up - image is too complex to fit in limits
-                break
+                if new_width < 100 or new_height < 100:
+                    # Give up - image is too complex to fit in limits
+                    break
 
-            image = image.resize((new_width, new_height), Image.Resampling.LANCZOS)
+                image = track(image.resize((new_width, new_height), Image.Resampling.LANCZOS))
 
+                buffer = io.BytesIO()
+                image.save(buffer, format="JPEG", quality=min_quality)
+                buffer.seek(0)
+                data = buffer.getvalue()
+
+                if len(data) <= self.MAX_IMAGE_SIZE_BYTES:
+                    return base64.standard_b64encode(data).decode("utf-8")
+
+            # Final fallback - return what we have
             buffer = io.BytesIO()
             image.save(buffer, format="JPEG", quality=min_quality)
             buffer.seek(0)
-            data = buffer.getvalue()
-
-            if len(data) <= self.MAX_IMAGE_SIZE_BYTES:
-                return base64.standard_b64encode(data).decode("utf-8")
-
-        # Final fallback - return what we have
-        buffer = io.BytesIO()
-        image.save(buffer, format="JPEG", quality=min_quality)
-        buffer.seek(0)
-        return base64.standard_b64encode(buffer.getvalue()).decode("utf-8")
+            return base64.standard_b64encode(buffer.getvalue()).decode("utf-8")
 
     def _parse_image(self, image: Image.Image) -> tuple[str, dict[str, int]]:
         """

--- a/src/parse_bench/inference/providers/parse/anthropic.py
+++ b/src/parse_bench/inference/providers/parse/anthropic.py
@@ -221,8 +221,8 @@ class AnthropicProvider(Provider):
     # API limit is 5MB for base64 data; base64 adds ~33% overhead, so raw limit is 5MB * 3/4
     MAX_IMAGE_SIZE_BYTES = int(5 * 1024 * 1024 * 3 / 4)  # ~3.75 MB raw -> ~5 MB base64
 
-    def _get_pricing(self) -> tuple[float, float]:
-        """Return (input_rate, output_rate) in USD per million tokens.
+    def _get_pricing(self) -> tuple[float, float] | None:
+        """Return known (input_rate, output_rate) in USD per million tokens.
 
         Uses longest-prefix matching to avoid ambiguity when one model
         prefix is a substring of another.
@@ -231,7 +231,7 @@ class AnthropicProvider(Provider):
             return (2.00, 10.00)
 
         matches = [(p, r) for p, r in _ANTHROPIC_PRICING_PER_M.items() if self._model.startswith(p)]
-        return max(matches, key=lambda x: len(x[0]))[1] if matches else (0.0, 0.0)
+        return max(matches, key=lambda x: len(x[0]))[1] if matches else None
 
     @staticmethod
     def _extract_text(response) -> str:  # type: ignore[no-untyped-def]
@@ -262,9 +262,9 @@ class AnthropicProvider(Provider):
         """Extract token counts from an Anthropic API response."""
         usage = getattr(response, "usage", None)
         if usage is None:
-            return {"input_tokens": 0, "output_tokens": 0, "thinking_tokens": 0, "total_tokens": 0}
-        input_tok = getattr(usage, "input_tokens", 0) or 0
-        output_tok = getattr(usage, "output_tokens", 0) or 0
+            return {}
+        input_value = getattr(usage, "input_tokens", None)
+        output_value = getattr(usage, "output_tokens", None)
         # With extended thinking, output_tokens includes thinking tokens.
         # Try to count thinking tokens from content blocks for reporting.
         thinking_tok = 0
@@ -272,13 +272,14 @@ class AnthropicProvider(Provider):
             if getattr(block, "type", None) == "thinking":
                 # Token count not directly available; use output_tokens as-is.
                 break
-        total_tok = input_tok + output_tok
-        return {
-            "input_tokens": input_tok,
-            "output_tokens": output_tok,
-            "thinking_tokens": thinking_tok,
-            "total_tokens": total_tok,
-        }
+        result = {"thinking_tokens": thinking_tok}
+        if input_value is not None:
+            result["input_tokens"] = int(input_value)
+        if output_value is not None:
+            result["output_tokens"] = int(output_value)
+        if input_value is not None and output_value is not None:
+            result["total_tokens"] = int(input_value) + int(output_value)
+        return result
 
     def _resize_to_perceived_size(self, image: Image.Image) -> Image.Image:
         """Pre-resize so the image Claude perceives is the image we recorded.
@@ -803,28 +804,33 @@ class AnthropicProvider(Provider):
             total_thinking = sum(u["thinking_tokens"] for u in page_usages)
             total_all = sum(u["total_tokens"] for u in page_usages)
 
-            # Compute cost
-            input_rate, output_rate = self._get_pricing()
-            annotate_attempt_costs(
-                api_attempts,
-                input_rate_per_million=input_rate,
-                output_rate_per_million=output_rate,
-            )
-            cost = (total_input * input_rate + (total_output + total_thinking) * output_rate) / 1_000_000
             usage_summary = (
                 {
                     "input_tokens": total_input,
                     "output_tokens": total_output,
                     "thinking_tokens": total_thinking,
                     "total_tokens": total_all,
-                    "cost_usd": cost,
-                    "cost_per_page_usd": cost / num_pages if num_pages > 0 else 0.0,
                     "input_tokens_per_page": total_input / num_pages if num_pages > 0 else 0.0,
                     "output_tokens_per_page": total_output / num_pages if num_pages > 0 else 0.0,
                 }
                 if attempt_usages_complete(page_usages)
                 else {}
             )
+            pricing = self._get_pricing()
+            if pricing is not None and attempt_usages_complete(page_usages):
+                input_rate, output_rate = pricing
+                annotate_attempt_costs(
+                    api_attempts,
+                    input_rate_per_million=input_rate,
+                    output_rate_per_million=output_rate,
+                )
+                cost = (total_input * input_rate + (total_output + total_thinking) * output_rate) / 1_000_000
+                usage_summary.update(
+                    {
+                        "cost_usd": cost,
+                        "cost_per_page_usd": cost / num_pages if num_pages > 0 else 0.0,
+                    }
+                )
 
             raw_output = {
                 "pages": pages,

--- a/src/parse_bench/inference/providers/parse/anthropic.py
+++ b/src/parse_bench/inference/providers/parse/anthropic.py
@@ -21,7 +21,7 @@ from parse_bench.inference.providers.base import (
 from parse_bench.inference.providers.parse._layout_utils import (
     build_layout_pages,
     items_to_markdown,
-    parse_layout_blocks,
+    parse_layout_response,
     resolve_layout_prompts,
     split_pdf_to_pages,
 )
@@ -144,6 +144,8 @@ class AnthropicProvider(Provider):
     capabilities to parse document content to markdown.
     """
 
+    PDF_RENDER_DPI = 150
+
     def __init__(self, provider_name: str, base_config: dict[str, Any] | None = None):
         """
         Initialize the provider.
@@ -165,7 +167,7 @@ class AnthropicProvider(Provider):
 
         # Configuration
         self._model = self.base_config.get("model", "claude-haiku-4-5-20251001")
-        self._dpi = self.base_config.get("dpi", 150)
+        self._dpi = self.base_config.get("dpi", self.PDF_RENDER_DPI)
         self._max_tokens = self.base_config.get("max_tokens", 8192)
         self._timeout = self.base_config.get("timeout", 120)
         self._mode = self.base_config.get("mode", "image")  # "image", "file", or "parse_with_layout"
@@ -204,7 +206,9 @@ class AnthropicProvider(Provider):
         try:
             import anthropic
 
-            self._client = anthropic.Anthropic(api_key=self._api_key)
+            # Retry exactly once at the active owner: per page for split modes,
+            # or in the outer document runner for native file mode.
+            self._client = anthropic.Anthropic(api_key=self._api_key, max_retries=0)
         except ImportError as e:
             raise ProviderConfigError("anthropic package not installed. Run: pip install anthropic") from e
 
@@ -227,11 +231,27 @@ class AnthropicProvider(Provider):
 
     @staticmethod
     def _extract_text(response) -> str:  # type: ignore[no-untyped-def]
-        """Extract text content from response, skipping any thinking blocks."""
-        for block in response.content or []:
+        """Extract non-empty text content, skipping any thinking blocks."""
+        content = getattr(response, "content", None)
+        if not content:
+            raise ProviderTransientError("Claude returned no content blocks")
+        text_parts: list[str] = []
+        for block in content:
             if getattr(block, "type", None) == "text":
-                return getattr(block, "text", "")
-        return ""
+                text = getattr(block, "text", None)
+                if isinstance(text, str):
+                    text_parts.append(text)
+        text = "".join(text_parts)
+        if not text.strip():
+            raise ProviderTransientError("Claude returned no non-empty text content")
+        return text
+
+    @staticmethod
+    def _parse_layout_response(text: str) -> list[dict[str, Any]]:
+        try:
+            return parse_layout_response(text)
+        except ValueError as exc:
+            raise ProviderTransientError(f"Claude returned malformed layout output: {exc}") from exc
 
     @staticmethod
     def _extract_usage(response) -> dict[str, int]:  # type: ignore[no-untyped-def]
@@ -397,6 +417,8 @@ class AnthropicProvider(Provider):
             content = self._extract_text(response)
             return content, usage
 
+        except (ProviderPermanentError, ProviderTransientError):
+            raise
         except Exception as e:
             error_str = str(e).lower()
             if any(kw in error_str for kw in ["timeout", "connection", "network"]):
@@ -452,9 +474,11 @@ class AnthropicProvider(Provider):
             usage = self._extract_usage(response)
             text = self._extract_text(response)
 
-            items = parse_layout_blocks(text)
+            items = self._parse_layout_response(text)
             return items, text, usage
 
+        except (ProviderPermanentError, ProviderTransientError):
+            raise
         except Exception as e:
             error_str = str(e).lower()
             if any(kw in error_str for kw in ["timeout", "connection", "network"]):
@@ -521,6 +545,8 @@ class AnthropicProvider(Provider):
             content = self._extract_text(response)
             return content, usage
 
+        except (ProviderPermanentError, ProviderTransientError):
+            raise
         except Exception as e:
             error_str = str(e).lower()
             if any(kw in error_str for kw in ["timeout", "connection", "network"]):
@@ -577,9 +603,11 @@ class AnthropicProvider(Provider):
             usage = self._extract_usage(response)
             text = self._extract_text(response)
 
-            items = parse_layout_blocks(text)
+            items = self._parse_layout_response(text)
             return items, text, usage
 
+        except (ProviderPermanentError, ProviderTransientError):
+            raise
         except Exception as e:
             error_str = str(e).lower()
             if any(kw in error_str for kw in ["timeout", "connection", "network"]):
@@ -651,7 +679,11 @@ class AnthropicProvider(Provider):
                     pdf_pages = split_pdf_to_pages(str(source_path))
                     pages = []
                     for page_index, (pdf_bytes, w, h) in enumerate(pdf_pages):
-                        items, raw_content, usage = self._parse_pdf_page_with_layout(pdf_bytes)
+                        items, raw_content, usage = run_page_with_retries(
+                            partial(self._parse_pdf_page_with_layout, pdf_bytes),
+                            provider_name=pipeline.provider_name,
+                            page_number=page_index + 1,
+                        )
                         page_usages.append(usage)
                         pages.append(
                             {
@@ -666,7 +698,11 @@ class AnthropicProvider(Provider):
                 else:
                     # Non-PDF: fall back to image-based layout parsing
                     with Image.open(source_path) as image:
-                        items, raw_content, usage = self._parse_image_with_layout(image)
+                        items, raw_content, usage = run_page_with_retries(
+                            partial(self._parse_image_with_layout, image),
+                            provider_name=pipeline.provider_name,
+                            page_number=1,
+                        )
                         page_usages.append(usage)
                         pages = [
                             {

--- a/src/parse_bench/inference/providers/parse/anthropic.py
+++ b/src/parse_bench/inference/providers/parse/anthropic.py
@@ -24,8 +24,11 @@ from parse_bench.inference.providers.parse._layout_utils import (
     parse_layout_response,
     resolve_layout_prompts,
     split_pdf_to_pages,
+    validated_sorted_page_records,
 )
 from parse_bench.inference.providers.parse._multipage_image import (
+    annotate_attempt_costs,
+    append_attempt_usages,
     close_derived_images,
     open_document_page_images,
     run_page_with_retries,
@@ -414,7 +417,11 @@ class AnthropicProvider(Provider):
             )
 
             usage = self._extract_usage(response)
-            content = self._extract_text(response)
+            try:
+                content = self._extract_text(response)
+            except ProviderTransientError as exc:
+                exc.attempt_stats = usage
+                raise
             return content, usage
 
         except (ProviderPermanentError, ProviderTransientError):
@@ -472,9 +479,12 @@ class AnthropicProvider(Provider):
             )
 
             usage = self._extract_usage(response)
-            text = self._extract_text(response)
-
-            items = self._parse_layout_response(text)
+            try:
+                text = self._extract_text(response)
+                items = self._parse_layout_response(text)
+            except ProviderTransientError as exc:
+                exc.attempt_stats = usage
+                raise
             return items, text, usage
 
         except (ProviderPermanentError, ProviderTransientError):
@@ -542,7 +552,11 @@ class AnthropicProvider(Provider):
             )
 
             usage = self._extract_usage(response)
-            content = self._extract_text(response)
+            try:
+                content = self._extract_text(response)
+            except ProviderTransientError as exc:
+                exc.attempt_stats = usage
+                raise
             return content, usage
 
         except (ProviderPermanentError, ProviderTransientError):
@@ -601,9 +615,12 @@ class AnthropicProvider(Provider):
             )
 
             usage = self._extract_usage(response)
-            text = self._extract_text(response)
-
-            items = self._parse_layout_response(text)
+            try:
+                text = self._extract_text(response)
+                items = self._parse_layout_response(text)
+            except ProviderTransientError as exc:
+                exc.attempt_stats = usage
+                raise
             return items, text, usage
 
         except (ProviderPermanentError, ProviderTransientError):
@@ -642,6 +659,7 @@ class AnthropicProvider(Provider):
 
         try:
             page_usages: list[dict[str, int]] = []
+            api_attempts: list[dict[str, object]] = []
 
             if self._mode == "file":
                 if source_path.suffix.lower() == ".pdf":
@@ -679,12 +697,15 @@ class AnthropicProvider(Provider):
                     pdf_pages = split_pdf_to_pages(str(source_path))
                     pages = []
                     for page_index, (pdf_bytes, w, h) in enumerate(pdf_pages):
+                        attempts: list[dict[str, object]] = []
                         items, raw_content, usage = run_page_with_retries(
                             partial(self._parse_pdf_page_with_layout, pdf_bytes),
                             provider_name=pipeline.provider_name,
                             page_number=page_index + 1,
+                            attempt_ledger=attempts,
                         )
-                        page_usages.append(usage)
+                        api_attempts.extend(attempts)
+                        append_attempt_usages(page_usages, attempts)
                         pages.append(
                             {
                                 "page_index": page_index,
@@ -698,12 +719,15 @@ class AnthropicProvider(Provider):
                 else:
                     # Non-PDF: fall back to image-based layout parsing
                     with Image.open(source_path) as image:
+                        attempts = []
                         items, raw_content, usage = run_page_with_retries(
                             partial(self._parse_image_with_layout, image),
                             provider_name=pipeline.provider_name,
                             page_number=1,
+                            attempt_ledger=attempts,
                         )
-                        page_usages.append(usage)
+                        api_attempts.extend(attempts)
+                        append_attempt_usages(page_usages, attempts)
                         pages = [
                             {
                                 "page_index": 0,
@@ -725,12 +749,15 @@ class AnthropicProvider(Provider):
                             # dims are exactly what the model perceives.
                             page = self._resize_to_perceived_size(image) if self._bbox_scale is None else image
                             try:
+                                attempts = []
                                 items, raw_content, usage = run_page_with_retries(
                                     partial(self._parse_image_with_layout, page),
                                     provider_name=pipeline.provider_name,
                                     page_number=page_index + 1,
+                                    attempt_ledger=attempts,
                                 )
-                                page_usages.append(usage)
+                                api_attempts.extend(attempts)
+                                append_attempt_usages(page_usages, attempts)
                                 pages.append(
                                     {
                                         "page_index": page_index,
@@ -744,12 +771,15 @@ class AnthropicProvider(Provider):
                                 if page is not image:
                                     page.close()
                         else:
+                            attempts = []
                             markdown, usage = run_page_with_retries(
                                 partial(self._parse_image, image),
                                 provider_name=pipeline.provider_name,
                                 page_number=page_index + 1,
+                                attempt_ledger=attempts,
                             )
-                            page_usages.append(usage)
+                            api_attempts.extend(attempts)
+                            append_attempt_usages(page_usages, attempts)
                             pages.append(
                                 {
                                     "page_index": page_index,
@@ -771,6 +801,11 @@ class AnthropicProvider(Provider):
 
             # Compute cost
             input_rate, output_rate = self._get_pricing()
+            annotate_attempt_costs(
+                api_attempts,
+                input_rate_per_million=input_rate,
+                output_rate_per_million=output_rate,
+            )
             cost = (total_input * input_rate + (total_output + total_thinking) * output_rate) / 1_000_000
 
             raw_output = {
@@ -792,6 +827,8 @@ class AnthropicProvider(Provider):
                 "cost_per_page_usd": cost / num_pages if num_pages > 0 else 0.0,
                 "input_tokens_per_page": total_input / num_pages if num_pages > 0 else 0.0,
                 "output_tokens_per_page": total_output / num_pages if num_pages > 0 else 0.0,
+                "num_api_calls": len(api_attempts) if api_attempts else len(page_usages),
+                "api_attempts": api_attempts,
             }
 
             return RawInferenceResult(
@@ -829,7 +866,7 @@ class AnthropicProvider(Provider):
         page_markdowns: list[str] = []
         layout_pages: list[ParseLayoutPageIR] = []
 
-        for page_data in raw_result.raw_output.get("pages", []):
+        for page_data in validated_sorted_page_records(raw_result.raw_output.get("pages", [])):
             page_index = page_data.get("page_index", 0)
 
             if mode in ("parse_with_layout", "parse_with_layout_file"):
@@ -853,8 +890,6 @@ class AnthropicProvider(Provider):
             pages.append(PageIR(page_index=page_index, markdown=markdown))
             page_markdowns.append(markdown)
 
-        # Sort by page index and concatenate
-        pages.sort(key=lambda p: p.page_index)
         full_markdown = "\n\n".join(page_markdowns)
 
         output = ParseOutput(

--- a/src/parse_bench/inference/providers/parse/anthropic.py
+++ b/src/parse_bench/inference/providers/parse/anthropic.py
@@ -24,6 +24,7 @@ from parse_bench.inference.providers.parse._layout_utils import (
     resolve_layout_prompts,
     split_pdf_to_pages,
 )
+from parse_bench.inference.providers.parse._multipage_image import open_document_page_images
 from parse_bench.inference.providers.registry import register_provider
 from parse_bench.schemas.parse_output import PageIR, ParseLayoutPageIR, ParseOutput
 from parse_bench.schemas.pipeline import PipelineSpec
@@ -341,24 +342,6 @@ class AnthropicProvider(Provider):
         buffer.seek(0)
         return base64.standard_b64encode(buffer.getvalue()).decode("utf-8")
 
-    def _pdf_to_images(self, pdf_path: str) -> list[Image.Image]:
-        """
-        Convert PDF pages to images.
-
-        :param pdf_path: Path to the PDF file
-        :return: List of PIL Images, one per page
-        """
-        try:
-            from pdf2image import convert_from_path
-        except ImportError as e:
-            raise ProviderConfigError("pdf2image package not installed. Run: pip install pdf2image") from e
-
-        try:
-            images = convert_from_path(pdf_path, dpi=self._dpi)
-            return images
-        except Exception as e:
-            raise ProviderPermanentError(f"Failed to convert PDF to images: {e}") from e
-
     def _parse_image(self, image: Image.Image) -> tuple[str, dict[str, int]]:
         """
         Send image to Claude and get markdown response.
@@ -644,17 +627,17 @@ class AnthropicProvider(Provider):
                     num_pages = 1  # We don't know actual page count in file mode
                 else:
                     # Non-PDF: fall back to image-based parsing
-                    image = Image.open(source_path)
-                    markdown, usage = self._parse_image(image)
-                    page_usages.append(usage)
-                    pages = [
-                        {
-                            "page_index": 0,
-                            "markdown": markdown,
-                            "width": image.width,
-                            "height": image.height,
-                        }
-                    ]
+                    with Image.open(source_path) as image:
+                        markdown, usage = self._parse_image(image)
+                        page_usages.append(usage)
+                        pages = [
+                            {
+                                "page_index": 0,
+                                "markdown": markdown,
+                                "width": image.width,
+                                "height": image.height,
+                            }
+                        ]
                     num_pages = 1
             elif self._mode == "parse_with_layout_file":
                 if source_path.suffix.lower() == ".pdf":
@@ -676,57 +659,56 @@ class AnthropicProvider(Provider):
                     num_pages = len(pdf_pages)
                 else:
                     # Non-PDF: fall back to image-based layout parsing
-                    image = Image.open(source_path)
-                    items, raw_content, usage = self._parse_image_with_layout(image)
-                    page_usages.append(usage)
-                    pages = [
-                        {
-                            "page_index": 0,
-                            "items": items,
-                            "raw_content": raw_content,
-                            "width": image.width,
-                            "height": image.height,
-                        }
-                    ]
+                    with Image.open(source_path) as image:
+                        items, raw_content, usage = self._parse_image_with_layout(image)
+                        page_usages.append(usage)
+                        pages = [
+                            {
+                                "page_index": 0,
+                                "items": items,
+                                "raw_content": raw_content,
+                                "width": image.width,
+                                "height": image.height,
+                            }
+                        ]
                     num_pages = 1
             else:
                 # Image mode (both "image" and "parse_with_layout"):
                 # convert PDF to images and process each page
-                if source_path.suffix.lower() == ".pdf":
-                    images = self._pdf_to_images(str(source_path))
-                else:
-                    images = [Image.open(source_path)]
-
-                # Parse each page
                 pages = []
-                for page_index, image in enumerate(images):  # type: ignore[assignment]
-                    if self._mode == "parse_with_layout":
-                        # In pixel mode, send the pre-resized image so the recorded
-                        # dims are exactly what the model perceives.
-                        page = self._resize_to_perceived_size(image) if self._bbox_scale is None else image
-                        items, raw_content, usage = self._parse_image_with_layout(page)
-                        page_usages.append(usage)
-                        pages.append(
-                            {
-                                "page_index": page_index,
-                                "items": items,
-                                "raw_content": raw_content,
-                                "width": page.width,
-                                "height": page.height,
-                            }
-                        )
-                    else:
-                        markdown, usage = self._parse_image(image)
-                        page_usages.append(usage)
-                        pages.append(
-                            {
-                                "page_index": page_index,
-                                "markdown": markdown,
-                                "width": image.width,
-                                "height": image.height,
-                            }
-                        )
-                num_pages = len(images)
+                with open_document_page_images(source_path, dpi=self._dpi) as images:
+                    for page_index, image in enumerate(images):
+                        if self._mode == "parse_with_layout":
+                            # In pixel mode, send the pre-resized image so the recorded
+                            # dims are exactly what the model perceives.
+                            page = self._resize_to_perceived_size(image) if self._bbox_scale is None else image
+                            try:
+                                items, raw_content, usage = self._parse_image_with_layout(page)
+                                page_usages.append(usage)
+                                pages.append(
+                                    {
+                                        "page_index": page_index,
+                                        "items": items,
+                                        "raw_content": raw_content,
+                                        "width": page.width,
+                                        "height": page.height,
+                                    }
+                                )
+                            finally:
+                                if page is not image:
+                                    page.close()
+                        else:
+                            markdown, usage = self._parse_image(image)
+                            page_usages.append(usage)
+                            pages.append(
+                                {
+                                    "page_index": page_index,
+                                    "markdown": markdown,
+                                    "width": image.width,
+                                    "height": image.height,
+                                }
+                            )
+                    num_pages = len(images)
 
             completed_at = datetime.now()
             latency_ms = int((completed_at - started_at).total_seconds() * 1000)

--- a/src/parse_bench/inference/providers/parse/anthropic.py
+++ b/src/parse_bench/inference/providers/parse/anthropic.py
@@ -29,6 +29,7 @@ from parse_bench.inference.providers.parse._layout_utils import (
 from parse_bench.inference.providers.parse._multipage_image import (
     annotate_attempt_costs,
     append_attempt_usages,
+    attempt_usages_complete,
     close_derived_images,
     open_document_page_images,
     run_page_with_retries,
@@ -703,6 +704,7 @@ class AnthropicProvider(Provider):
                             provider_name=pipeline.provider_name,
                             page_number=page_index + 1,
                             attempt_ledger=attempts,
+                            prior_attempt_ledger=api_attempts,
                         )
                         api_attempts.extend(attempts)
                         append_attempt_usages(page_usages, attempts)
@@ -755,6 +757,7 @@ class AnthropicProvider(Provider):
                                     provider_name=pipeline.provider_name,
                                     page_number=page_index + 1,
                                     attempt_ledger=attempts,
+                                    prior_attempt_ledger=api_attempts,
                                 )
                                 api_attempts.extend(attempts)
                                 append_attempt_usages(page_usages, attempts)
@@ -777,6 +780,7 @@ class AnthropicProvider(Provider):
                                 provider_name=pipeline.provider_name,
                                 page_number=page_index + 1,
                                 attempt_ledger=attempts,
+                                prior_attempt_ledger=api_attempts,
                             )
                             api_attempts.extend(attempts)
                             append_attempt_usages(page_usages, attempts)
@@ -807,6 +811,20 @@ class AnthropicProvider(Provider):
                 output_rate_per_million=output_rate,
             )
             cost = (total_input * input_rate + (total_output + total_thinking) * output_rate) / 1_000_000
+            usage_summary = (
+                {
+                    "input_tokens": total_input,
+                    "output_tokens": total_output,
+                    "thinking_tokens": total_thinking,
+                    "total_tokens": total_all,
+                    "cost_usd": cost,
+                    "cost_per_page_usd": cost / num_pages if num_pages > 0 else 0.0,
+                    "input_tokens_per_page": total_input / num_pages if num_pages > 0 else 0.0,
+                    "output_tokens_per_page": total_output / num_pages if num_pages > 0 else 0.0,
+                }
+                if attempt_usages_complete(page_usages)
+                else {}
+            )
 
             raw_output = {
                 "pages": pages,
@@ -819,14 +837,7 @@ class AnthropicProvider(Provider):
                     "max_tokens": self._max_tokens,
                     "mode": self._mode,
                 },
-                "input_tokens": total_input,
-                "output_tokens": total_output,
-                "thinking_tokens": total_thinking,
-                "total_tokens": total_all,
-                "cost_usd": cost,
-                "cost_per_page_usd": cost / num_pages if num_pages > 0 else 0.0,
-                "input_tokens_per_page": total_input / num_pages if num_pages > 0 else 0.0,
-                "output_tokens_per_page": total_output / num_pages if num_pages > 0 else 0.0,
+                **usage_summary,
                 "num_api_calls": len(api_attempts) if api_attempts else len(page_usages),
                 "api_attempts": api_attempts,
             }

--- a/src/parse_bench/inference/providers/parse/chandra2.py
+++ b/src/parse_bench/inference/providers/parse/chandra2.py
@@ -194,6 +194,8 @@ class Chandra2Provider(Provider):
         - api_key_env (str, default="VLLM_API_KEY"): Env var for API key (openai format only)
     """
 
+    PDF_RENDER_DPI = 192
+
     def __init__(self, provider_name: str, base_config: dict[str, Any] | None = None):
         super().__init__(provider_name, base_config)
 
@@ -214,7 +216,7 @@ class Chandra2Provider(Provider):
             raise ProviderConfigError(f"Invalid task '{self._task}'. Must be one of: {list(TASK_PROMPTS.keys())}")
 
         self._timeout = self.base_config.get("timeout", 600)
-        self._dpi = self.base_config.get("dpi", 192)
+        self._dpi = self.base_config.get("dpi", self.PDF_RENDER_DPI)
 
         # API key for authenticated vLLM endpoints
         api_key_env = self.base_config.get("api_key_env", "VLLM_API_KEY")

--- a/src/parse_bench/inference/providers/parse/chandra2.py
+++ b/src/parse_bench/inference/providers/parse/chandra2.py
@@ -31,6 +31,7 @@ from parse_bench.inference.providers.base import (
     ProviderPermanentError,
     ProviderTransientError,
 )
+from parse_bench.inference.providers.parse._multipage_image import normalize_pdf_pages, run_pdf_pages
 from parse_bench.inference.providers.registry import register_provider
 from parse_bench.schemas.parse_output import (
     LayoutItemIR,
@@ -358,6 +359,10 @@ class Chandra2Provider(Provider):
                 }
 
     def run_inference(self, pipeline: PipelineSpec, request: InferenceRequest) -> RawInferenceResult:
+        multipage_result = run_pdf_pages(pipeline, request, dpi=self._dpi, run_single_image=self.run_inference)
+        if multipage_result is not None:
+            return multipage_result
+
         if request.product_type != ProductType.PARSE:
             raise ProviderPermanentError(
                 f"Chandra2Provider only supports PARSE product type, got {request.product_type}"
@@ -557,6 +562,10 @@ class Chandra2Provider(Provider):
         return "\n".join(parts) if parts else raw_html
 
     def normalize(self, raw_result: RawInferenceResult) -> InferenceResult:
+        multipage_result = normalize_pdf_pages(raw_result, normalize_single_image=self.normalize)
+        if multipage_result is not None:
+            return multipage_result
+
         if raw_result.product_type != ProductType.PARSE:
             raise ProviderPermanentError(
                 f"Chandra2Provider only supports PARSE product type, got {raw_result.product_type}"

--- a/src/parse_bench/inference/providers/parse/deepseekocr2.py
+++ b/src/parse_bench/inference/providers/parse/deepseekocr2.py
@@ -23,6 +23,7 @@ from parse_bench.inference.providers.base import (
     ProviderPermanentError,
     ProviderTransientError,
 )
+from parse_bench.inference.providers.parse._multipage_image import normalize_pdf_pages, run_pdf_pages
 from parse_bench.inference.providers.registry import register_provider
 from parse_bench.schemas.parse_output import (
     LayoutItemIR,
@@ -128,6 +129,10 @@ class DeepSeekOCR2Provider(Provider):
         }
 
     def run_inference(self, pipeline: PipelineSpec, request: InferenceRequest) -> RawInferenceResult:
+        multipage_result = run_pdf_pages(pipeline, request, dpi=self._dpi, run_single_image=self.run_inference)
+        if multipage_result is not None:
+            return multipage_result
+
         if request.product_type != ProductType.PARSE:
             raise ProviderPermanentError(
                 f"DeepSeekOCR2Provider only supports PARSE product type, got {request.product_type}"
@@ -378,6 +383,10 @@ class DeepSeekOCR2Provider(Provider):
         ]
 
     def normalize(self, raw_result: RawInferenceResult) -> InferenceResult:
+        multipage_result = normalize_pdf_pages(raw_result, normalize_single_image=self.normalize)
+        if multipage_result is not None:
+            return multipage_result
+
         if raw_result.product_type != ProductType.PARSE:
             raise ProviderPermanentError(
                 f"DeepSeekOCR2Provider only supports PARSE product type, got {raw_result.product_type}"

--- a/src/parse_bench/inference/providers/parse/deepseekocr2.py
+++ b/src/parse_bench/inference/providers/parse/deepseekocr2.py
@@ -51,6 +51,8 @@ class DeepSeekOCR2Provider(Provider):
         - dpi (int, default=150): DPI for PDF to image conversion
     """
 
+    PDF_RENDER_DPI = 150
+
     def __init__(self, provider_name: str, base_config: dict[str, Any] | None = None):
         super().__init__(provider_name, base_config)
 
@@ -60,7 +62,7 @@ class DeepSeekOCR2Provider(Provider):
         self._server_url: str = server_url
 
         self._timeout = self.base_config.get("timeout", 600)
-        self._dpi = self.base_config.get("dpi", 150)
+        self._dpi = self.base_config.get("dpi", self.PDF_RENDER_DPI)
 
     def _pdf_to_image(self, pdf_path: Path) -> bytes:
         try:

--- a/src/parse_bench/inference/providers/parse/dots_ocr.py
+++ b/src/parse_bench/inference/providers/parse/dots_ocr.py
@@ -24,6 +24,7 @@ from parse_bench.inference.providers.base import (
     Provider,
     ProviderConfigError,
     ProviderPermanentError,
+    ProviderRetryExhaustedError,
     ProviderTransientError,
 )
 from parse_bench.inference.providers.parse._multipage_image import open_document_page_images
@@ -288,6 +289,26 @@ class DotsOcrParseProvider(Provider):
     # Per-page inference
     # ------------------------------------------------------------------
 
+    def _call_page_with_retries(self, image: Image.Image, page_number: int) -> str:
+        """Own transient retries at the billable page request boundary."""
+        max_attempts = 3
+        for attempt in range(max_attempts):
+            try:
+                return self._call_endpoint(image)
+            except ProviderTransientError as exc:
+                if attempt == max_attempts - 1:
+                    raise ProviderRetryExhaustedError(
+                        f"dots.ocr page {page_number} failed after {max_attempts} attempts: {exc}"
+                    ) from exc
+                delay = 15 * (2**attempt)
+                print(
+                    f"[dots.ocr] Transient error on page {page_number}: {exc}. "
+                    f"Retrying in {delay}s (attempt {attempt + 1}/{max_attempts})..."
+                )
+                time.sleep(delay)
+
+        raise AssertionError("unreachable")
+
     def _run_inference_pages(self, source_path: Path) -> dict[str, Any]:
         """Convert source file to images and run inference on each page."""
         pages = []
@@ -295,7 +316,7 @@ class DotsOcrParseProvider(Provider):
             for page_index, image in enumerate(images):
                 page_image = image if image.mode in ("RGB", "RGBA") else image.convert("RGB")
                 try:
-                    raw_text = self._call_endpoint(page_image)
+                    raw_text = self._call_page_with_retries(page_image, page_index + 1)
 
                     page_data: dict[str, Any] = {
                         "page_index": page_index,
@@ -306,10 +327,7 @@ class DotsOcrParseProvider(Provider):
 
                     if self._is_layout_mode:
                         # Parse structured JSON → typed layout items + reassemble markdown
-                        try:
-                            layout_items = self._parse_layout_items(raw_text)
-                        except ProviderPermanentError:
-                            layout_items = []
+                        layout_items = self._parse_layout_items(raw_text)
 
                         page_data["layout_items"] = [item.model_dump() for item in layout_items]
                         page_data["markdown"] = _reassemble_markdown(layout_items)
@@ -357,51 +375,25 @@ class DotsOcrParseProvider(Provider):
             )
 
         started_at = datetime.now()
-        max_retries = 3
-        last_error: Exception | None = None
+        try:
+            raw_output = self._run_inference_pages(source_path)
+        except (ProviderPermanentError, ProviderTransientError, ProviderConfigError):
+            raise
+        except Exception as exc:
+            raise ProviderPermanentError(f"Unexpected error during inference: {exc}") from exc
 
-        for attempt in range(max_retries):
-            try:
-                raw_output = self._run_inference_pages(source_path)
-
-                completed_at = datetime.now()
-                latency_ms = int((completed_at - started_at).total_seconds() * 1000)
-
-                return RawInferenceResult(
-                    request=request,
-                    pipeline=pipeline,
-                    pipeline_name=pipeline.pipeline_name,
-                    product_type=request.product_type,
-                    raw_output=raw_output,
-                    started_at=started_at,
-                    completed_at=completed_at,
-                    latency_in_ms=latency_ms,
-                )
-
-            except ProviderTransientError as e:
-                last_error = e
-                if attempt < max_retries - 1:
-                    delay = 15 * (2**attempt)
-                    print(
-                        f"[dots.ocr] Transient error on {request.example_id}: {e}. "
-                        f"Retrying in {delay}s (attempt {attempt + 1}/{max_retries})..."
-                    )
-                    time.sleep(delay)
-                    continue
-
-            except (ProviderPermanentError, ProviderConfigError) as e:
-                last_error = e
-                break
-
-            except Exception as e:
-                last_error = e
-                break
-
-        if isinstance(last_error, (ProviderPermanentError, ProviderTransientError, ProviderConfigError)):
-            raise last_error
-        if last_error is not None:
-            raise ProviderPermanentError(f"Unexpected error during inference: {last_error}") from last_error
-        raise ProviderPermanentError("Inference failed without an error")
+        completed_at = datetime.now()
+        latency_ms = int((completed_at - started_at).total_seconds() * 1000)
+        return RawInferenceResult(
+            request=request,
+            pipeline=pipeline,
+            pipeline_name=pipeline.pipeline_name,
+            product_type=request.product_type,
+            raw_output=raw_output,
+            started_at=started_at,
+            completed_at=completed_at,
+            latency_in_ms=latency_ms,
+        )
 
     # ------------------------------------------------------------------
     # normalize

--- a/src/parse_bench/inference/providers/parse/dots_ocr.py
+++ b/src/parse_bench/inference/providers/parse/dots_ocr.py
@@ -26,6 +26,7 @@ from parse_bench.inference.providers.base import (
     ProviderRateLimitError,
     ProviderTransientError,
 )
+from parse_bench.inference.providers.parse._layout_utils import validated_sorted_page_records
 from parse_bench.inference.providers.parse._multipage_image import (
     open_document_page_images,
     run_page_with_retries,
@@ -308,22 +309,31 @@ class DotsOcrParseProvider(Provider):
     # Per-page inference
     # ------------------------------------------------------------------
 
-    def _call_page_with_retries(self, image: Image.Image, page_number: int) -> str:
+    def _call_page_with_retries(
+        self,
+        image: Image.Image,
+        page_number: int,
+        attempt_ledger: list[dict[str, object]],
+    ) -> str:
         """Own transient retries at the billable page request boundary."""
         return run_page_with_retries(
             lambda: self._call_endpoint(image),
             provider_name="dots.ocr",
             page_number=page_number,
+            attempt_ledger=attempt_ledger,
         )
 
     def _run_inference_pages(self, source_path: Path) -> dict[str, Any]:
         """Convert source file to images and run inference on each page."""
         pages = []
+        api_attempts: list[dict[str, object]] = []
         with open_document_page_images(source_path, dpi=self._dpi) as images:
             for page_index, image in enumerate(images):
                 page_image = image if image.mode in ("RGB", "RGBA") else image.convert("RGB")
                 try:
-                    raw_text = self._call_page_with_retries(page_image, page_index + 1)
+                    attempts: list[dict[str, object]] = []
+                    raw_text = self._call_page_with_retries(page_image, page_index + 1, attempts)
+                    api_attempts.extend(attempts)
 
                     page_data: dict[str, Any] = {
                         "page_index": page_index,
@@ -354,6 +364,8 @@ class DotsOcrParseProvider(Provider):
             "num_pages": num_pages,
             "model": self._model,
             "prompt_mode": self._prompt_mode,
+            "num_api_calls": len(api_attempts),
+            "api_attempts": api_attempts,
             "config": {
                 "dpi": self._dpi,
                 "max_tokens": self._max_tokens,
@@ -416,7 +428,7 @@ class DotsOcrParseProvider(Provider):
         layout_pages: list[ParseLayoutPageIR] = []
         page_markdowns: list[str] = []
 
-        for page_data in raw_result.raw_output.get("pages", []):
+        for page_data in validated_sorted_page_records(raw_result.raw_output.get("pages", [])):
             page_index = page_data.get("page_index", 0)
             markdown = page_data.get("markdown", "")
             img_width = page_data.get("width", 0)
@@ -430,7 +442,8 @@ class DotsOcrParseProvider(Provider):
 
             # Build layout_pages from structured layout items (if available)
             layout_items = page_data.get("layout_items", [])
-            if layout_items and img_width > 0 and img_height > 0:
+            is_layout_mode = raw_result.raw_output.get("prompt_mode") in _LAYOUT_PROMPT_MODES
+            if is_layout_mode and img_width > 0 and img_height > 0:
                 layout_page = _build_layout_page(
                     layout_items=layout_items,
                     page_number=page_index + 1,
@@ -440,7 +453,6 @@ class DotsOcrParseProvider(Provider):
                 )
                 layout_pages.append(layout_page)
 
-        pages.sort(key=lambda p: p.page_index)
         full_markdown = "\n\n".join(page_markdowns)
 
         output = ParseOutput(

--- a/src/parse_bench/inference/providers/parse/dots_ocr.py
+++ b/src/parse_bench/inference/providers/parse/dots_ocr.py
@@ -14,7 +14,7 @@ import re
 import time
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from openai import OpenAI
 from PIL import Image
@@ -26,6 +26,7 @@ from parse_bench.inference.providers.base import (
     ProviderPermanentError,
     ProviderTransientError,
 )
+from parse_bench.inference.providers.parse._multipage_image import open_document_page_images
 from parse_bench.inference.providers.registry import register_provider
 from parse_bench.schemas.parse_output import (
     LayoutItemIR,
@@ -191,16 +192,6 @@ class DotsOcrParseProvider(Provider):
         buffer.seek(0)
         return base64.b64encode(buffer.getvalue()).decode("utf-8")
 
-    def _pdf_to_images(self, pdf_path: str) -> list[Image.Image]:
-        try:
-            from pdf2image import convert_from_path
-        except ImportError as e:
-            raise ProviderConfigError("pdf2image package not installed. Run: pip install pdf2image") from e
-        try:
-            return convert_from_path(pdf_path, dpi=self._dpi)
-        except Exception as e:
-            raise ProviderPermanentError(f"Failed to convert PDF to images: {e}") from e
-
     # ------------------------------------------------------------------
     # API call
     # ------------------------------------------------------------------
@@ -236,7 +227,7 @@ class DotsOcrParseProvider(Provider):
         content = response.choices[0].message.content
         if not content:
             raise ProviderPermanentError("Empty response from model")
-        return content
+        return cast(str, content)
 
     # ------------------------------------------------------------------
     # HTML sanitization
@@ -287,7 +278,7 @@ class DotsOcrParseProvider(Provider):
         adapter = TypeAdapter(list[DotsOcrLayoutItem])
         for candidate in candidates:
             try:
-                return adapter.validate_json(candidate)
+                return cast(list[DotsOcrLayoutItem], adapter.validate_json(candidate))
             except Exception:
                 continue
 
@@ -299,43 +290,43 @@ class DotsOcrParseProvider(Provider):
 
     def _run_inference_pages(self, source_path: Path) -> dict[str, Any]:
         """Convert source file to images and run inference on each page."""
-        if source_path.suffix.lower() == ".pdf":
-            images = self._pdf_to_images(str(source_path))
-        else:
-            images = [Image.open(source_path)]
-
         pages = []
-        for page_index, image in enumerate(images):
-            if image.mode not in ("RGB", "RGBA"):
-                image = image.convert("RGB")
-
-            raw_text = self._call_endpoint(image)
-
-            page_data: dict[str, Any] = {
-                "page_index": page_index,
-                "width": image.width,
-                "height": image.height,
-                "raw_response": raw_text,
-            }
-
-            if self._is_layout_mode:
-                # Parse structured JSON → typed layout items + reassemble markdown
+        with open_document_page_images(source_path, dpi=self._dpi) as images:
+            for page_index, image in enumerate(images):
+                page_image = image if image.mode in ("RGB", "RGBA") else image.convert("RGB")
                 try:
-                    layout_items = self._parse_layout_items(raw_text)
-                except ProviderPermanentError:
-                    layout_items = []
+                    raw_text = self._call_endpoint(page_image)
 
-                page_data["layout_items"] = [item.model_dump() for item in layout_items]
-                page_data["markdown"] = _reassemble_markdown(layout_items)
-            else:
-                page_data["markdown"] = raw_text
-                page_data["layout_items"] = []
+                    page_data: dict[str, Any] = {
+                        "page_index": page_index,
+                        "width": page_image.width,
+                        "height": page_image.height,
+                        "raw_response": raw_text,
+                    }
 
-            pages.append(page_data)
+                    if self._is_layout_mode:
+                        # Parse structured JSON → typed layout items + reassemble markdown
+                        try:
+                            layout_items = self._parse_layout_items(raw_text)
+                        except ProviderPermanentError:
+                            layout_items = []
+
+                        page_data["layout_items"] = [item.model_dump() for item in layout_items]
+                        page_data["markdown"] = _reassemble_markdown(layout_items)
+                    else:
+                        page_data["markdown"] = raw_text
+                        page_data["layout_items"] = []
+
+                    pages.append(page_data)
+                finally:
+                    if page_image is not image:
+                        page_image.close()
+
+            num_pages = len(images)
 
         return {
             "pages": pages,
-            "num_pages": len(images),
+            "num_pages": num_pages,
             "model": self._model,
             "prompt_mode": self._prompt_mode,
             "config": {

--- a/src/parse_bench/inference/providers/parse/dots_ocr.py
+++ b/src/parse_bench/inference/providers/parse/dots_ocr.py
@@ -13,7 +13,7 @@ import os
 import re
 from datetime import datetime
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, NoReturn, cast
 
 from openai import OpenAI
 from PIL import Image
@@ -23,6 +23,7 @@ from parse_bench.inference.providers.base import (
     Provider,
     ProviderConfigError,
     ProviderPermanentError,
+    ProviderRateLimitError,
     ProviderTransientError,
 )
 from parse_bench.inference.providers.parse._multipage_image import (
@@ -144,6 +145,8 @@ class DotsOcrParseProvider(Provider):
         - prompt_override (str, optional): Custom prompt text (overrides prompt_mode)
     """
 
+    PDF_RENDER_DPI = 150
+
     def __init__(
         self,
         provider_name: str,
@@ -161,12 +164,13 @@ class DotsOcrParseProvider(Provider):
         self._client = OpenAI(
             base_url=endpoint_url,
             api_key=os.getenv("DOTS_OCR_API_KEY", "not-needed"),
+            max_retries=0,
         )
 
         self._model = self.base_config.get("model", SERVED_MODEL_NAME)
         self._timeout = self.base_config.get("timeout", 180)
         self._max_tokens = self.base_config.get("max_tokens", 16384)
-        self._dpi = self.base_config.get("dpi", 150)
+        self._dpi = self.base_config.get("dpi", self.PDF_RENDER_DPI)
         self._temperature = self.base_config.get("temperature", 0.1)
         self._top_p = self.base_config.get("top_p", 0.9)
 
@@ -221,15 +225,29 @@ class DotsOcrParseProvider(Provider):
                 top_p=self._top_p,
             )
         except Exception as e:
-            error_msg = str(e).lower()
-            if "timeout" in error_msg or "connection" in error_msg:
-                raise ProviderTransientError(f"API call failed: {e}") from e
-            raise ProviderPermanentError(f"API call failed: {e}") from e
+            self._raise_api_error(e)
 
         content = response.choices[0].message.content
         if not content:
             raise ProviderPermanentError("Empty response from model")
         return cast(str, content)
+
+    @staticmethod
+    def _raise_api_error(exc: Exception) -> NoReturn:
+        """Classify real OpenAI-compatible transport and HTTP failures."""
+        from openai import APIConnectionError, APITimeoutError
+
+        if isinstance(exc, (APITimeoutError, APIConnectionError, TimeoutError, ConnectionError)):
+            raise ProviderTransientError(f"Transient dots.ocr API failure: {exc}") from exc
+
+        status_code = getattr(exc, "status_code", None)
+        if status_code is None:
+            status_code = getattr(getattr(exc, "response", None), "status_code", None)
+        if status_code == 429:
+            raise ProviderRateLimitError(f"dots.ocr rate limited (429): {exc}") from exc
+        if status_code == 408 or isinstance(status_code, int) and status_code >= 500:
+            raise ProviderTransientError(f"Transient dots.ocr HTTP {status_code}: {exc}") from exc
+        raise ProviderPermanentError(f"Permanent dots.ocr API failure: {exc}") from exc
 
     # ------------------------------------------------------------------
     # HTML sanitization

--- a/src/parse_bench/inference/providers/parse/dots_ocr.py
+++ b/src/parse_bench/inference/providers/parse/dots_ocr.py
@@ -11,7 +11,6 @@ import base64
 import io
 import os
 import re
-import time
 from datetime import datetime
 from pathlib import Path
 from typing import Any, cast
@@ -24,10 +23,12 @@ from parse_bench.inference.providers.base import (
     Provider,
     ProviderConfigError,
     ProviderPermanentError,
-    ProviderRetryExhaustedError,
     ProviderTransientError,
 )
-from parse_bench.inference.providers.parse._multipage_image import open_document_page_images
+from parse_bench.inference.providers.parse._multipage_image import (
+    open_document_page_images,
+    run_page_with_retries,
+)
 from parse_bench.inference.providers.registry import register_provider
 from parse_bench.schemas.parse_output import (
     LayoutItemIR,
@@ -291,23 +292,11 @@ class DotsOcrParseProvider(Provider):
 
     def _call_page_with_retries(self, image: Image.Image, page_number: int) -> str:
         """Own transient retries at the billable page request boundary."""
-        max_attempts = 3
-        for attempt in range(max_attempts):
-            try:
-                return self._call_endpoint(image)
-            except ProviderTransientError as exc:
-                if attempt == max_attempts - 1:
-                    raise ProviderRetryExhaustedError(
-                        f"dots.ocr page {page_number} failed after {max_attempts} attempts: {exc}"
-                    ) from exc
-                delay = 15 * (2**attempt)
-                print(
-                    f"[dots.ocr] Transient error on page {page_number}: {exc}. "
-                    f"Retrying in {delay}s (attempt {attempt + 1}/{max_attempts})..."
-                )
-                time.sleep(delay)
-
-        raise AssertionError("unreachable")
+        return run_page_with_retries(
+            lambda: self._call_endpoint(image),
+            provider_name="dots.ocr",
+            page_number=page_number,
+        )
 
     def _run_inference_pages(self, source_path: Path) -> dict[str, Any]:
         """Convert source file to images and run inference on each page."""

--- a/src/parse_bench/inference/providers/parse/dots_ocr.py
+++ b/src/parse_bench/inference/providers/parse/dots_ocr.py
@@ -314,6 +314,7 @@ class DotsOcrParseProvider(Provider):
         image: Image.Image,
         page_number: int,
         attempt_ledger: list[dict[str, object]],
+        prior_attempt_ledger: list[dict[str, object]],
     ) -> str:
         """Own transient retries at the billable page request boundary."""
         return run_page_with_retries(
@@ -321,6 +322,7 @@ class DotsOcrParseProvider(Provider):
             provider_name="dots.ocr",
             page_number=page_number,
             attempt_ledger=attempt_ledger,
+            prior_attempt_ledger=prior_attempt_ledger,
         )
 
     def _run_inference_pages(self, source_path: Path) -> dict[str, Any]:
@@ -332,7 +334,12 @@ class DotsOcrParseProvider(Provider):
                 page_image = image if image.mode in ("RGB", "RGBA") else image.convert("RGB")
                 try:
                     attempts: list[dict[str, object]] = []
-                    raw_text = self._call_page_with_retries(page_image, page_index + 1, attempts)
+                    raw_text = self._call_page_with_retries(
+                        page_image,
+                        page_index + 1,
+                        attempts,
+                        api_attempts,
+                    )
                     api_attempts.extend(attempts)
 
                     page_data: dict[str, Any] = {

--- a/src/parse_bench/inference/providers/parse/dots_ocr.py
+++ b/src/parse_bench/inference/providers/parse/dots_ocr.py
@@ -397,33 +397,11 @@ class DotsOcrParseProvider(Provider):
                 last_error = e
                 break
 
-        completed_at = datetime.now()
-        latency_ms = int((completed_at - started_at).total_seconds() * 1000)
-
-        error_msg = str(last_error)
-        if isinstance(last_error, TimeoutError):
-            error_msg = f"Request timed out after {self._timeout} seconds"
-
-        return RawInferenceResult(
-            request=request,
-            pipeline=pipeline,
-            pipeline_name=pipeline.pipeline_name,
-            product_type=request.product_type,
-            raw_output={
-                "pages": [],
-                "_error": error_msg,
-                "_error_type": type(last_error).__name__ if last_error else "Unknown",
-                "model": self._model,
-                "config": {
-                    "dpi": self._dpi,
-                    "max_tokens": self._max_tokens,
-                    "timeout": self._timeout,
-                },
-            },
-            started_at=started_at,
-            completed_at=completed_at,
-            latency_in_ms=latency_ms,
-        )
+        if isinstance(last_error, (ProviderPermanentError, ProviderTransientError, ProviderConfigError)):
+            raise last_error
+        if last_error is not None:
+            raise ProviderPermanentError(f"Unexpected error during inference: {last_error}") from last_error
+        raise ProviderPermanentError("Inference failed without an error")
 
     # ------------------------------------------------------------------
     # normalize

--- a/src/parse_bench/inference/providers/parse/dots_ocr.py
+++ b/src/parse_bench/inference/providers/parse/dots_ocr.py
@@ -28,6 +28,8 @@ from parse_bench.inference.providers.base import (
 )
 from parse_bench.inference.providers.parse._layout_utils import validated_sorted_page_records
 from parse_bench.inference.providers.parse._multipage_image import (
+    append_attempt_usages,
+    attempt_usages_complete,
     open_document_page_images,
     run_page_with_retries,
 )
@@ -203,8 +205,8 @@ class DotsOcrParseProvider(Provider):
     # API call
     # ------------------------------------------------------------------
 
-    def _call_endpoint(self, image: Image.Image) -> str:
-        """Call dots.ocr via OpenAI-compatible API and return raw response text."""
+    def _call_endpoint(self, image: Image.Image) -> tuple[str, dict[str, int]]:
+        """Call dots.ocr and return response text with any reported usage."""
         img_base64 = self._image_to_base64(image)
         try:
             response = self._client.chat.completions.create(
@@ -228,10 +230,32 @@ class DotsOcrParseProvider(Provider):
         except Exception as e:
             self._raise_api_error(e)
 
+        usage = self._extract_usage(response)
         content = response.choices[0].message.content
         if not content:
-            raise ProviderPermanentError("Empty response from model")
-        return cast(str, content)
+            raise ProviderTransientError("Empty response from model", attempt_stats=usage or None)
+        return cast(str, content), usage
+
+    @staticmethod
+    def _extract_usage(response: Any) -> dict[str, int]:
+        """Extract only token fields actually reported by the compatible API."""
+        raw_usage = getattr(response, "usage", None)
+        if raw_usage is None:
+            return {}
+        usage: dict[str, int] = {}
+        for key, attribute in (
+            ("input_tokens", "prompt_tokens"),
+            ("output_tokens", "completion_tokens"),
+            ("total_tokens", "total_tokens"),
+        ):
+            value = getattr(raw_usage, attribute, None)
+            if value is not None:
+                usage[key] = int(value)
+        details = getattr(raw_usage, "completion_tokens_details", None)
+        thinking_tokens = getattr(details, "reasoning_tokens", None) if details is not None else None
+        if thinking_tokens is not None:
+            usage["thinking_tokens"] = int(thinking_tokens)
+        return usage
 
     @staticmethod
     def _raise_api_error(exc: Exception) -> NoReturn:
@@ -315,10 +339,25 @@ class DotsOcrParseProvider(Provider):
         page_number: int,
         attempt_ledger: list[dict[str, object]],
         prior_attempt_ledger: list[dict[str, object]],
-    ) -> str:
+    ) -> tuple[str, dict[str, int], list[DotsOcrLayoutItem] | None]:
         """Own transient retries at the billable page request boundary."""
+
+        def call_and_validate() -> tuple[str, dict[str, int], list[DotsOcrLayoutItem] | None]:
+            response = self._call_endpoint(image)
+            if isinstance(response, tuple):
+                raw_text, usage = response
+            else:  # compatibility for custom test doubles and provider adapters
+                raw_text, usage = response, {}
+            if not self._is_layout_mode:
+                return raw_text, usage, None
+            try:
+                layout_items = self._parse_layout_items(raw_text)
+            except ProviderPermanentError as exc:
+                raise ProviderTransientError(str(exc), attempt_stats=usage or None) from exc
+            return raw_text, usage, layout_items
+
         return run_page_with_retries(
-            lambda: self._call_endpoint(image),
+            call_and_validate,
             provider_name="dots.ocr",
             page_number=page_number,
             attempt_ledger=attempt_ledger,
@@ -334,7 +373,7 @@ class DotsOcrParseProvider(Provider):
                 page_image = image if image.mode in ("RGB", "RGBA") else image.convert("RGB")
                 try:
                     attempts: list[dict[str, object]] = []
-                    raw_text = self._call_page_with_retries(
+                    raw_text, _, layout_items = self._call_page_with_retries(
                         page_image,
                         page_index + 1,
                         attempts,
@@ -350,9 +389,7 @@ class DotsOcrParseProvider(Provider):
                     }
 
                     if self._is_layout_mode:
-                        # Parse structured JSON → typed layout items + reassemble markdown
-                        layout_items = self._parse_layout_items(raw_text)
-
+                        assert layout_items is not None
                         page_data["layout_items"] = [item.model_dump() for item in layout_items]
                         page_data["markdown"] = _reassemble_markdown(layout_items)
                     else:
@@ -366,7 +403,7 @@ class DotsOcrParseProvider(Provider):
 
             num_pages = len(images)
 
-        return {
+        raw_output: dict[str, Any] = {
             "pages": pages,
             "num_pages": num_pages,
             "model": self._model,
@@ -379,6 +416,14 @@ class DotsOcrParseProvider(Provider):
                 "timeout": self._timeout,
             },
         }
+        attempt_usages: list[dict[str, int]] = []
+        append_attempt_usages(attempt_usages, api_attempts)
+        if attempt_usages_complete(attempt_usages):
+            for field in ("input_tokens", "output_tokens", "total_tokens"):
+                raw_output[field] = sum(int(usage[field]) for usage in attempt_usages)
+            if all("thinking_tokens" in usage for usage in attempt_usages):
+                raw_output["thinking_tokens"] = sum(int(usage["thinking_tokens"]) for usage in attempt_usages)
+        return raw_output
 
     # ------------------------------------------------------------------
     # run_inference

--- a/src/parse_bench/inference/providers/parse/falconocr.py
+++ b/src/parse_bench/inference/providers/parse/falconocr.py
@@ -155,6 +155,8 @@ class FalconOcrProvider(Provider):
         - temperature (float, default=0.0): Sampling temperature.
     """
 
+    PDF_RENDER_DPI = 200
+
     def __init__(self, provider_name: str, base_config: dict[str, Any] | None = None):
         super().__init__(provider_name, base_config)
 
@@ -166,7 +168,7 @@ class FalconOcrProvider(Provider):
         self._server_url: str = str(server_url).rstrip("/")
         self._task: str = str(self.base_config.get("task", "ocr"))
         self._timeout = int(self.base_config.get("timeout", 600))
-        self._dpi = int(self.base_config.get("dpi", 200))
+        self._dpi = int(self.base_config.get("dpi", self.PDF_RENDER_DPI))
         self._max_new_tokens = int(self.base_config.get("max_new_tokens", 4096))
         self._temperature = float(self.base_config.get("temperature", 0.0))
 

--- a/src/parse_bench/inference/providers/parse/falconocr.py
+++ b/src/parse_bench/inference/providers/parse/falconocr.py
@@ -23,6 +23,7 @@ from parse_bench.inference.providers.base import (
     ProviderPermanentError,
     ProviderTransientError,
 )
+from parse_bench.inference.providers.parse._multipage_image import normalize_pdf_pages, run_pdf_pages
 from parse_bench.inference.providers.registry import register_provider
 from parse_bench.schemas.layout_ontology import CanonicalLabel
 from parse_bench.schemas.parse_output import (
@@ -241,6 +242,10 @@ class FalconOcrProvider(Provider):
         }
 
     def run_inference(self, pipeline: PipelineSpec, request: InferenceRequest) -> RawInferenceResult:
+        multipage_result = run_pdf_pages(pipeline, request, dpi=self._dpi, run_single_image=self.run_inference)
+        if multipage_result is not None:
+            return multipage_result
+
         if request.product_type != ProductType.PARSE:
             raise ProviderPermanentError(
                 f"FalconOcrProvider only supports PARSE product type, got {request.product_type}"
@@ -369,6 +374,10 @@ class FalconOcrProvider(Provider):
         return "\n".join(result_parts)
 
     def normalize(self, raw_result: RawInferenceResult) -> InferenceResult:
+        multipage_result = normalize_pdf_pages(raw_result, normalize_single_image=self.normalize)
+        if multipage_result is not None:
+            return multipage_result
+
         if raw_result.product_type != ProductType.PARSE:
             raise ProviderPermanentError(
                 f"FalconOcrProvider only supports PARSE product type, got {raw_result.product_type}"

--- a/src/parse_bench/inference/providers/parse/gemma4.py
+++ b/src/parse_bench/inference/providers/parse/gemma4.py
@@ -38,6 +38,7 @@ from parse_bench.inference.providers.parse._layout_utils import (
     parse_layout_blocks,
     resolve_layout_prompts,
 )
+from parse_bench.inference.providers.parse._multipage_image import normalize_pdf_pages, run_pdf_pages
 from parse_bench.inference.providers.registry import register_provider
 from parse_bench.schemas.parse_output import ParseOutput
 from parse_bench.schemas.pipeline import PipelineSpec
@@ -266,6 +267,10 @@ class Gemma4Provider(Provider):
         return result
 
     def run_inference(self, pipeline: PipelineSpec, request: InferenceRequest) -> RawInferenceResult:
+        multipage_result = run_pdf_pages(pipeline, request, dpi=self._dpi, run_single_image=self.run_inference)
+        if multipage_result is not None:
+            return multipage_result
+
         if request.product_type != ProductType.PARSE:
             raise ProviderPermanentError(f"Gemma4Provider only supports PARSE, got {request.product_type}")
 
@@ -394,6 +399,10 @@ class Gemma4Provider(Provider):
     # ------------------------------------------------------------------
 
     def normalize(self, raw_result: RawInferenceResult) -> InferenceResult:
+        multipage_result = normalize_pdf_pages(raw_result, normalize_single_image=self.normalize)
+        if multipage_result is not None:
+            return multipage_result
+
         if raw_result.product_type != ProductType.PARSE:
             raise ProviderPermanentError(f"Gemma4Provider only supports PARSE, got {raw_result.product_type}")
 

--- a/src/parse_bench/inference/providers/parse/gemma4.py
+++ b/src/parse_bench/inference/providers/parse/gemma4.py
@@ -164,8 +164,8 @@ class Gemma4Provider(Provider):
         from PIL import Image
 
         try:
-            img = Image.open(file_path)
-            w, h = img.size
+            with Image.open(file_path) as img:
+                w, h = img.size
             return file_path.read_bytes(), w, h
         except Exception as e:
             raise ProviderPermanentError(f"Error reading image file: {e}") from e

--- a/src/parse_bench/inference/providers/parse/gemma4.py
+++ b/src/parse_bench/inference/providers/parse/gemma4.py
@@ -106,6 +106,8 @@ class Gemma4Provider(Provider):
         - api_key_env (str, default="VLLM_API_KEY"): Env var for API key
     """
 
+    PDF_RENDER_DPI = 150
+
     def __init__(self, provider_name: str, base_config: dict[str, Any] | None = None):
         super().__init__(provider_name, base_config)
 
@@ -119,7 +121,7 @@ class Gemma4Provider(Provider):
         # E4B outputs bboxes as [y1, x1, y2, x2]; 26B outputs correct [x1, y1, x2, y2]
         self._swap_bbox = self.base_config.get("swap_bbox", False)
         self._timeout = self.base_config.get("timeout", 600)
-        self._dpi = self.base_config.get("dpi", 150)
+        self._dpi = self.base_config.get("dpi", self.PDF_RENDER_DPI)
         self._max_tokens = self.base_config.get("max_tokens", 16384)
         self._temperature = self.base_config.get("temperature", 0.1)
 

--- a/src/parse_bench/inference/providers/parse/google.py
+++ b/src/parse_bench/inference/providers/parse/google.py
@@ -19,7 +19,7 @@ from parse_bench.inference.providers.base import (
 from parse_bench.inference.providers.parse._layout_utils import (
     build_layout_pages,
     items_to_markdown,
-    parse_layout_blocks,
+    parse_layout_response,
     resolve_layout_prompts,
     split_pdf_to_pages,
     swap_gemini_bbox,
@@ -121,6 +121,8 @@ class GoogleProvider(Provider):
     capabilities to parse document content to markdown.
     """
 
+    PDF_RENDER_DPI = 150
+
     def __init__(self, provider_name: str, base_config: dict[str, Any] | None = None):
         """
         Initialize the provider.
@@ -145,7 +147,7 @@ class GoogleProvider(Provider):
 
         # Configuration
         self._model = self.base_config.get("model", "gemini-3-flash-preview")
-        self._dpi = self.base_config.get("dpi", 150)
+        self._dpi = self.base_config.get("dpi", self.PDF_RENDER_DPI)
         self._max_tokens = self.base_config.get("max_tokens", 8192)
         self._timeout = self.base_config.get("timeout", 120)
         self._thinking_level = self.base_config.get("thinking_level", None)
@@ -183,7 +185,12 @@ class GoogleProvider(Provider):
             from google import genai
             from google.genai import types
 
-            self._client = genai.Client(api_key=self._api_key)
+            self._client = genai.Client(
+                api_key=self._api_key,
+                http_options=types.HttpOptions(
+                    retry_options=types.HttpRetryOptions(attempts=1),
+                ),
+            )
             self._types = types
         except ImportError as e:
             raise ProviderConfigError("google-genai package not installed. Run: pip install google-genai") from e
@@ -555,7 +562,10 @@ class GoogleProvider(Provider):
             if text is None:
                 raise ProviderTransientError(f"Gemini API returned no layout text: {self._failure_reason(response)}")
 
-            items = swap_gemini_bbox(parse_layout_blocks(text))
+            try:
+                items = swap_gemini_bbox(parse_layout_response(text))
+            except ValueError as exc:
+                raise ProviderTransientError(f"Gemini returned malformed layout output: {exc}") from exc
             return items, text, usage
 
         except (ProviderPermanentError, ProviderTransientError):
@@ -573,8 +583,8 @@ class GoogleProvider(Provider):
         Send raw PDF file to Gemini using inline data.
 
         Uses Gemini's document understanding capability to process
-        the PDF directly without converting to images. Retries once
-        if the response is empty.
+        the PDF directly without converting to images. The document runner
+        owns retries for this whole-document operation.
 
         :param pdf_path: Path to the PDF file
         :return: Tuple of (markdown content, usage dict)
@@ -616,21 +626,7 @@ class GoogleProvider(Provider):
             text = self._extract_text(response)
 
             if text is None:
-                reason1 = self._failure_reason(response)
-                # Single retry on empty response
-                response = self._client.models.generate_content(
-                    model=self._model,
-                    contents=contents,
-                    config=gen_config,
-                )
-                usage = self._extract_usage(response)
-                text = self._extract_text(response)
-
-            if text is None:
-                reason2 = self._failure_reason(response)
-                raise ProviderTransientError(
-                    f"Gemini API returned no PDF text after 2 attempts: 1st={reason1}, 2nd={reason2}"
-                )
+                raise ProviderTransientError(f"Gemini API returned no PDF text: {self._failure_reason(response)}")
             return text, usage
 
         except (ProviderPermanentError, ProviderTransientError):
@@ -681,22 +677,14 @@ class GoogleProvider(Provider):
             text = self._extract_text(response)
 
             if text is None:
-                reason1 = self._failure_reason(response)
-                response = self._client.models.generate_content(
-                    model=self._model,
-                    contents=contents,
-                    config=gen_config,
-                )
-                usage = self._extract_usage(response)
-                text = self._extract_text(response)
-
-            if text is None:
-                reason2 = self._failure_reason(response)
                 raise ProviderTransientError(
-                    f"Gemini API returned no PDF layout text after 2 attempts: 1st={reason1}, 2nd={reason2}"
+                    f"Gemini API returned no PDF layout text: {self._failure_reason(response)}"
                 )
 
-            items = swap_gemini_bbox(parse_layout_blocks(text))
+            try:
+                items = swap_gemini_bbox(parse_layout_response(text))
+            except ValueError as exc:
+                raise ProviderTransientError(f"Gemini returned malformed PDF layout output: {exc}") from exc
             return items, text, usage
 
         except (ProviderPermanentError, ProviderTransientError):
@@ -770,7 +758,11 @@ class GoogleProvider(Provider):
                     layout_pdf_pages = split_pdf_to_pages(str(source_path))
                     pages = []
                     for page_index, (pdf_bytes, w, h) in enumerate(layout_pdf_pages):
-                        items, raw_content, usage = self._parse_pdf_page_with_layout(pdf_bytes)
+                        items, raw_content, usage = run_page_with_retries(
+                            partial(self._parse_pdf_page_with_layout, pdf_bytes),
+                            provider_name=pipeline.provider_name,
+                            page_number=page_index + 1,
+                        )
                         page_usages.append(usage)
                         pages.append(
                             {
@@ -785,7 +777,11 @@ class GoogleProvider(Provider):
                 else:
                     # Non-PDF: fall back to image-based layout parsing
                     with Image.open(source_path) as image:
-                        items, raw_content, usage = self._parse_image_with_layout(image)
+                        items, raw_content, usage = run_page_with_retries(
+                            partial(self._parse_image_with_layout, image),
+                            provider_name=pipeline.provider_name,
+                            page_number=1,
+                        )
                         page_usages.append(usage)
                         pages = [
                             {

--- a/src/parse_bench/inference/providers/parse/google.py
+++ b/src/parse_bench/inference/providers/parse/google.py
@@ -511,9 +511,13 @@ class GoogleProvider(Provider):
 
             if text is None:
                 reason2 = self._failure_reason(response)
-                return f"[No output after 2 attempts: 1st={reason1}, 2nd={reason2}]", usage
+                raise ProviderTransientError(
+                    f"Gemini API returned no text after 2 attempts: 1st={reason1}, 2nd={reason2}"
+                )
             return text, usage
 
+        except (ProviderPermanentError, ProviderTransientError):
+            raise
         except Exception as e:
             error_str = str(e).lower()
             if any(kw in error_str for kw in ["timeout", "connection", "network"]):
@@ -572,11 +576,15 @@ class GoogleProvider(Provider):
 
             if text is None:
                 reason2 = self._failure_reason(response)
-                return [], f"[No output after 2 attempts: 1st={reason1}, 2nd={reason2}]", usage
+                raise ProviderTransientError(
+                    f"Gemini API returned no layout text after 2 attempts: 1st={reason1}, 2nd={reason2}"
+                )
 
             items = swap_gemini_bbox(parse_layout_blocks(text))
             return items, text, usage
 
+        except (ProviderPermanentError, ProviderTransientError):
+            raise
         except Exception as e:
             error_str = str(e).lower()
             if any(kw in error_str for kw in ["timeout", "connection", "network"]):
@@ -645,9 +653,13 @@ class GoogleProvider(Provider):
 
             if text is None:
                 reason2 = self._failure_reason(response)
-                return f"[No output after 2 attempts: 1st={reason1}, 2nd={reason2}]", usage
+                raise ProviderTransientError(
+                    f"Gemini API returned no PDF text after 2 attempts: 1st={reason1}, 2nd={reason2}"
+                )
             return text, usage
 
+        except (ProviderPermanentError, ProviderTransientError):
+            raise
         except Exception as e:
             error_str = str(e).lower()
             if any(kw in error_str for kw in ["timeout", "connection", "network"]):
@@ -705,11 +717,15 @@ class GoogleProvider(Provider):
 
             if text is None:
                 reason2 = self._failure_reason(response)
-                text = f"[No output after 2 attempts: 1st={reason1}, 2nd={reason2}]"
+                raise ProviderTransientError(
+                    f"Gemini API returned no PDF layout text after 2 attempts: 1st={reason1}, 2nd={reason2}"
+                )
 
             items = swap_gemini_bbox(parse_layout_blocks(text))
             return items, text, usage
 
+        except (ProviderPermanentError, ProviderTransientError):
+            raise
         except Exception as e:
             error_str = str(e).lower()
             if any(kw in error_str for kw in ["timeout", "connection", "network"]):

--- a/src/parse_bench/inference/providers/parse/google.py
+++ b/src/parse_bench/inference/providers/parse/google.py
@@ -23,6 +23,7 @@ from parse_bench.inference.providers.parse._layout_utils import (
     split_pdf_to_pages,
     swap_gemini_bbox,
 )
+from parse_bench.inference.providers.parse._multipage_image import open_document_page_images
 from parse_bench.inference.providers.parse.google_agentic_vision import (
     GoogleAgenticVisionRunner,
     build_layout_pages_from_agentic_items,
@@ -422,24 +423,6 @@ class GoogleProvider(Provider):
         image.save(buffer, format="JPEG", quality=min_quality)
         return buffer.getvalue()
 
-    def _pdf_to_images(self, pdf_path: str) -> list[Image.Image]:
-        """
-        Convert PDF pages to images.
-
-        :param pdf_path: Path to the PDF file
-        :return: List of PIL Images, one per page
-        """
-        try:
-            from pdf2image import convert_from_path
-        except ImportError as e:
-            raise ProviderConfigError("pdf2image package not installed. Run: pip install pdf2image") from e
-
-        try:
-            images = convert_from_path(pdf_path, dpi=self._dpi)
-            return images
-        except Exception as e:
-            raise ProviderPermanentError(f"Failed to convert PDF to images: {e}") from e
-
     @staticmethod
     def _extract_text(response) -> str | None:  # type: ignore[no-untyped-def]
         """Extract text from a Gemini response, or None if empty."""
@@ -774,17 +757,17 @@ class GoogleProvider(Provider):
                     num_pages = 1  # We don't know actual page count in file mode
                 else:
                     # Non-PDF: fall back to image-based parsing
-                    image = Image.open(source_path)
-                    markdown, usage = self._parse_image(image)
-                    page_usages.append(usage)
-                    pages = [
-                        {
-                            "page_index": 0,
-                            "markdown": markdown,
-                            "width": image.width,
-                            "height": image.height,
-                        }
-                    ]
+                    with Image.open(source_path) as image:
+                        markdown, usage = self._parse_image(image)
+                        page_usages.append(usage)
+                        pages = [
+                            {
+                                "page_index": 0,
+                                "markdown": markdown,
+                                "width": image.width,
+                                "height": image.height,
+                            }
+                        ]
                     num_pages = 1
             elif self._mode == "parse_with_layout_file":
                 if source_path.suffix.lower() == ".pdf":
@@ -806,103 +789,95 @@ class GoogleProvider(Provider):
                     num_pages = len(layout_pdf_pages)
                 else:
                     # Non-PDF: fall back to image-based layout parsing
-                    image = Image.open(source_path)
-                    items, raw_content, usage = self._parse_image_with_layout(image)
-                    page_usages.append(usage)
-                    pages = [
-                        {
-                            "page_index": 0,
-                            "items": items,
-                            "raw_content": raw_content,
-                            "width": image.width,
-                            "height": image.height,
-                        }
-                    ]
-                    num_pages = 1
-            elif self._mode == "parse_with_layout_agentic_vision":
-                if source_path.suffix.lower() == ".pdf":
-                    images = self._pdf_to_images(str(source_path))
-                else:
-                    images = [Image.open(source_path)]
-
-                num_pages = len(images)
-                runner = self._build_agentic_vision_runner(expected_page_calls=num_pages)
-                pages = []
-
-                for page_index, image in enumerate(images):  # type: ignore[assignment]
-                    img_bytes = self._image_to_bytes(image)
-
-                    try:
-                        page_result = runner.parse_page(
-                            page_index=page_index,
-                            image=image,
-                            image_bytes=img_bytes,
-                            image_mime_type="image/jpeg",
-                        )
-                        self._annotate_api_calls_with_costs(page_result.api_calls)
-                        page_usages.extend(
-                            call.get("usage", {}) for call in page_result.api_calls if isinstance(call, dict)
-                        )
-                        pages.append(
-                            {
-                                "page_index": page_result.page_index,
-                                "items": page_result.items,
-                                "markdown": page_result.markdown,
-                                "raw_content": page_result.raw_content,
-                                "width": page_result.width,
-                                "height": page_result.height,
-                                "image_mime_type": page_result.image_mime_type,
-                                "thought_summaries": page_result.thought_summaries,
-                                "thought_signatures": page_result.thought_signatures,
-                                "generated_code": page_result.generated_code,
-                                "code_execution_results": page_result.code_execution_results,
-                                "api_calls": page_result.api_calls,
-                            }
-                        )
-                    except (ProviderPermanentError, ProviderTransientError) as exc:
-                        debug_payload = exc.debug_payload if isinstance(exc.debug_payload, dict) else None
-                        if debug_payload is not None:
-                            maybe_calls = debug_payload.get("api_calls", [])
-                            if isinstance(maybe_calls, list):
-                                failed_api_calls = [call for call in maybe_calls if isinstance(call, dict)]
-                                self._annotate_api_calls_with_costs(failed_api_calls)
-                                page_usages.extend(call.get("usage", {}) for call in failed_api_calls)
-                                debug_payload["api_calls"] = failed_api_calls
-                        raise
-            else:
-                # Image mode (both "image" and "parse_with_layout"):
-                # convert PDF to images and process each page
-                if source_path.suffix.lower() == ".pdf":
-                    images = self._pdf_to_images(str(source_path))
-                else:
-                    images = [Image.open(source_path)]
-
-                pages = []
-                for page_index, image in enumerate(images):  # type: ignore[assignment]
-                    if self._mode == "parse_with_layout":
+                    with Image.open(source_path) as image:
                         items, raw_content, usage = self._parse_image_with_layout(image)
                         page_usages.append(usage)
-                        pages.append(
+                        pages = [
                             {
-                                "page_index": page_index,
+                                "page_index": 0,
                                 "items": items,
                                 "raw_content": raw_content,
                                 "width": image.width,
                                 "height": image.height,
                             }
-                        )
-                    else:
-                        markdown, usage = self._parse_image(image)
-                        page_usages.append(usage)
-                        pages.append(
-                            {
-                                "page_index": page_index,
-                                "markdown": markdown,
-                                "width": image.width,
-                                "height": image.height,
-                            }
-                        )
-                num_pages = len(images)
+                        ]
+                    num_pages = 1
+            elif self._mode == "parse_with_layout_agentic_vision":
+                pages = []
+                with open_document_page_images(source_path, dpi=self._dpi) as images:
+                    num_pages = len(images)
+                    runner = self._build_agentic_vision_runner(expected_page_calls=num_pages)
+
+                    for page_index, image in enumerate(images):
+                        img_bytes = self._image_to_bytes(image)
+
+                        try:
+                            page_result = runner.parse_page(
+                                page_index=page_index,
+                                image=image,
+                                image_bytes=img_bytes,
+                                image_mime_type="image/jpeg",
+                            )
+                            self._annotate_api_calls_with_costs(page_result.api_calls)
+                            page_usages.extend(
+                                call.get("usage", {}) for call in page_result.api_calls if isinstance(call, dict)
+                            )
+                            pages.append(
+                                {
+                                    "page_index": page_result.page_index,
+                                    "items": page_result.items,
+                                    "markdown": page_result.markdown,
+                                    "raw_content": page_result.raw_content,
+                                    "width": page_result.width,
+                                    "height": page_result.height,
+                                    "image_mime_type": page_result.image_mime_type,
+                                    "thought_summaries": page_result.thought_summaries,
+                                    "thought_signatures": page_result.thought_signatures,
+                                    "generated_code": page_result.generated_code,
+                                    "code_execution_results": page_result.code_execution_results,
+                                    "api_calls": page_result.api_calls,
+                                }
+                            )
+                        except (ProviderPermanentError, ProviderTransientError) as exc:
+                            debug_payload = exc.debug_payload if isinstance(exc.debug_payload, dict) else None
+                            if debug_payload is not None:
+                                maybe_calls = debug_payload.get("api_calls", [])
+                                if isinstance(maybe_calls, list):
+                                    failed_api_calls = [call for call in maybe_calls if isinstance(call, dict)]
+                                    self._annotate_api_calls_with_costs(failed_api_calls)
+                                    page_usages.extend(call.get("usage", {}) for call in failed_api_calls)
+                                    debug_payload["api_calls"] = failed_api_calls
+                            raise
+            else:
+                # Image mode (both "image" and "parse_with_layout"):
+                # convert PDF to images and process each page
+                pages = []
+                with open_document_page_images(source_path, dpi=self._dpi) as images:
+                    for page_index, image in enumerate(images):
+                        if self._mode == "parse_with_layout":
+                            items, raw_content, usage = self._parse_image_with_layout(image)
+                            page_usages.append(usage)
+                            pages.append(
+                                {
+                                    "page_index": page_index,
+                                    "items": items,
+                                    "raw_content": raw_content,
+                                    "width": image.width,
+                                    "height": image.height,
+                                }
+                            )
+                        else:
+                            markdown, usage = self._parse_image(image)
+                            page_usages.append(usage)
+                            pages.append(
+                                {
+                                    "page_index": page_index,
+                                    "markdown": markdown,
+                                    "width": image.width,
+                                    "height": image.height,
+                                }
+                            )
+                    num_pages = len(images)
 
             completed_at = datetime.now()
             latency_ms = int((completed_at - started_at).total_seconds() * 1000)

--- a/src/parse_bench/inference/providers/parse/google.py
+++ b/src/parse_bench/inference/providers/parse/google.py
@@ -202,25 +202,29 @@ class GoogleProvider(Provider):
     MAX_IMAGE_DIMENSION = 8000  # pixels
     MAX_IMAGE_SIZE_BYTES = 20 * 1024 * 1024  # 20 MB (raw bytes, no base64 overhead)
 
-    def _get_pricing(self) -> tuple[float, float]:
-        """Return (input_rate, output_rate) in USD per million tokens.
+    def _get_pricing(self) -> tuple[float, float] | None:
+        """Return known (input_rate, output_rate) in USD per million tokens.
 
         Uses longest-prefix matching to avoid ambiguity when one model
         prefix is a substring of another (e.g. "gemini-2.5-flash" vs
         "gemini-2.5-flash-lite").
         """
         matches = [(p, r) for p, r in _GEMINI_PRICING_PER_M.items() if self._model.startswith(p)]
-        return max(matches, key=lambda x: len(x[0]))[1] if matches else (0.0, 0.0)
+        return max(matches, key=lambda x: len(x[0]))[1] if matches else None
 
-    def _get_context_cache_pricing(self) -> tuple[float, float]:
-        """Return (cache_hit_rate, storage_rate) in USD per million tokens."""
+    def _get_context_cache_pricing(self) -> tuple[float, float] | None:
+        """Return known (cache_hit_rate, storage_rate) in USD per million tokens."""
         matches = [(p, r) for p, r in _GEMINI_CONTEXT_CACHE_PRICING_PER_M.items() if self._model.startswith(p)]
-        return max(matches, key=lambda x: len(x[0]))[1] if matches else (0.0, 0.0)
+        return max(matches, key=lambda x: len(x[0]))[1] if matches else None
 
-    def _usage_cost_breakdown(self, usage: dict[str, int]) -> dict[str, float]:
+    def _usage_cost_breakdown(self, usage: dict[str, int]) -> dict[str, float] | None:
         """Compute cost breakdown for one Gemini API call."""
-        input_rate, output_rate = self._get_pricing()
-        cache_hit_rate, _ = self._get_context_cache_pricing()
+        pricing = self._get_pricing()
+        cache_pricing = self._get_context_cache_pricing()
+        if pricing is None or cache_pricing is None:
+            return None
+        input_rate, output_rate = pricing
+        cache_hit_rate, _ = cache_pricing
 
         input_tokens = int(usage.get("input_tokens", 0) or 0)
         cached_content_tokens = min(input_tokens, int(usage.get("cached_content_tokens", 0) or 0))
@@ -245,21 +249,23 @@ class GoogleProvider(Provider):
 
     def _billable_response_error(self, message: str, usage: dict[str, int]) -> ProviderTransientError:
         """Retain usage and cost when a billed Gemini response is unusable."""
-        return ProviderTransientError(message, attempt_stats={**usage, **self._usage_cost_breakdown(usage)})
+        stats: dict[str, int | float] = dict(usage)
+        if attempt_usages_complete([usage]):
+            breakdown = self._usage_cost_breakdown(usage)
+            if breakdown is not None:
+                stats.update(breakdown)
+        return ProviderTransientError(message, attempt_stats=stats)
 
     def _compute_usage_cost_summary(
         self,
         usages: list[dict[str, int]],
         *,
         num_pages: int,
-        cache_storage_cost_usd: float = 0.0,
+        cache_storage_cost_usd: float | None = 0.0,
     ) -> dict[str, float | int]:
         """Aggregate token and cost accounting across all Gemini calls for one document."""
         if not attempt_usages_complete(usages):
-            return {
-                "num_api_calls": len(usages),
-                "cache_storage_cost_usd": cache_storage_cost_usd,
-            }
+            return {"num_api_calls": len(usages)}
         total_input = sum(int(usage.get("input_tokens", 0) or 0) for usage in usages)
         total_tool_use_prompt = sum(int(usage.get("tool_use_prompt_tokens", 0) or 0) for usage in usages)
         total_cached_content = sum(int(usage.get("cached_content_tokens", 0) or 0) for usage in usages)
@@ -267,13 +273,27 @@ class GoogleProvider(Provider):
         total_thinking = sum(int(usage.get("thinking_tokens", 0) or 0) for usage in usages)
         total_tokens = sum(int(usage.get("total_tokens", 0) or 0) for usage in usages)
 
+        summary: dict[str, float | int] = {
+            "input_tokens": total_input,
+            "tool_use_prompt_tokens": total_tool_use_prompt,
+            "cached_content_tokens": total_cached_content,
+            "output_tokens": total_output,
+            "thinking_tokens": total_thinking,
+            "total_tokens": total_tokens,
+            "num_api_calls": len(usages),
+            "input_tokens_per_page": total_input / num_pages if num_pages > 0 else 0.0,
+            "tool_use_prompt_tokens_per_page": total_tool_use_prompt / num_pages if num_pages > 0 else 0.0,
+            "cached_content_tokens_per_page": total_cached_content / num_pages if num_pages > 0 else 0.0,
+            "output_tokens_per_page": total_output / num_pages if num_pages > 0 else 0.0,
+        }
         per_call_breakdowns = [self._usage_cost_breakdown(usage) for usage in usages]
-        input_cost_usd = sum(breakdown["input_cost_usd"] for breakdown in per_call_breakdowns)
-        tool_use_prompt_cost_usd = sum(breakdown["tool_use_prompt_cost_usd"] for breakdown in per_call_breakdowns)
-        cached_input_cost_usd = sum(breakdown["cached_input_cost_usd"] for breakdown in per_call_breakdowns)
-        output_and_thinking_cost_usd = sum(
-            breakdown["output_and_thinking_cost_usd"] for breakdown in per_call_breakdowns
-        )
+        if cache_storage_cost_usd is None or any(breakdown is None for breakdown in per_call_breakdowns):
+            return summary
+        known_breakdowns = [breakdown for breakdown in per_call_breakdowns if breakdown is not None]
+        input_cost_usd = sum(breakdown["input_cost_usd"] for breakdown in known_breakdowns)
+        tool_use_prompt_cost_usd = sum(breakdown["tool_use_prompt_cost_usd"] for breakdown in known_breakdowns)
+        cached_input_cost_usd = sum(breakdown["cached_input_cost_usd"] for breakdown in known_breakdowns)
+        output_and_thinking_cost_usd = sum(breakdown["output_and_thinking_cost_usd"] for breakdown in known_breakdowns)
         cost_usd = (
             input_cost_usd
             + tool_use_prompt_cost_usd
@@ -282,26 +302,18 @@ class GoogleProvider(Provider):
             + cache_storage_cost_usd
         )
 
-        return {
-            "input_tokens": total_input,
-            "tool_use_prompt_tokens": total_tool_use_prompt,
-            "cached_content_tokens": total_cached_content,
-            "output_tokens": total_output,
-            "thinking_tokens": total_thinking,
-            "total_tokens": total_tokens,
-            "num_api_calls": len(usages),
-            "cost_usd": cost_usd,
-            "cost_per_page_usd": cost_usd / num_pages if num_pages > 0 else 0.0,
-            "input_cost_usd": input_cost_usd,
-            "tool_use_prompt_cost_usd": tool_use_prompt_cost_usd,
-            "cached_input_cost_usd": cached_input_cost_usd,
-            "output_and_thinking_cost_usd": output_and_thinking_cost_usd,
-            "cache_storage_cost_usd": cache_storage_cost_usd,
-            "input_tokens_per_page": total_input / num_pages if num_pages > 0 else 0.0,
-            "tool_use_prompt_tokens_per_page": total_tool_use_prompt / num_pages if num_pages > 0 else 0.0,
-            "cached_content_tokens_per_page": total_cached_content / num_pages if num_pages > 0 else 0.0,
-            "output_tokens_per_page": total_output / num_pages if num_pages > 0 else 0.0,
-        }
+        summary.update(
+            {
+                "cost_usd": cost_usd,
+                "cost_per_page_usd": cost_usd / num_pages if num_pages > 0 else 0.0,
+                "input_cost_usd": input_cost_usd,
+                "tool_use_prompt_cost_usd": tool_use_prompt_cost_usd,
+                "cached_input_cost_usd": cached_input_cost_usd,
+                "output_and_thinking_cost_usd": output_and_thinking_cost_usd,
+                "cache_storage_cost_usd": cache_storage_cost_usd,
+            }
+        )
+        return summary
 
     def _annotate_api_calls_with_costs(self, api_calls: list[dict[str, Any]]) -> None:
         """Populate cost fields for serialized Agentic Vision API calls."""
@@ -316,6 +328,10 @@ class GoogleProvider(Provider):
                 call.pop("cost_breakdown_usd", None)
                 continue
             breakdown = self._usage_cost_breakdown(usage)
+            if breakdown is None:
+                call.pop("cost_usd", None)
+                call.pop("cost_breakdown_usd", None)
+                continue
             call["cost_usd"] = breakdown["cost_usd"]
             call["cost_breakdown_usd"] = {
                 "input_cost_usd": breakdown["input_cost_usd"],
@@ -330,12 +346,16 @@ class GoogleProvider(Provider):
             if isinstance(stats, dict):
                 usage = {key: int(value) for key, value in stats.items() if key.endswith("tokens")}
                 if attempt_usages_complete([usage]):
-                    stats.update(self._usage_cost_breakdown(usage))
+                    breakdown = self._usage_cost_breakdown(usage)
+                    if breakdown is not None:
+                        stats.update(breakdown)
 
     def _build_agentic_vision_runner(self, expected_page_calls: int) -> GoogleAgenticVisionRunner:
         """Build the shared Agentic Vision runner for one document."""
-        input_rate, _ = self._get_pricing()
-        cache_hit_rate, storage_rate = self._get_context_cache_pricing()
+        pricing = self._get_pricing()
+        cache_pricing = self._get_context_cache_pricing()
+        input_rate = pricing[0] if pricing is not None else None
+        cache_hit_rate, storage_rate = cache_pricing if cache_pricing is not None else (None, None)
         return GoogleAgenticVisionRunner(
             client=self._client,
             types_module=self._types,
@@ -374,17 +394,17 @@ class GoogleProvider(Provider):
         """Extract token counts from a Gemini API response."""
         meta = getattr(response, "usage_metadata", None)
         if meta is None:
-            return {"input_tokens": 0, "output_tokens": 0, "thinking_tokens": 0, "total_tokens": 0}
-        input_tok = getattr(meta, "prompt_token_count", 0) or 0
-        output_tok = getattr(meta, "candidates_token_count", 0) or 0
-        thinking_tok = getattr(meta, "thoughts_token_count", 0) or 0
-        total_tok = getattr(meta, "total_token_count", 0) or 0
-        return {
-            "input_tokens": input_tok,
-            "output_tokens": output_tok,
-            "thinking_tokens": thinking_tok,
-            "total_tokens": total_tok,
-        }
+            return {}
+        usage: dict[str, int] = {"thinking_tokens": int(getattr(meta, "thoughts_token_count", 0) or 0)}
+        for key, attribute in (
+            ("input_tokens", "prompt_token_count"),
+            ("output_tokens", "candidates_token_count"),
+            ("total_tokens", "total_token_count"),
+        ):
+            value = getattr(meta, attribute, None)
+            if value is not None:
+                usage[key] = int(value)
+        return usage
 
     def _prepare_image_for_api(self, image: Image.Image) -> Image.Image:
         """
@@ -752,6 +772,7 @@ class GoogleProvider(Provider):
         started_at = datetime.now()
         runner: GoogleAgenticVisionRunner | None = None
         result: RawInferenceResult | None = None
+        terminal_debug_payload: dict[str, Any] | None = None
 
         try:
             page_usages: list[dict[str, int]] = []
@@ -874,12 +895,30 @@ class GoogleProvider(Provider):
                         except (ProviderPermanentError, ProviderTransientError) as exc:
                             debug_payload = exc.debug_payload if isinstance(exc.debug_payload, dict) else None
                             if debug_payload is not None:
+                                terminal_debug_payload = debug_payload
                                 maybe_calls = debug_payload.get("api_calls", [])
                                 if isinstance(maybe_calls, list):
                                     failed_api_calls = [call for call in maybe_calls if isinstance(call, dict)]
                                     self._annotate_api_calls_with_costs(failed_api_calls)
                                     page_usages.extend(call.get("usage", {}) for call in failed_api_calls)
-                                    debug_payload["api_calls"] = failed_api_calls
+                                    completed_api_calls: list[dict[str, Any]] = []
+                                    for completed_page in pages:
+                                        completed_page_calls = completed_page.get("api_calls")
+                                        if isinstance(completed_page_calls, list):
+                                            completed_api_calls.extend(
+                                                call for call in completed_page_calls if isinstance(call, dict)
+                                            )
+                                    debug_payload["api_calls"] = [*completed_api_calls, *failed_api_calls]
+                                cache_info = runner.cache_info
+                                if cache_info is not None:
+                                    debug_payload["explicit_context_cache"] = {
+                                        "name": cache_info.name,
+                                        "display_name": cache_info.display_name,
+                                        "token_count": cache_info.token_count,
+                                        "ttl_seconds": cache_info.ttl_seconds,
+                                        "storage_cost_usd": cache_info.storage_cost_usd,
+                                        "created": cache_info.created,
+                                    }
                             raise
             else:
                 # Image mode (both "image" and "parse_with_layout"):
@@ -958,14 +997,11 @@ class GoogleProvider(Provider):
                     cache_storage_cost_usd=cache_storage_cost_usd,
                 )
             else:
-                self._annotate_retry_attempts_with_costs(api_attempts)
                 total_input = sum(u["input_tokens"] for u in page_usages)
                 total_output = sum(u["output_tokens"] for u in page_usages)
                 total_thinking = sum(u["thinking_tokens"] for u in page_usages)
                 total_all = sum(u["total_tokens"] for u in page_usages)
 
-                input_rate, output_rate = self._get_pricing()
-                cost = (total_input * input_rate + (total_output + total_thinking) * output_rate) / 1_000_000
                 usage_summary = {
                     "num_api_calls": len(api_attempts) if api_attempts else len(page_usages),
                     **(
@@ -974,8 +1010,6 @@ class GoogleProvider(Provider):
                             "output_tokens": total_output,
                             "thinking_tokens": total_thinking,
                             "total_tokens": total_all,
-                            "cost_usd": cost,
-                            "cost_per_page_usd": cost / num_pages if num_pages > 0 else 0.0,
                             "input_tokens_per_page": total_input / num_pages if num_pages > 0 else 0.0,
                             "output_tokens_per_page": total_output / num_pages if num_pages > 0 else 0.0,
                         }
@@ -983,6 +1017,17 @@ class GoogleProvider(Provider):
                         else {}
                     ),
                 }
+                pricing = self._get_pricing()
+                if pricing is not None and attempt_usages_complete(page_usages):
+                    input_rate, output_rate = pricing
+                    self._annotate_retry_attempts_with_costs(api_attempts)
+                    cost = (total_input * input_rate + (total_output + total_thinking) * output_rate) / 1_000_000
+                    usage_summary.update(
+                        {
+                            "cost_usd": cost,
+                            "cost_per_page_usd": cost / num_pages if num_pages > 0 else 0.0,
+                        }
+                    )
 
             raw_output = {
                 "pages": pages,
@@ -1030,6 +1075,11 @@ class GoogleProvider(Provider):
         finally:
             if runner is not None:
                 runner.delete_prefix_cache()
+                if terminal_debug_payload is not None:
+                    terminal_debug_payload["cache_error"] = runner.cache_error
+                    cache_payload = terminal_debug_payload.get("explicit_context_cache")
+                    if isinstance(cache_payload, dict):
+                        cache_payload["deleted"] = runner.cache_deleted
                 if result is not None:
                     result.raw_output["cache_error"] = runner.cache_error
                     cache_payload = result.raw_output.get("explicit_context_cache")

--- a/src/parse_bench/inference/providers/parse/google.py
+++ b/src/parse_bench/inference/providers/parse/google.py
@@ -4,6 +4,7 @@ import io
 import logging
 import os
 from datetime import datetime
+from functools import partial
 from pathlib import Path
 from typing import Any
 
@@ -26,6 +27,7 @@ from parse_bench.inference.providers.parse._layout_utils import (
 from parse_bench.inference.providers.parse._multipage_image import (
     close_derived_images,
     open_document_page_images,
+    run_page_with_retries,
 )
 from parse_bench.inference.providers.parse.google_agentic_vision import (
     GoogleAgenticVisionRunner,
@@ -499,21 +501,7 @@ class GoogleProvider(Provider):
             text = self._extract_text(response)
 
             if text is None:
-                reason1 = self._failure_reason(response)
-                # Single retry on empty response
-                response = self._client.models.generate_content(
-                    model=self._model,
-                    contents=contents,
-                    config=gen_config,
-                )
-                usage = self._extract_usage(response)
-                text = self._extract_text(response)
-
-            if text is None:
-                reason2 = self._failure_reason(response)
-                raise ProviderTransientError(
-                    f"Gemini API returned no text after 2 attempts: 1st={reason1}, 2nd={reason2}"
-                )
+                raise ProviderTransientError(f"Gemini API returned no text: {self._failure_reason(response)}")
             return text, usage
 
         except (ProviderPermanentError, ProviderTransientError):
@@ -565,20 +553,7 @@ class GoogleProvider(Provider):
             text = self._extract_text(response)
 
             if text is None:
-                reason1 = self._failure_reason(response)
-                response = self._client.models.generate_content(
-                    model=self._model,
-                    contents=contents,
-                    config=gen_config,
-                )
-                usage = self._extract_usage(response)
-                text = self._extract_text(response)
-
-            if text is None:
-                reason2 = self._failure_reason(response)
-                raise ProviderTransientError(
-                    f"Gemini API returned no layout text after 2 attempts: 1st={reason1}, 2nd={reason2}"
-                )
+                raise ProviderTransientError(f"Gemini API returned no layout text: {self._failure_reason(response)}")
 
             items = swap_gemini_bbox(parse_layout_blocks(text))
             return items, text, usage
@@ -832,11 +807,16 @@ class GoogleProvider(Provider):
                         img_bytes = self._image_to_bytes(image)
 
                         try:
-                            page_result = runner.parse_page(
-                                page_index=page_index,
-                                image=image,
-                                image_bytes=img_bytes,
-                                image_mime_type="image/jpeg",
+                            page_result = run_page_with_retries(
+                                partial(
+                                    runner.parse_page,
+                                    page_index=page_index,
+                                    image=image,
+                                    image_bytes=img_bytes,
+                                    image_mime_type="image/jpeg",
+                                ),
+                                provider_name=pipeline.provider_name,
+                                page_number=page_index + 1,
                             )
                             self._annotate_api_calls_with_costs(page_result.api_calls)
                             page_usages.extend(
@@ -875,7 +855,11 @@ class GoogleProvider(Provider):
                 with open_document_page_images(source_path, dpi=self._dpi) as images:
                     for page_index, image in enumerate(images):
                         if self._mode == "parse_with_layout":
-                            items, raw_content, usage = self._parse_image_with_layout(image)
+                            items, raw_content, usage = run_page_with_retries(
+                                partial(self._parse_image_with_layout, image),
+                                provider_name=pipeline.provider_name,
+                                page_number=page_index + 1,
+                            )
                             page_usages.append(usage)
                             pages.append(
                                 {
@@ -887,7 +871,11 @@ class GoogleProvider(Provider):
                                 }
                             )
                         else:
-                            markdown, usage = self._parse_image(image)
+                            markdown, usage = run_page_with_retries(
+                                partial(self._parse_image, image),
+                                provider_name=pipeline.provider_name,
+                                page_number=page_index + 1,
+                            )
                             page_usages.append(usage)
                             pages.append(
                                 {

--- a/src/parse_bench/inference/providers/parse/google.py
+++ b/src/parse_bench/inference/providers/parse/google.py
@@ -27,6 +27,7 @@ from parse_bench.inference.providers.parse._layout_utils import (
 )
 from parse_bench.inference.providers.parse._multipage_image import (
     append_attempt_usages,
+    attempt_usages_complete,
     close_derived_images,
     open_document_page_images,
     run_page_with_retries,
@@ -254,6 +255,11 @@ class GoogleProvider(Provider):
         cache_storage_cost_usd: float = 0.0,
     ) -> dict[str, float | int]:
         """Aggregate token and cost accounting across all Gemini calls for one document."""
+        if not attempt_usages_complete(usages):
+            return {
+                "num_api_calls": len(usages),
+                "cache_storage_cost_usd": cache_storage_cost_usd,
+            }
         total_input = sum(int(usage.get("input_tokens", 0) or 0) for usage in usages)
         total_tool_use_prompt = sum(int(usage.get("tool_use_prompt_tokens", 0) or 0) for usage in usages)
         total_cached_content = sum(int(usage.get("cached_content_tokens", 0) or 0) for usage in usages)
@@ -305,6 +311,10 @@ class GoogleProvider(Provider):
             usage = call.get("usage", {})
             if not isinstance(usage, dict):
                 usage = {}
+            if not attempt_usages_complete([usage]):
+                call.pop("cost_usd", None)
+                call.pop("cost_breakdown_usd", None)
+                continue
             breakdown = self._usage_cost_breakdown(usage)
             call["cost_usd"] = breakdown["cost_usd"]
             call["cost_breakdown_usd"] = {
@@ -319,7 +329,8 @@ class GoogleProvider(Provider):
             stats = attempt.get("stats")
             if isinstance(stats, dict):
                 usage = {key: int(value) for key, value in stats.items() if key.endswith("tokens")}
-                stats.update(self._usage_cost_breakdown(usage))
+                if attempt_usages_complete([usage]):
+                    stats.update(self._usage_cost_breakdown(usage))
 
     def _build_agentic_vision_runner(self, expected_page_calls: int) -> GoogleAgenticVisionRunner:
         """Build the shared Agentic Vision runner for one document."""
@@ -788,6 +799,7 @@ class GoogleProvider(Provider):
                             provider_name=pipeline.provider_name,
                             page_number=page_index + 1,
                             attempt_ledger=attempts,
+                            prior_attempt_ledger=api_attempts,
                         )
                         api_attempts.extend(attempts)
                         append_attempt_usages(page_usages, attempts)
@@ -882,6 +894,7 @@ class GoogleProvider(Provider):
                                 provider_name=pipeline.provider_name,
                                 page_number=page_index + 1,
                                 attempt_ledger=attempts,
+                                prior_attempt_ledger=api_attempts,
                             )
                             api_attempts.extend(attempts)
                             append_attempt_usages(page_usages, attempts)
@@ -901,6 +914,7 @@ class GoogleProvider(Provider):
                                 provider_name=pipeline.provider_name,
                                 page_number=page_index + 1,
                                 attempt_ledger=attempts,
+                                prior_attempt_ledger=api_attempts,
                             )
                             api_attempts.extend(attempts)
                             append_attempt_usages(page_usages, attempts)
@@ -953,15 +967,21 @@ class GoogleProvider(Provider):
                 input_rate, output_rate = self._get_pricing()
                 cost = (total_input * input_rate + (total_output + total_thinking) * output_rate) / 1_000_000
                 usage_summary = {
-                    "input_tokens": total_input,
-                    "output_tokens": total_output,
-                    "thinking_tokens": total_thinking,
-                    "total_tokens": total_all,
-                    "cost_usd": cost,
-                    "cost_per_page_usd": cost / num_pages if num_pages > 0 else 0.0,
-                    "input_tokens_per_page": total_input / num_pages if num_pages > 0 else 0.0,
-                    "output_tokens_per_page": total_output / num_pages if num_pages > 0 else 0.0,
                     "num_api_calls": len(api_attempts) if api_attempts else len(page_usages),
+                    **(
+                        {
+                            "input_tokens": total_input,
+                            "output_tokens": total_output,
+                            "thinking_tokens": total_thinking,
+                            "total_tokens": total_all,
+                            "cost_usd": cost,
+                            "cost_per_page_usd": cost / num_pages if num_pages > 0 else 0.0,
+                            "input_tokens_per_page": total_input / num_pages if num_pages > 0 else 0.0,
+                            "output_tokens_per_page": total_output / num_pages if num_pages > 0 else 0.0,
+                        }
+                        if attempt_usages_complete(page_usages)
+                        else {}
+                    ),
                 }
 
             raw_output = {

--- a/src/parse_bench/inference/providers/parse/google.py
+++ b/src/parse_bench/inference/providers/parse/google.py
@@ -30,6 +30,7 @@ from parse_bench.inference.providers.parse._multipage_image import (
     attempt_usages_complete,
     close_derived_images,
     open_document_page_images,
+    run_page_once,
     run_page_with_retries,
 )
 from parse_bench.inference.providers.parse.google_agentic_vision import (
@@ -398,6 +399,8 @@ class GoogleProvider(Provider):
         usage: dict[str, int] = {"thinking_tokens": int(getattr(meta, "thoughts_token_count", 0) or 0)}
         for key, attribute in (
             ("input_tokens", "prompt_token_count"),
+            ("tool_use_prompt_tokens", "tool_use_prompt_token_count"),
+            ("cached_content_tokens", "cached_content_token_count"),
             ("output_tokens", "candidates_token_count"),
             ("total_tokens", "total_token_count"),
         ):
@@ -777,12 +780,19 @@ class GoogleProvider(Provider):
         try:
             page_usages: list[dict[str, int]] = []
             api_attempts: list[dict[str, object]] = []
+            attempts: list[dict[str, object]]
 
             if self._mode == "file":
                 if source_path.suffix.lower() == ".pdf":
                     # File mode: send raw PDF to API
-                    markdown, usage = self._parse_pdf_file(str(source_path))
-                    page_usages.append(usage)
+                    attempts = []
+                    markdown, usage = run_page_once(
+                        partial(self._parse_pdf_file, str(source_path)),
+                        page_number=1,
+                        attempt_ledger=attempts,
+                    )
+                    api_attempts.extend(attempts)
+                    append_attempt_usages(page_usages, attempts)
                     # In file mode, we get one response for the entire document
                     # We don't have page-level info, so we treat it as a single "page"
                     pages = [
@@ -797,8 +807,14 @@ class GoogleProvider(Provider):
                 else:
                     # Non-PDF: fall back to image-based parsing
                     with Image.open(source_path) as image:
-                        markdown, usage = self._parse_image(image)
-                        page_usages.append(usage)
+                        attempts = []
+                        markdown, usage = run_page_once(
+                            partial(self._parse_image, image),
+                            page_number=1,
+                            attempt_ledger=attempts,
+                        )
+                        api_attempts.extend(attempts)
+                        append_attempt_usages(page_usages, attempts)
                         pages = [
                             {
                                 "page_index": 0,
@@ -814,7 +830,7 @@ class GoogleProvider(Provider):
                     layout_pdf_pages = split_pdf_to_pages(str(source_path))
                     pages = []
                     for page_index, (pdf_bytes, w, h) in enumerate(layout_pdf_pages):
-                        attempts: list[dict[str, object]] = []
+                        attempts = []
                         items, raw_content, usage = run_page_with_retries(
                             partial(self._parse_pdf_page_with_layout, pdf_bytes),
                             provider_name=pipeline.provider_name,
@@ -997,37 +1013,10 @@ class GoogleProvider(Provider):
                     cache_storage_cost_usd=cache_storage_cost_usd,
                 )
             else:
-                total_input = sum(u["input_tokens"] for u in page_usages)
-                total_output = sum(u["output_tokens"] for u in page_usages)
-                total_thinking = sum(u["thinking_tokens"] for u in page_usages)
-                total_all = sum(u["total_tokens"] for u in page_usages)
-
-                usage_summary = {
-                    "num_api_calls": len(api_attempts) if api_attempts else len(page_usages),
-                    **(
-                        {
-                            "input_tokens": total_input,
-                            "output_tokens": total_output,
-                            "thinking_tokens": total_thinking,
-                            "total_tokens": total_all,
-                            "input_tokens_per_page": total_input / num_pages if num_pages > 0 else 0.0,
-                            "output_tokens_per_page": total_output / num_pages if num_pages > 0 else 0.0,
-                        }
-                        if attempt_usages_complete(page_usages)
-                        else {}
-                    ),
-                }
-                pricing = self._get_pricing()
-                if pricing is not None and attempt_usages_complete(page_usages):
-                    input_rate, output_rate = pricing
+                usage_summary = self._compute_usage_cost_summary(page_usages, num_pages=num_pages)
+                usage_summary["num_api_calls"] = len(api_attempts) if api_attempts else len(page_usages)
+                if attempt_usages_complete(page_usages):
                     self._annotate_retry_attempts_with_costs(api_attempts)
-                    cost = (total_input * input_rate + (total_output + total_thinking) * output_rate) / 1_000_000
-                    usage_summary.update(
-                        {
-                            "cost_usd": cost,
-                            "cost_per_page_usd": cost / num_pages if num_pages > 0 else 0.0,
-                        }
-                    )
 
             raw_output = {
                 "pages": pages,

--- a/src/parse_bench/inference/providers/parse/google.py
+++ b/src/parse_bench/inference/providers/parse/google.py
@@ -803,16 +803,11 @@ class GoogleProvider(Provider):
                         img_bytes = self._image_to_bytes(image)
 
                         try:
-                            page_result = run_page_with_retries(
-                                partial(
-                                    runner.parse_page,
-                                    page_index=page_index,
-                                    image=image,
-                                    image_bytes=img_bytes,
-                                    image_mime_type="image/jpeg",
-                                ),
-                                provider_name=pipeline.provider_name,
-                                page_number=page_index + 1,
+                            page_result = runner.parse_page(
+                                page_index=page_index,
+                                image=image,
+                                image_bytes=img_bytes,
+                                image_mime_type="image/jpeg",
                             )
                             self._annotate_api_calls_with_costs(page_result.api_calls)
                             page_usages.extend(

--- a/src/parse_bench/inference/providers/parse/google.py
+++ b/src/parse_bench/inference/providers/parse/google.py
@@ -23,8 +23,10 @@ from parse_bench.inference.providers.parse._layout_utils import (
     resolve_layout_prompts,
     split_pdf_to_pages,
     swap_gemini_bbox,
+    validated_sorted_page_records,
 )
 from parse_bench.inference.providers.parse._multipage_image import (
+    append_attempt_usages,
     close_derived_images,
     open_document_page_images,
     run_page_with_retries,
@@ -240,6 +242,10 @@ class GoogleProvider(Provider):
             "cost_usd": cost_usd,
         }
 
+    def _billable_response_error(self, message: str, usage: dict[str, int]) -> ProviderTransientError:
+        """Retain usage and cost when a billed Gemini response is unusable."""
+        return ProviderTransientError(message, attempt_stats={**usage, **self._usage_cost_breakdown(usage)})
+
     def _compute_usage_cost_summary(
         self,
         usages: list[dict[str, int]],
@@ -307,6 +313,13 @@ class GoogleProvider(Provider):
                 "cached_input_cost_usd": breakdown["cached_input_cost_usd"],
                 "output_and_thinking_cost_usd": breakdown["output_and_thinking_cost_usd"],
             }
+
+    def _annotate_retry_attempts_with_costs(self, attempts: list[dict[str, object]]) -> None:
+        for attempt in attempts:
+            stats = attempt.get("stats")
+            if isinstance(stats, dict):
+                usage = {key: int(value) for key, value in stats.items() if key.endswith("tokens")}
+                stats.update(self._usage_cost_breakdown(usage))
 
     def _build_agentic_vision_runner(self, expected_page_calls: int) -> GoogleAgenticVisionRunner:
         """Build the shared Agentic Vision runner for one document."""
@@ -508,7 +521,9 @@ class GoogleProvider(Provider):
             text = self._extract_text(response)
 
             if text is None:
-                raise ProviderTransientError(f"Gemini API returned no text: {self._failure_reason(response)}")
+                raise self._billable_response_error(
+                    f"Gemini API returned no text: {self._failure_reason(response)}", usage
+                )
             return text, usage
 
         except (ProviderPermanentError, ProviderTransientError):
@@ -560,12 +575,14 @@ class GoogleProvider(Provider):
             text = self._extract_text(response)
 
             if text is None:
-                raise ProviderTransientError(f"Gemini API returned no layout text: {self._failure_reason(response)}")
+                raise self._billable_response_error(
+                    f"Gemini API returned no layout text: {self._failure_reason(response)}", usage
+                )
 
             try:
                 items = swap_gemini_bbox(parse_layout_response(text))
             except ValueError as exc:
-                raise ProviderTransientError(f"Gemini returned malformed layout output: {exc}") from exc
+                raise self._billable_response_error(f"Gemini returned malformed layout output: {exc}", usage) from exc
             return items, text, usage
 
         except (ProviderPermanentError, ProviderTransientError):
@@ -626,7 +643,9 @@ class GoogleProvider(Provider):
             text = self._extract_text(response)
 
             if text is None:
-                raise ProviderTransientError(f"Gemini API returned no PDF text: {self._failure_reason(response)}")
+                raise self._billable_response_error(
+                    f"Gemini API returned no PDF text: {self._failure_reason(response)}", usage
+                )
             return text, usage
 
         except (ProviderPermanentError, ProviderTransientError):
@@ -677,14 +696,16 @@ class GoogleProvider(Provider):
             text = self._extract_text(response)
 
             if text is None:
-                raise ProviderTransientError(
-                    f"Gemini API returned no PDF layout text: {self._failure_reason(response)}"
+                raise self._billable_response_error(
+                    f"Gemini API returned no PDF layout text: {self._failure_reason(response)}", usage
                 )
 
             try:
                 items = swap_gemini_bbox(parse_layout_response(text))
             except ValueError as exc:
-                raise ProviderTransientError(f"Gemini returned malformed PDF layout output: {exc}") from exc
+                raise self._billable_response_error(
+                    f"Gemini returned malformed PDF layout output: {exc}", usage
+                ) from exc
             return items, text, usage
 
         except (ProviderPermanentError, ProviderTransientError):
@@ -718,9 +739,12 @@ class GoogleProvider(Provider):
             raise ProviderPermanentError(f"GoogleProvider supports {supported_extensions}, got {source_path.suffix}")
 
         started_at = datetime.now()
+        runner: GoogleAgenticVisionRunner | None = None
+        result: RawInferenceResult | None = None
 
         try:
             page_usages: list[dict[str, int]] = []
+            api_attempts: list[dict[str, object]] = []
 
             if self._mode == "file":
                 if source_path.suffix.lower() == ".pdf":
@@ -758,12 +782,15 @@ class GoogleProvider(Provider):
                     layout_pdf_pages = split_pdf_to_pages(str(source_path))
                     pages = []
                     for page_index, (pdf_bytes, w, h) in enumerate(layout_pdf_pages):
+                        attempts: list[dict[str, object]] = []
                         items, raw_content, usage = run_page_with_retries(
                             partial(self._parse_pdf_page_with_layout, pdf_bytes),
                             provider_name=pipeline.provider_name,
                             page_number=page_index + 1,
+                            attempt_ledger=attempts,
                         )
-                        page_usages.append(usage)
+                        api_attempts.extend(attempts)
+                        append_attempt_usages(page_usages, attempts)
                         pages.append(
                             {
                                 "page_index": page_index,
@@ -777,12 +804,15 @@ class GoogleProvider(Provider):
                 else:
                     # Non-PDF: fall back to image-based layout parsing
                     with Image.open(source_path) as image:
+                        attempts = []
                         items, raw_content, usage = run_page_with_retries(
                             partial(self._parse_image_with_layout, image),
                             provider_name=pipeline.provider_name,
                             page_number=1,
+                            attempt_ledger=attempts,
                         )
-                        page_usages.append(usage)
+                        api_attempts.extend(attempts)
+                        append_attempt_usages(page_usages, attempts)
                         pages = [
                             {
                                 "page_index": 0,
@@ -846,12 +876,15 @@ class GoogleProvider(Provider):
                 with open_document_page_images(source_path, dpi=self._dpi) as images:
                     for page_index, image in enumerate(images):
                         if self._mode == "parse_with_layout":
+                            attempts = []
                             items, raw_content, usage = run_page_with_retries(
                                 partial(self._parse_image_with_layout, image),
                                 provider_name=pipeline.provider_name,
                                 page_number=page_index + 1,
+                                attempt_ledger=attempts,
                             )
-                            page_usages.append(usage)
+                            api_attempts.extend(attempts)
+                            append_attempt_usages(page_usages, attempts)
                             pages.append(
                                 {
                                     "page_index": page_index,
@@ -862,12 +895,15 @@ class GoogleProvider(Provider):
                                 }
                             )
                         else:
+                            attempts = []
                             markdown, usage = run_page_with_retries(
                                 partial(self._parse_image, image),
                                 provider_name=pipeline.provider_name,
                                 page_number=page_index + 1,
+                                attempt_ledger=attempts,
                             )
-                            page_usages.append(usage)
+                            api_attempts.extend(attempts)
+                            append_attempt_usages(page_usages, attempts)
                             pages.append(
                                 {
                                     "page_index": page_index,
@@ -894,7 +930,13 @@ class GoogleProvider(Provider):
                 config_info["min_cacheable_tokens"] = self._min_cacheable_tokens
 
             if self._mode == "parse_with_layout_agentic_vision":
-                cache_info = runner.cache_info if "runner" in locals() else None
+                assert runner is not None
+                api_attempts = []
+                for page in pages:
+                    page_calls = page.get("api_calls")
+                    if isinstance(page_calls, list):
+                        api_attempts.extend(call for call in page_calls if isinstance(call, dict))
+                cache_info = runner.cache_info
                 cache_storage_cost_usd = cache_info.storage_cost_usd if cache_info is not None else 0.0
                 usage_summary = self._compute_usage_cost_summary(
                     page_usages,
@@ -902,6 +944,7 @@ class GoogleProvider(Provider):
                     cache_storage_cost_usd=cache_storage_cost_usd,
                 )
             else:
+                self._annotate_retry_attempts_with_costs(api_attempts)
                 total_input = sum(u["input_tokens"] for u in page_usages)
                 total_output = sum(u["output_tokens"] for u in page_usages)
                 total_thinking = sum(u["thinking_tokens"] for u in page_usages)
@@ -918,6 +961,7 @@ class GoogleProvider(Provider):
                     "cost_per_page_usd": cost / num_pages if num_pages > 0 else 0.0,
                     "input_tokens_per_page": total_input / num_pages if num_pages > 0 else 0.0,
                     "output_tokens_per_page": total_output / num_pages if num_pages > 0 else 0.0,
+                    "num_api_calls": len(api_attempts) if api_attempts else len(page_usages),
                 }
 
             raw_output = {
@@ -928,10 +972,12 @@ class GoogleProvider(Provider):
                 "bbox_scale": self._bbox_scale,
                 "config": config_info,
                 **usage_summary,
+                "api_attempts": api_attempts,
             }
             if self._mode == "parse_with_layout_agentic_vision":
-                cache_info = runner.cache_info if "runner" in locals() else None
-                raw_output["cache_error"] = runner.cache_error if "runner" in locals() else None
+                assert runner is not None
+                cache_info = runner.cache_info
+                raw_output["cache_error"] = runner.cache_error
                 raw_output["explicit_context_cache"] = (
                     {
                         "name": cache_info.name,
@@ -945,7 +991,7 @@ class GoogleProvider(Provider):
                     else None
                 )
 
-            return RawInferenceResult(
+            result = RawInferenceResult(
                 request=request,
                 pipeline=pipeline,
                 pipeline_name=pipeline.pipeline_name,
@@ -955,11 +1001,20 @@ class GoogleProvider(Provider):
                 completed_at=completed_at,
                 latency_in_ms=latency_ms,
             )
+            return result
 
         except (ProviderPermanentError, ProviderTransientError, ProviderConfigError):
             raise
         except Exception as e:
             raise ProviderPermanentError(f"Unexpected error during inference: {e}") from e
+        finally:
+            if runner is not None:
+                runner.delete_prefix_cache()
+                if result is not None:
+                    result.raw_output["cache_error"] = runner.cache_error
+                    cache_payload = result.raw_output.get("explicit_context_cache")
+                    if isinstance(cache_payload, dict):
+                        cache_payload["deleted"] = runner.cache_deleted
 
     def normalize(self, raw_result: RawInferenceResult) -> InferenceResult:
         """
@@ -980,7 +1035,7 @@ class GoogleProvider(Provider):
         page_markdowns: list[str] = []
         layout_pages: list[ParseLayoutPageIR] = []
 
-        for page_data in raw_result.raw_output.get("pages", []):
+        for page_data in validated_sorted_page_records(raw_result.raw_output.get("pages", [])):
             page_index = page_data.get("page_index", 0)
 
             if mode in ("parse_with_layout", "parse_with_layout_file"):
@@ -1015,8 +1070,6 @@ class GoogleProvider(Provider):
             pages.append(PageIR(page_index=page_index, markdown=markdown))
             page_markdowns.append(markdown)
 
-        # Sort by page index and concatenate
-        pages.sort(key=lambda p: p.page_index)
         full_markdown = "\n\n".join(page_markdowns)
 
         output = ParseOutput(

--- a/src/parse_bench/inference/providers/parse/google.py
+++ b/src/parse_bench/inference/providers/parse/google.py
@@ -23,7 +23,10 @@ from parse_bench.inference.providers.parse._layout_utils import (
     split_pdf_to_pages,
     swap_gemini_bbox,
 )
-from parse_bench.inference.providers.parse._multipage_image import open_document_page_images
+from parse_bench.inference.providers.parse._multipage_image import (
+    close_derived_images,
+    open_document_page_images,
+)
 from parse_bench.inference.providers.parse.google_agentic_vision import (
     GoogleAgenticVisionRunner,
     build_layout_pages_from_agentic_items,
@@ -379,49 +382,50 @@ class GoogleProvider(Provider):
         - Images exceeding 20MB (reduces quality iteratively)
         """
         # Resize if dimensions exceed limit
-        image = self._prepare_image_for_api(image)
+        with close_derived_images(image) as track:
+            image = track(self._prepare_image_for_api(image))
 
-        # Convert to RGB if necessary (e.g., RGBA images)
-        if image.mode in ("RGBA", "P"):
-            image = image.convert("RGB")
+            # Convert to RGB if necessary (e.g., RGBA images)
+            if image.mode in ("RGBA", "P"):
+                image = track(image.convert("RGB"))
 
-        # Try encoding with decreasing quality until under size limit
-        quality = 85
-        min_quality = 20
+            # Try encoding with decreasing quality until under size limit
+            quality = 85
+            min_quality = 20
 
-        while quality >= min_quality:
-            buffer = io.BytesIO()
-            image.save(buffer, format="JPEG", quality=quality)
-            data = buffer.getvalue()
+            while quality >= min_quality:
+                buffer = io.BytesIO()
+                image.save(buffer, format="JPEG", quality=quality)
+                data = buffer.getvalue()
 
-            if len(data) <= self.MAX_IMAGE_SIZE_BYTES:
-                return data
+                if len(data) <= self.MAX_IMAGE_SIZE_BYTES:
+                    return data
 
-            quality -= 10
+                quality -= 10
 
-        # If still too large after quality reduction, resize the image
-        while True:
-            width, height = image.size
-            new_width = int(width * 0.8)
-            new_height = int(height * 0.8)
+            # If still too large after quality reduction, resize the image
+            while True:
+                width, height = image.size
+                new_width = int(width * 0.8)
+                new_height = int(height * 0.8)
 
-            if new_width < 100 or new_height < 100:
-                # Give up - image is too complex to fit in limits
-                break
+                if new_width < 100 or new_height < 100:
+                    # Give up - image is too complex to fit in limits
+                    break
 
-            image = image.resize((new_width, new_height), Image.Resampling.LANCZOS)
+                image = track(image.resize((new_width, new_height), Image.Resampling.LANCZOS))
 
+                buffer = io.BytesIO()
+                image.save(buffer, format="JPEG", quality=min_quality)
+                data = buffer.getvalue()
+
+                if len(data) <= self.MAX_IMAGE_SIZE_BYTES:
+                    return data
+
+            # Final fallback - return what we have
             buffer = io.BytesIO()
             image.save(buffer, format="JPEG", quality=min_quality)
-            data = buffer.getvalue()
-
-            if len(data) <= self.MAX_IMAGE_SIZE_BYTES:
-                return data
-
-        # Final fallback - return what we have
-        buffer = io.BytesIO()
-        image.save(buffer, format="JPEG", quality=min_quality)
-        return buffer.getvalue()
+            return buffer.getvalue()
 
     @staticmethod
     def _extract_text(response) -> str | None:  # type: ignore[no-untyped-def]

--- a/src/parse_bench/inference/providers/parse/google_agentic_vision.py
+++ b/src/parse_bench/inference/providers/parse/google_agentic_vision.py
@@ -6,13 +6,18 @@ import hashlib
 import json
 import logging
 import re
+import time
 from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any
 
 from PIL import Image
 
-from parse_bench.inference.providers.base import ProviderPermanentError, ProviderTransientError
+from parse_bench.inference.providers.base import (
+    ProviderPermanentError,
+    ProviderRetryExhaustedError,
+    ProviderTransientError,
+)
 from parse_bench.inference.providers.parse._layout_utils import LABEL_MAP, items_to_markdown
 from parse_bench.schemas.parse_output import LayoutItemIR, LayoutSegmentIR, ParseLayoutPageIR
 
@@ -684,7 +689,7 @@ class GoogleAgenticVisionRunner:
         image_mime_type: str,
         max_attempts: int = 3,
     ) -> AgenticVisionPageResult:
-        """Run one Agentic Vision page parse with retry on malformed final wrapped output."""
+        """Run one Agentic Vision page parse with the complete page retry budget."""
         cache_info = self._maybe_create_prefix_cache()
         use_cached_prefix = cache_info is not None
         cache_name = cache_info.name if cache_info is not None else None
@@ -726,7 +731,30 @@ class GoogleAgenticVisionRunner:
                     config=self._build_generation_config(cache_name),
                 )
             except Exception as exc:
-                raise classify_gemini_api_exception(exc) from exc
+                classified = classify_gemini_api_exception(exc)
+                if not isinstance(classified, ProviderTransientError):
+                    raise classified from exc
+
+                last_error = str(classified)
+                api_calls.append(
+                    {
+                        "page_index": page_index,
+                        "attempt": attempt,
+                        "request": request_summary,
+                        "response": None,
+                        "response_parts": [],
+                        "usage": extract_usage_from_response(None),
+                        "final_text": "",
+                        "error": {
+                            "type": type(classified).__name__,
+                            "message": last_error,
+                        },
+                        "cost_usd": 0.0,
+                    }
+                )
+                if attempt < max_attempts:
+                    time.sleep(2.0 * (2 ** (attempt - 1)))
+                continue
 
             usage = extract_usage_from_response(response)
             response_parts = extract_serialized_response_parts(response)
@@ -773,8 +801,8 @@ class GoogleAgenticVisionRunner:
 
             retry_instruction = build_retry_instruction(response, last_error, attempt=attempt)
 
-        raise ProviderPermanentError(
-            f"Failed to obtain valid Agentic Vision wrapped layout output after {max_attempts} attempts: {last_error}",
+        raise ProviderRetryExhaustedError(
+            f"Google Agentic Vision page {page_index + 1} failed after {max_attempts} attempts: {last_error}",
             debug_payload={
                 "mode": "parse_with_layout_agentic_vision",
                 "page_index": page_index,

--- a/src/parse_bench/inference/providers/parse/google_agentic_vision.py
+++ b/src/parse_bench/inference/providers/parse/google_agentic_vision.py
@@ -789,13 +789,12 @@ class GoogleAgenticVisionRunner:
                         "request": request_summary,
                         "response": None,
                         "response_parts": [],
-                        "usage": extract_usage_from_response(None),
+                        "usage": {},
                         "final_text": "",
                         "error": {
                             "type": type(classified).__name__,
                             "message": last_error,
                         },
-                        "cost_usd": 0.0,
                     }
                 )
                 if attempt < max_attempts:

--- a/src/parse_bench/inference/providers/parse/google_agentic_vision.py
+++ b/src/parse_bench/inference/providers/parse/google_agentic_vision.py
@@ -147,9 +147,9 @@ class AgenticVisionCacheInfo:
 
     name: str
     display_name: str
-    token_count: int
+    token_count: int | None
     ttl_seconds: int
-    storage_cost_usd: float
+    storage_cost_usd: float | None
     created: bool
 
 
@@ -582,9 +582,9 @@ class GoogleAgenticVisionRunner:
         enable_explicit_context_cache: bool,
         context_cache_ttl_seconds: int,
         min_cacheable_tokens: int,
-        input_cost_per_million: float,
-        cache_hit_cost_per_million: float,
-        cache_storage_cost_per_million_token_hour: float,
+        input_cost_per_million: float | None,
+        cache_hit_cost_per_million: float | None,
+        cache_storage_cost_per_million_token_hour: float | None,
         expected_page_calls: int,
     ) -> None:
         self._client = client
@@ -673,12 +673,14 @@ class GoogleAgenticVisionRunner:
             self._cache_error = str(exc)
             return None
 
-        token_count = int(getattr(getattr(cache, "usage_metadata", None), "total_token_count", 0) or 0)
+        usage_metadata = getattr(cache, "usage_metadata", None)
+        raw_token_count = getattr(usage_metadata, "total_token_count", None)
+        token_count = int(raw_token_count) if raw_token_count is not None else None
         ttl_hours = self._context_cache_ttl_seconds / 3600.0
         storage_cost_usd = (
             token_count * self._cache_storage_cost_per_million_token_hour * ttl_hours / 1_000_000
-            if token_count > 0
-            else 0.0
+            if token_count is not None and self._cache_storage_cost_per_million_token_hour is not None
+            else None
         )
         self._cache_info = AgenticVisionCacheInfo(
             name=str(getattr(cache, "name", "")),
@@ -823,7 +825,6 @@ class GoogleAgenticVisionRunner:
                 "response_parts": response_parts,
                 "usage": usage,
                 "final_text": final_text,
-                "cost_usd": 0.0,
             }
             api_calls.append(call_record)
 
@@ -864,22 +865,20 @@ def extract_usage_from_response(response: Any) -> dict[str, int]:
     """Extract all usage buckets relevant to Agentic Vision accounting."""
     meta = getattr(response, "usage_metadata", None)
     if meta is None:
-        return {
-            "input_tokens": 0,
-            "tool_use_prompt_tokens": 0,
-            "cached_content_tokens": 0,
-            "output_tokens": 0,
-            "thinking_tokens": 0,
-            "total_tokens": 0,
-        }
-    return {
-        "input_tokens": int(getattr(meta, "prompt_token_count", 0) or 0),
-        "tool_use_prompt_tokens": int(getattr(meta, "tool_use_prompt_token_count", 0) or 0),
-        "cached_content_tokens": int(getattr(meta, "cached_content_token_count", 0) or 0),
-        "output_tokens": int(getattr(meta, "candidates_token_count", 0) or 0),
-        "thinking_tokens": int(getattr(meta, "thoughts_token_count", 0) or 0),
-        "total_tokens": int(getattr(meta, "total_token_count", 0) or 0),
-    }
+        return {}
+    usage: dict[str, int] = {}
+    for key, attribute in (
+        ("input_tokens", "prompt_token_count"),
+        ("tool_use_prompt_tokens", "tool_use_prompt_token_count"),
+        ("cached_content_tokens", "cached_content_token_count"),
+        ("output_tokens", "candidates_token_count"),
+        ("thinking_tokens", "thoughts_token_count"),
+        ("total_tokens", "total_token_count"),
+    ):
+        value = getattr(meta, attribute, None)
+        if value is not None:
+            usage[key] = int(value)
+    return usage
 
 
 def classify_gemini_api_exception(exc: Exception) -> Exception:

--- a/src/parse_bench/inference/providers/parse/google_agentic_vision.py
+++ b/src/parse_bench/inference/providers/parse/google_agentic_vision.py
@@ -780,9 +780,6 @@ class GoogleAgenticVisionRunner:
                 )
             except Exception as exc:
                 classified = classify_gemini_api_exception(exc)
-                if not isinstance(classified, ProviderTransientError):
-                    raise classified from exc
-
                 last_error = str(classified)
                 api_calls.append(
                     {
@@ -799,6 +796,18 @@ class GoogleAgenticVisionRunner:
                         },
                     }
                 )
+                if not isinstance(classified, ProviderTransientError):
+                    if isinstance(classified, ProviderPermanentError):
+                        classified.debug_payload = {
+                            "mode": "parse_with_layout_agentic_vision",
+                            "page_index": page_index,
+                            "page_width": width,
+                            "page_height": height,
+                            "image_mime_type": image_mime_type,
+                            "api_calls": api_calls,
+                            "last_error": last_error,
+                        }
+                    raise classified from exc
                 if attempt < max_attempts:
                     time.sleep(2.0 * (2 ** (attempt - 1)))
                 continue

--- a/src/parse_bench/inference/providers/parse/google_agentic_vision.py
+++ b/src/parse_bench/inference/providers/parse/google_agentic_vision.py
@@ -601,6 +601,7 @@ class GoogleAgenticVisionRunner:
         self._expected_page_calls = expected_page_calls
         self._cache_info: AgenticVisionCacheInfo | None = None
         self._cache_error: str | None = None
+        self._cache_deleted = False
 
     @property
     def cache_info(self) -> AgenticVisionCacheInfo | None:
@@ -609,6 +610,23 @@ class GoogleAgenticVisionRunner:
     @property
     def cache_error(self) -> str | None:
         return self._cache_error
+
+    @property
+    def cache_deleted(self) -> bool:
+        return self._cache_deleted
+
+    def delete_prefix_cache(self) -> None:
+        """Delete the document-scoped server cache once, including failure paths."""
+        if self._cache_deleted or self._cache_info is None or not self._cache_info.name:
+            return
+        try:
+            self._client.caches.delete(name=self._cache_info.name)
+        except Exception as exc:  # cleanup must not replace the document outcome
+            logger.warning("Failed to delete Gemini context cache for Agentic Vision: %s", exc)
+            message = f"cache deletion failed: {exc}"
+            self._cache_error = f"{self._cache_error}; {message}" if self._cache_error else message
+        else:
+            self._cache_deleted = True
 
     def _maybe_create_prefix_cache(self) -> AgenticVisionCacheInfo | None:
         if self._cache_info is not None:

--- a/src/parse_bench/inference/providers/parse/google_agentic_vision.py
+++ b/src/parse_bench/inference/providers/parse/google_agentic_vision.py
@@ -9,7 +9,7 @@ import re
 import time
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import Any
+from typing import Any, cast
 
 from PIL import Image
 
@@ -25,6 +25,18 @@ logger = logging.getLogger(__name__)
 
 TRANSIENT_ERROR_KEYWORDS = ("timeout", "connection", "network")
 RATE_LIMIT_ERROR_KEYWORDS = ("rate_limit", "rate limit", "429", "resource_exhausted")
+_TRANSIENT_STATUS_CODES = {408, 429, 500, 502, 503, 504}
+_STATUS_NAME_CODES = {
+    "request_timeout": 408,
+    "deadline_exceeded": 504,
+    "resource_exhausted": 429,
+    "internal": 500,
+    "internal_server_error": 500,
+    "bad_gateway": 502,
+    "unavailable": 503,
+    "service_unavailable": 503,
+    "gateway_timeout": 504,
+}
 
 CORE11_LABELS = [
     "Caption",
@@ -55,6 +67,7 @@ SYSTEM_PROMPT_AGENTIC_VISION = (
     "- data-label must be one of: Caption, Footnote, Formula, List-item, Page-footer, "
     "Page-header, Picture, Section-header, Table, Text, Title.\n"
     "- Every piece of content must be inside exactly one <div> wrapper.\n"
+    "- If and only if the page is visually blank, return exactly [] with no wrappers or other text.\n"
     "- Start from the full page image and preserve reading order from that full-page view.\n"
     "- First try to read and ground content from the full page image.\n"
     "- If you zoom, crop, rotate, or enhance the page using code execution, always convert the final box "
@@ -88,6 +101,7 @@ USER_PROMPT_AGENTIC_VISION_PREFIX = (
     "After inspection, return the wrapped markdown as assistant text. If you must use code for the final step, "
     "print only one raw triple-quoted string containing the wrapped markdown and nothing else.\n"
     "Output ONLY the wrapped content, no explanations.\n"
+    "For a visually blank page, output exactly [] and nothing else.\n"
 )
 
 RETRY_PROMPT_RECITATION = (
@@ -417,6 +431,9 @@ def _normalize_bbox_2d(value: object) -> list[int]:
 
 def parse_agentic_layout_blocks(content: str) -> AgenticVisionPageResponse:
     """Parse wrapped layout blocks using Gemini-native y-first bbox ordering."""
+    if content.strip() == "[]":
+        return AgenticVisionPageResponse(raw_content="", items=[])
+
     raw_matches: list[tuple[int, list[int], str, str, str]] = []
 
     for match in _PATTERN_BBOX_FIRST.finditer(content):
@@ -459,7 +476,7 @@ def parse_page_response(response: Any) -> AgenticVisionPageResponse:
     errors: list[str] = []
     for payload in _candidate_layout_payloads(response):
         parsed = parse_agentic_layout_blocks(payload)
-        if parsed.items:
+        if parsed.items or payload.strip() == "[]":
             return parsed
         errors.append("No wrapped layout blocks found")
 
@@ -496,8 +513,19 @@ def build_layout_pages_from_agentic_items(
     page_number: int,
 ) -> tuple[str, list[ParseLayoutPageIR]]:
     """Convert wrapped Agentic Vision items to page markdown and ParseLayoutPageIR."""
-    if not items_data or not image_width or not image_height:
+    if not image_width or not image_height:
         return "", []
+
+    if not items_data:
+        return "", [
+            ParseLayoutPageIR(
+                page_number=page_number,
+                width=float(image_width),
+                height=float(image_height),
+                md="",
+                items=[],
+            )
+        ]
 
     markdown = items_to_markdown(items_data)
     layout_items: list[LayoutItemIR] = []
@@ -839,9 +867,50 @@ def extract_usage_from_response(response: Any) -> dict[str, int]:
 
 def classify_gemini_api_exception(exc: Exception) -> Exception:
     """Classify raw SDK exceptions into retryable provider errors when possible."""
+    status_code = _extract_gemini_status_code(exc)
+    if status_code == 429:
+        return cast(Exception, ProviderTransientError(f"Rate limited: {exc}"))
+    if status_code in _TRANSIENT_STATUS_CODES or (status_code is not None and status_code >= 500):
+        return cast(Exception, ProviderTransientError(f"Transient error calling Gemini API: {exc}"))
+    if status_code is not None and 400 <= status_code < 500:
+        return cast(Exception, ProviderPermanentError(f"Error calling Gemini API: {exc}"))
+
     error_str = str(exc).lower()
+    if isinstance(exc, (TimeoutError, ConnectionError)):
+        return cast(Exception, ProviderTransientError(f"Transient error calling Gemini API: {exc}"))
     if any(keyword in error_str for keyword in TRANSIENT_ERROR_KEYWORDS):
-        return ProviderTransientError(f"Transient error calling Gemini API: {exc}")
+        return cast(Exception, ProviderTransientError(f"Transient error calling Gemini API: {exc}"))
     if any(keyword in error_str for keyword in RATE_LIMIT_ERROR_KEYWORDS):
-        return ProviderTransientError(f"Rate limited: {exc}")
-    return ProviderPermanentError(f"Error calling Gemini API: {exc}")
+        return cast(Exception, ProviderTransientError(f"Rate limited: {exc}"))
+    return cast(Exception, ProviderPermanentError(f"Error calling Gemini API: {exc}"))
+
+
+def _extract_gemini_status_code(exc: Exception) -> int | None:
+    """Extract an HTTP-like status from Google SDK and api_core exceptions."""
+    response = getattr(exc, "response", None)
+    candidates = [
+        getattr(exc, "status_code", None),
+        getattr(exc, "code", None),
+        getattr(exc, "status", None),
+        getattr(response, "status_code", None),
+        getattr(response, "status", None),
+    ]
+    for candidate in candidates:
+        if callable(candidate):
+            try:
+                candidate = candidate()
+            except TypeError:
+                continue
+        if candidate is None:
+            continue
+
+        raw_value = getattr(candidate, "value", candidate)
+        if isinstance(raw_value, int):
+            return raw_value
+        if isinstance(raw_value, str) and raw_value.isdigit():
+            return int(raw_value)
+
+        name = str(getattr(candidate, "name", candidate)).lower().replace("-", "_").replace(" ", "_")
+        if name in _STATUS_NAME_CODES:
+            return _STATUS_NAME_CODES[name]
+    return None

--- a/src/parse_bench/inference/providers/parse/granite_vision.py
+++ b/src/parse_bench/inference/providers/parse/granite_vision.py
@@ -29,6 +29,7 @@ from parse_bench.inference.providers.base import (
     ProviderPermanentError,
     ProviderTransientError,
 )
+from parse_bench.inference.providers.parse._multipage_image import normalize_pdf_pages, run_pdf_pages
 from parse_bench.inference.providers.registry import register_provider
 from parse_bench.schemas.parse_output import ParseOutput
 from parse_bench.schemas.pipeline import PipelineSpec
@@ -252,6 +253,10 @@ class GraniteVisionProvider(Provider):
         }
 
     def run_inference(self, pipeline: PipelineSpec, request: InferenceRequest) -> RawInferenceResult:
+        multipage_result = run_pdf_pages(pipeline, request, dpi=self._dpi, run_single_image=self.run_inference)
+        if multipage_result is not None:
+            return multipage_result
+
         if request.product_type != ProductType.PARSE:
             raise ProviderPermanentError(
                 f"GraniteVisionProvider only supports PARSE product type, got {request.product_type}"
@@ -446,6 +451,10 @@ class GraniteVisionProvider(Provider):
         return "\n".join(result_parts)
 
     def normalize(self, raw_result: RawInferenceResult) -> InferenceResult:
+        multipage_result = normalize_pdf_pages(raw_result, normalize_single_image=self.normalize)
+        if multipage_result is not None:
+            return multipage_result
+
         if raw_result.product_type != ProductType.PARSE:
             raise ProviderPermanentError(
                 f"GraniteVisionProvider only supports PARSE product type, got {raw_result.product_type}"

--- a/src/parse_bench/inference/providers/parse/granite_vision.py
+++ b/src/parse_bench/inference/providers/parse/granite_vision.py
@@ -69,6 +69,8 @@ class GraniteVisionProvider(Provider):
         - api_key_env (str, default="VLLM_API_KEY"): Env var for API key
     """
 
+    PDF_RENDER_DPI = 150
+
     def __init__(self, provider_name: str, base_config: dict[str, Any] | None = None):
         super().__init__(provider_name, base_config)
 
@@ -106,7 +108,7 @@ class GraniteVisionProvider(Provider):
         self._task = task_cfg
 
         self._timeout = self.base_config.get("timeout", 600)
-        self._dpi = self.base_config.get("dpi", 150)
+        self._dpi = self.base_config.get("dpi", self.PDF_RENDER_DPI)
         self._served_model_name: str = str(self.base_config.get("served_model_name", SERVED_MODEL_NAME))
 
         # API key for authenticated vLLM endpoints

--- a/src/parse_bench/inference/providers/parse/infinity_parser2.py
+++ b/src/parse_bench/inference/providers/parse/infinity_parser2.py
@@ -251,7 +251,12 @@ class InfinityParser2Provider(Provider):
         }
 
     @staticmethod
-    def _decode_layout_elements(result: Any, *, context: str) -> list[dict[str, Any]]:
+    def _decode_layout_elements(
+        result: Any,
+        *,
+        context: str,
+        allow_empty: bool = False,
+    ) -> list[dict[str, Any]]:
         if not isinstance(result, str) or not result.strip():
             raise ProviderPermanentError(f"{context} is empty or is not JSON text")
         try:
@@ -260,7 +265,7 @@ class InfinityParser2Provider(Provider):
             raise ProviderPermanentError(f"{context} is not valid JSON: {exc}") from exc
         if not isinstance(decoded, list):
             raise ProviderPermanentError(f"{context} must decode to a list of layout elements")
-        if not decoded:
+        if not decoded and not allow_empty:
             raise ProviderPermanentError(f"{context} contains no layout elements")
         if any(not isinstance(element, dict) for element in decoded):
             raise ProviderPermanentError(f"{context} contains a non-object layout element")
@@ -281,7 +286,14 @@ class InfinityParser2Provider(Provider):
         aborts inference rather than silently substituting the shallow result.
         """
         try:
-            elements = self._decode_layout_elements(result, context="InfinityParser2 deep-parsing input")
+            elements = self._decode_layout_elements(
+                result,
+                context="InfinityParser2 deep-parsing input",
+                allow_empty=True,
+            )
+
+            if not elements:
+                return result
 
             figure_elements = [elem for elem in elements if elem.get("category", "").strip().lower() == "figure"]
             if not figure_elements:
@@ -337,10 +349,14 @@ class InfinityParser2Provider(Provider):
         page_width = raw_result.raw_output["_config"]["page_width"]
         page_height = raw_result.raw_output["_config"]["page_height"]
 
-        elements = self._decode_layout_elements(result_str, context="InfinityParser2 result")
+        elements = self._decode_layout_elements(
+            result_str,
+            context="InfinityParser2 result",
+            allow_empty=True,
+        )
 
         # Group elements by page
-        pages_dict: dict[int, list[dict]] = {}
+        pages_dict: dict[int, list[dict]] = {1: []} if not elements else {}
         for element_index, elem in enumerate(elements):
             page_num = elem.get("page", 1)
             if not isinstance(page_num, int) or isinstance(page_num, bool) or page_num < 1:

--- a/src/parse_bench/inference/providers/parse/infinity_parser2.py
+++ b/src/parse_bench/inference/providers/parse/infinity_parser2.py
@@ -250,6 +250,22 @@ class InfinityParser2Provider(Provider):
             "layout_segments": [layout_seg],
         }
 
+    @staticmethod
+    def _decode_layout_elements(result: Any, *, context: str) -> list[dict[str, Any]]:
+        if not isinstance(result, str) or not result.strip():
+            raise ProviderPermanentError(f"{context} is empty or is not JSON text")
+        try:
+            decoded = json.loads(result)
+        except json.JSONDecodeError as exc:
+            raise ProviderPermanentError(f"{context} is not valid JSON: {exc}") from exc
+        if not isinstance(decoded, list):
+            raise ProviderPermanentError(f"{context} must decode to a list of layout elements")
+        if not decoded:
+            raise ProviderPermanentError(f"{context} contains no layout elements")
+        if any(not isinstance(element, dict) for element in decoded):
+            raise ProviderPermanentError(f"{context} contains a non-object layout element")
+        return decoded
+
     def _apply_deep_parsing(
         self,
         result: str,
@@ -265,9 +281,7 @@ class InfinityParser2Provider(Provider):
         aborts inference rather than silently substituting the shallow result.
         """
         try:
-            elements: list[dict] = json.loads(result)
-            if not isinstance(elements, list):
-                return result
+            elements = self._decode_layout_elements(result, context="InfinityParser2 deep-parsing input")
 
             figure_elements = [elem for elem in elements if elem.get("category", "").strip().lower() == "figure"]
             if not figure_elements:
@@ -293,8 +307,14 @@ class InfinityParser2Provider(Provider):
                     "custom_prompt": "please convert the image to a markdown table",
                     "max_new_tokens": 2048,
                 }
-                deep_results = [self._parser.parse(img, **deep_parse_kwargs) for img in pil_figure_images]
-                for elem, deep_result in zip(figure_elements, deep_results, strict=True):
+                for figure_index, (elem, figure_image) in enumerate(
+                    zip(figure_elements, pil_figure_images, strict=True), start=1
+                ):
+                    deep_result = self._parser.parse(figure_image, **deep_parse_kwargs)
+                    if not isinstance(deep_result, str) or not deep_result.strip():
+                        raise ProviderPermanentError(
+                            f"InfinityParser2 deep response for figure {figure_index} is empty or invalid"
+                        )
                     elem["text"] = deep_result
 
             return json.dumps(elements)
@@ -317,24 +337,19 @@ class InfinityParser2Provider(Provider):
         page_width = raw_result.raw_output["_config"]["page_width"]
         page_height = raw_result.raw_output["_config"]["page_height"]
 
-        # Load elements
-        try:
-            elements: list[dict] = json.loads(result_str)
-            if not isinstance(elements, list):
-                elements = []
-        except json.JSONDecodeError:
-            elements = []
+        elements = self._decode_layout_elements(result_str, context="InfinityParser2 result")
 
         # Group elements by page
         pages_dict: dict[int, list[dict]] = {}
-        for elem in elements:
+        for element_index, elem in enumerate(elements):
             page_num = elem.get("page", 1)
+            if not isinstance(page_num, int) or isinstance(page_num, bool) or page_num < 1:
+                raise ProviderPermanentError(
+                    f"InfinityParser2 layout element {element_index} has invalid page: {page_num!r}"
+                )
             if page_num not in pages_dict:
                 pages_dict[page_num] = []
             pages_dict[page_num].append(elem)
-
-        if not pages_dict:
-            pages_dict = {1: []}
 
         if len(pages_dict) != 1:
             raise ProviderPermanentError(
@@ -412,7 +427,12 @@ class InfinityParser2Provider(Provider):
                 f"InfinityParser2Provider only supports PARSE product type, got {raw_result.product_type}"
             )
 
-        output = self._normalize(raw_result)
+        try:
+            output = self._normalize(raw_result)
+        except (ProviderPermanentError, ProviderTransientError, ProviderConfigError):
+            raise
+        except Exception as exc:
+            raise ProviderPermanentError(f"Invalid InfinityParser2 normalized result: {exc}") from exc
 
         return InferenceResult(
             request=raw_result.request,

--- a/src/parse_bench/inference/providers/parse/infinity_parser2.py
+++ b/src/parse_bench/inference/providers/parse/infinity_parser2.py
@@ -75,6 +75,8 @@ class InfinityParser2Provider(Provider):
         - deep_parsing_mode (bool, default=True): Parse figure content.
     """
 
+    PDF_RENDER_DPI = 300
+
     def __init__(self, provider_name: str, base_config: dict[str, Any] | None = None):
         super().__init__(provider_name, base_config)
 
@@ -160,7 +162,12 @@ class InfinityParser2Provider(Provider):
             raise ProviderPermanentError(f"Error parsing document: {e}") from e
 
     def run_inference(self, pipeline: PipelineSpec, request: InferenceRequest) -> RawInferenceResult:
-        multipage_result = run_pdf_pages(pipeline, request, dpi=300, run_single_image=self.run_inference)
+        multipage_result = run_pdf_pages(
+            pipeline,
+            request,
+            dpi=InfinityParser2Provider.PDF_RENDER_DPI,
+            run_single_image=self.run_inference,
+        )
         if multipage_result is not None:
             return multipage_result
 
@@ -473,7 +480,12 @@ def load_image(file_path: str) -> tuple[PILImage.Image, float, float]:
     """
     path = Path(file_path)
     if path.suffix.lower() == ".pdf":
-        images = convert_from_path(str(path), dpi=300, first_page=1, last_page=1)
+        images = convert_from_path(
+            str(path),
+            dpi=InfinityParser2Provider.PDF_RENDER_DPI,
+            first_page=1,
+            last_page=1,
+        )
         if not images:
             raise ProviderPermanentError(f"Failed to render PDF page: {file_path}")
         try:

--- a/src/parse_bench/inference/providers/parse/infinity_parser2.py
+++ b/src/parse_bench/inference/providers/parse/infinity_parser2.py
@@ -1,7 +1,6 @@
 """Provider for Infinity-Parser2 PARSE via infinity_parser2 SDK with vLLM server."""
 
 import json
-import logging
 import re
 import traceback
 from datetime import datetime
@@ -31,8 +30,6 @@ from parse_bench.schemas.pipeline_io import (
     RawInferenceResult,
 )
 from parse_bench.schemas.product import ProductType
-
-logger = logging.getLogger(__name__)
 
 DEFAULT_MODEL_NAME = "infly/Infinity-Parser2-Flash"
 
@@ -153,6 +150,8 @@ class InfinityParser2Provider(Provider):
             finally:
                 pil_image.close()
 
+        except (ProviderPermanentError, ProviderTransientError, ProviderConfigError):
+            raise
         except Exception as e:
             error_str = str(e).lower()
             transient_keywords = ["timeout", "network", "connection", "cuda", "out of memory", "oom"]
@@ -262,7 +261,8 @@ class InfinityParser2Provider(Provider):
         ``pil_image``, re-parses the cropped images with a custom table-extraction prompt,
         and overwrites ``elem["text"]`` in place before serializing back to JSON.
 
-        Returns the (possibly modified) JSON string.
+        Returns the modified JSON string. Any configured deep-parsing failure
+        aborts inference rather than silently substituting the shallow result.
         """
         try:
             elements: list[dict] = json.loads(result)
@@ -299,9 +299,14 @@ class InfinityParser2Provider(Provider):
 
             return json.dumps(elements)
 
-        except Exception:
-            logger.exception("Deep parsing pass failed; returning shallow parse result")
-            return result
+        except (ProviderPermanentError, ProviderTransientError, ProviderConfigError):
+            raise
+        except Exception as e:
+            error_str = str(e).lower()
+            transient_keywords = ["timeout", "network", "connection", "cuda", "out of memory", "oom"]
+            if any(keyword in error_str for keyword in transient_keywords):
+                raise ProviderTransientError(f"Error during deep parsing (GPU/memory): {e}") from e
+            raise ProviderPermanentError(f"Error during deep parsing: {e}") from e
 
     def _normalize(self, raw_result: RawInferenceResult) -> ParseOutput:
         """Normalize JSON layout result into ParseOutput with pages, layout_pages, and markdown."""

--- a/src/parse_bench/inference/providers/parse/infinity_parser2.py
+++ b/src/parse_bench/inference/providers/parse/infinity_parser2.py
@@ -17,7 +17,11 @@ from parse_bench.inference.providers.base import (
     ProviderPermanentError,
     ProviderTransientError,
 )
-from parse_bench.inference.providers.parse._multipage_image import normalize_pdf_pages, run_pdf_pages
+from parse_bench.inference.providers.parse._multipage_image import (
+    close_derived_images,
+    normalize_pdf_pages,
+    run_pdf_pages,
+)
 from parse_bench.inference.providers.registry import register_provider
 from parse_bench.schemas.parse_output import PageIR, ParseLayoutPageIR, ParseOutput
 from parse_bench.schemas.pipeline import PipelineSpec
@@ -127,24 +131,27 @@ class InfinityParser2Provider(Provider):
                 parse_kwargs["temperature"] = self._temperature
 
             pil_image, page_width, page_height = load_image(file_path)
-            result = self._parser.parse(pil_image, **parse_kwargs)
+            try:
+                result = self._parser.parse(pil_image, **parse_kwargs)
 
-            if self._deep_parsing_mode:
-                result = self._apply_deep_parsing(result, pil_image)
+                if self._deep_parsing_mode:
+                    result = self._apply_deep_parsing(result, pil_image)
 
-            return {
-                "result": result,
-                "_config": {
-                    "model_name": self._model_name,
-                    "backend": "vllm-server",
-                    "api_url": self._api_url,
-                    "task_type": self._task_type,
-                    "output_format": self._output_format,
-                    "batch_size": self._batch_size,
-                    "page_width": page_width,
-                    "page_height": page_height,
-                },
-            }
+                return {
+                    "result": result,
+                    "_config": {
+                        "model_name": self._model_name,
+                        "backend": "vllm-server",
+                        "api_url": self._api_url,
+                        "task_type": self._task_type,
+                        "output_format": self._output_format,
+                        "batch_size": self._batch_size,
+                        "page_width": page_width,
+                        "page_height": page_height,
+                    },
+                }
+            finally:
+                pil_image.close()
 
         except Exception as e:
             error_str = str(e).lower()
@@ -266,26 +273,29 @@ class InfinityParser2Provider(Provider):
             if not figure_elements:
                 return result
 
-            pil_figure_images = [
-                pil_image.crop(
-                    (
-                        max(0, int(elem["bbox"][0])),
-                        max(0, int(elem["bbox"][1])),
-                        min(pil_image.width, int(elem["bbox"][2])),
-                        min(pil_image.height, int(elem["bbox"][3])),
+            with close_derived_images(pil_image) as track:
+                pil_figure_images = [
+                    track(
+                        pil_image.crop(
+                            (
+                                max(0, int(elem["bbox"][0])),
+                                max(0, int(elem["bbox"][1])),
+                                min(pil_image.width, int(elem["bbox"][2])),
+                                min(pil_image.height, int(elem["bbox"][3])),
+                            )
+                        )
                     )
-                )
-                for elem in figure_elements
-            ]
+                    for elem in figure_elements
+                ]
 
-            deep_parse_kwargs = {
-                "task_type": "custom",
-                "custom_prompt": "please convert the image to a markdown table",
-                "max_new_tokens": 2048,
-            }
-            deep_results = [self._parser.parse(img, **deep_parse_kwargs) for img in pil_figure_images]
-            for elem, deep_result in zip(figure_elements, deep_results, strict=True):
-                elem["text"] = deep_result
+                deep_parse_kwargs = {
+                    "task_type": "custom",
+                    "custom_prompt": "please convert the image to a markdown table",
+                    "max_new_tokens": 2048,
+                }
+                deep_results = [self._parser.parse(img, **deep_parse_kwargs) for img in pil_figure_images]
+                for elem, deep_result in zip(figure_elements, deep_results, strict=True):
+                    elem["text"] = deep_result
 
             return json.dumps(elements)
 
@@ -425,9 +435,14 @@ def load_image(file_path: str) -> tuple[PILImage.Image, float, float]:
         images = convert_from_path(str(path), dpi=300, first_page=1, last_page=1)
         if not images:
             raise ProviderPermanentError(f"Failed to render PDF page: {file_path}")
-        pil_image = images[0].convert("RGB")
+        try:
+            pil_image = images[0].convert("RGB")
+        finally:
+            for image in images:
+                image.close()
     else:
-        pil_image = PILImage.open(str(path)).convert("RGB")
+        with PILImage.open(str(path)) as image:
+            pil_image = image.convert("RGB")
 
     width, height = pil_image.size
     return pil_image, float(width), float(height)

--- a/src/parse_bench/inference/providers/parse/infinity_parser2.py
+++ b/src/parse_bench/inference/providers/parse/infinity_parser2.py
@@ -1,11 +1,11 @@
 """Provider for Infinity-Parser2 PARSE via infinity_parser2 SDK with vLLM server."""
 
-from datetime import datetime
 import json
 import logging
-from pathlib import Path
 import re
 import traceback
+from datetime import datetime
+from pathlib import Path
 from typing import Any
 
 from pdf2image import convert_from_path
@@ -17,8 +17,9 @@ from parse_bench.inference.providers.base import (
     ProviderPermanentError,
     ProviderTransientError,
 )
+from parse_bench.inference.providers.parse._multipage_image import normalize_pdf_pages, run_pdf_pages
 from parse_bench.inference.providers.registry import register_provider
-from parse_bench.schemas.parse_output import ParseLayoutPageIR, ParseOutput, PageIR
+from parse_bench.schemas.parse_output import PageIR, ParseLayoutPageIR, ParseOutput
 from parse_bench.schemas.pipeline import PipelineSpec
 from parse_bench.schemas.pipeline_io import (
     InferenceRequest,
@@ -153,6 +154,10 @@ class InfinityParser2Provider(Provider):
             raise ProviderPermanentError(f"Error parsing document: {e}") from e
 
     def run_inference(self, pipeline: PipelineSpec, request: InferenceRequest) -> RawInferenceResult:
+        multipage_result = run_pdf_pages(pipeline, request, dpi=300, run_single_image=self.run_inference)
+        if multipage_result is not None:
+            return multipage_result
+
         if request.product_type != ProductType.PARSE:
             raise ProviderPermanentError(
                 f"InfinityParser2Provider only supports PARSE product type, got {request.product_type}"
@@ -257,10 +262,7 @@ class InfinityParser2Provider(Provider):
             if not isinstance(elements, list):
                 return result
 
-            figure_elements = [
-                elem for elem in elements
-                if elem.get("category", "").strip().lower() == "figure"
-            ]
+            figure_elements = [elem for elem in elements if elem.get("category", "").strip().lower() == "figure"]
             if not figure_elements:
                 return result
 
@@ -282,7 +284,7 @@ class InfinityParser2Provider(Provider):
                 "max_new_tokens": 2048,
             }
             deep_results = [self._parser.parse(img, **deep_parse_kwargs) for img in pil_figure_images]
-            for elem, deep_result in zip(figure_elements, deep_results):
+            for elem, deep_result in zip(figure_elements, deep_results, strict=True):
                 elem["text"] = deep_result
 
             return json.dumps(elements)
@@ -386,6 +388,10 @@ class InfinityParser2Provider(Provider):
         )
 
     def normalize(self, raw_result: RawInferenceResult) -> InferenceResult:
+        multipage_result = normalize_pdf_pages(raw_result, normalize_single_image=self.normalize)
+        if multipage_result is not None:
+            return multipage_result
+
         if raw_result.product_type != ProductType.PARSE:
             raise ProviderPermanentError(
                 f"InfinityParser2Provider only supports PARSE product type, got {raw_result.product_type}"
@@ -430,6 +436,7 @@ def load_image(file_path: str) -> tuple[PILImage.Image, float, float]:
 # =============================================================================
 # Postprocess for chart2table
 # =============================================================================
+
 
 def _is_valid_md_table(table_text: str) -> bool:
     """Check if a markdown table is valid (non-empty)."""
@@ -544,6 +551,7 @@ def _convert_nonstandard_table(text: str) -> str:
 # Postprocess for HTML table header
 # =============================================================================
 
+
 def _is_year_cell(text: str) -> bool:
     """Return True if text looks like a date/year (yyyy, yyyymm, yyyymmdd, etc.)."""
     text = text.strip()
@@ -582,8 +590,7 @@ def _determine_header_row_count(rows: list) -> int:
         return 0
 
     def non_empty_cells(row):
-        return [td.get_text(strip=True) for td in row.find_all("td", recursive=False)
-                if td.get_text(strip=True)]
+        return [td.get_text(strip=True) for td in row.find_all("td", recursive=False) if td.get_text(strip=True)]
 
     def stats(row_list):
         """Return (pure_text_count, pure_number_count, total) for a list of rows."""
@@ -623,15 +630,15 @@ def _determine_header_row_count(rows: list) -> int:
     best_i = -1
     best_score = -1.0
     for i in range(3):
-        header_rows = rows[:i + 1]
-        data_rows = rows[i + 1:]
+        header_rows = rows[: i + 1]
+        data_rows = rows[i + 1 :]
         if not header_rows or not data_rows:
             continue
         header_text, header_num, header_total = stats(header_rows)
         data_text, data_num, data_total = stats(data_rows)
         if header_total == 0 or data_total == 0:
             continue
-        if (header_text / header_total >= 0.5 and data_num / data_total >= 0.5):
+        if header_text / header_total >= 0.5 and data_num / data_total >= 0.5:
             score = header_text / header_total + data_num / data_total
             if score > best_score:
                 best_score = score

--- a/src/parse_bench/inference/providers/parse/kdl_frontier_nano.py
+++ b/src/parse_bench/inference/providers/parse/kdl_frontier_nano.py
@@ -3220,9 +3220,7 @@ class KdlFrontierNanoProvider(Provider):
 
         with document:
             if document.page_count > self._max_pages:
-                raise ProviderPermanentError(
-                    f"Document has {document.page_count} pages > max_pages={self._max_pages}."
-                )
+                raise ProviderPermanentError(f"Document has {document.page_count} pages > max_pages={self._max_pages}.")
             if document.page_count < 1:
                 raise ProviderPermanentError("Document rendered to zero pages.")
             images = self._iter_page_images(document, mat)
@@ -3243,24 +3241,18 @@ class KdlFrontierNanoProvider(Provider):
             except Exception as exc:
                 if image is not None:
                     image.close()
-                raise ProviderPermanentError(
-                    f"Failed to render document page {page_number}: {exc}"
-                ) from exc
+                raise ProviderPermanentError(f"Failed to render document page {page_number}: {exc}") from exc
             try:
                 yield image
             finally:
                 image.close()
 
-    def run_inference(
-        self, pipeline: PipelineSpec, request: InferenceRequest
-    ) -> RawInferenceResult:
+    def run_inference(self, pipeline: PipelineSpec, request: InferenceRequest) -> RawInferenceResult:
         source_path = Path(request.source_file_path)
         if not source_path.exists():
             raise ProviderPermanentError(f"Source file not found: {source_path}")
         started_at = datetime.now()
-        engine = _NanoEngine(
-            self._endpoint_url, self._model, self._max_concurrent, self._timeout
-        )
+        engine = _NanoEngine(self._endpoint_url, self._model, self._max_concurrent, self._timeout)
         try:
             with self._open_page_images(source_path) as page_images:
                 raw_output = self.run_async_from_sync(engine.parse_pages(page_images))

--- a/src/parse_bench/inference/providers/parse/kdl_frontier_nano.py
+++ b/src/parse_bench/inference/providers/parse/kdl_frontier_nano.py
@@ -3119,21 +3119,34 @@ class _NanoEngine:
             pass
 
         layout_image = track(prepare_native_layout_image(image))
-        layout_content = await self._run_stage_with_retries(
-            lambda: _nano_chat(
+
+        async def parse_layout_stage() -> str | _NanoStageResponse:
+            response = await _nano_chat(
                 client,
                 self._url,
                 _nano_payload("layout", self._model, layout_image),
                 semaphore,
-            ),
+            )
+            content = response.content if isinstance(response, _NanoStageResponse) else response
+            usage = response.usage if isinstance(response, _NanoStageResponse) else {}
+            if not is_native_layout_response(content):
+                raise ProviderTransientError(
+                    f"Page {page_no} returned a non-native layout response",
+                    attempt_stats=usage,
+                )
+            if not parse_native_layout_tokens(content):
+                raise ProviderTransientError(
+                    f"Page {page_no} returned malformed native layout tokens",
+                    attempt_stats=usage,
+                )
+            return response
+
+        layout_content = await self._run_stage_with_retries(
+            parse_layout_stage,
             page_no=page_no,
             stage="layout",
         )
-        if not is_native_layout_response(layout_content):
-            raise ProviderPermanentError(f"Page {page_no} returned a non-native layout response")
         items = parse_native_layout_tokens(layout_content)
-        if not items:
-            raise ProviderPermanentError(f"Page {page_no} returned malformed native layout tokens")
         for item in items:
             item["page_number"] = page_no
         buckets = _nano_group_by_bucket(items, image, track)

--- a/src/parse_bench/inference/providers/parse/kdl_frontier_nano.py
+++ b/src/parse_bench/inference/providers/parse/kdl_frontier_nano.py
@@ -49,7 +49,7 @@ import os
 import re
 import unicodedata
 from collections import Counter
-from collections.abc import Callable, Generator, Iterable, Iterator, Mapping, Sequence
+from collections.abc import Awaitable, Callable, Generator, Iterable, Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from datetime import datetime
 from decimal import Decimal
@@ -2948,24 +2948,33 @@ class _NanoEngine:
         image: Image.Image,
         page_no: int,
     ) -> list[dict[str, Any]]:
+        with close_derived_images(image) as track:
+            return await self._parse_page_with_owned_images(
+                client,
+                semaphore,
+                image,
+                page_no,
+                track,
+            )
+
+    async def _run_stage_with_retries[T](
+        self,
+        call: Callable[[], Awaitable[T]],
+        *,
+        page_no: int,
+        stage: str,
+    ) -> T:
+        """Retry one physical KDL stage without replaying completed siblings."""
         max_attempts = 3
         for attempt in range(max_attempts):
             try:
-                with close_derived_images(image) as track:
-                    return await self._parse_page_with_owned_images(
-                        client,
-                        semaphore,
-                        image,
-                        page_no,
-                        track,
-                    )
+                return await call()
             except ProviderTransientError as exc:
                 if attempt == max_attempts - 1:
                     raise ProviderRetryExhaustedError(
-                        f"KDL page {page_no} failed after {max_attempts} attempts: {exc}"
+                        f"KDL page {page_no} failed after {max_attempts} attempts during {stage}: {exc}"
                     ) from exc
                 await asyncio.sleep(2.0 * (2**attempt))
-
         raise AssertionError("unreachable")
 
     async def _parse_page_with_owned_images(
@@ -2986,11 +2995,15 @@ class _NanoEngine:
             pass
 
         layout_image = track(prepare_native_layout_image(image))
-        layout_content = await _nano_chat(
-            client,
-            self._url,
-            _nano_payload("layout", self._model, layout_image),
-            semaphore,
+        layout_content = await self._run_stage_with_retries(
+            lambda: _nano_chat(
+                client,
+                self._url,
+                _nano_payload("layout", self._model, layout_image),
+                semaphore,
+            ),
+            page_no=page_no,
+            stage="layout",
         )
         if not is_native_layout_response(layout_content):
             raise ProviderPermanentError(f"Page {page_no} returned a non-native layout response")
@@ -3015,7 +3028,11 @@ class _NanoEngine:
             if stage == "picture" and (pre.width < 25 or pre.height < 25):
                 el["content"] = ""
                 return
-            content = await _nano_chat(client, self._url, _nano_payload(stage, self._model, pre), semaphore)
+            content = await self._run_stage_with_retries(
+                lambda: _nano_chat(client, self._url, _nano_payload(stage, self._model, pre), semaphore),
+                page_no=page_no,
+                stage=f"{stage} recognition",
+            )
             if stage == "picture":
                 _nano_apply_picture_result(el, content)
             else:
@@ -3023,11 +3040,15 @@ class _NanoEngine:
 
         async def recognize_table_fullpage(el: dict[str, Any]) -> None:
             assert fullpage_table is not None
-            content = await _nano_chat(
-                client,
-                self._url,
-                _nano_payload("table", self._model, fullpage_table),
-                semaphore,
+            content = await self._run_stage_with_retries(
+                lambda: _nano_chat(
+                    client,
+                    self._url,
+                    _nano_payload("table", self._model, fullpage_table),
+                    semaphore,
+                ),
+                page_no=page_no,
+                stage="full-page table recognition",
             )
             if content is not None and _nano_is_single_clean_otsl(content):
                 el["content"] = content

--- a/src/parse_bench/inference/providers/parse/kdl_frontier_nano.py
+++ b/src/parse_bench/inference/providers/parse/kdl_frontier_nano.py
@@ -3073,6 +3073,8 @@ class KdlFrontierNanoProvider(Provider):
     """Standalone provider for KDLAI/KDL-Frontier-Parser-nano (one vLLM
     endpoint + deterministic orchestration; no other learned components)."""
 
+    PDF_RENDER_DPI = 144
+
     def __init__(self, provider_name: str, base_config: dict[str, Any] | None = None):
         super().__init__(provider_name, base_config)
         self._endpoint_url = (self.base_config.get("endpoint_url") or os.getenv("KDL_NANO_ENDPOINT_URL") or "").rstrip(
@@ -3084,7 +3086,7 @@ class KdlFrontierNanoProvider(Provider):
                 "URL ending in /v1, serving KDLAI/KDL-Frontier-Parser-nano)."
             )
         self._model = self.base_config.get("model") or os.getenv("KDL_NANO_MODEL") or "kdl-frontier-parser-nano"
-        self._dpi = int(self.base_config.get("dpi", os.getenv("KDL_NANO_DPI", "144")))
+        self._dpi = int(self.base_config.get("dpi", os.getenv("KDL_NANO_DPI", str(self.PDF_RENDER_DPI))))
         self._timeout = float(self.base_config.get("timeout", 900))
         self._max_pages = int(self.base_config.get("max_pages", os.getenv("KDL_NANO_MAX_PAGES", "400")))
         self._max_concurrent = int(os.getenv("KDL_NANO_MAX_CONCURRENT", "8"))

--- a/src/parse_bench/inference/providers/parse/kdl_frontier_nano.py
+++ b/src/parse_bench/inference/providers/parse/kdl_frontier_nano.py
@@ -3242,6 +3242,7 @@ class KdlFrontierNanoProvider(Provider):
         if (
             source_page_numbers != sorted(source_page_numbers)
             or len(source_page_numbers) != len(set(source_page_numbers))
+            or source_page_numbers != list(range(1, len(source_page_numbers) + 1))
             or set(markdown_by_page) != set(source_page_numbers)
             or len(markdown_by_page) != len(md_pages)
         ):
@@ -3254,7 +3255,13 @@ class KdlFrontierNanoProvider(Provider):
             )
             for source_page_number in source_page_numbers
         ]
-        full_markdown = raw.get("markdown") or "\n\n<!-- page-break -->\n\n".join(p.markdown for p in pages)
+        markdown_parts: list[str] = []
+        for index, page in enumerate(pages):
+            if index:
+                markdown_parts.append(f"---\n\n**Page {page.page_index + 1}**")
+            if page.markdown:
+                markdown_parts.append(page.markdown)
+        full_markdown = "\n\n".join(markdown_parts)
 
         layout_pages: list[ParseLayoutPageIR] = []
         for p in raw_pages:

--- a/src/parse_bench/inference/providers/parse/kdl_frontier_nano.py
+++ b/src/parse_bench/inference/providers/parse/kdl_frontier_nano.py
@@ -46,6 +46,8 @@ import os
 import re
 import unicodedata
 from collections import Counter
+from collections.abc import Generator, Iterable, Iterator
+from contextlib import contextmanager
 from datetime import datetime
 from decimal import Decimal
 from pathlib import Path
@@ -62,6 +64,7 @@ from parse_bench.inference.providers.base import (
     ProviderPermanentError,
     ProviderTransientError,
 )
+from parse_bench.inference.providers.parse._multipage_image import PageImages, close_derived_images
 from parse_bench.inference.providers.registry import register_provider
 from parse_bench.schemas.parse_output import (
     LayoutItemIR,
@@ -3027,13 +3030,14 @@ class _NanoEngine:
         self._max_concurrent = max_concurrent
         self._timeout_s = timeout_s
 
-    async def parse_pages(self, page_images: List[Image.Image]) -> dict:
+    async def parse_pages(self, page_images: Iterable[Image.Image]) -> dict:
         semaphore = asyncio.Semaphore(self._max_concurrent)
         elements: List[Dict[str, Any]] = []
         async with httpx.AsyncClient(timeout=self._timeout_s) as client:
             for page_no, image in enumerate(page_images, start=1):
-                image = normalize_image_mode(image, "RGB")
-                page_elements = await self._parse_page(client, semaphore, image, page_no)
+                with close_derived_images(image) as track:
+                    normalized = track(normalize_image_mode(image, "RGB"))
+                    page_elements = await self._parse_page(client, semaphore, normalized, page_no)
                 elements.extend(page_elements)
 
         for el in elements:
@@ -3195,23 +3199,57 @@ class KdlFrontierNanoProvider(Provider):
         )
         self._max_concurrent = int(os.getenv("KDL_NANO_MAX_CONCURRENT", "8"))
 
-    def _load_page_images(self, source_path: Path) -> List[Image.Image]:
+    @contextmanager
+    def _open_page_images(self, source_path: Path) -> Iterator[PageImages]:
         if source_path.suffix.lower() in (".png", ".jpg", ".jpeg", ".jfif"):
-            return [Image.open(source_path)]
+            image = Image.open(source_path)
+            try:
+                yield PageImages(1, iter((image,)))
+            finally:
+                image.close()
+            return
+
         import fitz  # PyMuPDF
 
         zoom = self._dpi / 72.0
         mat = fitz.Matrix(zoom, zoom)
-        images: List[Image.Image] = []
-        with fitz.open(str(source_path)) as doc:
-            if doc.page_count > self._max_pages:
+        try:
+            document = fitz.open(str(source_path))
+        except Exception as exc:
+            raise ProviderPermanentError(f"Failed to open document: {exc}") from exc
+
+        with document:
+            if document.page_count > self._max_pages:
                 raise ProviderPermanentError(
-                    f"Document has {doc.page_count} pages > max_pages={self._max_pages}."
+                    f"Document has {document.page_count} pages > max_pages={self._max_pages}."
                 )
-            for page in doc:
-                pix = page.get_pixmap(matrix=mat, alpha=False)
-                images.append(Image.open(io.BytesIO(pix.tobytes("png"))))
-        return images
+            if document.page_count < 1:
+                raise ProviderPermanentError("Document rendered to zero pages.")
+            images = self._iter_page_images(document, mat)
+            try:
+                yield PageImages(document.page_count, images)
+            finally:
+                images.close()
+
+    @staticmethod
+    def _iter_page_images(document: Any, matrix: Any) -> Generator[Image.Image]:
+        for page_number, page in enumerate(document, start=1):
+            image: Image.Image | None = None
+            try:
+                pixmap = page.get_pixmap(matrix=matrix, alpha=False)
+                png_bytes = pixmap.tobytes("png")
+                image = Image.open(io.BytesIO(png_bytes))
+                image.load()
+            except Exception as exc:
+                if image is not None:
+                    image.close()
+                raise ProviderPermanentError(
+                    f"Failed to render document page {page_number}: {exc}"
+                ) from exc
+            try:
+                yield image
+            finally:
+                image.close()
 
     def run_inference(
         self, pipeline: PipelineSpec, request: InferenceRequest
@@ -3220,22 +3258,18 @@ class KdlFrontierNanoProvider(Provider):
         if not source_path.exists():
             raise ProviderPermanentError(f"Source file not found: {source_path}")
         started_at = datetime.now()
-        try:
-            page_images = self._load_page_images(source_path)
-        except ProviderPermanentError:
-            raise
-        except Exception as e:
-            raise ProviderPermanentError(f"Failed to load document: {e}") from e
-        if not page_images:
-            raise ProviderPermanentError("Document rendered to zero pages.")
-
         engine = _NanoEngine(
             self._endpoint_url, self._model, self._max_concurrent, self._timeout
         )
         try:
-            raw_output = self.run_async_from_sync(engine.parse_pages(page_images))
-        except Exception as e:
-            raise ProviderTransientError(f"Pipeline failed: {e}") from e
+            with self._open_page_images(source_path) as page_images:
+                raw_output = self.run_async_from_sync(engine.parse_pages(page_images))
+        except (ProviderPermanentError, ProviderTransientError):
+            raise
+        except (TimeoutError, httpx.HTTPError) as exc:
+            raise ProviderTransientError(f"Pipeline failed: {exc}") from exc
+        except Exception as exc:
+            raise ProviderPermanentError(f"Unexpected pipeline failure: {exc}") from exc
         completed_at = datetime.now()
         return RawInferenceResult(
             request=request,

--- a/src/parse_bench/inference/providers/parse/kdl_frontier_nano.py
+++ b/src/parse_bench/inference/providers/parse/kdl_frontier_nano.py
@@ -33,6 +33,7 @@ Most of this file is vendored verbatim from the (closed-source) KDL DeepParser
 orchestrator so the maintainers can reproduce the submitted numbers end to end;
 section banners mark the vendored module boundaries.
 """
+
 import asyncio
 import base64
 import enum
@@ -119,6 +120,7 @@ class ElementCategory(str, Enum):
     # 수학 요소
     FORMULA = "Formula"
 
+
 # ==========================================================================
 # [vendored] recognition_contract
 # ==========================================================================
@@ -178,6 +180,7 @@ def _category_value(category: str | ElementCategory) -> str:
         return category.value
     return str(category).strip()
 
+
 # ==========================================================================
 # [vendored] layout_contract
 # ==========================================================================
@@ -207,9 +210,7 @@ CANONICAL_LAYOUT_CATEGORIES = (
 
 DEFAULT_LAYOUT_CATEGORY = ElementCategory.TEXT.value
 
-_CANONICAL_BY_CASEFOLD = {
-    category.casefold(): category for category in CANONICAL_LAYOUT_CATEGORIES
-}
+_CANONICAL_BY_CASEFOLD = {category.casefold(): category for category in CANONICAL_LAYOUT_CATEGORIES}
 
 
 def normalize_layout_category(
@@ -235,11 +236,7 @@ def _map_provider_category(
     if not provider_category_map:
         return category
 
-    return (
-        provider_category_map.get(category)
-        or provider_category_map.get(category.casefold())
-        or category
-    )
+    return provider_category_map.get(category) or provider_category_map.get(category.casefold()) or category
 
 
 def _canonicalize_category(category: Any) -> str:
@@ -253,6 +250,7 @@ def _stringify_category(category: Any) -> str:
     if category is None:
         return ""
     return str(category).strip()
+
 
 # ==========================================================================
 # [vendored] image_preprocessing
@@ -345,10 +343,7 @@ def calculate_dimensions(
     # 종횡비 검증
     aspect_ratio = max(height, width) / min(height, width)
     if aspect_ratio > ImageConfig.MAX_ASPECT_RATIO:
-        raise ValueError(
-            f"종횡비가 너무 큽니다. 최대 {ImageConfig.MAX_ASPECT_RATIO}:1, "
-            f"현재 {aspect_ratio:.1f}:1"
-        )
+        raise ValueError(f"종횡비가 너무 큽니다. 최대 {ImageConfig.MAX_ASPECT_RATIO}:1, 현재 {aspect_ratio:.1f}:1")
 
     # factor의 배수로 조정
     target_height = max(factor, _round_by_factor(height, factor))
@@ -369,12 +364,8 @@ def calculate_dimensions(
         # 확대 후 최대 픽셀 수 재검사
         if target_height * target_width > max_pixels:
             scale = math.sqrt((target_height * target_width) / max_pixels)
-            target_height = max(
-                factor, _floor_by_factor(int(target_height / scale), factor)
-            )
-            target_width = max(
-                factor, _floor_by_factor(int(target_width / scale), factor)
-            )
+            target_height = max(factor, _floor_by_factor(int(target_height / scale), factor))
+            target_width = max(factor, _floor_by_factor(int(target_width / scale), factor))
 
     return target_width, target_height
 
@@ -646,9 +637,7 @@ def prepare_native_layout_image(image: Image.Image) -> Image.Image:
 def parse_native_raw_layout_tokens(content: str) -> list[NativeLayoutItem]:
     items: list[NativeLayoutItem] = []
     for match in _NATIVE_LAYOUT_RE.finditer(content):
-        converted_bbox = _convert_native_layout_bbox(
-            (match.group(1), match.group(2), match.group(3), match.group(4))
-        )
+        converted_bbox = _convert_native_layout_bbox((match.group(1), match.group(2), match.group(3), match.group(4)))
         if converted_bbox is None:
             continue
 
@@ -680,24 +669,19 @@ def normalize_native_layout_items(
     list_containers = [
         item
         for item in raw_items
-        if item.raw_category == "list"
-        and _has_contained_child(item, raw_items, _LIST_CHILD_CATEGORIES)
+        if item.raw_category == "list" and _has_contained_child(item, raw_items, _LIST_CHILD_CATEGORIES)
     ]
     image_blocks = [
         item
         for item in raw_items
-        if item.raw_category == "image_block"
-        and _has_contained_child(item, raw_items, _IMAGE_BLOCK_CHILD_CATEGORIES)
+        if item.raw_category == "image_block" and _has_contained_child(item, raw_items, _IMAGE_BLOCK_CHILD_CATEGORIES)
     ]
-    equation_blocks = [
-        item for item in raw_items if item.raw_category == "equation_block"
-    ]
+    equation_blocks = [item for item in raw_items if item.raw_category == "equation_block"]
     equation_child_orders = {
         child.layout_order
         for block in equation_blocks
         for child in raw_items
-        if child.raw_category in _EQUATION_CHILD_CATEGORIES
-        and _bbox_contains(block.bbox, child.bbox)
+        if child.raw_category in _EQUATION_CHILD_CATEGORIES and _bbox_contains(block.bbox, child.bbox)
     }
 
     normalized_items: list[NormalizedNativeLayoutItem] = []
@@ -717,8 +701,7 @@ def normalize_native_layout_items(
             children = [
                 _attachment_from_raw_item(child)
                 for child in raw_items
-                if child.raw_category in _EQUATION_CHILD_CATEGORIES
-                and _bbox_contains(item.bbox, child.bbox)
+                if child.raw_category in _EQUATION_CHILD_CATEGORIES and _bbox_contains(item.bbox, child.bbox)
             ]
             if children:
                 metadata["children"] = children
@@ -772,8 +755,7 @@ def _convert_native_layout_bbox(
 
 def _category_for_item(item: NativeLayoutItem, metadata: dict[str, Any]) -> str:
     if item.raw_category in _LIST_CHILD_CATEGORIES and (
-        item.raw_category in {"list_item", "ref_text"}
-        or metadata.get("parent_raw_category") == "list"
+        item.raw_category in {"list_item", "ref_text"} or metadata.get("parent_raw_category") == "list"
     ):
         return "List-item"
     return normalize_layout_category(item.raw_category, NATIVE_LAYOUT_CATEGORY_MAP)
@@ -821,8 +803,7 @@ def _find_containing_parent(
     candidates = [
         parent
         for parent in parents
-        if parent.layout_order != item.layout_order
-        and _bbox_contains(parent.bbox, item.bbox)
+        if parent.layout_order != item.layout_order and _bbox_contains(parent.bbox, item.bbox)
     ]
     return min(candidates, key=lambda parent: _bbox_area(parent.bbox), default=None)
 
@@ -867,14 +848,8 @@ def _attach_caption_and_footnote_refs(
         if parent is None:
             continue
 
-        key = (
-            "attached_footnotes"
-            if item.raw_category.endswith("_footnote")
-            else "attached_captions"
-        )
-        parent.metadata.setdefault(key, []).append(
-            _attachment_from_normalized_item(item)
-        )
+        key = "attached_footnotes" if item.raw_category.endswith("_footnote") else "attached_captions"
+        parent.metadata.setdefault(key, []).append(_attachment_from_normalized_item(item))
         item.metadata.update(
             {
                 "attached_to_raw_category": parent.raw_category,
@@ -893,8 +868,7 @@ def _find_nearest_attachment_parent(
     candidates = [
         candidate
         for candidate in items
-        if candidate.layout_order != item.layout_order
-        and candidate.raw_category in parent_raw_categories
+        if candidate.layout_order != item.layout_order and candidate.raw_category in parent_raw_categories
     ]
     return min(
         candidates,
@@ -919,6 +893,7 @@ def _attachment_distance(
         vertical_gap = 0.0
 
     return vertical_gap + horizontal_gap
+
 
 # ==========================================================================
 # [vendored] otsl_converter
@@ -1057,9 +1032,7 @@ OTSL_UCEL = "<ucel>"
 OTSL_XCEL = "<xcel>"
 
 NON_CAPTURING_TAG_GROUP = "(?:<fcel>|<ecel>|<nl>|<lcel>|<ucel>|<xcel>)"
-OTSL_FIND_PATTERN = re.compile(
-    f"{NON_CAPTURING_TAG_GROUP}.*?(?={NON_CAPTURING_TAG_GROUP}|$)", flags=re.DOTALL
-)
+OTSL_FIND_PATTERN = re.compile(f"{NON_CAPTURING_TAG_GROUP}.*?(?={NON_CAPTURING_TAG_GROUP}|$)", flags=re.DOTALL)
 IGNORABLE_OTSL_TAIL_PATTERN = re.compile(
     r"(?:\s|<br\s*/?>|<nl>|</otsl>)+",
     flags=re.IGNORECASE,
@@ -1076,20 +1049,14 @@ def otsl_extract_tokens_and_text(s: str) -> Tuple[List[str], List[str]]:
     Returns:
         Tuple[List[str], List[str]]: (tokens, text_parts)
     """
-    pattern = (
-        r"("
-        + r"|".join([OTSL_NL, OTSL_FCEL, OTSL_ECEL, OTSL_LCEL, OTSL_UCEL, OTSL_XCEL])
-        + r")"
-    )
+    pattern = r"(" + r"|".join([OTSL_NL, OTSL_FCEL, OTSL_ECEL, OTSL_LCEL, OTSL_UCEL, OTSL_XCEL]) + r")"
     tokens = re.findall(pattern, s)
     text_parts = re.split(pattern, s)
     text_parts = [token for token in text_parts if token.strip()]
     return tokens, text_parts
 
 
-def otsl_parse_texts(
-    texts: List[str], tokens: List[str]
-) -> Tuple[List[TableCell], List[List[str]]]:
+def otsl_parse_texts(texts: List[str], tokens: List[str]) -> Tuple[List[TableCell], List[List[str]]]:
     """
     Parse OTSL text and tags into TableCell objects and tag structure.
 
@@ -1101,11 +1068,7 @@ def otsl_parse_texts(
         Tuple[List[TableCell], List[List[str]]]: (table_cells, split_row_tokens)
     """
     split_word = OTSL_NL
-    split_row_tokens = [
-        list(y)
-        for x, y in itertools.groupby(tokens, lambda z: z == split_word)
-        if not x
-    ]
+    split_row_tokens = [list(y) for x, y in itertools.groupby(tokens, lambda z: z == split_word) if not x]
     table_cells: List[TableCell] = []
     r_idx = 0
     c_idx = 0
@@ -1138,9 +1101,7 @@ def otsl_parse_texts(
                 text_idx += 1
         texts = new_texts
 
-    def count_right(
-        tokens: List[List[str]], c_idx: int, r_idx: int, which_tokens: List[str]
-    ) -> int:
+    def count_right(tokens: List[List[str]], c_idx: int, r_idx: int, which_tokens: List[str]) -> int:
         span = 0
         c_idx_iter = c_idx
         while tokens[r_idx][c_idx_iter] in which_tokens:
@@ -1150,9 +1111,7 @@ def otsl_parse_texts(
                 return span
         return span
 
-    def count_down(
-        tokens: List[List[str]], c_idx: int, r_idx: int, which_tokens: List[str]
-    ) -> int:
+    def count_down(tokens: List[List[str]], c_idx: int, r_idx: int, which_tokens: List[str]) -> int:
         span = 0
         r_idx_iter = r_idx
         while tokens[r_idx_iter][c_idx] in which_tokens:
@@ -1172,22 +1131,16 @@ def otsl_parse_texts(
                 cell_text = texts[i + 1]
                 right_offset = 2
 
-            next_right_cell = (
-                texts[i + right_offset] if i + right_offset < len(texts) else ""
-            )
+            next_right_cell = texts[i + right_offset] if i + right_offset < len(texts) else ""
             next_bottom_cell = ""
             if r_idx + 1 < len(split_row_tokens):
                 if c_idx < len(split_row_tokens[r_idx + 1]):
                     next_bottom_cell = split_row_tokens[r_idx + 1][c_idx]
 
             if next_right_cell in [OTSL_LCEL, OTSL_XCEL]:
-                col_span += count_right(
-                    split_row_tokens, c_idx + 1, r_idx, [OTSL_LCEL, OTSL_XCEL]
-                )
+                col_span += count_right(split_row_tokens, c_idx + 1, r_idx, [OTSL_LCEL, OTSL_XCEL])
             if next_bottom_cell in [OTSL_UCEL, OTSL_XCEL]:
-                row_span += count_down(
-                    split_row_tokens, c_idx, r_idx + 1, [OTSL_UCEL, OTSL_XCEL]
-                )
+                row_span += count_down(split_row_tokens, c_idx, r_idx + 1, [OTSL_UCEL, OTSL_XCEL])
 
             table_cells.append(
                 TableCell(
@@ -1273,9 +1226,7 @@ def otsl_pad_to_sqr_v2(otsl_str: str) -> str:
         for i, cell_str in enumerate(raw_cells):
             if cell_str.startswith(OTSL_FCEL):
                 min_len = i + 1
-        row_data.append(
-            {"raw_cells": raw_cells, "total_len": total_len, "min_len": min_len}
-        )
+        row_data.append({"raw_cells": raw_cells, "total_len": total_len, "min_len": min_len})
     if not row_data:
         return OTSL_NL
     global_min_width = max(row["min_len"] for row in row_data) if row_data else 0
@@ -1327,9 +1278,7 @@ def convert_otsl_to_html(otsl_content: str) -> str:
     return export_to_html(table_data)
 
 
-def _collapse_placeholder_with_ignorable_tail(
-    otsl_content: str, placeholders: List[str]
-) -> str:
+def _collapse_placeholder_with_ignorable_tail(otsl_content: str, placeholders: List[str]) -> str:
     stripped = otsl_content.strip()
     for placeholder in placeholders:
         if stripped == placeholder:
@@ -1344,9 +1293,7 @@ def _collapse_placeholder_with_ignorable_tail(
 _OTSL_STRUCTURAL_TAG_RE = re.compile(r"<(?:otsl|fcel|ecel|lcel|ucel|xcel)>")
 
 
-def _flatten_top_level_table_placeholders(
-    otsl_content: str, placeholder_to_html: Dict[str, str]
-) -> str | None:
+def _flatten_top_level_table_placeholders(otsl_content: str, placeholder_to_html: Dict[str, str]) -> str | None:
     """If the top level is one or more table placeholders plus only non-OTSL
     text (sibling tables and/or a the model-appended caption/note after
     ``</otsl>``), return the concatenated HTML of those tables in order of
@@ -1435,9 +1382,7 @@ def convert_otsl_to_html_v2(otsl_content: str, debug: bool = False) -> str:
         placeholder_to_otsl[placeholder] = inner_otsl
 
         # 원본에서 해당 블록을 placeholder로 치환
-        otsl_content = (
-            otsl_content[: match.start()] + placeholder + otsl_content[match.end() :]
-        )
+        otsl_content = otsl_content[: match.start()] + placeholder + otsl_content[match.end() :]
         iteration += 1
 
     if debug:
@@ -1446,9 +1391,7 @@ def convert_otsl_to_html_v2(otsl_content: str, debug: bool = False) -> str:
 
     # 최상위 <otsl> 태그 제거
     otsl_content = re.sub(r"^<otsl>|</otsl>$", "", otsl_content.strip())
-    otsl_content = _collapse_placeholder_with_ignorable_tail(
-        otsl_content, list(placeholder_to_otsl)
-    )
+    otsl_content = _collapse_placeholder_with_ignorable_tail(otsl_content, list(placeholder_to_otsl))
 
     # 2단계: 모든 레벨의 OTSL을 HTML로 변환 (placeholder 포함된 채로)
     placeholder_to_html: Dict[str, str] = {}
@@ -1458,15 +1401,11 @@ def convert_otsl_to_html_v2(otsl_content: str, debug: bool = False) -> str:
             inner_html = convert_otsl_to_html(otsl)
             placeholder_to_html[placeholder] = inner_html
             if debug:
-                logger.debug(
-                    f"Converted {placeholder[:30]}... to HTML: {inner_html[:80]}..."
-                )
+                logger.debug(f"Converted {placeholder[:30]}... to HTML: {inner_html[:80]}...")
         except Exception as e:
             placeholder_to_html[placeholder] = "<table></table>"
             if debug:
-                logger.error(
-                    "OTSL conversion failed", placeholder=placeholder, error=str(e)
-                )
+                logger.error("OTSL conversion failed", placeholder=placeholder, error=str(e))
 
     # 최상위 레벨도 HTML로 변환
     top_stripped = otsl_content.strip()
@@ -1523,7 +1462,9 @@ if __name__ == "__main__":
     print()
 
     # 간단한 중첩 테이블 테스트
-    simple_nested = "<otsl><fcel>Outer A<fcel><otsl><fcel>Inner 1<fcel>Inner 2<nl></otsl><nl><fcel>Outer B<fcel>Outer C<nl></otsl>"
+    simple_nested = (
+        "<otsl><fcel>Outer A<fcel><otsl><fcel>Inner 1<fcel>Inner 2<nl></otsl><nl><fcel>Outer B<fcel>Outer C<nl></otsl>"
+    )
     print("=== Simple nested (v2) ===")
     print(convert_otsl_to_html_v2(simple_nested, debug=True))
 
@@ -1555,9 +1496,7 @@ def find_shortest_repeating_substring(s: str) -> Union[str, None]:
     return None
 
 
-def find_repeating_suffix(
-    s: str, min_len: int = 8, min_repeats: int = 5
-) -> Union[Tuple[str, str, int], None]:
+def find_repeating_suffix(s: str, min_len: int = 8, min_repeats: int = 5) -> Union[Tuple[str, str, int], None]:
     """
     Detect if string ends with a repeating phrase.
 
@@ -1708,10 +1647,7 @@ def truncate_repetitive_content(
             return candidate if len(candidate) < len(normalized) else line
 
         # 줄 단위로 처리해 줄바꿈 구조를 보존한다 (n-gram 반복은 줄 내부 구문 루프가 대상).
-        content = "\n".join(
-            _dedup_ngrams(line) if line.strip() else line
-            for line in content.split("\n")
-        )
+        content = "\n".join(_dedup_ngrams(line) if line.strip() else line for line in content.split("\n"))
         stripped_content = content.strip()
 
     # Priority 0: Remove long sequences of separator/symbol characters
@@ -1763,6 +1699,7 @@ def truncate_repetitive_content(
 
     return content
 
+
 # ==========================================================================
 # [vendored] picture_response_validator
 # ==========================================================================
@@ -1778,9 +1715,7 @@ from decimal import Decimal
 # [vendor-strip] from loguru import logger
 
 _SEPARATOR_PATTERN = re.compile(r"^\s*\|(?:\s*:?-+:?\s*\|)+\s*$")
-_KRW_EXPR_PATTERN = re.compile(
-    r"(?P<expr>(?:\d[\d,]*\s*(?:조원|억원|만원|조|억|만|원)\s*)+)"
-)
+_KRW_EXPR_PATTERN = re.compile(r"(?P<expr>(?:\d[\d,]*\s*(?:조원|억원|만원|조|억|만|원)\s*)+)")
 _KRW_SEGMENT_PATTERN = re.compile(r"(\d[\d,]*)\s*(조원|억원|만원|조|억|만|원)")
 
 _KRW_UNIT_MULTIPLIERS = {
@@ -1826,9 +1761,7 @@ def normalize_markdown_table_content(content: str) -> str:
 
     normalized = content.replace("｜", "|")
     lines = normalized.splitlines()
-    table_line_indices = [
-        idx for idx, line in enumerate(lines) if line.strip().startswith("|")
-    ]
+    table_line_indices = [idx for idx, line in enumerate(lines) if line.strip().startswith("|")]
 
     if len(table_line_indices) < 2:
         return normalized
@@ -1836,9 +1769,7 @@ def normalize_markdown_table_content(content: str) -> str:
     first_idx = table_line_indices[0]
     header_line = lines[first_idx].strip()
 
-    if first_idx + 1 < len(lines) and _SEPARATOR_PATTERN.match(
-        lines[first_idx + 1].strip()
-    ):
+    if first_idx + 1 < len(lines) and _SEPARATOR_PATTERN.match(lines[first_idx + 1].strip()):
         return normalized
 
     header_cells = split_markdown_table_row(header_line)
@@ -1987,12 +1918,8 @@ def merge_translated_table_with_source_values(
     translated = normalize_markdown_table_content(translated_content)
     source = normalize_chart_table_currency_values(source_content)
 
-    translated_lines = [
-        line for line in translated.splitlines() if line.strip().startswith("|")
-    ]
-    source_lines = [
-        line for line in source.splitlines() if line.strip().startswith("|")
-    ]
+    translated_lines = [line for line in translated.splitlines() if line.strip().startswith("|")]
+    source_lines = [line for line in source.splitlines() if line.strip().startswith("|")]
 
     if len(translated_lines) < 3 or len(translated_lines) != len(source_lines):
         return translated
@@ -2007,9 +1934,7 @@ def merge_translated_table_with_source_values(
         return translated
 
     merged_rows: list[list[str]] = []
-    for row_idx, (translated_row, source_row) in enumerate(
-        zip(translated_rows, source_rows)
-    ):
+    for row_idx, (translated_row, source_row) in enumerate(zip(translated_rows, source_rows)):
         if row_idx == 1:
             merged_rows.append(["---"] * len(translated_rows[0]))
             continue
@@ -2116,12 +2041,8 @@ def is_valid_markdown_table(content: str) -> bool:
 
 import html as _html
 
-_NATIVE_CLASS_PATTERN = re.compile(
-    r"<\|class_start\|>\s*(?P<cls>[^<|]*?)\s*<\|class_end\|>", re.S
-)
-_NATIVE_CONTENT_PATTERN = re.compile(
-    r"<\|content_start\|>(?P<body>.*?)<\|content_end\|>", re.S
-)
+_NATIVE_CLASS_PATTERN = re.compile(r"<\|class_start\|>\s*(?P<cls>[^<|]*?)\s*<\|class_end\|>", re.S)
+_NATIVE_CONTENT_PATTERN = re.compile(r"<\|content_start\|>(?P<body>.*?)<\|content_end\|>", re.S)
 _NATIVE_TOKEN_PATTERN = re.compile(r"<\|[^|>]*\|>")
 
 
@@ -2164,6 +2085,7 @@ def parse_native_chart_tokens(content):
     table = re.sub(r"^!\[", "", table.strip()).rstrip("]").strip()
     return image_type, table
 
+
 # ==========================================================================
 # [vendored] table_processor(functions)
 # ==========================================================================
@@ -2188,11 +2110,7 @@ from typing import Match
 
 def looks_like_otsl(content: str) -> bool:
     """Return True when table content starts with wrapped or bare OTSL tokens."""
-    return bool(
-        content.lstrip().startswith(
-            ("<otsl>", "<fcel>", "<ecel>", "<lcel>", "<ucel>", "<xcel>", "<nl>")
-        )
-    )
+    return bool(content.lstrip().startswith(("<otsl>", "<fcel>", "<ecel>", "<lcel>", "<ucel>", "<xcel>", "<nl>")))
 
 
 def looks_like_html_table(content: str) -> bool:
@@ -2204,9 +2122,7 @@ def looks_like_html_table(content: str) -> bool:
     # Relax detection for serialized/escaped table strings such as:
     # "\"<table ...>\"" or "<table rowspan=\\\"2\\\">".
     lowered = stripped.lower()
-    return "<table" in lowered and any(
-        marker in lowered for marker in ("rowspan", "colspan", "<tr", "<td")
-    )
+    return "<table" in lowered and any(marker in lowered for marker in ("rowspan", "colspan", "<tr", "<td"))
 
 
 def normalize_span_attributes(content: str) -> str:
@@ -2296,12 +2212,9 @@ def remove_dots_from_html_cells(html_content: str) -> str:
         return f"<td{attrs}>{td_content}</td>"
 
     # <td>...</td> 패턴을 찾아서 처리 (태그 속성도 고려)
-    result = re.sub(
-        r"<td([^>]*)>(.*?)</td>", clean_dots_in_td, html_content, flags=re.DOTALL
-    )
+    result = re.sub(r"<td([^>]*)>(.*?)</td>", clean_dots_in_td, html_content, flags=re.DOTALL)
 
     return result
-
 
 
 # ==========================================================================
@@ -2375,7 +2288,6 @@ def normalize_inline_markdown_table(content: str) -> str:
         rows.append(row)
 
     return "\n".join(rows) if len(rows) >= 2 else normalized
-
 
 
 # ==========================================================================
@@ -2461,8 +2373,14 @@ def header_mark(md: str) -> str:
 # Rule 2: curly-quote fold  (port of wf_rule_4_transform.fold_md)
 # --------------------------------------------------------------------------------------
 _QUOTE_FOLD = {
-    "‘": "'", "’": "'", "‚": "'", "‛": "'",   # single quotes
-    "“": '"', "”": '"', "„": '"', "‟": '"',   # double quotes
+    "‘": "'",
+    "’": "'",
+    "‚": "'",
+    "‛": "'",  # single quotes
+    "“": '"',
+    "”": '"',
+    "„": '"',
+    "‟": '"',  # double quotes
 }
 _QUOTE_TABLE = str.maketrans(_QUOTE_FOLD)
 
@@ -2600,6 +2518,7 @@ def postprocess_markdown(md: str, *, title_variant: str = "aggressive") -> str:
         pass
     return md
 
+
 # ==========================================================================
 # [core] KDL-Frontier-Parser-nano orchestration
 # ==========================================================================
@@ -2670,8 +2589,14 @@ _NANO_LOSSLESS_STAGES = {"table"}
 
 _TEXT_BUCKET_CATEGORIES = {
     # TextElementPostProcessor.TEXT_CATEGORIES (n-gram repetition cleanup)
-    "Title", "Section-header", "Text", "Page-header",
-    "Page-footer", "List-item", "Caption", "Footnote",
+    "Title",
+    "Section-header",
+    "Text",
+    "Page-header",
+    "Page-footer",
+    "List-item",
+    "Caption",
+    "Footnote",
 }
 
 _BLOCKQUOTE_CATEGORIES = {"Caption", "Footnote", "Page-header", "Page-footer"}
@@ -2680,11 +2605,7 @@ _BLOCKQUOTE_CATEGORIES = {"Caption", "Footnote", "Page-header", "Page-footer"}
 def _nano_image_to_data_uri(image: Image.Image, *, lossless: bool = False) -> str:
     """Port of message_builder.image_to_bytes + base64 data-URI encoding."""
     buffered = io.BytesIO()
-    if (
-        lossless
-        or image.mode in ("RGBA", "LA")
-        or (image.mode == "P" and "transparency" in image.info)
-    ):
+    if lossless or image.mode in ("RGBA", "LA") or (image.mode == "P" and "transparency" in image.info):
         mime_type = "image/png"
         image.save(buffered, format="PNG")
     else:
@@ -2707,20 +2628,14 @@ def _nano_payload(stage: str, model: str, image: Image.Image) -> dict:
                 "content": [
                     {
                         "type": "image_url",
-                        "image_url": {
-                            "url": _nano_image_to_data_uri(
-                                image, lossless=stage in _NANO_LOSSLESS_STAGES
-                            )
-                        },
+                        "image_url": {"url": _nano_image_to_data_uri(image, lossless=stage in _NANO_LOSSLESS_STAGES)},
                     },
                     {"type": "text", "text": _NANO_PROMPTS[stage]},
                 ],
             }
         ],
         "temperature": 0.0,
-        "max_tokens": int(
-            os.getenv(_NANO_MAX_TOKENS_ENV[stage][0], str(_NANO_MAX_TOKENS_ENV[stage][1]))
-        ),
+        "max_tokens": int(os.getenv(_NANO_MAX_TOKENS_ENV[stage][0], str(_NANO_MAX_TOKENS_ENV[stage][1]))),
     }
     extra = _NANO_EXTRA_PAYLOAD[stage]
     if extra is not None:
@@ -2775,12 +2690,12 @@ def _nano_group_by_bucket(
         "formula": [],
     }
     im_w, im_h = original_image.size
-    for item in content:
+    for item_index, item in enumerate(content):
         cat = item.get("category", "Text")
         mapped_cat = layout_recognition_bucket(cat)
         bbox = item.get("bbox", [])
         if not bbox or len(bbox) != 4:
-            continue
+            raise ProviderPermanentError(f"Malformed layout item {item_index}: expected a four-coordinate bbox")
         try:
             x1, y1, x2, y2 = bbox
             left = int(round(x1 * im_w))
@@ -2799,8 +2714,10 @@ def _nano_group_by_bucket(
             preprocessed_img = track_image(preprocess_for_vlm(cropped_img))
             if is_monochromatic(preprocessed_img):
                 continue
-        except Exception:
-            continue
+        except (ProviderPermanentError, ProviderTransientError):
+            raise
+        except Exception as exc:
+            raise ProviderPermanentError(f"Failed to crop or preprocess layout item {item_index}: {exc}") from exc
         element_info = {
             "bbox": bbox,
             "category": cat,
@@ -2817,11 +2734,7 @@ def _nano_group_by_bucket(
 
 
 def _nano_is_single_clean_otsl(content: Any) -> bool:
-    return (
-        isinstance(content, str)
-        and content.count("<otsl>") == 1
-        and ("<fcel>" in content or "<ecel>" in content)
-    )
+    return isinstance(content, str) and content.count("<otsl>") == 1 and ("<fcel>" in content or "<ecel>" in content)
 
 
 def _nano_apply_picture_result(el: Dict[str, Any], content: str | None) -> None:
@@ -2882,20 +2795,13 @@ def _nano_postprocess_element(el: Dict[str, Any]) -> None:
             el["content"] = f"![{truncate_repetitive_content(content)}]"
         elif category == "Chart":
             cleaned = normalize_inline_markdown_table(content)
-            el["content"] = _markdown_lib.markdown(
-                html.escape(cleaned), extensions=["tables"]
-            )
+            el["content"] = _markdown_lib.markdown(html.escape(cleaned), extensions=["tables"])
         elif category == "Formula":
             cleaned = truncate_repetitive_content(content)
-            if ("\\(" in cleaned and "\\)" in cleaned) or (
-                "\\[" in cleaned and "\\]" in cleaned
-            ):
+            if ("\\(" in cleaned and "\\)" in cleaned) or ("\\[" in cleaned and "\\]" in cleaned):
                 cleaned = cleaned.replace("$", "")
                 cleaned = (
-                    cleaned.replace("\\(", " $ ")
-                    .replace("\\)", " $ ")
-                    .replace("\\[", " $$ ")
-                    .replace("\\]", " $$ ")
+                    cleaned.replace("\\(", " $ ").replace("\\)", " $ ").replace("\\[", " $$ ").replace("\\]", " $$ ")
                 )
             el["content"] = cleaned
     except Exception as e:  # keep original content on post-processing failure
@@ -2922,6 +2828,7 @@ def _preserve_inline_markup(content: str) -> str:
     content = _HTML_STRIKE_OPEN_RE.sub("~~", content)
     content = _HTML_STRIKE_CLOSE_RE.sub("~~", content)
     return content
+
 
 def _nano_format_blockquote(content: str) -> str:
     stripped = content.strip()
@@ -2984,14 +2891,15 @@ def _nano_format_element(el: Dict[str, Any]) -> str:
 
 def _nano_assemble_markdown(
     elements: List[Dict[str, Any]],
+    page_numbers: Iterable[int],
 ) -> Tuple[str, List[Dict[str, Any]]]:
     """Port of response_builder._build_markdown_context/_build_full_markdown:
     sort by (page, layout_order), group contiguous same-page List-items into
     one block, drop empty blocks, page separators '---\\n\\n**Page N**' in the
     full document string only."""
     valid = [
-        e for e in sorted(elements, key=lambda e: (e.get("page_number", 1),
-                                                   e.get("layout_order", 0)))
+        e
+        for e in sorted(elements, key=lambda e: (e.get("page_number", 1), e.get("layout_order", 0)))
         if isinstance(e.get("page_number"), int)
         and not isinstance(e.get("page_number"), bool)
         and e.get("page_number", 0) >= 1
@@ -3019,35 +2927,27 @@ def _nano_assemble_markdown(
         if content:
             blocks.append((page, content))
 
-    md_parts: List[str] = []
-    current_page: int | None = None
-    for page, content in blocks:
-        if current_page is not None and page != current_page:
-            md_parts.append(f"---\n\n**Page {page}**")
-        md_parts.append(content)
-        current_page = page
-
-    pages_md: Dict[int, List[str]] = {}
+    pages_md: Dict[int, List[str]] = {page_number: [] for page_number in page_numbers}
     for page, content in blocks:
         pages_md.setdefault(page, []).append(content)
-    markdown_pages = [
-        {"page_number": page, "content": "\n\n".join(parts)}
-        for page, parts in sorted(pages_md.items())
-    ]
+
+    md_parts: List[str] = []
+    for index, (page, parts) in enumerate(sorted(pages_md.items())):
+        if index:
+            md_parts.append(f"---\n\n**Page {page}**")
+        content = "\n\n".join(parts)
+        if content:
+            md_parts.append(content)
+    markdown_pages = [{"page_number": page, "content": "\n\n".join(parts)} for page, parts in sorted(pages_md.items())]
     return "\n\n".join(md_parts), markdown_pages
 
 
 class _NanoEngine:
     """Per-document pipeline against one OpenAI-compatible vLLM endpoint."""
 
-    def __init__(self, endpoint_url: str, model: str, max_concurrent: int,
-                 timeout_s: float):
+    def __init__(self, endpoint_url: str, model: str, max_concurrent: int, timeout_s: float):
         base = endpoint_url.rstrip("/")
-        self._url = (
-            base + "/chat/completions"
-            if base.endswith("/v1")
-            else base + "/v1/chat/completions"
-        )
+        self._url = base + "/chat/completions" if base.endswith("/v1") else base + "/v1/chat/completions"
         self._model = model
         self._max_concurrent = max_concurrent
         self._timeout_s = timeout_s
@@ -3055,8 +2955,10 @@ class _NanoEngine:
     async def parse_pages(self, page_images: Iterable[Image.Image]) -> dict:
         semaphore = asyncio.Semaphore(self._max_concurrent)
         elements: List[Dict[str, Any]] = []
+        page_numbers: list[int] = []
         async with httpx.AsyncClient(timeout=self._timeout_s) as client:
             for page_no, image in enumerate(page_images, start=1):
+                page_numbers.append(page_no)
                 with close_derived_images(image) as track:
                     normalized = track(normalize_image_mode(image, "RGB"))
                     page_elements = await self._parse_page(client, semaphore, normalized, page_no)
@@ -3065,14 +2967,14 @@ class _NanoEngine:
         for el in elements:
             _nano_postprocess_element(el)
 
-        full_md, markdown_pages = _nano_assemble_markdown(elements)
+        full_md, markdown_pages = _nano_assemble_markdown(elements, page_numbers)
         # rule-based post-processing (the kdl_frontier mode gate is always on
         # for this provider): header_mark -> quote_fold -> title_promote
         full_md = postprocess_markdown(full_md)
         for page in markdown_pages:
             page["content"] = postprocess_markdown(page["content"])
 
-        pages_payload: Dict[int, List[Dict[str, Any]]] = {}
+        pages_payload: Dict[int, List[Dict[str, Any]]] = {page_number: [] for page_number in page_numbers}
         for el in elements:
             pages_payload.setdefault(el["page_number"], []).append(
                 {
@@ -3085,10 +2987,7 @@ class _NanoEngine:
         return {
             "markdown": full_md,
             "markdown_pages": markdown_pages,
-            "pages": [
-                {"page_number": n, "elements": els}
-                for n, els in sorted(pages_payload.items())
-            ],
+            "pages": [{"page_number": n, "elements": els} for n, els in sorted(pages_payload.items())],
         }
 
     async def _parse_page(
@@ -3131,12 +3030,11 @@ class _NanoEngine:
             _nano_payload("layout", self._model, layout_image),
             semaphore,
         )
-        if not layout_content or not layout_content.strip():
-            return []
         if not is_native_layout_response(layout_content):
-            logger.warning("page %d: layout response has no <|box_start|> tokens", page_no)
-            return []
+            raise ProviderPermanentError(f"Page {page_no} returned a non-native layout response")
         items = parse_native_layout_tokens(layout_content)
+        if not items:
+            raise ProviderPermanentError(f"Page {page_no} returned malformed native layout tokens")
         for item in items:
             item["page_number"] = page_no
         buckets = _nano_group_by_bucket(items, image, track)
@@ -3155,9 +3053,7 @@ class _NanoEngine:
             if stage == "picture" and (pre.width < 25 or pre.height < 25):
                 el["content"] = ""
                 return
-            content = await _nano_chat(
-                client, self._url, _nano_payload(stage, self._model, pre), semaphore
-            )
+            content = await _nano_chat(client, self._url, _nano_payload(stage, self._model, pre), semaphore)
             if stage == "picture":
                 _nano_apply_picture_result(el, content)
             else:
@@ -3318,8 +3214,11 @@ class KdlFrontierNanoProvider(Provider):
             if None in (x1, y1, x2, y2):
                 return None
             return LayoutSegmentIR(
-                x=float(x1), y=float(y1),
-                w=float(x2) - float(x1), h=float(y2) - float(y1), label=label,
+                x=float(x1),
+                y=float(y1),
+                w=float(x2) - float(x1),
+                h=float(y2) - float(y1),
+                label=label,
             )
         except Exception:
             return None
@@ -3329,20 +3228,40 @@ class KdlFrontierNanoProvider(Provider):
             raise ProviderPermanentError("KdlFrontierNanoProvider only supports PARSE.")
         raw = raw_result.raw_output
 
-        md_pages = sorted(
-            raw.get("markdown_pages") or [],
-            key=lambda d: d.get("page_number") or 0,
-        )
+        raw_pages = raw.get("pages")
+        md_pages = raw.get("markdown_pages")
+        if not isinstance(raw_pages, list) or not isinstance(md_pages, list):
+            raise ProviderPermanentError("KDL output is missing page collections")
+
+        def page_number(entry: Any, collection: str) -> int:
+            if not isinstance(entry, dict):
+                raise ProviderPermanentError(f"KDL {collection} entry is not an object")
+            value = entry.get("page_number")
+            if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+                raise ProviderPermanentError(f"KDL {collection} entry has invalid page_number: {value!r}")
+            return value
+
+        source_page_numbers = [page_number(page, "pages") for page in raw_pages]
+        markdown_by_page = {page_number(page, "markdown_pages"): page for page in md_pages}
+        if (
+            source_page_numbers != sorted(source_page_numbers)
+            or len(source_page_numbers) != len(set(source_page_numbers))
+            or set(markdown_by_page) != set(source_page_numbers)
+            or len(markdown_by_page) != len(md_pages)
+        ):
+            raise ProviderPermanentError("KDL output page identities are inconsistent")
+
         pages = [
-            PageIR(page_index=idx, markdown=str(mp.get("content", "")))
-            for idx, mp in enumerate(md_pages)
+            PageIR(
+                page_index=source_page_number - 1,
+                markdown=str(markdown_by_page[source_page_number].get("content", "")),
+            )
+            for source_page_number in source_page_numbers
         ]
-        full_markdown = raw.get("markdown") or "\n\n<!-- page-break -->\n\n".join(
-            p.markdown for p in pages
-        )
+        full_markdown = raw.get("markdown") or "\n\n<!-- page-break -->\n\n".join(p.markdown for p in pages)
 
         layout_pages: list[ParseLayoutPageIR] = []
-        for p in raw.get("pages") or []:
+        for p in raw_pages:
             items: list[LayoutItemIR] = []
             for e in p.get("elements") or []:
                 seg = self._bbox_to_segment(e.get("bbox"), str(e.get("category", "")) or None)
@@ -3354,12 +3273,7 @@ class KdlFrontierNanoProvider(Provider):
                         layout_segments=[seg] if seg else [],
                     )
                 )
-            try:
-                layout_pages.append(
-                    ParseLayoutPageIR(page_number=int(p.get("page_number") or 1), items=items)
-                )
-            except Exception:
-                pass
+            layout_pages.append(ParseLayoutPageIR(page_number=page_number(p, "pages"), items=items))
 
         output = ParseOutput(
             task_type="parse",

--- a/src/parse_bench/inference/providers/parse/kdl_frontier_nano.py
+++ b/src/parse_bench/inference/providers/parse/kdl_frontier_nano.py
@@ -66,6 +66,7 @@ from parse_bench.inference.providers.base import (
     Provider,
     ProviderConfigError,
     ProviderPermanentError,
+    ProviderRetryExhaustedError,
     ProviderTransientError,
 )
 from parse_bench.inference.providers.parse._multipage_image import PageImages, close_derived_images
@@ -2607,32 +2608,24 @@ async def _nano_chat(
     payload: dict,
     semaphore: asyncio.Semaphore,
 ) -> str:
-    """POST a chat request, classifying terminal client and retryable failures."""
-    last_exc: Exception | None = None
+    """POST one stage request and classify failures for the page retry owner."""
     async with semaphore:
-        for attempt in range(3):  # tenacity stop_after_attempt(3) equivalent
-            try:
-                resp = await client.post(
-                    url,
-                    json={**payload, "chat_template_kwargs": {"enable_thinking": False}},
-                )
-                if resp.status_code >= 500 or resp.status_code in (408, 429):
-                    raise httpx.HTTPStatusError(f"{resp.status_code}", request=resp.request, response=resp)
-                if resp.status_code >= 400:
-                    raise ProviderPermanentError(
-                        f"Stage request rejected with HTTP {resp.status_code}: {resp.text[:200]}"
-                    )
-                data = resp.json()
-                content = data["choices"][0]["message"]["content"]
-                if not isinstance(content, str) or not content.strip():
-                    raise ValueError("stage response contained no text content")
-                return content
-            except (httpx.HTTPError, TimeoutError, IndexError, KeyError, TypeError, ValueError) as e:
-                last_exc = e
-                if attempt < 2:
-                    await asyncio.sleep(min(10.0, 2.0 * (2**attempt)))
-    assert last_exc is not None
-    raise ProviderTransientError(f"Stage request failed after 3 attempts: {last_exc}") from last_exc
+        try:
+            resp = await client.post(
+                url,
+                json={**payload, "chat_template_kwargs": {"enable_thinking": False}},
+            )
+            if resp.status_code >= 500 or resp.status_code in (408, 429):
+                raise httpx.HTTPStatusError(f"{resp.status_code}", request=resp.request, response=resp)
+            if resp.status_code >= 400:
+                raise ProviderPermanentError(f"Stage request rejected with HTTP {resp.status_code}: {resp.text[:200]}")
+            data = resp.json()
+            content = data["choices"][0]["message"]["content"]
+            if not isinstance(content, str) or not content.strip():
+                raise ValueError("stage response contained no text content")
+            return content
+        except (httpx.HTTPError, TimeoutError, IndexError, KeyError, TypeError, ValueError) as exc:
+            raise ProviderTransientError(f"Stage request failed: {exc}") from exc
 
 
 def _nano_group_by_bucket(
@@ -2955,14 +2948,25 @@ class _NanoEngine:
         image: Image.Image,
         page_no: int,
     ) -> list[dict[str, Any]]:
-        with close_derived_images(image) as track:
-            return await self._parse_page_with_owned_images(
-                client,
-                semaphore,
-                image,
-                page_no,
-                track,
-            )
+        max_attempts = 3
+        for attempt in range(max_attempts):
+            try:
+                with close_derived_images(image) as track:
+                    return await self._parse_page_with_owned_images(
+                        client,
+                        semaphore,
+                        image,
+                        page_no,
+                        track,
+                    )
+            except ProviderTransientError as exc:
+                if attempt == max_attempts - 1:
+                    raise ProviderRetryExhaustedError(
+                        f"KDL page {page_no} failed after {max_attempts} attempts: {exc}"
+                    ) from exc
+                await asyncio.sleep(2.0 * (2**attempt))
+
+        raise AssertionError("unreachable")
 
     async def _parse_page_with_owned_images(
         self,

--- a/src/parse_bench/inference/providers/parse/kdl_frontier_nano.py
+++ b/src/parse_bench/inference/providers/parse/kdl_frontier_nano.py
@@ -34,6 +34,8 @@ orchestrator so the maintainers can reproduce the submitted numbers end to end;
 section banners mark the vendored module boundaries.
 """
 
+# ruff: noqa: E501 -- vendored regression corpus contains an intentionally long OTSL sample.
+
 import asyncio
 import base64
 import enum
@@ -47,12 +49,13 @@ import os
 import re
 import unicodedata
 from collections import Counter
-from collections.abc import Callable, Generator, Iterable, Iterator
+from collections.abc import Callable, Generator, Iterable, Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from datetime import datetime
 from decimal import Decimal
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Match, Tuple, Union, cast
+from re import Match
+from typing import Any, Literal, cast
 
 import httpx
 import markdown as _markdown_lib
@@ -89,9 +92,7 @@ logger = logging.getLogger("kdl_frontier_nano")
 Enum = enum.Enum
 
 # from deepparser_v2/config/model_flow.py (verbatim values)
-from typing import Literal as _Literal  # explicit: alias below needs Literal at module init
-
-RecognitionStage = _Literal["text", "table", "picture", "formula"]
+RecognitionStage = Literal["text", "table", "picture", "formula"]
 RECOGNITION_STAGES: tuple = ("text", "table", "picture", "formula")
 
 
@@ -127,8 +128,6 @@ class ElementCategory(str, Enum):
 """Recognition bucket contract shared by planning and layout grouping."""
 
 # [vendor-strip] from __future__ import annotations
-
-from typing import Sequence
 
 # [vendor-strip] from ..schemas.element_schema import ElementCategory
 # [vendor-strip] from .model_flow import RECOGNITION_STAGES, RecognitionStage
@@ -185,9 +184,6 @@ def _category_value(category: str | ElementCategory) -> str:
 # [vendored] layout_contract
 # ==========================================================================
 """Layout category contract shared by layout provider adapters."""
-
-from collections.abc import Mapping
-from typing import Any
 
 # [vendor-strip] from ..config.recognition_contract import category_to_recognition_bucket
 # [vendor-strip] from ..schemas.element_schema import ElementCategory
@@ -257,12 +253,8 @@ def _stringify_category(category: Any) -> str:
 # ==========================================================================
 # [vendor-strip] from __future__ import annotations
 
-import math
-from typing import Tuple
 
 # [vendor-strip] from loguru import logger
-from PIL import Image
-from pydantic import BaseModel, Field
 
 
 # 이미지 처리 설정값
@@ -338,7 +330,7 @@ def calculate_dimensions(
     factor: int = ImageConfig.FACTOR,
     min_pixels: int = ImageConfig.MIN_PIXELS,
     max_pixels: int = ImageConfig.MAX_PIXELS,
-) -> Tuple[int, int]:
+) -> tuple[int, int]:
     """이미지 크기 계산"""
     # 종횡비 검증
     aspect_ratio = max(height, width) / min(height, width)
@@ -383,8 +375,8 @@ def smart_resize(image: Image.Image) -> Image.Image:
             return resized_img
         else:
             return image
-    except Exception:
-        raise ValueError(f"Failed to resize image: {image}")
+    except Exception as exc:
+        raise ValueError(f"Failed to resize image: {image}") from exc
 
 
 def is_monochromatic(image: Image.Image) -> bool:
@@ -519,12 +511,6 @@ def preprocess_for_vlm(image: Image.Image) -> Image.Image:
 # [vendored] native_layout
 # ==========================================================================
 """the model layout token parsing utilities."""
-
-import re
-from typing import Any
-
-from PIL import Image
-from pydantic import BaseModel, Field
 
 # [vendor-strip] from .layout_contract import normalize_layout_category
 
@@ -912,13 +898,7 @@ def _attachment_distance(
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import html
-import itertools
-import re
-from typing import Any, Dict, List, Tuple, cast
-
 # [vendor-strip] from loguru import logger
-from pydantic import BaseModel, computed_field, model_validator
 
 
 class TableCell(BaseModel):
@@ -985,12 +965,12 @@ class TableData(BaseModel):
         num_cols (int): Number of columns.
     """
 
-    table_cells: List[TableCell] = []
+    table_cells: list[TableCell] = []
     num_rows: int = 0
     num_cols: int = 0
 
     @computed_field
-    def grid(self) -> List[List[TableCell]]:
+    def grid(self) -> list[list[TableCell]]:
         """
         Returns a 2D grid of TableCell objects for the table.
 
@@ -1039,7 +1019,7 @@ IGNORABLE_OTSL_TAIL_PATTERN = re.compile(
 )
 
 
-def otsl_extract_tokens_and_text(s: str) -> Tuple[List[str], List[str]]:
+def otsl_extract_tokens_and_text(s: str) -> tuple[list[str], list[str]]:
     """
     Extract OTSL tags and text parts from the input string.
 
@@ -1056,7 +1036,7 @@ def otsl_extract_tokens_and_text(s: str) -> Tuple[List[str], List[str]]:
     return tokens, text_parts
 
 
-def otsl_parse_texts(texts: List[str], tokens: List[str]) -> Tuple[List[TableCell], List[List[str]]]:
+def otsl_parse_texts(texts: list[str], tokens: list[str]) -> tuple[list[TableCell], list[list[str]]]:
     """
     Parse OTSL text and tags into TableCell objects and tag structure.
 
@@ -1069,7 +1049,7 @@ def otsl_parse_texts(texts: List[str], tokens: List[str]) -> Tuple[List[TableCel
     """
     split_word = OTSL_NL
     split_row_tokens = [list(y) for x, y in itertools.groupby(tokens, lambda z: z == split_word) if not x]
-    table_cells: List[TableCell] = []
+    table_cells: list[TableCell] = []
     r_idx = 0
     c_idx = 0
 
@@ -1101,7 +1081,7 @@ def otsl_parse_texts(texts: List[str], tokens: List[str]) -> Tuple[List[TableCel
                 text_idx += 1
         texts = new_texts
 
-    def count_right(tokens: List[List[str]], c_idx: int, r_idx: int, which_tokens: List[str]) -> int:
+    def count_right(tokens: list[list[str]], c_idx: int, r_idx: int, which_tokens: list[str]) -> int:
         span = 0
         c_idx_iter = c_idx
         while tokens[r_idx][c_idx_iter] in which_tokens:
@@ -1111,7 +1091,7 @@ def otsl_parse_texts(texts: List[str], tokens: List[str]) -> Tuple[List[TableCel
                 return span
         return span
 
-    def count_down(tokens: List[List[str]], c_idx: int, r_idx: int, which_tokens: List[str]) -> int:
+    def count_down(tokens: list[list[str]], c_idx: int, r_idx: int, which_tokens: list[str]) -> int:
         span = 0
         r_idx_iter = r_idx
         while tokens[r_idx_iter][c_idx] in which_tokens:
@@ -1214,7 +1194,7 @@ def otsl_pad_to_sqr_v2(otsl_str: str) -> str:
     if OTSL_NL not in otsl_str:
         return otsl_str + OTSL_NL
     lines = otsl_str.split(OTSL_NL)
-    row_data: List[Dict[str, Any]] = []
+    row_data: list[dict[str, Any]] = []
     for line in lines:
         if not line:
             continue
@@ -1244,7 +1224,7 @@ def otsl_pad_to_sqr_v2(otsl_str: str) -> str:
 
     repaired_lines = []
     for row in row_data:
-        cells = cast(List[str], row["raw_cells"])
+        cells = cast(list[str], row["raw_cells"])
         current_len = len(cells)
         # Never truncate rows here. Merge markers such as <lcel>/<ucel>/<xcel>
         # carry structural information, so cutting longer rows can drop content.
@@ -1278,7 +1258,7 @@ def convert_otsl_to_html(otsl_content: str) -> str:
     return export_to_html(table_data)
 
 
-def _collapse_placeholder_with_ignorable_tail(otsl_content: str, placeholders: List[str]) -> str:
+def _collapse_placeholder_with_ignorable_tail(otsl_content: str, placeholders: list[str]) -> str:
     stripped = otsl_content.strip()
     for placeholder in placeholders:
         if stripped == placeholder:
@@ -1293,7 +1273,7 @@ def _collapse_placeholder_with_ignorable_tail(otsl_content: str, placeholders: L
 _OTSL_STRUCTURAL_TAG_RE = re.compile(r"<(?:otsl|fcel|ecel|lcel|ucel|xcel)>")
 
 
-def _flatten_top_level_table_placeholders(otsl_content: str, placeholder_to_html: Dict[str, str]) -> str | None:
+def _flatten_top_level_table_placeholders(otsl_content: str, placeholder_to_html: dict[str, str]) -> str | None:
     """If the top level is one or more table placeholders plus only non-OTSL
     text (sibling tables and/or a the model-appended caption/note after
     ``</otsl>``), return the concatenated HTML of those tables in order of
@@ -1355,7 +1335,7 @@ def convert_otsl_to_html_v2(otsl_content: str, debug: bool = False) -> str:
 
     # 1단계: 모든 중첩 테이블을 placeholder로 치환하고 OTSL 저장
     # placeholder -> OTSL 매핑 (아직 HTML 아님!)
-    placeholder_to_otsl: Dict[str, str] = {}
+    placeholder_to_otsl: dict[str, str] = {}
 
     # 가장 안쪽 <otsl>...</otsl> 블록을 찾는 정규식
     nested_pattern = r"<otsl>((?:(?!<otsl>).)*?)</otsl>"
@@ -1394,7 +1374,7 @@ def convert_otsl_to_html_v2(otsl_content: str, debug: bool = False) -> str:
     otsl_content = _collapse_placeholder_with_ignorable_tail(otsl_content, list(placeholder_to_otsl))
 
     # 2단계: 모든 레벨의 OTSL을 HTML로 변환 (placeholder 포함된 채로)
-    placeholder_to_html: Dict[str, str] = {}
+    placeholder_to_html: dict[str, str] = {}
 
     for placeholder, otsl in placeholder_to_otsl.items():
         try:
@@ -1405,7 +1385,7 @@ def convert_otsl_to_html_v2(otsl_content: str, debug: bool = False) -> str:
         except Exception as e:
             placeholder_to_html[placeholder] = "<table></table>"
             if debug:
-                logger.error("OTSL conversion failed", placeholder=placeholder, error=str(e))
+                logger.error("OTSL conversion failed (%s): %s", placeholder, e)
 
     # 최상위 레벨도 HTML로 변환
     top_stripped = otsl_content.strip()
@@ -1468,16 +1448,11 @@ if __name__ == "__main__":
     print("=== Simple nested (v2) ===")
     print(convert_otsl_to_html_v2(simple_nested, debug=True))
 
+
 # ==========================================================================
 # [vendored] truncate_repeat
 # ==========================================================================
-import re
-import unicodedata
-from collections import Counter
-from typing import Tuple, Union
-
-
-def find_shortest_repeating_substring(s: str) -> Union[str, None]:
+def find_shortest_repeating_substring(s: str) -> str | None:
     """
     Find the shortest substring that repeats to form the entire string.
 
@@ -1496,7 +1471,7 @@ def find_shortest_repeating_substring(s: str) -> Union[str, None]:
     return None
 
 
-def find_repeating_suffix(s: str, min_len: int = 8, min_repeats: int = 5) -> Union[Tuple[str, str, int], None]:
+def find_repeating_suffix(s: str, min_len: int = 8, min_repeats: int = 5) -> tuple[str, str, int] | None:
     """
     Detect if string ends with a repeating phrase.
 
@@ -1708,9 +1683,6 @@ Picture Response Validator
 
 VLM에서 반환된 picture/chart/flowchart 응답의 유효성을 검증합니다.
 """
-
-import re
-from decimal import Decimal
 
 # [vendor-strip] from loguru import logger
 
@@ -1934,13 +1906,13 @@ def merge_translated_table_with_source_values(
         return translated
 
     merged_rows: list[list[str]] = []
-    for row_idx, (translated_row, source_row) in enumerate(zip(translated_rows, source_rows)):
+    for row_idx, (translated_row, source_row) in enumerate(zip(translated_rows, source_rows, strict=False)):
         if row_idx == 1:
             merged_rows.append(["---"] * len(translated_rows[0]))
             continue
 
         merged_row = []
-        for translated_cell, source_cell in zip(translated_row, source_row):
+        for translated_cell, source_cell in zip(translated_row, source_row, strict=False):
             if (
                 _KRW_VALUE_PATTERN.fullmatch(source_cell)
                 or _PERCENT_PATTERN.fullmatch(source_cell)
@@ -2039,8 +2011,6 @@ def is_valid_markdown_table(content: str) -> bool:
 # chart table reaches the markdown as a clean, parseable table.
 # ---------------------------------------------------------------------------
 
-import html as _html
-
 _NATIVE_CLASS_PATTERN = re.compile(r"<\|class_start\|>\s*(?P<cls>[^<|]*?)\s*<\|class_end\|>", re.S)
 _NATIVE_CONTENT_PATTERN = re.compile(r"<\|content_start\|>(?P<body>.*?)<\|content_end\|>", re.S)
 _NATIVE_TOKEN_PATTERN = re.compile(r"<\|[^|>]*\|>")
@@ -2060,7 +2030,7 @@ def parse_native_chart_tokens(content):
         return None
     # Unescape HTML entities and drop wrapping image/paragraph syntax so the
     # token markers are visible (e.g. "![<|class_start|>..." or "<p>&lt;|..").
-    text = _html.unescape(content)
+    text = html.unescape(content)
     if "<|content_start|>" not in text and "<|class_start|>" not in text:
         return None
 
@@ -2094,11 +2064,6 @@ TableElementPostProcessor
 
 테이블 요소의 OTSL 태그를 HTML로 변환합니다.
 """
-
-import html
-import json
-import re
-from typing import Match
 
 # [vendor-strip] from loguru import logger
 
@@ -2226,10 +2191,6 @@ DataChartElementPostProcessor
 차트 요소를 후처리합니다 (현재는 bypass).
 """
 
-import html
-import re
-
-import markdown
 # [vendor-strip] from loguru import logger
 
 # [vendor-strip] from ..schemas.element_schema import DocumentElement, ElementCategory
@@ -2310,9 +2271,6 @@ STRUCTURE (and TEDS-Structure) is unchanged. Stdlib-only (no model, no I/O).
 """
 
 # [vendor-strip] from __future__ import annotations
-
-import re
-from collections import Counter
 
 # --------------------------------------------------------------------------------------
 # Rule 1: multi-level table-header marking  (port of header_transform.transform_markdown)
@@ -2737,7 +2695,7 @@ def _nano_is_single_clean_otsl(content: Any) -> bool:
     return isinstance(content, str) and content.count("<otsl>") == 1 and ("<fcel>" in content or "<ecel>" in content)
 
 
-def _nano_apply_picture_result(el: Dict[str, Any], content: str | None) -> None:
+def _nano_apply_picture_result(el: dict[str, Any], content: str | None) -> None:
     """Port of picture_recognition.apply_picture_result for the single-model
     run (enable_chart=True, caption_language='en').
 
@@ -2773,7 +2731,7 @@ def _nano_apply_picture_result(el: Dict[str, Any], content: str | None) -> None:
         el["content"] = content_str
 
 
-def _nano_postprocess_element(el: Dict[str, Any]) -> None:
+def _nano_postprocess_element(el: dict[str, Any]) -> None:
     """Port of postprocessing.PostProcessor (first matching processor wins;
     failures keep the original content)."""
     content = el.get("content") or ""
@@ -2849,7 +2807,7 @@ def _nano_format_formula(content: str) -> str:
     return f"```latex\n{stripped}\n```"
 
 
-def _nano_image_markdown(el: Dict[str, Any]) -> str:
+def _nano_image_markdown(el: dict[str, Any]) -> str:
     image_src = el.get("picture_path") or ""
     if not image_src:
         return ""
@@ -2857,7 +2815,7 @@ def _nano_image_markdown(el: Dict[str, Any]) -> str:
     return f"![{alt}]({image_src})"
 
 
-def _nano_format_element(el: Dict[str, Any]) -> str:
+def _nano_format_element(el: dict[str, Any]) -> str:
     category = el.get("category", "Text")
     content = el.get("content") or ""
     if category in ("Title", "Section-header"):
@@ -2890,9 +2848,9 @@ def _nano_format_element(el: Dict[str, Any]) -> str:
 
 
 def _nano_assemble_markdown(
-    elements: List[Dict[str, Any]],
+    elements: list[dict[str, Any]],
     page_numbers: Iterable[int],
-) -> Tuple[str, List[Dict[str, Any]]]:
+) -> tuple[str, list[dict[str, Any]]]:
     """Port of response_builder._build_markdown_context/_build_full_markdown:
     sort by (page, layout_order), group contiguous same-page List-items into
     one block, drop empty blocks, page separators '---\\n\\n**Page N**' in the
@@ -2904,7 +2862,7 @@ def _nano_assemble_markdown(
         and not isinstance(e.get("page_number"), bool)
         and e.get("page_number", 0) >= 1
     ]
-    blocks: List[Tuple[int, str]] = []  # (page_number, content)
+    blocks: list[tuple[int, str]] = []  # (page_number, content)
     index = 0
     while index < len(valid):
         el = valid[index]
@@ -2927,11 +2885,11 @@ def _nano_assemble_markdown(
         if content:
             blocks.append((page, content))
 
-    pages_md: Dict[int, List[str]] = {page_number: [] for page_number in page_numbers}
+    pages_md: dict[int, list[str]] = {page_number: [] for page_number in page_numbers}
     for page, content in blocks:
         pages_md.setdefault(page, []).append(content)
 
-    md_parts: List[str] = []
+    md_parts: list[str] = []
     for index, (page, parts) in enumerate(sorted(pages_md.items())):
         if index:
             md_parts.append(f"---\n\n**Page {page}**")
@@ -2954,7 +2912,7 @@ class _NanoEngine:
 
     async def parse_pages(self, page_images: Iterable[Image.Image]) -> dict:
         semaphore = asyncio.Semaphore(self._max_concurrent)
-        elements: List[Dict[str, Any]] = []
+        elements: list[dict[str, Any]] = []
         page_numbers: list[int] = []
         async with httpx.AsyncClient(timeout=self._timeout_s) as client:
             for page_no, image in enumerate(page_images, start=1):
@@ -2974,7 +2932,7 @@ class _NanoEngine:
         for page in markdown_pages:
             page["content"] = postprocess_markdown(page["content"])
 
-        pages_payload: Dict[int, List[Dict[str, Any]]] = {page_number: [] for page_number in page_numbers}
+        pages_payload: dict[int, list[dict[str, Any]]] = {page_number: [] for page_number in page_numbers}
         for el in elements:
             pages_payload.setdefault(el["page_number"], []).append(
                 {
@@ -3211,7 +3169,7 @@ class KdlFrontierNanoProvider(Provider):
                 x1, y1, x2, y2 = bbox
             else:
                 return None
-            if None in (x1, y1, x2, y2):
+            if x1 is None or y1 is None or x2 is None or y2 is None:
                 return None
             return LayoutSegmentIR(
                 x=float(x1),

--- a/src/parse_bench/inference/providers/parse/kdl_frontier_nano.py
+++ b/src/parse_bench/inference/providers/parse/kdl_frontier_nano.py
@@ -51,6 +51,7 @@ import unicodedata
 from collections import Counter
 from collections.abc import Awaitable, Callable, Generator, Iterable, Iterator, Mapping, Sequence
 from contextlib import contextmanager
+from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
 from pathlib import Path
@@ -69,7 +70,12 @@ from parse_bench.inference.providers.base import (
     ProviderRetryExhaustedError,
     ProviderTransientError,
 )
-from parse_bench.inference.providers.parse._multipage_image import PageImages, close_derived_images
+from parse_bench.inference.providers.parse._multipage_image import (
+    PageImages,
+    annotate_attempt_costs,
+    attempt_usages_complete,
+    close_derived_images,
+)
 from parse_bench.inference.providers.registry import register_provider
 from parse_bench.schemas.parse_output import (
     LayoutItemIR,
@@ -2602,13 +2608,20 @@ def _nano_payload(stage: str, model: str, image: Image.Image) -> dict:
     return payload
 
 
+@dataclass(frozen=True)
+class _NanoStageResponse:
+    content: str
+    usage: dict[str, int]
+
+
 async def _nano_chat(
     client: httpx.AsyncClient,
     url: str,
     payload: dict,
     semaphore: asyncio.Semaphore,
-) -> str:
+) -> _NanoStageResponse:
     """POST one stage request and classify failures for the page retry owner."""
+    usage: dict[str, int] = {}
     async with semaphore:
         try:
             resp = await client.post(
@@ -2620,12 +2633,30 @@ async def _nano_chat(
             if resp.status_code >= 400:
                 raise ProviderPermanentError(f"Stage request rejected with HTTP {resp.status_code}: {resp.text[:200]}")
             data = resp.json()
+            raw_usage = data.get("usage")
+            if isinstance(raw_usage, dict):
+                for key, source_key in (
+                    ("input_tokens", "prompt_tokens"),
+                    ("output_tokens", "completion_tokens"),
+                    ("total_tokens", "total_tokens"),
+                ):
+                    value = raw_usage.get(source_key)
+                    if value is not None:
+                        usage[key] = int(value)
+                details = raw_usage.get("completion_tokens_details")
+                if isinstance(details, dict) and details.get("reasoning_tokens") is not None:
+                    usage["thinking_tokens"] = int(details["reasoning_tokens"])
             content = data["choices"][0]["message"]["content"]
             if not isinstance(content, str) or not content.strip():
                 raise ValueError("stage response contained no text content")
-            return content
+            return _NanoStageResponse(content=content, usage=usage)
+        except ProviderPermanentError:
+            raise
         except (httpx.HTTPError, TimeoutError, IndexError, KeyError, TypeError, ValueError) as exc:
-            raise ProviderTransientError(f"Stage request failed: {exc}") from exc
+            raise ProviderTransientError(
+                f"Stage request failed: {exc}",
+                attempt_stats=usage or None,
+            ) from exc
 
 
 def _nano_group_by_bucket(
@@ -2896,14 +2927,26 @@ def _nano_assemble_markdown(
 class _NanoEngine:
     """Per-document pipeline against one OpenAI-compatible vLLM endpoint."""
 
-    def __init__(self, endpoint_url: str, model: str, max_concurrent: int, timeout_s: float):
+    def __init__(
+        self,
+        endpoint_url: str,
+        model: str,
+        max_concurrent: int,
+        timeout_s: float,
+        input_cost_per_million: float | None = None,
+        output_cost_per_million: float | None = None,
+    ):
         base = endpoint_url.rstrip("/")
         self._url = base + "/chat/completions" if base.endswith("/v1") else base + "/v1/chat/completions"
         self._model = model
         self._max_concurrent = max_concurrent
         self._timeout_s = timeout_s
+        self._input_cost_per_million = input_cost_per_million
+        self._output_cost_per_million = output_cost_per_million
+        self._api_attempts: list[dict[str, object]] = []
 
     async def parse_pages(self, page_images: Iterable[Image.Image]) -> dict:
+        self._api_attempts = []
         semaphore = asyncio.Semaphore(self._max_concurrent)
         elements: list[dict[str, Any]] = []
         page_numbers: list[int] = []
@@ -2935,11 +2978,36 @@ class _NanoEngine:
                     "layout_order": el.get("layout_order", 0),
                 }
             )
-        return {
+        raw_output = {
             "markdown": full_md,
             "markdown_pages": markdown_pages,
             "pages": [{"page_number": n, "elements": els} for n, els in sorted(pages_payload.items())],
+            "model": self._model,
+            "num_api_calls": len(self._api_attempts),
+            "api_attempts": self._api_attempts,
         }
+        attempt_usages = [
+            cast(dict[str, int], attempt["stats"])
+            for attempt in self._api_attempts
+            if isinstance(attempt.get("stats"), dict)
+        ]
+        if attempt_usages_complete(attempt_usages):
+            for field in ("input_tokens", "output_tokens", "thinking_tokens", "total_tokens"):
+                raw_output[field] = sum(int(usage.get(field, 0)) for usage in attempt_usages)
+            if self._input_cost_per_million is not None and self._output_cost_per_million is not None:
+                annotate_attempt_costs(
+                    self._api_attempts,
+                    input_rate_per_million=self._input_cost_per_million,
+                    output_rate_per_million=self._output_cost_per_million,
+                )
+                cost_usd = sum(
+                    float(stats["cost_usd"])
+                    for attempt in self._api_attempts
+                    if isinstance((stats := attempt.get("stats")), dict) and "cost_usd" in stats
+                )
+                raw_output["cost_usd"] = cost_usd
+                raw_output["cost_per_page_usd"] = cost_usd / len(page_numbers) if page_numbers else 0.0
+        return raw_output
 
     async def _parse_page(
         self,
@@ -2957,24 +3025,80 @@ class _NanoEngine:
                 track,
             )
 
-    async def _run_stage_with_retries[T](
+    def _annotate_attempt_cost(self, record: dict[str, object]) -> None:
+        """Attach cost when this endpoint has explicit pricing and usage is known."""
+        if self._input_cost_per_million is None or self._output_cost_per_million is None:
+            return
+        annotate_attempt_costs(
+            [record],
+            input_rate_per_million=self._input_cost_per_million,
+            output_rate_per_million=self._output_cost_per_million,
+        )
+
+    async def _run_stage_with_retries(
         self,
-        call: Callable[[], Awaitable[T]],
+        call: Callable[[], Awaitable[str | _NanoStageResponse]],
         *,
         page_no: int,
         stage: str,
-    ) -> T:
+    ) -> str:
         """Retry one physical KDL stage without replaying completed siblings."""
         max_attempts = 3
         for attempt in range(max_attempts):
+            record: dict[str, object] = {
+                "call_index": len(self._api_attempts) + 1,
+                "page_number": page_no,
+                "stage": stage,
+                "attempt": attempt + 1,
+                "status": "running",
+                "stats": {},
+            }
+            self._api_attempts.append(record)
             try:
-                return await call()
+                result = await call()
+            except asyncio.CancelledError:
+                record["status"] = "cancelled"
+                raise
+            except ProviderPermanentError as exc:
+                record.update(
+                    {
+                        "status": "failed",
+                        "stats": dict(exc.attempt_stats or {}),
+                        "error_type": type(exc).__name__,
+                        "error": str(exc),
+                    }
+                )
+                self._annotate_attempt_cost(record)
+                payload = dict(exc.debug_payload or {})
+                payload["attempts"] = self._api_attempts
+                exc.debug_payload = payload
+                raise
             except ProviderTransientError as exc:
+                record.update(
+                    {
+                        "status": "failed",
+                        "stats": dict(exc.attempt_stats or {}),
+                        "error_type": type(exc).__name__,
+                        "error": str(exc),
+                    }
+                )
+                self._annotate_attempt_cost(record)
                 if attempt == max_attempts - 1:
                     raise ProviderRetryExhaustedError(
-                        f"KDL page {page_no} failed after {max_attempts} attempts during {stage}: {exc}"
+                        f"KDL page {page_no} failed after {max_attempts} attempts during {stage}: {exc}",
+                        debug_payload={"attempts": self._api_attempts},
                     ) from exc
                 await asyncio.sleep(2.0 * (2**attempt))
+            else:
+                if isinstance(result, _NanoStageResponse):
+                    content = result.content
+                    stats = result.usage
+                else:
+                    content = result
+                    stats = {}
+                record.update({"status": "succeeded", "stats": stats})
+                self._annotate_attempt_cost(record)
+                return content
         raise AssertionError("unreachable")
 
     async def _parse_page_with_owned_images(
@@ -3122,6 +3246,17 @@ class KdlFrontierNanoProvider(Provider):
         self._timeout = float(self.base_config.get("timeout", 900))
         self._max_pages = int(self.base_config.get("max_pages", os.getenv("KDL_NANO_MAX_PAGES", "400")))
         self._max_concurrent = int(os.getenv("KDL_NANO_MAX_CONCURRENT", "8"))
+        input_cost = self.base_config.get("input_cost_per_million")
+        output_cost = self.base_config.get("output_cost_per_million")
+        if (input_cost is None) != (output_cost is None):
+            raise ProviderConfigError("KDL pricing requires both input_cost_per_million and output_cost_per_million")
+        self._input_cost_per_million = float(input_cost) if input_cost is not None else None
+        self._output_cost_per_million = float(output_cost) if output_cost is not None else None
+        if any(
+            rate is not None and (not math.isfinite(rate) or rate < 0)
+            for rate in (self._input_cost_per_million, self._output_cost_per_million)
+        ):
+            raise ProviderConfigError("KDL pricing rates must be finite non-negative numbers")
 
     @contextmanager
     def _open_page_images(self, source_path: Path) -> Iterator[PageImages]:
@@ -3176,7 +3311,14 @@ class KdlFrontierNanoProvider(Provider):
         if not source_path.exists():
             raise ProviderPermanentError(f"Source file not found: {source_path}")
         started_at = datetime.now()
-        engine = _NanoEngine(self._endpoint_url, self._model, self._max_concurrent, self._timeout)
+        engine = _NanoEngine(
+            self._endpoint_url,
+            self._model,
+            self._max_concurrent,
+            self._timeout,
+            self._input_cost_per_million,
+            self._output_cost_per_million,
+        )
         try:
             with self._open_page_images(source_path) as page_images:
                 raw_output = self.run_async_from_sync(engine.parse_pages(page_images))

--- a/src/parse_bench/inference/providers/parse/kdl_frontier_nano.py
+++ b/src/parse_bench/inference/providers/parse/kdl_frontier_nano.py
@@ -46,7 +46,7 @@ import os
 import re
 import unicodedata
 from collections import Counter
-from collections.abc import Generator, Iterable, Iterator
+from collections.abc import Callable, Generator, Iterable, Iterator
 from contextlib import contextmanager
 from datetime import datetime
 from decimal import Decimal
@@ -323,7 +323,12 @@ def normalize_image_mode(image: Image.Image, target_mode: str = "RGB") -> Image.
     if image.mode == "RGBA" and target_mode == "RGB":
         # RGBA를 RGB로 변환 시 흰색 배경 추가
         background = Image.new("RGB", image.size, ImageConfig.DEFAULT_BACKGROUND_COLOR)
-        background.paste(image, mask=image.split()[3])  # 알파 채널을 마스크로 사용
+        try:
+            with image.getchannel("A") as alpha:
+                background.paste(image, mask=alpha)
+        except Exception:
+            background.close()
+            raise
         return background
 
     return image.convert(target_mode)
@@ -416,78 +421,81 @@ def is_monochromatic(image: Image.Image) -> bool:
 def analyze_page_content(image: Image.Image) -> PageContentMetrics:
     """Estimate whether a page has visible content without calling a detector."""
     try:
-        normalized = normalize_image_mode(image, "RGB")
-        width, height = normalized.size
-        scale = min(1.0, CONTENT_ANALYSIS_MAX_DIMENSION / max(width, height))
-        if scale < 1.0:
-            sample_size = (max(1, int(width * scale)), max(1, int(height * scale)))
-            normalized = normalized.resize(
-                sample_size,
-                resample=Image.Resampling.BILINEAR,
+        with close_derived_images(image) as track:
+            normalized = track(normalize_image_mode(image, "RGB"))
+            width, height = normalized.size
+            scale = min(1.0, CONTENT_ANALYSIS_MAX_DIMENSION / max(width, height))
+            if scale < 1.0:
+                sample_size = (max(1, int(width * scale)), max(1, int(height * scale)))
+                normalized = track(
+                    normalized.resize(
+                        sample_size,
+                        resample=Image.Resampling.BILINEAR,
+                    )
+                )
+
+            grayscale = track(normalized.convert("L"))
+            pixels = list(grayscale.getdata())
+            total_pixels = len(pixels)
+            if total_pixels == 0:
+                return PageContentMetrics(
+                    foreground_ratio=0.0,
+                    edge_ratio=0.0,
+                    intensity_variance=0.0,
+                    is_blank=True,
+                )
+
+            sorted_pixels = sorted(pixels)
+            background_index = min(
+                total_pixels - 1,
+                int(total_pixels * 0.95),
+            )
+            background_level = sorted_pixels[background_index]
+            foreground_pixels = sum(
+                1
+                for value in pixels
+                if (
+                    background_level - value >= FOREGROUND_DELTA_THRESHOLD
+                    and value < FOREGROUND_DARK_THRESHOLD
+                )
+            )
+            foreground_ratio = foreground_pixels / total_pixels
+
+            mean = sum(pixels) / total_pixels
+            intensity_variance = sum((value - mean) ** 2 for value in pixels) / total_pixels
+
+            sample_width, sample_height = grayscale.size
+            edge_pairs = 0
+            edge_hits = 0
+            for y in range(sample_height):
+                row_offset = y * sample_width
+                for x in range(sample_width):
+                    value = pixels[row_offset + x]
+                    if x + 1 < sample_width:
+                        edge_pairs += 1
+                        if abs(value - pixels[row_offset + x + 1]) >= EDGE_DELTA_THRESHOLD:
+                            edge_hits += 1
+                    if y + 1 < sample_height:
+                        edge_pairs += 1
+                        if (
+                            abs(value - pixels[row_offset + sample_width + x])
+                            >= EDGE_DELTA_THRESHOLD
+                        ):
+                            edge_hits += 1
+
+            edge_ratio = edge_hits / edge_pairs if edge_pairs else 0.0
+            is_blank = (
+                foreground_ratio < BLANK_FOREGROUND_RATIO_THRESHOLD
+                and edge_ratio < BLANK_EDGE_RATIO_THRESHOLD
+                and intensity_variance < BLANK_INTENSITY_VARIANCE_THRESHOLD
             )
 
-        grayscale = normalized.convert("L")
-        pixels = list(grayscale.getdata())
-        total_pixels = len(pixels)
-        if total_pixels == 0:
             return PageContentMetrics(
-                foreground_ratio=0.0,
-                edge_ratio=0.0,
-                intensity_variance=0.0,
-                is_blank=True,
+                foreground_ratio=round(foreground_ratio, 6),
+                edge_ratio=round(edge_ratio, 6),
+                intensity_variance=round(float(intensity_variance), 6),
+                is_blank=is_blank,
             )
-
-        sorted_pixels = sorted(pixels)
-        background_index = min(
-            total_pixels - 1,
-            int(total_pixels * 0.95),
-        )
-        background_level = sorted_pixels[background_index]
-        foreground_pixels = sum(
-            1
-            for value in pixels
-            if (
-                background_level - value >= FOREGROUND_DELTA_THRESHOLD
-                and value < FOREGROUND_DARK_THRESHOLD
-            )
-        )
-        foreground_ratio = foreground_pixels / total_pixels
-
-        mean = sum(pixels) / total_pixels
-        intensity_variance = sum((value - mean) ** 2 for value in pixels) / total_pixels
-
-        sample_width, sample_height = grayscale.size
-        edge_pairs = 0
-        edge_hits = 0
-        for y in range(sample_height):
-            row_offset = y * sample_width
-            for x in range(sample_width):
-                value = pixels[row_offset + x]
-                if x + 1 < sample_width:
-                    edge_pairs += 1
-                    if abs(value - pixels[row_offset + x + 1]) >= EDGE_DELTA_THRESHOLD:
-                        edge_hits += 1
-                if y + 1 < sample_height:
-                    edge_pairs += 1
-                    if (
-                        abs(value - pixels[row_offset + sample_width + x])
-                        >= EDGE_DELTA_THRESHOLD
-                    ):
-                        edge_hits += 1
-
-        edge_ratio = edge_hits / edge_pairs if edge_pairs else 0.0
-        is_blank = (
-            foreground_ratio < BLANK_FOREGROUND_RATIO_THRESHOLD
-            and edge_ratio < BLANK_EDGE_RATIO_THRESHOLD
-            and intensity_variance < BLANK_INTENSITY_VARIANCE_THRESHOLD
-        )
-
-        return PageContentMetrics(
-            foreground_ratio=round(foreground_ratio, 6),
-            edge_ratio=round(edge_ratio, 6),
-            intensity_variance=round(float(intensity_variance), 6),
-            is_blank=is_blank,
-        )
     except Exception as e:
         logger.warning(f"Failed to analyze page content: {e}")
         return PageContentMetrics(
@@ -509,12 +517,17 @@ def preprocess_for_vlm(image: Image.Image) -> Image.Image:
         전처리된 PIL 이미지
     """
     # 1. 이미지 모드 정규화
-    image = normalize_image_mode(image, "RGB")
+    normalized = normalize_image_mode(image, "RGB")
+    try:
+        processed = smart_resize(normalized)
+    except Exception:
+        if normalized is not image:
+            normalized.close()
+        raise
 
-    # 2. 스마트 리사이즈
-    image = smart_resize(image)
-
-    return image
+    if processed is not normalized and normalized is not image:
+        normalized.close()
+    return processed
 
 # ==========================================================================
 # [vendored] native_layout
@@ -624,10 +637,15 @@ def is_native_layout_response(content: Any) -> bool:
 
 
 def prepare_native_layout_image(image: Image.Image) -> Image.Image:
-    return image.convert("RGB").resize(
-        NATIVE_LAYOUT_IMAGE_SIZE,
-        Image.Resampling.BICUBIC,
-    )
+    converted = image.convert("RGB")
+    try:
+        return converted.resize(
+            NATIVE_LAYOUT_IMAGE_SIZE,
+            Image.Resampling.BICUBIC,
+        )
+    finally:
+        if converted is not image:
+            converted.close()
 
 
 def parse_native_raw_layout_tokens(content: str) -> list[NativeLayoutItem]:
@@ -2675,10 +2693,12 @@ def _nano_image_to_data_uri(image: Image.Image, *, lossless: bool = False) -> st
         mime_type = "image/png"
         image.save(buffered, format="PNG")
     else:
-        if image.mode not in ("L", "RGB", "CMYK"):
-            image = image.convert("RGB")
-        mime_type = "image/jpeg"
-        image.save(buffered, format="JPEG", quality=95)
+        with close_derived_images(image) as track:
+            encoded_image = image
+            if image.mode not in ("L", "RGB", "CMYK"):
+                encoded_image = track(image.convert("RGB"))
+            mime_type = "image/jpeg"
+            encoded_image.save(buffered, format="JPEG", quality=95)
     b64 = base64.b64encode(buffered.getvalue()).decode("ascii")
     return f"data:{mime_type};base64,{b64}"
 
@@ -2718,9 +2738,8 @@ async def _nano_chat(
     url: str,
     payload: dict,
     semaphore: asyncio.Semaphore,
-) -> str | None:
-    """POST a chat/completions request. Returns content, or None on failure
-    (the orchestrator keeps failed elements with content='')."""
+) -> str:
+    """POST a chat request, classifying terminal client and retryable failures."""
     last_exc: Exception | None = None
     async with semaphore:
         for attempt in range(3):  # tenacity stop_after_attempt(3) equivalent
@@ -2729,24 +2748,31 @@ async def _nano_chat(
                     url,
                     json={**payload, "chat_template_kwargs": {"enable_thinking": False}},
                 )
-                if resp.status_code >= 500:
+                if resp.status_code >= 500 or resp.status_code in (408, 429):
                     raise httpx.HTTPStatusError(
                         f"{resp.status_code}", request=resp.request, response=resp
                     )
                 if resp.status_code >= 400:
-                    logger.warning("4xx from endpoint (not retried): %s", resp.text[:200])
-                    return None
+                    raise ProviderPermanentError(
+                        f"Stage request rejected with HTTP {resp.status_code}: {resp.text[:200]}"
+                    )
                 data = resp.json()
-                return data["choices"][0]["message"]["content"]
-            except (httpx.HTTPError, asyncio.TimeoutError, KeyError, ValueError) as e:
+                content = data["choices"][0]["message"]["content"]
+                if not isinstance(content, str) or not content.strip():
+                    raise ValueError("stage response contained no text content")
+                return content
+            except (httpx.HTTPError, asyncio.TimeoutError, IndexError, KeyError, TypeError, ValueError) as e:
                 last_exc = e
-                await asyncio.sleep(min(10.0, 2.0 * (2 ** attempt)))
-    logger.warning("stage request failed after retries: %s", last_exc)
-    return None
+                if attempt < 2:
+                    await asyncio.sleep(min(10.0, 2.0 * (2**attempt)))
+    assert last_exc is not None
+    raise ProviderTransientError(f"Stage request failed after 3 attempts: {last_exc}") from last_exc
 
 
 def _nano_group_by_bucket(
-    content: List[Dict[str, Any]], original_image: Image.Image
+    content: List[Dict[str, Any]],
+    original_image: Image.Image,
+    track_image: Callable[[Image.Image], Image.Image],
 ) -> Dict[str, List[Dict[str, Any]]]:
     """Verbatim port of result_parser.group_content_by_category."""
     result: Dict[str, List[Dict[str, Any]]] = {
@@ -2773,8 +2799,8 @@ def _nano_group_by_bucket(
             pixel_height = lower - upper
             if pixel_width < 5 or pixel_height < 5:
                 continue
-            cropped_img = original_image.crop((left, upper, right, lower))
-            preprocessed_img = preprocess_for_vlm(cropped_img)
+            cropped_img = track_image(original_image.crop((left, upper, right, lower)))
+            preprocessed_img = track_image(preprocess_for_vlm(cropped_img))
             if is_monochromatic(preprocessed_img):
                 continue
         except Exception:
@@ -3076,6 +3102,23 @@ class _NanoEngine:
         image: Image.Image,
         page_no: int,
     ) -> List[Dict[str, Any]]:
+        with close_derived_images(image) as track:
+            return await self._parse_page_with_owned_images(
+                client,
+                semaphore,
+                image,
+                page_no,
+                track,
+            )
+
+    async def _parse_page_with_owned_images(
+        self,
+        client: httpx.AsyncClient,
+        semaphore: asyncio.Semaphore,
+        image: Image.Image,
+        page_no: int,
+        track: Callable[[Image.Image], Image.Image],
+    ) -> List[Dict[str, Any]]:
         w, h = image.size
         if min(w, h) < 32:
             return []
@@ -3085,7 +3128,7 @@ class _NanoEngine:
         except Exception:
             pass
 
-        layout_image = prepare_native_layout_image(image)
+        layout_image = track(prepare_native_layout_image(image))
         layout_content = await _nano_chat(
             client, self._url, _nano_payload("layout", self._model, layout_image),
             semaphore,
@@ -3098,12 +3141,12 @@ class _NanoEngine:
         items = parse_native_layout_tokens(layout_content)
         for item in items:
             item["page_number"] = page_no
-        buckets = _nano_group_by_bucket(items, image)
+        buckets = _nano_group_by_bucket(items, image, track)
 
         # native full-page table route (single-table pages preserve multi-line
         # cells only with full-page context; adopted only for single clean OTSL)
         fullpage_table = (
-            preprocess_for_vlm(image) if len(buckets["table"]) == 1 else None
+            track(preprocess_for_vlm(image)) if len(buckets["table"]) == 1 else None
         )
 
         tasks = []
@@ -3125,6 +3168,7 @@ class _NanoEngine:
                 el["content"] = content if content is not None else ""
 
         async def recognize_table_fullpage(el: Dict[str, Any]) -> None:
+            assert fullpage_table is not None
             content = await _nano_chat(
                 client, self._url,
                 _nano_payload("table", self._model, fullpage_table), semaphore,

--- a/src/parse_bench/inference/providers/parse/kdl_frontier_nano.py
+++ b/src/parse_bench/inference/providers/parse/kdl_frontier_nano.py
@@ -454,10 +454,7 @@ def analyze_page_content(image: Image.Image) -> PageContentMetrics:
             foreground_pixels = sum(
                 1
                 for value in pixels
-                if (
-                    background_level - value >= FOREGROUND_DELTA_THRESHOLD
-                    and value < FOREGROUND_DARK_THRESHOLD
-                )
+                if (background_level - value >= FOREGROUND_DELTA_THRESHOLD and value < FOREGROUND_DARK_THRESHOLD)
             )
             foreground_ratio = foreground_pixels / total_pixels
 
@@ -477,10 +474,7 @@ def analyze_page_content(image: Image.Image) -> PageContentMetrics:
                             edge_hits += 1
                     if y + 1 < sample_height:
                         edge_pairs += 1
-                        if (
-                            abs(value - pixels[row_offset + sample_width + x])
-                            >= EDGE_DELTA_THRESHOLD
-                        ):
+                        if abs(value - pixels[row_offset + sample_width + x]) >= EDGE_DELTA_THRESHOLD:
                             edge_hits += 1
 
             edge_ratio = edge_hits / edge_pairs if edge_pairs else 0.0
@@ -528,6 +522,7 @@ def preprocess_for_vlm(image: Image.Image) -> Image.Image:
     if processed is not normalized and normalized is not image:
         normalized.close()
     return processed
+
 
 # ==========================================================================
 # [vendored] native_layout
@@ -991,7 +986,7 @@ class TableCell(BaseModel):
         Returns:
             Any: TableCell-compatible dict.
         """
-        if isinstance(data, Dict):
+        if isinstance(data, dict):
             if "text" in data:
                 return data
             text = data["bbox"].get("token", "")
@@ -2749,9 +2744,7 @@ async def _nano_chat(
                     json={**payload, "chat_template_kwargs": {"enable_thinking": False}},
                 )
                 if resp.status_code >= 500 or resp.status_code in (408, 429):
-                    raise httpx.HTTPStatusError(
-                        f"{resp.status_code}", request=resp.request, response=resp
-                    )
+                    raise httpx.HTTPStatusError(f"{resp.status_code}", request=resp.request, response=resp)
                 if resp.status_code >= 400:
                     raise ProviderPermanentError(
                         f"Stage request rejected with HTTP {resp.status_code}: {resp.text[:200]}"
@@ -2761,7 +2754,7 @@ async def _nano_chat(
                 if not isinstance(content, str) or not content.strip():
                     raise ValueError("stage response contained no text content")
                 return content
-            except (httpx.HTTPError, asyncio.TimeoutError, IndexError, KeyError, TypeError, ValueError) as e:
+            except (httpx.HTTPError, TimeoutError, IndexError, KeyError, TypeError, ValueError) as e:
                 last_exc = e
                 if attempt < 2:
                     await asyncio.sleep(min(10.0, 2.0 * (2**attempt)))
@@ -2770,13 +2763,16 @@ async def _nano_chat(
 
 
 def _nano_group_by_bucket(
-    content: List[Dict[str, Any]],
+    content: list[dict[str, Any]],
     original_image: Image.Image,
     track_image: Callable[[Image.Image], Image.Image],
-) -> Dict[str, List[Dict[str, Any]]]:
+) -> dict[str, list[dict[str, Any]]]:
     """Verbatim port of result_parser.group_content_by_category."""
-    result: Dict[str, List[Dict[str, Any]]] = {
-        "text": [], "table": [], "picture": [], "formula": [],
+    result: dict[str, list[dict[str, Any]]] = {
+        "text": [],
+        "table": [],
+        "picture": [],
+        "formula": [],
     }
     im_w, im_h = original_image.size
     for item in content:
@@ -3101,7 +3097,7 @@ class _NanoEngine:
         semaphore: asyncio.Semaphore,
         image: Image.Image,
         page_no: int,
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         with close_derived_images(image) as track:
             return await self._parse_page_with_owned_images(
                 client,
@@ -3118,7 +3114,7 @@ class _NanoEngine:
         image: Image.Image,
         page_no: int,
         track: Callable[[Image.Image], Image.Image],
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         w, h = image.size
         if min(w, h) < 32:
             return []
@@ -3130,7 +3126,9 @@ class _NanoEngine:
 
         layout_image = track(prepare_native_layout_image(image))
         layout_content = await _nano_chat(
-            client, self._url, _nano_payload("layout", self._model, layout_image),
+            client,
+            self._url,
+            _nano_payload("layout", self._model, layout_image),
             semaphore,
         )
         if not layout_content or not layout_content.strip():
@@ -3145,13 +3143,11 @@ class _NanoEngine:
 
         # native full-page table route (single-table pages preserve multi-line
         # cells only with full-page context; adopted only for single clean OTSL)
-        fullpage_table = (
-            track(preprocess_for_vlm(image)) if len(buckets["table"]) == 1 else None
-        )
+        fullpage_table = track(preprocess_for_vlm(image)) if len(buckets["table"]) == 1 else None
 
         tasks = []
 
-        async def recognize(stage: str, el: Dict[str, Any]) -> None:
+        async def recognize(stage: str, el: dict[str, Any]) -> None:
             pre = el.get("preprocessed_image")
             if pre is None:
                 el["content"] = ""
@@ -3167,11 +3163,13 @@ class _NanoEngine:
             else:
                 el["content"] = content if content is not None else ""
 
-        async def recognize_table_fullpage(el: Dict[str, Any]) -> None:
+        async def recognize_table_fullpage(el: dict[str, Any]) -> None:
             assert fullpage_table is not None
             content = await _nano_chat(
-                client, self._url,
-                _nano_payload("table", self._model, fullpage_table), semaphore,
+                client,
+                self._url,
+                _nano_payload("table", self._model, fullpage_table),
+                semaphore,
             )
             if content is not None and _nano_is_single_clean_otsl(content):
                 el["content"] = content
@@ -3191,7 +3189,7 @@ class _NanoEngine:
             tasks.append(recognize("formula", el))
         await asyncio.gather(*tasks)
 
-        page_elements: List[Dict[str, Any]] = []
+        page_elements: list[dict[str, Any]] = []
         picture_idx = 0
         for bucket_name in ("text", "table", "picture", "formula"):
             for el in buckets[bucket_name]:
@@ -3205,10 +3203,8 @@ class _NanoEngine:
                     # metrics consume the markdown text only and never
                     # dereference image paths.
                     if cropped is not None and cropped.width >= 25 and cropped.height >= 25:
-                        el["picture_path"] = (
-                            "artifacts/cropped_pictures/"
-                            f"page_{page_no:03d}_picture_{picture_idx:03d}.png"
-                        )
+                        picture_name = f"page_{page_no:03d}_picture_{picture_idx:03d}.png"
+                        el["picture_path"] = f"artifacts/cropped_pictures/{picture_name}"
                     picture_idx += 1
                 page_elements.append(el)
         return page_elements
@@ -3221,26 +3217,18 @@ class KdlFrontierNanoProvider(Provider):
 
     def __init__(self, provider_name: str, base_config: dict[str, Any] | None = None):
         super().__init__(provider_name, base_config)
-        self._endpoint_url = (
-            self.base_config.get("endpoint_url")
-            or os.getenv("KDL_NANO_ENDPOINT_URL")
-            or ""
-        ).rstrip("/")
+        self._endpoint_url = (self.base_config.get("endpoint_url") or os.getenv("KDL_NANO_ENDPOINT_URL") or "").rstrip(
+            "/"
+        )
         if not self._endpoint_url:
             raise ProviderConfigError(
                 "KDL_NANO_ENDPOINT_URL is required (vLLM OpenAI-compatible base "
                 "URL ending in /v1, serving KDLAI/KDL-Frontier-Parser-nano)."
             )
-        self._model = (
-            self.base_config.get("model")
-            or os.getenv("KDL_NANO_MODEL")
-            or "kdl-frontier-parser-nano"
-        )
+        self._model = self.base_config.get("model") or os.getenv("KDL_NANO_MODEL") or "kdl-frontier-parser-nano"
         self._dpi = int(self.base_config.get("dpi", os.getenv("KDL_NANO_DPI", "144")))
         self._timeout = float(self.base_config.get("timeout", 900))
-        self._max_pages = int(
-            self.base_config.get("max_pages", os.getenv("KDL_NANO_MAX_PAGES", "400"))
-        )
+        self._max_pages = int(self.base_config.get("max_pages", os.getenv("KDL_NANO_MAX_PAGES", "400")))
         self._max_concurrent = int(os.getenv("KDL_NANO_MAX_CONCURRENT", "8"))
 
     @contextmanager

--- a/src/parse_bench/inference/providers/parse/kdl_frontier_nano.py
+++ b/src/parse_bench/inference/providers/parse/kdl_frontier_nano.py
@@ -3005,7 +3005,7 @@ class _NanoEngine:
         # cells only with full-page context; adopted only for single clean OTSL)
         fullpage_table = track(preprocess_for_vlm(image)) if len(buckets["table"]) == 1 else None
 
-        tasks = []
+        recognition_coroutines = []
 
         async def recognize(stage: str, el: dict[str, Any]) -> None:
             pre = el.get("preprocessed_image")
@@ -3035,17 +3035,28 @@ class _NanoEngine:
             await recognize("table", el)
 
         for el in buckets["text"]:
-            tasks.append(recognize("text", el))
+            recognition_coroutines.append(recognize("text", el))
         for i, el in enumerate(buckets["table"]):
             if fullpage_table is not None and i == 0:
-                tasks.append(recognize_table_fullpage(el))
+                recognition_coroutines.append(recognize_table_fullpage(el))
             else:
-                tasks.append(recognize("table", el))
+                recognition_coroutines.append(recognize("table", el))
         for el in buckets["picture"]:
-            tasks.append(recognize("picture", el))
+            recognition_coroutines.append(recognize("picture", el))
         for el in buckets["formula"]:
-            tasks.append(recognize("formula", el))
-        await asyncio.gather(*tasks)
+            recognition_coroutines.append(recognize("formula", el))
+
+        recognition_tasks = [asyncio.create_task(coroutine) for coroutine in recognition_coroutines]
+        try:
+            await asyncio.gather(*recognition_tasks)
+        except BaseException:
+            for task in recognition_tasks:
+                if not task.done():
+                    task.cancel()
+            # Keep page-owned crops and preprocessed images alive until every
+            # billable sibling has observed cancellation and settled.
+            await asyncio.gather(*recognition_tasks, return_exceptions=True)
+            raise
 
         page_elements: list[dict[str, Any]] = []
         picture_idx = 0

--- a/src/parse_bench/inference/providers/parse/mineru25.py
+++ b/src/parse_bench/inference/providers/parse/mineru25.py
@@ -29,6 +29,7 @@ from parse_bench.inference.providers.base import (
     ProviderPermanentError,
     ProviderTransientError,
 )
+from parse_bench.inference.providers.parse._multipage_image import normalize_pdf_pages, run_pdf_pages
 from parse_bench.inference.providers.registry import register_provider
 from parse_bench.schemas.parse_output import (
     LayoutItemIR,
@@ -132,6 +133,10 @@ class MinerU25Provider(Provider):
         }
 
     def run_inference(self, pipeline: PipelineSpec, request: InferenceRequest) -> RawInferenceResult:
+        multipage_result = run_pdf_pages(pipeline, request, dpi=self._dpi, run_single_image=self.run_inference)
+        if multipage_result is not None:
+            return multipage_result
+
         if request.product_type != ProductType.PARSE:
             raise ProviderPermanentError(
                 f"MinerU25Provider only supports PARSE product type, got {request.product_type}"
@@ -333,6 +338,10 @@ class MinerU25Provider(Provider):
         ]
 
     def normalize(self, raw_result: RawInferenceResult) -> InferenceResult:
+        multipage_result = normalize_pdf_pages(raw_result, normalize_single_image=self.normalize)
+        if multipage_result is not None:
+            return multipage_result
+
         if raw_result.product_type != ProductType.PARSE:
             raise ProviderPermanentError(
                 f"MinerU25Provider only supports PARSE product type, got {raw_result.product_type}"

--- a/src/parse_bench/inference/providers/parse/mineru25.py
+++ b/src/parse_bench/inference/providers/parse/mineru25.py
@@ -57,6 +57,8 @@ class MinerU25Provider(Provider):
         - dpi (int, default=150): PDF → image render DPI
     """
 
+    PDF_RENDER_DPI = 150
+
     def __init__(self, provider_name: str, base_config: dict[str, Any] | None = None):
         super().__init__(provider_name, base_config)
 
@@ -67,7 +69,7 @@ class MinerU25Provider(Provider):
             )
         self._server_url: str = str(server_url)
         self._timeout = self.base_config.get("timeout", 600)
-        self._dpi = self.base_config.get("dpi", 150)
+        self._dpi = self.base_config.get("dpi", self.PDF_RENDER_DPI)
 
     def _pdf_to_image(self, pdf_path: Path) -> bytes:
         try:

--- a/src/parse_bench/inference/providers/parse/mineru2605pro.py
+++ b/src/parse_bench/inference/providers/parse/mineru2605pro.py
@@ -34,6 +34,7 @@ from parse_bench.inference.providers.base import (
     ProviderPermanentError,
     ProviderTransientError,
 )
+from parse_bench.inference.providers.parse._multipage_image import normalize_pdf_pages, run_pdf_pages
 from parse_bench.inference.providers.registry import register_provider
 from parse_bench.schemas.parse_output import (
     LayoutItemIR,
@@ -138,6 +139,10 @@ class MinerU2605ProProvider(Provider):
         }
 
     def run_inference(self, pipeline: PipelineSpec, request: InferenceRequest) -> RawInferenceResult:
+        multipage_result = run_pdf_pages(pipeline, request, dpi=self._dpi, run_single_image=self.run_inference)
+        if multipage_result is not None:
+            return multipage_result
+
         if request.product_type != ProductType.PARSE:
             raise ProviderPermanentError(
                 f"MinerU2605ProProvider only supports PARSE product type, got {request.product_type}"
@@ -352,6 +357,10 @@ class MinerU2605ProProvider(Provider):
         ]
 
     def normalize(self, raw_result: RawInferenceResult) -> InferenceResult:
+        multipage_result = normalize_pdf_pages(raw_result, normalize_single_image=self.normalize)
+        if multipage_result is not None:
+            return multipage_result
+
         if raw_result.product_type != ProductType.PARSE:
             raise ProviderPermanentError(
                 f"MinerU2605ProProvider only supports PARSE product type, got {raw_result.product_type}"

--- a/src/parse_bench/inference/providers/parse/mineru2605pro.py
+++ b/src/parse_bench/inference/providers/parse/mineru2605pro.py
@@ -62,6 +62,8 @@ class MinerU2605ProProvider(Provider):
         - dpi (int, default=150): PDF → image render DPI
     """
 
+    PDF_RENDER_DPI = 150
+
     def __init__(self, provider_name: str, base_config: dict[str, Any] | None = None):
         super().__init__(provider_name, base_config)
 
@@ -72,7 +74,7 @@ class MinerU2605ProProvider(Provider):
             )
         self._server_url: str = str(server_url)
         self._timeout = self.base_config.get("timeout", 600)
-        self._dpi = self.base_config.get("dpi", 150)
+        self._dpi = self.base_config.get("dpi", self.PDF_RENDER_DPI)
 
     def _pdf_to_image(self, pdf_path: Path) -> bytes:
         try:

--- a/src/parse_bench/inference/providers/parse/mineru_diffusion.py
+++ b/src/parse_bench/inference/providers/parse/mineru_diffusion.py
@@ -62,6 +62,8 @@ class MinerUDiffusionProvider(Provider):
         - dpi (int, default=150): PDF -> image render DPI
     """
 
+    PDF_RENDER_DPI = 150
+
     def __init__(self, provider_name: str, base_config: dict[str, Any] | None = None):
         super().__init__(provider_name, base_config)
 
@@ -73,7 +75,7 @@ class MinerUDiffusionProvider(Provider):
             )
         self._server_url: str = str(server_url)
         self._timeout = self.base_config.get("timeout", 900)
-        self._dpi = self.base_config.get("dpi", 150)
+        self._dpi = self.base_config.get("dpi", self.PDF_RENDER_DPI)
 
     def _pdf_to_image(self, pdf_path: Path) -> bytes:
         try:

--- a/src/parse_bench/inference/providers/parse/mineru_diffusion.py
+++ b/src/parse_bench/inference/providers/parse/mineru_diffusion.py
@@ -33,6 +33,7 @@ from parse_bench.inference.providers.base import (
     ProviderPermanentError,
     ProviderTransientError,
 )
+from parse_bench.inference.providers.parse._multipage_image import normalize_pdf_pages, run_pdf_pages
 from parse_bench.inference.providers.registry import register_provider
 from parse_bench.schemas.parse_output import (
     LayoutItemIR,
@@ -131,6 +132,10 @@ class MinerUDiffusionProvider(Provider):
         }
 
     def run_inference(self, pipeline: PipelineSpec, request: InferenceRequest) -> RawInferenceResult:
+        multipage_result = run_pdf_pages(pipeline, request, dpi=self._dpi, run_single_image=self.run_inference)
+        if multipage_result is not None:
+            return multipage_result
+
         if request.product_type != ProductType.PARSE:
             raise ProviderPermanentError(
                 f"MinerUDiffusionProvider only supports PARSE product type, got {request.product_type}"
@@ -305,6 +310,10 @@ class MinerUDiffusionProvider(Provider):
         ]
 
     def normalize(self, raw_result: RawInferenceResult) -> InferenceResult:
+        multipage_result = normalize_pdf_pages(raw_result, normalize_single_image=self.normalize)
+        if multipage_result is not None:
+            return multipage_result
+
         if raw_result.product_type != ProductType.PARSE:
             raise ProviderPermanentError(
                 f"MinerUDiffusionProvider only supports PARSE product type, got {raw_result.product_type}"

--- a/src/parse_bench/inference/providers/parse/nemotron_omni.py
+++ b/src/parse_bench/inference/providers/parse/nemotron_omni.py
@@ -37,6 +37,7 @@ from parse_bench.inference.providers.parse._layout_utils import (
     items_to_markdown,
     parse_layout_blocks,
 )
+from parse_bench.inference.providers.parse._multipage_image import normalize_pdf_pages, run_pdf_pages
 from parse_bench.inference.providers.registry import register_provider
 from parse_bench.schemas.parse_output import ParseOutput
 from parse_bench.schemas.pipeline import PipelineSpec
@@ -116,8 +117,7 @@ class NemotronOmniProvider(Provider):
         server_url = self.base_config.get("server_url") or os.getenv("NEMOTRON_OMNI_SERVER_URL")
         if not server_url:
             raise ProviderConfigError(
-                "NemotronOmni provider requires 'server_url' in config or "
-                "NEMOTRON_OMNI_SERVER_URL in the environment."
+                "NemotronOmni provider requires 'server_url' in config or NEMOTRON_OMNI_SERVER_URL in the environment."
             )
         self._server_url: str = str(server_url)
 
@@ -270,6 +270,10 @@ class NemotronOmniProvider(Provider):
         return result
 
     def run_inference(self, pipeline: PipelineSpec, request: InferenceRequest) -> RawInferenceResult:
+        multipage_result = run_pdf_pages(pipeline, request, dpi=self._dpi, run_single_image=self.run_inference)
+        if multipage_result is not None:
+            return multipage_result
+
         if request.product_type != ProductType.PARSE:
             raise ProviderPermanentError(f"NemotronOmniProvider only supports PARSE, got {request.product_type}")
 
@@ -398,6 +402,10 @@ class NemotronOmniProvider(Provider):
     # ------------------------------------------------------------------
 
     def normalize(self, raw_result: RawInferenceResult) -> InferenceResult:
+        multipage_result = normalize_pdf_pages(raw_result, normalize_single_image=self.normalize)
+        if multipage_result is not None:
+            return multipage_result
+
         if raw_result.product_type != ProductType.PARSE:
             raise ProviderPermanentError(f"NemotronOmniProvider only supports PARSE, got {raw_result.product_type}")
 

--- a/src/parse_bench/inference/providers/parse/nemotron_omni.py
+++ b/src/parse_bench/inference/providers/parse/nemotron_omni.py
@@ -111,6 +111,8 @@ class NemotronOmniProvider(Provider):
         - api_key_env (str, default="VLLM_API_KEY"): Env var for API key
     """
 
+    PDF_RENDER_DPI = 150
+
     def __init__(self, provider_name: str, base_config: dict[str, Any] | None = None):
         super().__init__(provider_name, base_config)
 
@@ -124,7 +126,7 @@ class NemotronOmniProvider(Provider):
         self._model = self.base_config.get("model", DEFAULT_SERVED_MODEL_NAME)
         self._prompt_mode = self.base_config.get("prompt_mode", "parse")
         self._timeout = self.base_config.get("timeout", 900)
-        self._dpi = self.base_config.get("dpi", 150)
+        self._dpi = self.base_config.get("dpi", self.PDF_RENDER_DPI)
         self._max_tokens = self.base_config.get("max_tokens", 8192)
         self._temperature = self.base_config.get("temperature", 0.2)
         self._top_k = self.base_config.get("top_k", 1)

--- a/src/parse_bench/inference/providers/parse/nemotron_omni.py
+++ b/src/parse_bench/inference/providers/parse/nemotron_omni.py
@@ -169,8 +169,8 @@ class NemotronOmniProvider(Provider):
         from PIL import Image
 
         try:
-            img = Image.open(file_path)
-            w, h = img.size
+            with Image.open(file_path) as img:
+                w, h = img.size
             return file_path.read_bytes(), w, h
         except Exception as e:
             raise ProviderPermanentError(f"Error reading image file: {e}") from e

--- a/src/parse_bench/inference/providers/parse/openai.py
+++ b/src/parse_bench/inference/providers/parse/openai.py
@@ -22,8 +22,11 @@ from parse_bench.inference.providers.parse._layout_utils import (
     parse_layout_response,
     resolve_layout_prompts,
     split_pdf_to_pages,
+    validated_sorted_page_records,
 )
 from parse_bench.inference.providers.parse._multipage_image import (
+    annotate_attempt_costs,
+    append_attempt_usages,
     close_derived_images,
     open_document_page_images,
     run_page_with_retries,
@@ -306,7 +309,12 @@ class OpenAIProvider(Provider):
             usage = self._extract_usage(response)
 
             # Extract text from response
-            return self._extract_response_text(response, context="image"), usage
+            try:
+                text = self._extract_response_text(response, context="image")
+            except ProviderTransientError as exc:
+                exc.attempt_stats = usage
+                raise
+            return text, usage
 
         except (ProviderPermanentError, ProviderTransientError):
             raise
@@ -354,8 +362,12 @@ class OpenAIProvider(Provider):
             response = self._client.chat.completions.create(**kwargs)
 
             usage = self._extract_usage(response)
-            text = self._extract_response_text(response, context="image layout")
-            items = self._parse_layout_response(text)
+            try:
+                text = self._extract_response_text(response, context="image layout")
+                items = self._parse_layout_response(text)
+            except ProviderTransientError as exc:
+                exc.attempt_stats = usage
+                raise
             return items, text, usage
 
         except (ProviderPermanentError, ProviderTransientError):
@@ -415,7 +427,12 @@ class OpenAIProvider(Provider):
             usage = self._extract_usage(response)
 
             # Extract text from response
-            return self._extract_response_text(response, context="PDF"), usage
+            try:
+                text = self._extract_response_text(response, context="PDF")
+            except ProviderTransientError as exc:
+                exc.attempt_stats = usage
+                raise
+            return text, usage
 
         except (ProviderPermanentError, ProviderTransientError):
             raise
@@ -464,8 +481,12 @@ class OpenAIProvider(Provider):
             response = self._client.chat.completions.create(**kwargs)
 
             usage = self._extract_usage(response)
-            text = self._extract_response_text(response, context="PDF layout page")
-            items = self._parse_layout_response(text)
+            try:
+                text = self._extract_response_text(response, context="PDF layout page")
+                items = self._parse_layout_response(text)
+            except ProviderTransientError as exc:
+                exc.attempt_stats = usage
+                raise
             return items, text, usage
 
         except (ProviderPermanentError, ProviderTransientError):
@@ -530,6 +551,7 @@ class OpenAIProvider(Provider):
 
         try:
             page_usages: list[dict[str, int]] = []
+            api_attempts: list[dict[str, object]] = []
 
             if self._mode == "file":
                 if source_path.suffix.lower() == ".pdf":
@@ -567,12 +589,15 @@ class OpenAIProvider(Provider):
                     pdf_pages = split_pdf_to_pages(str(source_path))
                     pages = []
                     for page_index, (pdf_bytes, w, h) in enumerate(pdf_pages):
+                        attempts: list[dict[str, object]] = []
                         items, raw_content, usage = run_page_with_retries(
                             partial(self._parse_pdf_page_with_layout, pdf_bytes),
                             provider_name=pipeline.provider_name,
                             page_number=page_index + 1,
+                            attempt_ledger=attempts,
                         )
-                        page_usages.append(usage)
+                        api_attempts.extend(attempts)
+                        append_attempt_usages(page_usages, attempts)
                         pages.append(
                             {
                                 "page_index": page_index,
@@ -586,12 +611,15 @@ class OpenAIProvider(Provider):
                 else:
                     # Non-PDF: fall back to image-based layout parsing
                     with Image.open(source_path) as image:
+                        attempts = []
                         items, raw_content, usage = run_page_with_retries(
                             partial(self._parse_image_with_layout, image),
                             provider_name=pipeline.provider_name,
                             page_number=1,
+                            attempt_ledger=attempts,
                         )
-                        page_usages.append(usage)
+                        api_attempts.extend(attempts)
+                        append_attempt_usages(page_usages, attempts)
                         pages = [
                             {
                                 "page_index": 0,
@@ -609,12 +637,15 @@ class OpenAIProvider(Provider):
                 with open_document_page_images(source_path, dpi=self._dpi) as images:
                     for page_index, image in enumerate(images):
                         if self._mode == "parse_with_layout":
+                            attempts = []
                             items, raw_content, usage = run_page_with_retries(
                                 partial(self._parse_image_with_layout, image),
                                 provider_name=pipeline.provider_name,
                                 page_number=page_index + 1,
+                                attempt_ledger=attempts,
                             )
-                            page_usages.append(usage)
+                            api_attempts.extend(attempts)
+                            append_attempt_usages(page_usages, attempts)
                             pages.append(
                                 {
                                     "page_index": page_index,
@@ -625,12 +656,15 @@ class OpenAIProvider(Provider):
                                 }
                             )
                         else:
+                            attempts = []
                             markdown, usage = run_page_with_retries(
                                 partial(self._parse_image, image),
                                 provider_name=pipeline.provider_name,
                                 page_number=page_index + 1,
+                                attempt_ledger=attempts,
                             )
-                            page_usages.append(usage)
+                            api_attempts.extend(attempts)
+                            append_attempt_usages(page_usages, attempts)
                             pages.append(
                                 {
                                     "page_index": page_index,
@@ -652,6 +686,11 @@ class OpenAIProvider(Provider):
 
             # Compute cost
             input_rate, output_rate = self._get_pricing()
+            annotate_attempt_costs(
+                api_attempts,
+                input_rate_per_million=input_rate,
+                output_rate_per_million=output_rate,
+            )
             cost = (total_input * input_rate + (total_output + total_thinking) * output_rate) / 1_000_000
 
             config_info: dict[str, Any] = {
@@ -677,6 +716,8 @@ class OpenAIProvider(Provider):
                 "cost_per_page_usd": cost / num_pages if num_pages > 0 else 0.0,
                 "input_tokens_per_page": total_input / num_pages if num_pages > 0 else 0.0,
                 "output_tokens_per_page": total_output / num_pages if num_pages > 0 else 0.0,
+                "num_api_calls": len(api_attempts) if api_attempts else len(page_usages),
+                "api_attempts": api_attempts,
             }
 
             return RawInferenceResult(
@@ -714,7 +755,7 @@ class OpenAIProvider(Provider):
         page_markdowns: list[str] = []
         layout_pages: list[ParseLayoutPageIR] = []
 
-        for page_data in raw_result.raw_output.get("pages", []):
+        for page_data in validated_sorted_page_records(raw_result.raw_output.get("pages", [])):
             page_index = page_data.get("page_index", 0)
 
             if mode in ("parse_with_layout", "parse_with_layout_file"):
@@ -738,8 +779,6 @@ class OpenAIProvider(Provider):
             pages.append(PageIR(page_index=page_index, markdown=markdown))
             page_markdowns.append(markdown)
 
-        # Sort by page index and concatenate in sorted order
-        pages.sort(key=lambda p: p.page_index)
         full_markdown = "\n\n".join(page_markdowns)
 
         output = ParseOutput(

--- a/src/parse_bench/inference/providers/parse/openai.py
+++ b/src/parse_bench/inference/providers/parse/openai.py
@@ -22,6 +22,7 @@ from parse_bench.inference.providers.parse._layout_utils import (
     resolve_layout_prompts,
     split_pdf_to_pages,
 )
+from parse_bench.inference.providers.parse._multipage_image import open_document_page_images
 from parse_bench.inference.providers.registry import register_provider
 from parse_bench.schemas.parse_output import PageIR, ParseLayoutPageIR, ParseOutput
 from parse_bench.schemas.pipeline import PipelineSpec
@@ -255,24 +256,6 @@ class OpenAIProvider(Provider):
         image.save(buffer, format="JPEG", quality=min_quality)
         buffer.seek(0)
         return base64.standard_b64encode(buffer.getvalue()).decode("utf-8")
-
-    def _pdf_to_images(self, pdf_path: str) -> list[Image.Image]:
-        """
-        Convert PDF pages to images.
-
-        :param pdf_path: Path to the PDF file
-        :return: List of PIL Images, one per page
-        """
-        try:
-            from pdf2image import convert_from_path
-        except ImportError as e:
-            raise ProviderConfigError("pdf2image package not installed. Run: pip install pdf2image") from e
-
-        try:
-            images = convert_from_path(pdf_path, dpi=self._dpi)
-            return images
-        except Exception as e:
-            raise ProviderPermanentError(f"Failed to convert PDF to images: {e}") from e
 
     def _parse_image(self, image: Image.Image) -> tuple[str, dict[str, int]]:
         """
@@ -533,17 +516,17 @@ class OpenAIProvider(Provider):
                     num_pages = 1  # We don't know actual page count in file mode
                 else:
                     # Non-PDF: fall back to image-based parsing
-                    image = Image.open(source_path)
-                    markdown, usage = self._parse_image(image)
-                    page_usages.append(usage)
-                    pages = [
-                        {
-                            "page_index": 0,
-                            "markdown": markdown,
-                            "width": image.width,
-                            "height": image.height,
-                        }
-                    ]
+                    with Image.open(source_path) as image:
+                        markdown, usage = self._parse_image(image)
+                        page_usages.append(usage)
+                        pages = [
+                            {
+                                "page_index": 0,
+                                "markdown": markdown,
+                                "width": image.width,
+                                "height": image.height,
+                            }
+                        ]
                     num_pages = 1
             elif self._mode == "parse_with_layout_file":
                 if source_path.suffix.lower() == ".pdf":
@@ -565,54 +548,49 @@ class OpenAIProvider(Provider):
                     num_pages = len(pdf_pages)
                 else:
                     # Non-PDF: fall back to image-based layout parsing
-                    image = Image.open(source_path)
-                    items, raw_content, usage = self._parse_image_with_layout(image)
-                    page_usages.append(usage)
-                    pages = [
-                        {
-                            "page_index": 0,
-                            "items": items,
-                            "raw_content": raw_content,
-                            "width": image.width,
-                            "height": image.height,
-                        }
-                    ]
-                    num_pages = 1
-            else:
-                # Image mode (both "image" and "parse_with_layout"):
-                # convert PDF to images and process each page
-                if source_path.suffix.lower() == ".pdf":
-                    images = self._pdf_to_images(str(source_path))
-                else:
-                    images = [Image.open(source_path)]
-
-                # Parse each page
-                pages = []
-                for page_index, image in enumerate(images):  # type: ignore[assignment]
-                    if self._mode == "parse_with_layout":
+                    with Image.open(source_path) as image:
                         items, raw_content, usage = self._parse_image_with_layout(image)
                         page_usages.append(usage)
-                        pages.append(
+                        pages = [
                             {
-                                "page_index": page_index,
+                                "page_index": 0,
                                 "items": items,
                                 "raw_content": raw_content,
                                 "width": image.width,
                                 "height": image.height,
                             }
-                        )
-                    else:
-                        markdown, usage = self._parse_image(image)
-                        page_usages.append(usage)
-                        pages.append(
-                            {
-                                "page_index": page_index,
-                                "markdown": markdown,
-                                "width": image.width,
-                                "height": image.height,
-                            }
-                        )
-                num_pages = len(images)
+                        ]
+                    num_pages = 1
+            else:
+                # Image mode (both "image" and "parse_with_layout"):
+                # convert PDF to images and process each page
+                pages = []
+                with open_document_page_images(source_path, dpi=self._dpi) as images:
+                    for page_index, image in enumerate(images):
+                        if self._mode == "parse_with_layout":
+                            items, raw_content, usage = self._parse_image_with_layout(image)
+                            page_usages.append(usage)
+                            pages.append(
+                                {
+                                    "page_index": page_index,
+                                    "items": items,
+                                    "raw_content": raw_content,
+                                    "width": image.width,
+                                    "height": image.height,
+                                }
+                            )
+                        else:
+                            markdown, usage = self._parse_image(image)
+                            page_usages.append(usage)
+                            pages.append(
+                                {
+                                    "page_index": page_index,
+                                    "markdown": markdown,
+                                    "width": image.width,
+                                    "height": image.height,
+                                }
+                            )
+                    num_pages = len(images)
 
             completed_at = datetime.now()
             latency_ms = int((completed_at - started_at).total_seconds() * 1000)

--- a/src/parse_bench/inference/providers/parse/openai.py
+++ b/src/parse_bench/inference/providers/parse/openai.py
@@ -4,6 +4,7 @@ import base64
 import io
 import os
 from datetime import datetime
+from functools import partial
 from pathlib import Path
 from typing import Any
 
@@ -25,6 +26,7 @@ from parse_bench.inference.providers.parse._layout_utils import (
 from parse_bench.inference.providers.parse._multipage_image import (
     close_derived_images,
     open_document_page_images,
+    run_page_with_retries,
 )
 from parse_bench.inference.providers.registry import register_provider
 from parse_bench.schemas.parse_output import PageIR, ParseLayoutPageIR, ParseOutput
@@ -469,7 +471,7 @@ class OpenAIProvider(Provider):
             if any(kw in error_str for kw in ["rate_limit", "rate limit", "429"]):
                 raise ProviderTransientError(f"Rate limited: {e}") from e
             # GPT-5.6 intermittently returns a 401 "insufficient permissions"
-            # that clears on retry; treat it as transient so the runner retries.
+            # that clears on retry; classify it for the active retry owner.
             is_gpt56_401_blip = (
                 self._model.startswith("gpt-5.6-") and "insufficient permissions for this operation" in error_str
             )
@@ -572,7 +574,11 @@ class OpenAIProvider(Provider):
                 with open_document_page_images(source_path, dpi=self._dpi) as images:
                     for page_index, image in enumerate(images):
                         if self._mode == "parse_with_layout":
-                            items, raw_content, usage = self._parse_image_with_layout(image)
+                            items, raw_content, usage = run_page_with_retries(
+                                partial(self._parse_image_with_layout, image),
+                                provider_name=pipeline.provider_name,
+                                page_number=page_index + 1,
+                            )
                             page_usages.append(usage)
                             pages.append(
                                 {
@@ -584,7 +590,11 @@ class OpenAIProvider(Provider):
                                 }
                             )
                         else:
-                            markdown, usage = self._parse_image(image)
+                            markdown, usage = run_page_with_retries(
+                                partial(self._parse_image, image),
+                                provider_name=pipeline.provider_name,
+                                page_number=page_index + 1,
+                            )
                             page_usages.append(usage)
                             pages.append(
                                 {

--- a/src/parse_bench/inference/providers/parse/openai.py
+++ b/src/parse_bench/inference/providers/parse/openai.py
@@ -30,6 +30,7 @@ from parse_bench.inference.providers.parse._multipage_image import (
     attempt_usages_complete,
     close_derived_images,
     open_document_page_images,
+    run_page_once,
     run_page_with_retries,
 )
 from parse_bench.inference.providers.registry import register_provider
@@ -185,6 +186,10 @@ class OpenAIProvider(Provider):
         details = getattr(usage, "completion_tokens_details", None)
         thinking_tok = getattr(details, "reasoning_tokens", 0) or 0 if details else 0
         result = {"thinking_tokens": int(thinking_tok)}
+        prompt_details = getattr(usage, "prompt_tokens_details", None)
+        cached_tokens = getattr(prompt_details, "cached_tokens", None) if prompt_details else None
+        if cached_tokens is not None:
+            result["cached_content_tokens"] = int(cached_tokens)
         for key, attribute in (
             ("input_tokens", "prompt_tokens"),
             ("output_tokens", "completion_tokens"),
@@ -554,12 +559,19 @@ class OpenAIProvider(Provider):
         try:
             page_usages: list[dict[str, int]] = []
             api_attempts: list[dict[str, object]] = []
+            attempts: list[dict[str, object]]
 
             if self._mode == "file":
                 if source_path.suffix.lower() == ".pdf":
                     # File mode: send raw PDF to API
-                    markdown, usage = self._parse_pdf_file(str(source_path))
-                    page_usages.append(usage)
+                    attempts = []
+                    markdown, usage = run_page_once(
+                        partial(self._parse_pdf_file, str(source_path)),
+                        page_number=1,
+                        attempt_ledger=attempts,
+                    )
+                    api_attempts.extend(attempts)
+                    append_attempt_usages(page_usages, attempts)
                     # In file mode, we get one response for the entire document
                     # We don't have page-level info, so we treat it as a single "page"
                     pages = [
@@ -574,8 +586,14 @@ class OpenAIProvider(Provider):
                 else:
                     # Non-PDF: fall back to image-based parsing
                     with Image.open(source_path) as image:
-                        markdown, usage = self._parse_image(image)
-                        page_usages.append(usage)
+                        attempts = []
+                        markdown, usage = run_page_once(
+                            partial(self._parse_image, image),
+                            page_number=1,
+                            attempt_ledger=attempts,
+                        )
+                        api_attempts.extend(attempts)
+                        append_attempt_usages(page_usages, attempts)
                         pages = [
                             {
                                 "page_index": 0,
@@ -591,7 +609,7 @@ class OpenAIProvider(Provider):
                     pdf_pages = split_pdf_to_pages(str(source_path))
                     pages = []
                     for page_index, (pdf_bytes, w, h) in enumerate(pdf_pages):
-                        attempts: list[dict[str, object]] = []
+                        attempts = []
                         items, raw_content, usage = run_page_with_retries(
                             partial(self._parse_pdf_page_with_layout, pdf_bytes),
                             provider_name=pipeline.provider_name,
@@ -683,24 +701,23 @@ class OpenAIProvider(Provider):
             completed_at = datetime.now()
             latency_ms = int((completed_at - started_at).total_seconds() * 1000)
 
-            # Aggregate token usage across pages
-            total_input = sum(u["input_tokens"] for u in page_usages)
-            total_output = sum(u["output_tokens"] for u in page_usages)
-            total_thinking = sum(u["thinking_tokens"] for u in page_usages)
-            total_all = sum(u["total_tokens"] for u in page_usages)
-
-            usage_summary = (
-                {
-                    "input_tokens": total_input,
-                    "output_tokens": total_output,
-                    "thinking_tokens": total_thinking,
-                    "total_tokens": total_all,
-                    "input_tokens_per_page": total_input / num_pages if num_pages > 0 else 0.0,
-                    "output_tokens_per_page": total_output / num_pages if num_pages > 0 else 0.0,
-                }
-                if attempt_usages_complete(page_usages)
-                else {}
-            )
+            # Aggregate token usage only when every physical call reported it.
+            usage_summary: dict[str, int | float] = {}
+            if attempt_usages_complete(page_usages):
+                total_input = sum(u["input_tokens"] for u in page_usages)
+                total_output = sum(u["output_tokens"] for u in page_usages)
+                total_thinking = sum(u["thinking_tokens"] for u in page_usages)
+                total_all = sum(u["total_tokens"] for u in page_usages)
+                usage_summary.update(
+                    {
+                        "input_tokens": total_input,
+                        "output_tokens": total_output,
+                        "thinking_tokens": total_thinking,
+                        "total_tokens": total_all,
+                        "input_tokens_per_page": total_input / num_pages if num_pages > 0 else 0.0,
+                        "output_tokens_per_page": total_output / num_pages if num_pages > 0 else 0.0,
+                    }
+                )
             pricing = self._get_pricing()
             if pricing is not None and attempt_usages_complete(page_usages):
                 input_rate, output_rate = pricing
@@ -708,14 +725,16 @@ class OpenAIProvider(Provider):
                     api_attempts,
                     input_rate_per_million=input_rate,
                     output_rate_per_million=output_rate,
+                    output_tokens_include_thinking=True,
                 )
-                cost = (total_input * input_rate + (total_output + total_thinking) * output_rate) / 1_000_000
-                usage_summary.update(
-                    {
-                        "cost_usd": cost,
-                        "cost_per_page_usd": cost / num_pages if num_pages > 0 else 0.0,
-                    }
-                )
+                if not any(usage.get("cached_content_tokens", 0) for usage in page_usages):
+                    cost = (total_input * input_rate + total_output * output_rate) / 1_000_000
+                    usage_summary.update(
+                        {
+                            "cost_usd": cost,
+                            "cost_per_page_usd": cost / num_pages if num_pages > 0 else 0.0,
+                        }
+                    )
 
             config_info: dict[str, Any] = {
                 "dpi": self._dpi,

--- a/src/parse_bench/inference/providers/parse/openai.py
+++ b/src/parse_bench/inference/providers/parse/openai.py
@@ -22,7 +22,10 @@ from parse_bench.inference.providers.parse._layout_utils import (
     resolve_layout_prompts,
     split_pdf_to_pages,
 )
-from parse_bench.inference.providers.parse._multipage_image import open_document_page_images
+from parse_bench.inference.providers.parse._multipage_image import (
+    close_derived_images,
+    open_document_page_images,
+)
 from parse_bench.inference.providers.registry import register_provider
 from parse_bench.schemas.parse_output import PageIR, ParseLayoutPageIR, ParseOutput
 from parse_bench.schemas.pipeline import PipelineSpec
@@ -210,52 +213,53 @@ class OpenAIProvider(Provider):
         - Images exceeding size limit after encoding (reduces quality iteratively)
         """
         # Resize if dimensions exceed limit
-        image = self._prepare_image_for_api(image)
+        with close_derived_images(image) as track:
+            image = track(self._prepare_image_for_api(image))
 
-        # Convert to RGB if necessary (e.g., RGBA images)
-        if image.mode in ("RGBA", "P"):
-            image = image.convert("RGB")
+            # Convert to RGB if necessary (e.g., RGBA images)
+            if image.mode in ("RGBA", "P"):
+                image = track(image.convert("RGB"))
 
-        # Try encoding with decreasing quality until under size limit
-        quality = 85
-        min_quality = 20
+            # Try encoding with decreasing quality until under size limit
+            quality = 85
+            min_quality = 20
 
-        while quality >= min_quality:
-            buffer = io.BytesIO()
-            image.save(buffer, format="JPEG", quality=quality)
-            buffer.seek(0)
-            data = buffer.getvalue()
+            while quality >= min_quality:
+                buffer = io.BytesIO()
+                image.save(buffer, format="JPEG", quality=quality)
+                buffer.seek(0)
+                data = buffer.getvalue()
 
-            if len(data) <= self.MAX_IMAGE_SIZE_BYTES:
-                return base64.standard_b64encode(data).decode("utf-8")
+                if len(data) <= self.MAX_IMAGE_SIZE_BYTES:
+                    return base64.standard_b64encode(data).decode("utf-8")
 
-            quality -= 10
+                quality -= 10
 
-        # If still too large after quality reduction, resize the image
-        while True:
-            width, height = image.size
-            new_width = int(width * 0.8)
-            new_height = int(height * 0.8)
+            # If still too large after quality reduction, resize the image
+            while True:
+                width, height = image.size
+                new_width = int(width * 0.8)
+                new_height = int(height * 0.8)
 
-            if new_width < 100 or new_height < 100:
-                # Give up - image is too complex to fit in limits
-                break
+                if new_width < 100 or new_height < 100:
+                    # Give up - image is too complex to fit in limits
+                    break
 
-            image = image.resize((new_width, new_height), Image.Resampling.LANCZOS)
+                image = track(image.resize((new_width, new_height), Image.Resampling.LANCZOS))
 
+                buffer = io.BytesIO()
+                image.save(buffer, format="JPEG", quality=min_quality)
+                buffer.seek(0)
+                data = buffer.getvalue()
+
+                if len(data) <= self.MAX_IMAGE_SIZE_BYTES:
+                    return base64.standard_b64encode(data).decode("utf-8")
+
+            # Final fallback - return what we have
             buffer = io.BytesIO()
             image.save(buffer, format="JPEG", quality=min_quality)
             buffer.seek(0)
-            data = buffer.getvalue()
-
-            if len(data) <= self.MAX_IMAGE_SIZE_BYTES:
-                return base64.standard_b64encode(data).decode("utf-8")
-
-        # Final fallback - return what we have
-        buffer = io.BytesIO()
-        image.save(buffer, format="JPEG", quality=min_quality)
-        buffer.seek(0)
-        return base64.standard_b64encode(buffer.getvalue()).decode("utf-8")
+            return base64.standard_b64encode(buffer.getvalue()).decode("utf-8")
 
     def _parse_image(self, image: Image.Image) -> tuple[str, dict[str, int]]:
         """

--- a/src/parse_bench/inference/providers/parse/openai.py
+++ b/src/parse_bench/inference/providers/parse/openai.py
@@ -27,6 +27,7 @@ from parse_bench.inference.providers.parse._layout_utils import (
 from parse_bench.inference.providers.parse._multipage_image import (
     annotate_attempt_costs,
     append_attempt_usages,
+    attempt_usages_complete,
     close_derived_images,
     open_document_page_images,
     run_page_with_retries,
@@ -595,6 +596,7 @@ class OpenAIProvider(Provider):
                             provider_name=pipeline.provider_name,
                             page_number=page_index + 1,
                             attempt_ledger=attempts,
+                            prior_attempt_ledger=api_attempts,
                         )
                         api_attempts.extend(attempts)
                         append_attempt_usages(page_usages, attempts)
@@ -643,6 +645,7 @@ class OpenAIProvider(Provider):
                                 provider_name=pipeline.provider_name,
                                 page_number=page_index + 1,
                                 attempt_ledger=attempts,
+                                prior_attempt_ledger=api_attempts,
                             )
                             api_attempts.extend(attempts)
                             append_attempt_usages(page_usages, attempts)
@@ -662,6 +665,7 @@ class OpenAIProvider(Provider):
                                 provider_name=pipeline.provider_name,
                                 page_number=page_index + 1,
                                 attempt_ledger=attempts,
+                                prior_attempt_ledger=api_attempts,
                             )
                             api_attempts.extend(attempts)
                             append_attempt_usages(page_usages, attempts)
@@ -692,6 +696,20 @@ class OpenAIProvider(Provider):
                 output_rate_per_million=output_rate,
             )
             cost = (total_input * input_rate + (total_output + total_thinking) * output_rate) / 1_000_000
+            usage_summary = (
+                {
+                    "input_tokens": total_input,
+                    "output_tokens": total_output,
+                    "thinking_tokens": total_thinking,
+                    "total_tokens": total_all,
+                    "cost_usd": cost,
+                    "cost_per_page_usd": cost / num_pages if num_pages > 0 else 0.0,
+                    "input_tokens_per_page": total_input / num_pages if num_pages > 0 else 0.0,
+                    "output_tokens_per_page": total_output / num_pages if num_pages > 0 else 0.0,
+                }
+                if attempt_usages_complete(page_usages)
+                else {}
+            )
 
             config_info: dict[str, Any] = {
                 "dpi": self._dpi,
@@ -708,14 +726,7 @@ class OpenAIProvider(Provider):
                 "mode": self._mode,
                 "bbox_scale": self._bbox_scale,
                 "config": config_info,
-                "input_tokens": total_input,
-                "output_tokens": total_output,
-                "thinking_tokens": total_thinking,
-                "total_tokens": total_all,
-                "cost_usd": cost,
-                "cost_per_page_usd": cost / num_pages if num_pages > 0 else 0.0,
-                "input_tokens_per_page": total_input / num_pages if num_pages > 0 else 0.0,
-                "output_tokens_per_page": total_output / num_pages if num_pages > 0 else 0.0,
+                **usage_summary,
                 "num_api_calls": len(api_attempts) if api_attempts else len(page_usages),
                 "api_attempts": api_attempts,
             }

--- a/src/parse_bench/inference/providers/parse/openai.py
+++ b/src/parse_bench/inference/providers/parse/openai.py
@@ -19,7 +19,7 @@ from parse_bench.inference.providers.base import (
 from parse_bench.inference.providers.parse._layout_utils import (
     build_layout_pages,
     items_to_markdown,
-    parse_layout_blocks,
+    parse_layout_response,
     resolve_layout_prompts,
     split_pdf_to_pages,
 )
@@ -104,6 +104,8 @@ class OpenAIProvider(Provider):
     capabilities to parse document content to markdown.
     """
 
+    PDF_RENDER_DPI = 150
+
     def __init__(self, provider_name: str, base_config: dict[str, Any] | None = None):
         """
         Initialize the provider.
@@ -127,7 +129,7 @@ class OpenAIProvider(Provider):
 
         # Configuration
         self._model = self.base_config.get("model", "gpt-5-mini")
-        self._dpi = self.base_config.get("dpi", 150)
+        self._dpi = self.base_config.get("dpi", self.PDF_RENDER_DPI)
         self._max_tokens = self.base_config.get("max_tokens", 8192)
         self._timeout = self.base_config.get("timeout", 120)
         self._reasoning_effort = self.base_config.get("reasoning_effort", None)
@@ -149,7 +151,9 @@ class OpenAIProvider(Provider):
         try:
             from openai import OpenAI
 
-            self._client = OpenAI(api_key=self._api_key)
+            # Retry exactly once at the active owner: per page for split modes,
+            # or in the outer document runner for native file mode.
+            self._client = OpenAI(api_key=self._api_key, max_retries=0)
         except ImportError as e:
             raise ProviderConfigError("openai package not installed. Run: pip install openai") from e
 
@@ -302,9 +306,10 @@ class OpenAIProvider(Provider):
             usage = self._extract_usage(response)
 
             # Extract text from response
-            content = response.choices[0].message.content if response.choices else ""
-            return (content or ""), usage
+            return self._extract_response_text(response, context="image"), usage
 
+        except (ProviderPermanentError, ProviderTransientError):
+            raise
         except Exception as e:
             error_str = str(e).lower()
             if any(kw in error_str for kw in ["timeout", "connection", "network"]):
@@ -349,12 +354,12 @@ class OpenAIProvider(Provider):
             response = self._client.chat.completions.create(**kwargs)
 
             usage = self._extract_usage(response)
-            content = response.choices[0].message.content if response.choices else ""
-            text = content or ""
-
-            items = parse_layout_blocks(text)
+            text = self._extract_response_text(response, context="image layout")
+            items = self._parse_layout_response(text)
             return items, text, usage
 
+        except (ProviderPermanentError, ProviderTransientError):
+            raise
         except Exception as e:
             error_str = str(e).lower()
             if any(kw in error_str for kw in ["timeout", "connection", "network"]):
@@ -410,9 +415,10 @@ class OpenAIProvider(Provider):
             usage = self._extract_usage(response)
 
             # Extract text from response
-            content = response.choices[0].message.content if response.choices else ""
-            return (content or ""), usage
+            return self._extract_response_text(response, context="PDF"), usage
 
+        except (ProviderPermanentError, ProviderTransientError):
+            raise
         except Exception as e:
             error_str = str(e).lower()
             if any(kw in error_str for kw in ["timeout", "connection", "network"]):
@@ -458,12 +464,12 @@ class OpenAIProvider(Provider):
             response = self._client.chat.completions.create(**kwargs)
 
             usage = self._extract_usage(response)
-            content = response.choices[0].message.content if response.choices else ""
-            text = content or ""
-
-            items = parse_layout_blocks(text)
+            text = self._extract_response_text(response, context="PDF layout page")
+            items = self._parse_layout_response(text)
             return items, text, usage
 
+        except (ProviderPermanentError, ProviderTransientError):
+            raise
         except Exception as e:
             error_str = str(e).lower()
             if any(kw in error_str for kw in ["timeout", "connection", "network"]):
@@ -478,6 +484,27 @@ class OpenAIProvider(Provider):
             if is_gpt56_401_blip:
                 raise ProviderTransientError(f"Transient OpenAI 401 (retryable): {e}") from e
             raise ProviderPermanentError(f"Error calling OpenAI API: {e}") from e
+
+    @staticmethod
+    def _extract_response_text(response: Any, *, context: str) -> str:
+        """Return non-empty message text from a structurally valid response."""
+        choices = getattr(response, "choices", None)
+        if not choices:
+            raise ProviderTransientError(f"OpenAI returned no choices for {context}")
+        message = getattr(choices[0], "message", None)
+        if message is None or not hasattr(message, "content"):
+            raise ProviderTransientError(f"OpenAI returned no message content for {context}")
+        content = message.content
+        if not isinstance(content, str) or not content.strip():
+            raise ProviderTransientError(f"OpenAI returned empty message content for {context}")
+        return content
+
+    @staticmethod
+    def _parse_layout_response(text: str) -> list[dict[str, Any]]:
+        try:
+            return parse_layout_response(text)
+        except ValueError as exc:
+            raise ProviderTransientError(f"OpenAI returned malformed layout output: {exc}") from exc
 
     def run_inference(self, pipeline: PipelineSpec, request: InferenceRequest) -> RawInferenceResult:
         """
@@ -540,7 +567,11 @@ class OpenAIProvider(Provider):
                     pdf_pages = split_pdf_to_pages(str(source_path))
                     pages = []
                     for page_index, (pdf_bytes, w, h) in enumerate(pdf_pages):
-                        items, raw_content, usage = self._parse_pdf_page_with_layout(pdf_bytes)
+                        items, raw_content, usage = run_page_with_retries(
+                            partial(self._parse_pdf_page_with_layout, pdf_bytes),
+                            provider_name=pipeline.provider_name,
+                            page_number=page_index + 1,
+                        )
                         page_usages.append(usage)
                         pages.append(
                             {
@@ -555,7 +586,11 @@ class OpenAIProvider(Provider):
                 else:
                     # Non-PDF: fall back to image-based layout parsing
                     with Image.open(source_path) as image:
-                        items, raw_content, usage = self._parse_image_with_layout(image)
+                        items, raw_content, usage = run_page_with_retries(
+                            partial(self._parse_image_with_layout, image),
+                            provider_name=pipeline.provider_name,
+                            page_number=1,
+                        )
                         page_usages.append(usage)
                         pages = [
                             {

--- a/src/parse_bench/inference/providers/parse/openai.py
+++ b/src/parse_bench/inference/providers/parse/openai.py
@@ -166,33 +166,34 @@ class OpenAIProvider(Provider):
     # API limit is 20MB for base64 data; base64 adds ~33% overhead, so raw limit is 20MB * 3/4
     MAX_IMAGE_SIZE_BYTES = int(20 * 1024 * 1024 * 3 / 4)  # ~15 MB raw -> ~20 MB base64
 
-    def _get_pricing(self) -> tuple[float, float]:
-        """Return (input_rate, output_rate) in USD per million tokens.
+    def _get_pricing(self) -> tuple[float, float] | None:
+        """Return known (input_rate, output_rate) in USD per million tokens.
 
         Uses longest-prefix matching to avoid ambiguity when one model
         prefix is a substring of another.
         """
         matches = [(p, r) for p, r in _OPENAI_PRICING_PER_M.items() if self._model.startswith(p)]
-        return max(matches, key=lambda x: len(x[0]))[1] if matches else (0.0, 0.0)
+        return max(matches, key=lambda x: len(x[0]))[1] if matches else None
 
     @staticmethod
     def _extract_usage(response) -> dict[str, int]:  # type: ignore[no-untyped-def]
         """Extract token counts from an OpenAI API response."""
         usage = getattr(response, "usage", None)
         if usage is None:
-            return {"input_tokens": 0, "output_tokens": 0, "thinking_tokens": 0, "total_tokens": 0}
-        input_tok = getattr(usage, "prompt_tokens", 0) or 0
-        output_tok = getattr(usage, "completion_tokens", 0) or 0
-        total_tok = getattr(usage, "total_tokens", 0) or 0
+            return {}
         # Reasoning tokens (o-series models)
         details = getattr(usage, "completion_tokens_details", None)
         thinking_tok = getattr(details, "reasoning_tokens", 0) or 0 if details else 0
-        return {
-            "input_tokens": input_tok,
-            "output_tokens": output_tok,
-            "thinking_tokens": thinking_tok,
-            "total_tokens": total_tok,
-        }
+        result = {"thinking_tokens": int(thinking_tok)}
+        for key, attribute in (
+            ("input_tokens", "prompt_tokens"),
+            ("output_tokens", "completion_tokens"),
+            ("total_tokens", "total_tokens"),
+        ):
+            value = getattr(usage, attribute, None)
+            if value is not None:
+                result[key] = int(value)
+        return result
 
     def _prepare_image_for_api(self, image: Image.Image) -> Image.Image:
         """
@@ -688,28 +689,33 @@ class OpenAIProvider(Provider):
             total_thinking = sum(u["thinking_tokens"] for u in page_usages)
             total_all = sum(u["total_tokens"] for u in page_usages)
 
-            # Compute cost
-            input_rate, output_rate = self._get_pricing()
-            annotate_attempt_costs(
-                api_attempts,
-                input_rate_per_million=input_rate,
-                output_rate_per_million=output_rate,
-            )
-            cost = (total_input * input_rate + (total_output + total_thinking) * output_rate) / 1_000_000
             usage_summary = (
                 {
                     "input_tokens": total_input,
                     "output_tokens": total_output,
                     "thinking_tokens": total_thinking,
                     "total_tokens": total_all,
-                    "cost_usd": cost,
-                    "cost_per_page_usd": cost / num_pages if num_pages > 0 else 0.0,
                     "input_tokens_per_page": total_input / num_pages if num_pages > 0 else 0.0,
                     "output_tokens_per_page": total_output / num_pages if num_pages > 0 else 0.0,
                 }
                 if attempt_usages_complete(page_usages)
                 else {}
             )
+            pricing = self._get_pricing()
+            if pricing is not None and attempt_usages_complete(page_usages):
+                input_rate, output_rate = pricing
+                annotate_attempt_costs(
+                    api_attempts,
+                    input_rate_per_million=input_rate,
+                    output_rate_per_million=output_rate,
+                )
+                cost = (total_input * input_rate + (total_output + total_thinking) * output_rate) / 1_000_000
+                usage_summary.update(
+                    {
+                        "cost_usd": cost,
+                        "cost_per_page_usd": cost / num_pages if num_pages > 0 else 0.0,
+                    }
+                )
 
             config_info: dict[str, Any] = {
                 "dpi": self._dpi,

--- a/src/parse_bench/inference/providers/parse/paddleocr.py
+++ b/src/parse_bench/inference/providers/parse/paddleocr.py
@@ -58,6 +58,8 @@ class PaddleOCRProvider(Provider):
         - dpi (int, default=150): DPI for PDF to image conversion
     """
 
+    PDF_RENDER_DPI = 150
+
     def __init__(self, provider_name: str, base_config: dict[str, Any] | None = None):
         """
         Initialize the PaddleOCR provider.
@@ -85,7 +87,7 @@ class PaddleOCRProvider(Provider):
             raise ProviderConfigError(f"Invalid task '{self._task}'. Must be one of: {list(TASK_PROMPTS.keys())}")
 
         self._timeout = self.base_config.get("timeout", 600)
-        self._dpi = self.base_config.get("dpi", 150)
+        self._dpi = self.base_config.get("dpi", self.PDF_RENDER_DPI)
 
         # Model name sent to the vLLM server. Defaults to the 1.5 model; override
         # via the ``served_model_name`` key for other releases (e.g. PaddleOCR-VL-1.6-0.9B).

--- a/src/parse_bench/inference/providers/parse/paddleocr.py
+++ b/src/parse_bench/inference/providers/parse/paddleocr.py
@@ -17,6 +17,7 @@ from parse_bench.inference.providers.base import (
     ProviderPermanentError,
     ProviderTransientError,
 )
+from parse_bench.inference.providers.parse._multipage_image import normalize_pdf_pages, run_pdf_pages
 from parse_bench.inference.providers.registry import register_provider
 from parse_bench.schemas.parse_output import ParseOutput
 from parse_bench.schemas.pipeline import PipelineSpec
@@ -261,6 +262,10 @@ class PaddleOCRProvider(Provider):
         :return: Raw inference result
         :raises ProviderError: For any provider-related failures
         """
+        multipage_result = run_pdf_pages(pipeline, request, dpi=self._dpi, run_single_image=self.run_inference)
+        if multipage_result is not None:
+            return multipage_result
+
         if request.product_type != ProductType.PARSE:
             raise ProviderPermanentError(
                 f"PaddleOCRProvider only supports PARSE product type, got {request.product_type}"
@@ -461,6 +466,10 @@ class PaddleOCRProvider(Provider):
         :return: Inference result with both raw and normalized outputs
         :raises ProviderError: For any normalization failures
         """
+        multipage_result = normalize_pdf_pages(raw_result, normalize_single_image=self.normalize)
+        if multipage_result is not None:
+            return multipage_result
+
         if raw_result.product_type != ProductType.PARSE:
             raise ProviderPermanentError(
                 f"PaddleOCRProvider only supports PARSE product type, got {raw_result.product_type}"

--- a/src/parse_bench/inference/providers/parse/paddleocr.py
+++ b/src/parse_bench/inference/providers/parse/paddleocr.py
@@ -290,53 +290,26 @@ class PaddleOCRProvider(Provider):
             )
 
         try:
-            # Run async inference
             raw_output = asyncio.run(self._run_inference_async(image_bytes))
+        except (ProviderPermanentError, ProviderTransientError):
+            raise
+        except (TimeoutError, aiohttp.ClientError) as exc:
+            raise ProviderTransientError(f"PaddleOCR request failed: {exc}") from exc
+        except Exception as exc:
+            raise ProviderPermanentError(f"Unexpected error during PaddleOCR inference: {exc}") from exc
 
-            completed_at = datetime.now()
-            latency_ms = int((completed_at - started_at).total_seconds() * 1000)
-
-            return RawInferenceResult(
-                request=request,
-                pipeline=pipeline,
-                pipeline_name=pipeline.pipeline_name,
-                product_type=request.product_type,
-                raw_output=raw_output,
-                started_at=started_at,
-                completed_at=completed_at,
-                latency_in_ms=latency_ms,
-            )
-
-        except (TimeoutError, ProviderPermanentError, ProviderTransientError, Exception) as e:
-            # Return empty result with error info instead of failing
-            # This allows workflow to continue while tracking the error
-            completed_at = datetime.now()
-            latency_ms = int((completed_at - started_at).total_seconds() * 1000)
-
-            error_msg = str(e)
-            if isinstance(e, asyncio.TimeoutError):
-                error_msg = f"Request timed out after {self._timeout} seconds"
-
-            return RawInferenceResult(
-                request=request,
-                pipeline=pipeline,
-                pipeline_name=pipeline.pipeline_name,
-                product_type=request.product_type,
-                raw_output={
-                    "markdown": "",
-                    "_error": error_msg,
-                    "_error_type": type(e).__name__,
-                    "_config": {
-                        "server_url": self._server_url,
-                        "api_format": self._api_format,
-                        "task": self._task,
-                        "dpi": self._dpi,
-                    },
-                },
-                started_at=started_at,
-                completed_at=completed_at,
-                latency_in_ms=latency_ms,
-            )
+        completed_at = datetime.now()
+        latency_ms = int((completed_at - started_at).total_seconds() * 1000)
+        return RawInferenceResult(
+            request=request,
+            pipeline=pipeline,
+            pipeline_name=pipeline.pipeline_name,
+            product_type=request.product_type,
+            raw_output=raw_output,
+            started_at=started_at,
+            completed_at=completed_at,
+            latency_in_ms=latency_ms,
+        )
 
     @staticmethod
     def _sanitize_html_attributes(markdown: str) -> str:

--- a/src/parse_bench/inference/providers/parse/pymupdf4llm.py
+++ b/src/parse_bench/inference/providers/parse/pymupdf4llm.py
@@ -12,6 +12,7 @@ from parse_bench.inference.providers.base import (
     ProviderConfigError,
     ProviderPermanentError,
 )
+from parse_bench.inference.providers.parse._layout_utils import validated_sorted_page_records
 from parse_bench.inference.providers.registry import register_provider
 from parse_bench.schemas.parse_output import (
     LayoutItemIR,
@@ -326,8 +327,8 @@ class PyMuPDF4LLMProvider(Provider):
         pages: list[PageIR] = []
         layout_pages: list[ParseLayoutPageIR] = []
         page_texts: list[str] = []
-        for page_data in raw_result.raw_output.get("pages", []):
-            page_index = page_data.get("page_index", 0)
+        for page_data in validated_sorted_page_records(raw_result.raw_output.get("pages")):
+            page_index = page_data["page_index"]
             raw_markdown = page_data.get("text", "") or ""
             layout_page = self._build_layout_page(page_data, raw_markdown=raw_markdown)
             if layout_page is not None:

--- a/src/parse_bench/inference/providers/parse/qwen3_5.py
+++ b/src/parse_bench/inference/providers/parse/qwen3_5.py
@@ -28,6 +28,7 @@ from parse_bench.inference.providers.base import (
     ProviderPermanentError,
     ProviderTransientError,
 )
+from parse_bench.inference.providers.parse._multipage_image import normalize_pdf_pages, run_pdf_pages
 from parse_bench.inference.providers.registry import register_provider
 from parse_bench.schemas.parse_output import (
     LayoutItemIR,
@@ -334,6 +335,10 @@ class Qwen35Provider(Provider):
             }
 
     def run_inference(self, pipeline: PipelineSpec, request: InferenceRequest) -> RawInferenceResult:
+        multipage_result = run_pdf_pages(pipeline, request, dpi=self._dpi, run_single_image=self.run_inference)
+        if multipage_result is not None:
+            return multipage_result
+
         if request.product_type != ProductType.PARSE:
             raise ProviderPermanentError(f"Qwen35Provider only supports PARSE, got {request.product_type}")
 
@@ -463,6 +468,10 @@ class Qwen35Provider(Provider):
     # ------------------------------------------------------------------
 
     def normalize(self, raw_result: RawInferenceResult) -> InferenceResult:
+        multipage_result = normalize_pdf_pages(raw_result, normalize_single_image=self.normalize)
+        if multipage_result is not None:
+            return multipage_result
+
         if raw_result.product_type != ProductType.PARSE:
             raise ProviderPermanentError(f"Qwen35Provider only supports PARSE, got {raw_result.product_type}")
 

--- a/src/parse_bench/inference/providers/parse/qwen3_5.py
+++ b/src/parse_bench/inference/providers/parse/qwen3_5.py
@@ -184,8 +184,8 @@ class Qwen35Provider(Provider):
         from PIL import Image
 
         try:
-            img = Image.open(file_path)
-            w, h = img.size
+            with Image.open(file_path) as img:
+                w, h = img.size
             return file_path.read_bytes(), w, h
         except Exception as e:
             raise ProviderPermanentError(f"Error reading image file: {e}") from e

--- a/src/parse_bench/inference/providers/parse/qwen3_5.py
+++ b/src/parse_bench/inference/providers/parse/qwen3_5.py
@@ -138,6 +138,8 @@ class Qwen35Provider(Provider):
         - api_key_env (str, default="VLLM_API_KEY"): Env var for API key
     """
 
+    PDF_RENDER_DPI = 150
+
     def __init__(self, provider_name: str, base_config: dict[str, Any] | None = None):
         super().__init__(provider_name, base_config)
 
@@ -149,7 +151,7 @@ class Qwen35Provider(Provider):
         self._model = self.base_config.get("model", DEFAULT_SERVED_MODEL_NAME)
         self._prompt_mode = self.base_config.get("prompt_mode", "parse")
         self._timeout = self.base_config.get("timeout", 600)
-        self._dpi = self.base_config.get("dpi", 150)
+        self._dpi = self.base_config.get("dpi", self.PDF_RENDER_DPI)
         self._max_tokens = self.base_config.get("max_tokens", 16384)
         self._temperature = self.base_config.get("temperature", 0.1)
 

--- a/src/parse_bench/inference/providers/parse/surya2.py
+++ b/src/parse_bench/inference/providers/parse/surya2.py
@@ -101,6 +101,8 @@ class Surya2Provider(Provider):
         - dpi (int, default=192): DPI for PDF→image (matches surya IMAGE_DPI_HIGHRES)
     """
 
+    PDF_RENDER_DPI = 192
+
     def __init__(self, provider_name: str, base_config: dict[str, Any] | None = None):
         super().__init__(provider_name, base_config)
 
@@ -112,7 +114,7 @@ class Surya2Provider(Provider):
             )
         self._server_url: str = str(server_url)
         self._timeout = self.base_config.get("timeout", 600)
-        self._dpi = self.base_config.get("dpi", 192)
+        self._dpi = self.base_config.get("dpi", self.PDF_RENDER_DPI)
 
     def _pdf_to_image(self, pdf_path: Path) -> bytes:
         try:

--- a/src/parse_bench/inference/providers/parse/surya2.py
+++ b/src/parse_bench/inference/providers/parse/surya2.py
@@ -27,6 +27,7 @@ from parse_bench.inference.providers.base import (
     ProviderPermanentError,
     ProviderTransientError,
 )
+from parse_bench.inference.providers.parse._multipage_image import normalize_pdf_pages, run_pdf_pages
 from parse_bench.inference.providers.registry import register_provider
 from parse_bench.schemas.parse_output import (
     LayoutItemIR,
@@ -178,6 +179,10 @@ class Surya2Provider(Provider):
             }
 
     def run_inference(self, pipeline: PipelineSpec, request: InferenceRequest) -> RawInferenceResult:
+        multipage_result = run_pdf_pages(pipeline, request, dpi=self._dpi, run_single_image=self.run_inference)
+        if multipage_result is not None:
+            return multipage_result
+
         if request.product_type != ProductType.PARSE:
             raise ProviderPermanentError(f"Surya2Provider only supports PARSE product type, got {request.product_type}")
 
@@ -308,6 +313,10 @@ class Surya2Provider(Provider):
         ]
 
     def normalize(self, raw_result: RawInferenceResult) -> InferenceResult:
+        multipage_result = normalize_pdf_pages(raw_result, normalize_single_image=self.normalize)
+        if multipage_result is not None:
+            return multipage_result
+
         if raw_result.product_type != ProductType.PARSE:
             raise ProviderPermanentError(
                 f"Surya2Provider only supports PARSE product type, got {raw_result.product_type}"

--- a/src/parse_bench/inference/providers/parse/tesseract.py
+++ b/src/parse_bench/inference/providers/parse/tesseract.py
@@ -150,40 +150,39 @@ class TesseractProvider(Provider):
             ) from e
 
         try:
-            image = Image.open(image_path)
+            with Image.open(image_path) as image:
+                # Perform OCR
+                if self._output_type == "text":
+                    text = pytesseract.image_to_string(image, lang=self._lang, config=self._config)
+                elif self._output_type == "dict":
+                    data = pytesseract.image_to_data(
+                        image, lang=self._lang, config=self._config, output_type=pytesseract.Output.DICT
+                    )
+                    text = " ".join([word for word in data.get("text", []) if word.strip()])
+                elif self._output_type == "data":
+                    text = pytesseract.image_to_data(image, lang=self._lang, config=self._config)
+                elif self._output_type == "boxes":
+                    text = pytesseract.image_to_boxes(image, lang=self._lang, config=self._config)
+                elif self._output_type == "osd":
+                    text = pytesseract.image_to_osd(image, config=self._config)
+                else:
+                    text = pytesseract.image_to_string(image, lang=self._lang, config=self._config)
 
-            # Perform OCR
-            if self._output_type == "text":
-                text = pytesseract.image_to_string(image, lang=self._lang, config=self._config)
-            elif self._output_type == "dict":
-                data = pytesseract.image_to_data(
-                    image, lang=self._lang, config=self._config, output_type=pytesseract.Output.DICT
-                )
-                text = " ".join([word for word in data.get("text", []) if word.strip()])
-            elif self._output_type == "data":
-                text = pytesseract.image_to_data(image, lang=self._lang, config=self._config)
-            elif self._output_type == "boxes":
-                text = pytesseract.image_to_boxes(image, lang=self._lang, config=self._config)
-            elif self._output_type == "osd":
-                text = pytesseract.image_to_osd(image, config=self._config)
-            else:
-                text = pytesseract.image_to_string(image, lang=self._lang, config=self._config)
-
-            return {
-                "pages": [
-                    {
-                        "page_index": 0,
-                        "text": text,
-                        "width": image.width,
-                        "height": image.height,
-                    }
-                ],
-                "num_pages": 1,
-                "config": {
-                    "lang": self._lang,
-                    "output_type": self._output_type,
-                },
-            }
+                return {
+                    "pages": [
+                        {
+                            "page_index": 0,
+                            "text": text,
+                            "width": image.width,
+                            "height": image.height,
+                        }
+                    ],
+                    "num_pages": 1,
+                    "config": {
+                        "lang": self._lang,
+                        "output_type": self._output_type,
+                    },
+                }
 
         except FileNotFoundError as e:
             raise ProviderPermanentError(f"Image file not found: {image_path}") from e

--- a/src/parse_bench/inference/providers/parse/tesseract.py
+++ b/src/parse_bench/inference/providers/parse/tesseract.py
@@ -1,8 +1,9 @@
 """Provider for Tesseract OCR PARSE."""
 
 from datetime import datetime
+from functools import partial
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from parse_bench.inference.providers.base import (
     Provider,
@@ -10,7 +11,10 @@ from parse_bench.inference.providers.base import (
     ProviderPermanentError,
     ProviderTransientError,
 )
-from parse_bench.inference.providers.parse._multipage_image import open_document_page_images
+from parse_bench.inference.providers.parse._multipage_image import (
+    open_document_page_images,
+    run_page_with_retries,
+)
 from parse_bench.inference.providers.registry import register_provider
 from parse_bench.schemas.parse_output import PageIR, ParseOutput
 from parse_bench.schemas.pipeline import PipelineSpec
@@ -63,31 +67,47 @@ class TesseractProvider(Provider):
         except ImportError as e:
             raise ProviderConfigError("pytesseract package not installed. Run: pip install pytesseract") from e
 
+        def ocr_page(image: Any) -> str:
+            try:
+                if self._output_type == "text":
+                    return cast(str, pytesseract.image_to_string(image, lang=self._lang, config=self._config))
+                if self._output_type == "dict":
+                    data = pytesseract.image_to_data(
+                        image,
+                        lang=self._lang,
+                        config=self._config,
+                        output_type=pytesseract.Output.DICT,
+                    )
+                    return " ".join(word for word in data.get("text", []) if word.strip())
+                if self._output_type == "data":
+                    return cast(str, pytesseract.image_to_data(image, lang=self._lang, config=self._config))
+                if self._output_type == "boxes":
+                    return cast(str, pytesseract.image_to_boxes(image, lang=self._lang, config=self._config))
+                if self._output_type == "osd":
+                    return cast(str, pytesseract.image_to_osd(image, config=self._config))
+                return cast(str, pytesseract.image_to_string(image, lang=self._lang, config=self._config))
+            except Exception as exc:
+                error_str = str(exc).lower()
+                if any(keyword in error_str for keyword in ["timeout", "memory", "resource"]):
+                    raise ProviderTransientError(f"Transient error during OCR: {exc}") from exc
+                if "tesseract" in error_str and any(
+                    keyword in error_str for keyword in ["not found", "not installed", "command"]
+                ):
+                    raise ProviderConfigError(
+                        "Tesseract OCR engine not found. Please install Tesseract: "
+                        "https://github.com/tesseract-ocr/tesseract"
+                    ) from exc
+                raise ProviderPermanentError(f"Error during OCR: {exc}") from exc
+
         try:
             pages = []
             with open_document_page_images(pdf_path, dpi=self._dpi) as images:
                 for page_index, image in enumerate(images):
-                    # A failed page invalidates the document. Let the outer
-                    # classifier preserve retryable failures instead of
-                    # emitting a partial document with an error placeholder.
-                    if self._output_type == "text":
-                        text = pytesseract.image_to_string(image, lang=self._lang, config=self._config)
-                    elif self._output_type == "dict":
-                        data = pytesseract.image_to_data(
-                            image,
-                            lang=self._lang,
-                            config=self._config,
-                            output_type=pytesseract.Output.DICT,
-                        )
-                        text = " ".join([word for word in data.get("text", []) if word.strip()])
-                    elif self._output_type == "data":
-                        text = pytesseract.image_to_data(image, lang=self._lang, config=self._config)
-                    elif self._output_type == "boxes":
-                        text = pytesseract.image_to_boxes(image, lang=self._lang, config=self._config)
-                    elif self._output_type == "osd":
-                        text = pytesseract.image_to_osd(image, config=self._config)
-                    else:
-                        text = pytesseract.image_to_string(image, lang=self._lang, config=self._config)
+                    text = run_page_with_retries(
+                        partial(ocr_page, image),
+                        provider_name="tesseract",
+                        page_number=page_index + 1,
+                    )
 
                     pages.append(
                         {

--- a/src/parse_bench/inference/providers/parse/tesseract.py
+++ b/src/parse_bench/inference/providers/parse/tesseract.py
@@ -11,6 +11,7 @@ from parse_bench.inference.providers.base import (
     ProviderPermanentError,
     ProviderTransientError,
 )
+from parse_bench.inference.providers.parse._layout_utils import validated_sorted_page_records
 from parse_bench.inference.providers.parse._multipage_image import (
     open_document_page_images,
     run_page_with_retries,
@@ -284,8 +285,8 @@ class TesseractProvider(Provider):
         pages: list[PageIR] = []
         page_texts = []
 
-        for page_data in raw_result.raw_output.get("pages", []):
-            page_index = page_data.get("page_index", 0)
+        for page_data in validated_sorted_page_records(raw_result.raw_output.get("pages")):
+            page_index = page_data["page_index"]
             text = page_data.get("text", "")
 
             pages.append(PageIR(page_index=page_index, markdown=text))

--- a/src/parse_bench/inference/providers/parse/tesseract.py
+++ b/src/parse_bench/inference/providers/parse/tesseract.py
@@ -35,6 +35,8 @@ class TesseractProvider(Provider):
     Handles scanned documents where embedded text is not available.
     """
 
+    PDF_RENDER_DPI = 300
+
     def __init__(self, provider_name: str, base_config: dict[str, Any] | None = None):
         """
         Initialize the provider.
@@ -51,7 +53,7 @@ class TesseractProvider(Provider):
         super().__init__(provider_name, base_config)
         self._lang = self.base_config.get("lang", "eng")
         self._config = self.base_config.get("config", "")
-        self._dpi = self.base_config.get("dpi", 300)
+        self._dpi = self.base_config.get("dpi", self.PDF_RENDER_DPI)
         self._output_type = self.base_config.get("output_type", "text")
 
     def _ocr_pdf(self, pdf_path: str) -> dict[str, Any]:

--- a/src/parse_bench/inference/providers/parse/tesseract.py
+++ b/src/parse_bench/inference/providers/parse/tesseract.py
@@ -67,43 +67,36 @@ class TesseractProvider(Provider):
             pages = []
             with open_document_page_images(pdf_path, dpi=self._dpi) as images:
                 for page_index, image in enumerate(images):
-                    try:
-                        # Perform OCR based on output type
-                        if self._output_type == "text":
-                            text = pytesseract.image_to_string(image, lang=self._lang, config=self._config)
-                        elif self._output_type == "dict":
-                            data = pytesseract.image_to_data(
-                                image,
-                                lang=self._lang,
-                                config=self._config,
-                                output_type=pytesseract.Output.DICT,
-                            )
-                            text = " ".join([word for word in data.get("text", []) if word.strip()])
-                        elif self._output_type == "data":
-                            text = pytesseract.image_to_data(image, lang=self._lang, config=self._config)
-                        elif self._output_type == "boxes":
-                            text = pytesseract.image_to_boxes(image, lang=self._lang, config=self._config)
-                        elif self._output_type == "osd":
-                            text = pytesseract.image_to_osd(image, config=self._config)
-                        else:
-                            text = pytesseract.image_to_string(image, lang=self._lang, config=self._config)
+                    # A failed page invalidates the document. Let the outer
+                    # classifier preserve retryable failures instead of
+                    # emitting a partial document with an error placeholder.
+                    if self._output_type == "text":
+                        text = pytesseract.image_to_string(image, lang=self._lang, config=self._config)
+                    elif self._output_type == "dict":
+                        data = pytesseract.image_to_data(
+                            image,
+                            lang=self._lang,
+                            config=self._config,
+                            output_type=pytesseract.Output.DICT,
+                        )
+                        text = " ".join([word for word in data.get("text", []) if word.strip()])
+                    elif self._output_type == "data":
+                        text = pytesseract.image_to_data(image, lang=self._lang, config=self._config)
+                    elif self._output_type == "boxes":
+                        text = pytesseract.image_to_boxes(image, lang=self._lang, config=self._config)
+                    elif self._output_type == "osd":
+                        text = pytesseract.image_to_osd(image, config=self._config)
+                    else:
+                        text = pytesseract.image_to_string(image, lang=self._lang, config=self._config)
 
-                        pages.append(
-                            {
-                                "page_index": page_index,
-                                "text": text,
-                                "width": image.width,
-                                "height": image.height,
-                            }
-                        )
-                    except Exception as e:
-                        pages.append(
-                            {
-                                "page_index": page_index,
-                                "text": "",
-                                "error": str(e),
-                            }
-                        )
+                    pages.append(
+                        {
+                            "page_index": page_index,
+                            "text": text,
+                            "width": image.width,
+                            "height": image.height,
+                        }
+                    )
 
                 num_pages = len(images)
 
@@ -117,6 +110,8 @@ class TesseractProvider(Provider):
                 },
             }
 
+        except (ProviderPermanentError, ProviderTransientError, ProviderConfigError):
+            raise
         except FileNotFoundError as e:
             raise ProviderPermanentError(f"PDF file not found: {pdf_path}") from e
         except Exception as e:

--- a/src/parse_bench/inference/providers/parse/tesseract.py
+++ b/src/parse_bench/inference/providers/parse/tesseract.py
@@ -10,6 +10,7 @@ from parse_bench.inference.providers.base import (
     ProviderPermanentError,
     ProviderTransientError,
 )
+from parse_bench.inference.providers.parse._multipage_image import open_document_page_images
 from parse_bench.inference.providers.registry import register_provider
 from parse_bench.schemas.parse_output import PageIR, ParseOutput
 from parse_bench.schemas.pipeline import PipelineSpec
@@ -59,60 +60,56 @@ class TesseractProvider(Provider):
         """
         try:
             import pytesseract
-            from pdf2image import convert_from_path
         except ImportError as e:
-            missing_pkg = "pytesseract" if "pytesseract" in str(e) else "pdf2image"
-            raise ProviderConfigError(
-                f"{missing_pkg} package not installed. Run: pip install pytesseract pdf2image"
-            ) from e
+            raise ProviderConfigError("pytesseract package not installed. Run: pip install pytesseract") from e
 
         try:
-            # Convert PDF pages to images
-            images = convert_from_path(pdf_path, dpi=self._dpi)
-
             pages = []
-            for page_index, image in enumerate(images):
-                try:
-                    # Perform OCR based on output type
-                    if self._output_type == "text":
-                        text = pytesseract.image_to_string(image, lang=self._lang, config=self._config)
-                    elif self._output_type == "dict":
-                        data = pytesseract.image_to_data(
-                            image,
-                            lang=self._lang,
-                            config=self._config,
-                            output_type=pytesseract.Output.DICT,
-                        )
-                        text = " ".join([word for word in data.get("text", []) if word.strip()])
-                    elif self._output_type == "data":
-                        text = pytesseract.image_to_data(image, lang=self._lang, config=self._config)
-                    elif self._output_type == "boxes":
-                        text = pytesseract.image_to_boxes(image, lang=self._lang, config=self._config)
-                    elif self._output_type == "osd":
-                        text = pytesseract.image_to_osd(image, config=self._config)
-                    else:
-                        text = pytesseract.image_to_string(image, lang=self._lang, config=self._config)
+            with open_document_page_images(pdf_path, dpi=self._dpi) as images:
+                for page_index, image in enumerate(images):
+                    try:
+                        # Perform OCR based on output type
+                        if self._output_type == "text":
+                            text = pytesseract.image_to_string(image, lang=self._lang, config=self._config)
+                        elif self._output_type == "dict":
+                            data = pytesseract.image_to_data(
+                                image,
+                                lang=self._lang,
+                                config=self._config,
+                                output_type=pytesseract.Output.DICT,
+                            )
+                            text = " ".join([word for word in data.get("text", []) if word.strip()])
+                        elif self._output_type == "data":
+                            text = pytesseract.image_to_data(image, lang=self._lang, config=self._config)
+                        elif self._output_type == "boxes":
+                            text = pytesseract.image_to_boxes(image, lang=self._lang, config=self._config)
+                        elif self._output_type == "osd":
+                            text = pytesseract.image_to_osd(image, config=self._config)
+                        else:
+                            text = pytesseract.image_to_string(image, lang=self._lang, config=self._config)
 
-                    pages.append(
-                        {
-                            "page_index": page_index,
-                            "text": text,
-                            "width": image.width,
-                            "height": image.height,
-                        }
-                    )
-                except Exception as e:
-                    pages.append(
-                        {
-                            "page_index": page_index,
-                            "text": "",
-                            "error": str(e),
-                        }
-                    )
+                        pages.append(
+                            {
+                                "page_index": page_index,
+                                "text": text,
+                                "width": image.width,
+                                "height": image.height,
+                            }
+                        )
+                    except Exception as e:
+                        pages.append(
+                            {
+                                "page_index": page_index,
+                                "text": "",
+                                "error": str(e),
+                            }
+                        )
+
+                num_pages = len(images)
 
             return {
                 "pages": pages,
-                "num_pages": len(images),
+                "num_pages": num_pages,
                 "config": {
                     "lang": self._lang,
                     "dpi": self._dpi,

--- a/src/parse_bench/inference/providers/parse/textract.py
+++ b/src/parse_bench/inference/providers/parse/textract.py
@@ -61,6 +61,8 @@ class TextractProvider(Provider):
     Tables are converted to HTML to preserve their visual structure.
     """
 
+    PDF_RENDER_DPI = 300
+
     def __init__(self, provider_name: str, base_config: dict[str, Any] | None = None):
         """
         Initialize the provider.
@@ -274,7 +276,7 @@ class TextractProvider(Provider):
                     raise ProviderPermanentError(f"Invalid document: {error_message}") from exc
                 raise ProviderTransientError(f"AWS Textract error: {error_message}") from exc
 
-        with open_document_page_images(path, dpi=300) as images:
+        with open_document_page_images(path, dpi=self.PDF_RENDER_DPI) as images:
             for page_num, image in enumerate(images):
                 # Convert PIL image to bytes, resizing if needed for Textract limits
                 img_bytes = self._resize_image_for_textract(image)

--- a/src/parse_bench/inference/providers/parse/textract.py
+++ b/src/parse_bench/inference/providers/parse/textract.py
@@ -271,7 +271,7 @@ class TextractProvider(Provider):
         current_page = 0
 
         def analyze_page(img_bytes: bytes, feature_types: list[str]) -> dict[str, Any]:
-            from botocore.exceptions import ClientError
+            from botocore.exceptions import BotoCoreError, ClientError
 
             try:
                 if feature_types:
@@ -295,6 +295,8 @@ class TextractProvider(Provider):
                 if error_code in ("InvalidParameterException", "UnsupportedDocumentException"):
                     raise ProviderPermanentError(f"Invalid document: {error_message}") from exc
                 raise ProviderTransientError(f"AWS Textract error: {error_message}") from exc
+            except BotoCoreError as exc:
+                raise ProviderTransientError(f"AWS Textract transport error: {exc}") from exc
 
         with open_document_page_images(path, dpi=self.PDF_RENDER_DPI) as images:
             for page_num, image in enumerate(images):
@@ -399,7 +401,7 @@ class TextractProvider(Provider):
             )
 
         # Build full document markdown
-        full_markdown = "\n\n".join(page["markdown"] for page in pages_data if page["markdown"])  # type: ignore[misc]
+        full_markdown = "\n\n".join(page["markdown"] for page in pages_data)  # type: ignore[misc]
 
         return {
             "pages": pages_data,
@@ -548,7 +550,7 @@ class TextractProvider(Provider):
 
         # Build layout_pages for layout cross-evaluation
         blocks = textract_response.get("Blocks", [])
-        layout_pages = _build_layout_pages(blocks)
+        layout_pages = _build_layout_pages(blocks, num_pages=markdown_result.get("num_pages", 0))
 
         output = ParseOutput(
             task_type="parse",
@@ -571,7 +573,7 @@ class TextractProvider(Provider):
         )
 
 
-def _build_layout_pages(blocks: list[dict[str, Any]]) -> list[ParseLayoutPageIR]:
+def _build_layout_pages(blocks: list[dict[str, Any]], *, num_pages: int | None = None) -> list[ParseLayoutPageIR]:
     """Build layout_pages from Textract LAYOUT_* blocks for layout cross-evaluation.
 
     Groups LAYOUT_* blocks by page and converts each block's normalized [0,1]
@@ -594,6 +596,13 @@ def _build_layout_pages(blocks: list[dict[str, Any]]) -> list[ParseLayoutPageIR]
         if block_type in TEXTRACT_LABEL_MAP:
             page_num = block.get("Page", 1)
             pages_blocks[page_num].append(block)
+
+    if num_pages is None:
+        num_pages = max(pages_blocks, default=0)
+    if not isinstance(num_pages, int) or isinstance(num_pages, bool) or num_pages < 0:
+        raise ProviderPermanentError("Textract page count must be a non-negative integer")
+    for page_num in range(1, num_pages + 1):
+        pages_blocks.setdefault(page_num, [])
 
     layout_pages: list[ParseLayoutPageIR] = []
     for page_num in sorted(pages_blocks.keys()):

--- a/src/parse_bench/inference/providers/parse/textract.py
+++ b/src/parse_bench/inference/providers/parse/textract.py
@@ -1,6 +1,7 @@
 """Provider for AWS Textract document parsing."""
 
 import os
+from contextlib import ExitStack
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -123,35 +124,42 @@ class TextractProvider(Provider):
 
         from PIL import Image
 
-        # Step 1: Resize if dimensions exceed limit
-        width, height = image.size
-        if width > self._MAX_DIMENSION or height > self._MAX_DIMENSION:
-            scale = min(self._MAX_DIMENSION / width, self._MAX_DIMENSION / height)
-            new_width = int(width * scale)
-            new_height = int(height * scale)
-            image = image.resize((new_width, new_height), Image.Resampling.LANCZOS)
+        with ExitStack() as derived_images:
+            original = image
 
-        # Step 2: Try PNG first
-        img_buffer = io.BytesIO()
-        image.save(img_buffer, format="PNG", optimize=True)
-        img_bytes = img_buffer.getvalue()
+            # Step 1: Resize if dimensions exceed limit
+            width, height = image.size
+            if width > self._MAX_DIMENSION or height > self._MAX_DIMENSION:
+                scale = min(self._MAX_DIMENSION / width, self._MAX_DIMENSION / height)
+                new_width = int(width * scale)
+                new_height = int(height * scale)
+                image = image.resize((new_width, new_height), Image.Resampling.LANCZOS)
+                if image is not original:
+                    derived_images.callback(image.close)
 
-        # Step 3: If still too large, progressively reduce size
-        scale = 0.9
-        while len(img_bytes) > self._TARGET_BYTES and scale > 0.3:
-            new_width = int(image.size[0] * scale)
-            new_height = int(image.size[1] * scale)
-            resized = image.resize((new_width, new_height), Image.Resampling.LANCZOS)
-
+            # Step 2: Try PNG first
             img_buffer = io.BytesIO()
-            resized.save(img_buffer, format="PNG", optimize=True)
+            image.save(img_buffer, format="PNG", optimize=True)
             img_bytes = img_buffer.getvalue()
 
-            if len(img_bytes) <= self._TARGET_BYTES:
-                break
-            scale *= 0.9
+            # Step 3: If still too large, progressively reduce size
+            scale = 0.9
+            while len(img_bytes) > self._TARGET_BYTES and scale > 0.3:
+                new_width = int(image.size[0] * scale)
+                new_height = int(image.size[1] * scale)
+                resized = image.resize((new_width, new_height), Image.Resampling.LANCZOS)
+                if resized is not original:
+                    derived_images.callback(resized.close)
 
-        return img_bytes
+                img_buffer = io.BytesIO()
+                resized.save(img_buffer, format="PNG", optimize=True)
+                img_bytes = img_buffer.getvalue()
+
+                if len(img_bytes) <= self._TARGET_BYTES:
+                    break
+                scale *= 0.9
+
+            return img_bytes
 
     def _analyze_document(self, file_path: str) -> dict[str, Any]:
         """

--- a/src/parse_bench/inference/providers/parse/textract.py
+++ b/src/parse_bench/inference/providers/parse/textract.py
@@ -11,6 +11,7 @@ from parse_bench.inference.providers.base import (
     ProviderPermanentError,
     ProviderTransientError,
 )
+from parse_bench.inference.providers.parse._multipage_image import open_document_page_images
 from parse_bench.inference.providers.registry import register_provider
 from parse_bench.schemas.parse_output import (
     LayoutItemIR,
@@ -232,59 +233,49 @@ class TextractProvider(Provider):
         if suffix in {".png", ".jpg", ".jpeg", ".tiff", ".tif"}:
             return self._analyze_document(file_path)
 
-        # For PDFs, convert each page to image and process
-        try:
-            from pdf2image import convert_from_path
-        except ImportError as e:
-            raise ProviderConfigError("pdf2image package not installed. Run: pip install pdf2image") from e
-
-        try:
-            images = convert_from_path(file_path, dpi=300)
-        except Exception as e:
-            raise ProviderPermanentError(f"Failed to convert PDF to images: {e}") from e
-
         all_blocks: list[dict[str, Any]] = []
         current_page = 0
 
-        for page_num, image in enumerate(images):
-            # Convert PIL image to bytes, resizing if needed for Textract limits
-            img_bytes = self._resize_image_for_textract(image)
+        with open_document_page_images(path, dpi=300) as images:
+            for page_num, image in enumerate(images):
+                # Convert PIL image to bytes, resizing if needed for Textract limits
+                img_bytes = self._resize_image_for_textract(image)
 
-            # Analyze this page
-            feature_types = ["LAYOUT"]
-            if self._detect_tables:
-                feature_types.append("TABLES")
-            if self._detect_forms:
-                feature_types.append("FORMS")
+                # Analyze this page
+                feature_types = ["LAYOUT"]
+                if self._detect_tables:
+                    feature_types.append("TABLES")
+                if self._detect_forms:
+                    feature_types.append("FORMS")
 
-            try:
-                from botocore.exceptions import ClientError
+                try:
+                    from botocore.exceptions import ClientError
 
-                if feature_types:
-                    response = self._textract_client.analyze_document(
-                        Document={"Bytes": img_bytes},
-                        FeatureTypes=feature_types,
-                    )
-                else:
-                    response = self._textract_client.detect_document_text(Document={"Bytes": img_bytes})
+                    if feature_types:
+                        response = self._textract_client.analyze_document(
+                            Document={"Bytes": img_bytes},
+                            FeatureTypes=feature_types,
+                        )
+                    else:
+                        response = self._textract_client.detect_document_text(Document={"Bytes": img_bytes})
 
-                # Add page number to blocks and accumulate
-                for block in response.get("Blocks", []):
-                    block["Page"] = page_num + 1
-                    all_blocks.append(block)
+                    # Add page number to blocks and accumulate
+                    for block in response.get("Blocks", []):
+                        block["Page"] = page_num + 1
+                        all_blocks.append(block)
 
-                current_page = page_num + 1
+                    current_page = page_num + 1
 
-            except ClientError as e:
-                error_code = e.response.get("Error", {}).get("Code", "")
-                error_message = e.response.get("Error", {}).get("Message", str(e))
+                except ClientError as e:
+                    error_code = e.response.get("Error", {}).get("Code", "")
+                    error_message = e.response.get("Error", {}).get("Message", str(e))
 
-                if error_code in ("ThrottlingException", "ProvisionedThroughputExceededException"):
-                    raise ProviderTransientError(f"Rate limit exceeded: {error_message}") from e
-                elif error_code in ("InvalidParameterException", "UnsupportedDocumentException"):
-                    raise ProviderPermanentError(f"Invalid document: {error_message}") from e
-                else:
-                    raise ProviderTransientError(f"AWS Textract error: {error_message}") from e
+                    if error_code in ("ThrottlingException", "ProvisionedThroughputExceededException"):
+                        raise ProviderTransientError(f"Rate limit exceeded: {error_message}") from e
+                    elif error_code in ("InvalidParameterException", "UnsupportedDocumentException"):
+                        raise ProviderPermanentError(f"Invalid document: {error_message}") from e
+                    else:
+                        raise ProviderTransientError(f"AWS Textract error: {error_message}") from e
 
         return {
             "Blocks": all_blocks,

--- a/src/parse_bench/inference/providers/parse/textract.py
+++ b/src/parse_bench/inference/providers/parse/textract.py
@@ -100,6 +100,7 @@ class TextractProvider(Provider):
         # Initialize boto3 client
         try:
             import boto3
+            from botocore.config import Config
         except ImportError as e:
             raise ProviderConfigError("boto3 package not installed. Run: pip install boto3") from e
 
@@ -108,6 +109,7 @@ class TextractProvider(Provider):
             aws_access_key_id=self._aws_access_key_id,
             aws_secret_access_key=self._aws_secret_access_key,
             region_name=self._aws_region,
+            config=Config(retries={"total_max_attempts": 1, "mode": "standard"}),
         )
 
     # Textract synchronous API limits

--- a/src/parse_bench/inference/providers/parse/textract.py
+++ b/src/parse_bench/inference/providers/parse/textract.py
@@ -1,7 +1,6 @@
 """Provider for AWS Textract document parsing."""
 
 import os
-from contextlib import ExitStack
 from datetime import datetime
 from functools import partial
 from pathlib import Path
@@ -11,6 +10,7 @@ from parse_bench.inference.providers.base import (
     Provider,
     ProviderConfigError,
     ProviderPermanentError,
+    ProviderRetryExhaustedError,
     ProviderTransientError,
 )
 from parse_bench.inference.providers.parse._multipage_image import (
@@ -132,42 +132,52 @@ class TextractProvider(Provider):
 
         from PIL import Image
 
-        with ExitStack() as derived_images:
-            original = image
-
+        original = image
+        base = image
+        candidate = None
+        try:
             # Step 1: Resize if dimensions exceed limit
-            width, height = image.size
+            width, height = base.size
             if width > self._MAX_DIMENSION or height > self._MAX_DIMENSION:
                 scale = min(self._MAX_DIMENSION / width, self._MAX_DIMENSION / height)
                 new_width = int(width * scale)
                 new_height = int(height * scale)
-                image = image.resize((new_width, new_height), Image.Resampling.LANCZOS)
-                if image is not original:
-                    derived_images.callback(image.close)
+                base = base.resize((new_width, new_height), Image.Resampling.LANCZOS)
 
             # Step 2: Try PNG first
             img_buffer = io.BytesIO()
-            image.save(img_buffer, format="PNG", optimize=True)
+            base.save(img_buffer, format="PNG", optimize=True)
             img_bytes = img_buffer.getvalue()
 
             # Step 3: If still too large, progressively reduce size
             scale = 0.9
             while len(img_bytes) > self._TARGET_BYTES and scale > 0.3:
-                new_width = int(image.size[0] * scale)
-                new_height = int(image.size[1] * scale)
-                resized = image.resize((new_width, new_height), Image.Resampling.LANCZOS)
-                if resized is not original:
-                    derived_images.callback(resized.close)
+                if candidate is not None:
+                    candidate.close()
+                    candidate = None
+                new_width = int(base.size[0] * scale)
+                new_height = int(base.size[1] * scale)
+                resized = base.resize((new_width, new_height), Image.Resampling.LANCZOS)
+                try:
+                    img_buffer = io.BytesIO()
+                    resized.save(img_buffer, format="PNG", optimize=True)
+                    img_bytes = img_buffer.getvalue()
+                except Exception:
+                    resized.close()
+                    raise
 
-                img_buffer = io.BytesIO()
-                resized.save(img_buffer, format="PNG", optimize=True)
-                img_bytes = img_buffer.getvalue()
+                candidate = resized
 
                 if len(img_bytes) <= self._TARGET_BYTES:
                     break
                 scale *= 0.9
 
             return img_bytes
+        finally:
+            if candidate is not None:
+                candidate.close()
+            if base is not original:
+                base.close()
 
     def _analyze_document(self, file_path: str) -> dict[str, Any]:
         """
@@ -231,7 +241,7 @@ class TextractProvider(Provider):
         except Exception as e:
             raise ProviderTransientError(f"Unexpected error calling Textract: {e}") from e
 
-    def _analyze_multipage_document(self, file_path: str) -> dict[str, Any]:
+    def _analyze_multipage_document(self, file_path: str) -> tuple[dict[str, Any], list[dict[str, object]]]:
         """
         Analyze a multi-page document using AWS Textract async API.
 
@@ -247,9 +257,17 @@ class TextractProvider(Provider):
 
         # For images, use direct synchronous API
         if suffix in {".png", ".jpg", ".jpeg", ".tiff", ".tif"}:
-            return self._analyze_document(file_path)
+            direct_attempts: list[dict[str, object]] = []
+            response = run_page_with_retries(
+                partial(self._analyze_document, file_path),
+                provider_name="textract",
+                page_number=1,
+                attempt_ledger=direct_attempts,
+            )
+            return response, direct_attempts
 
         all_blocks: list[dict[str, Any]] = []
+        api_attempts: list[dict[str, object]] = []
         current_page = 0
 
         def analyze_page(img_bytes: bytes, feature_types: list[str]) -> dict[str, Any]:
@@ -290,21 +308,33 @@ class TextractProvider(Provider):
                 if self._detect_forms:
                     feature_types.append("FORMS")
 
-                response = run_page_with_retries(
-                    partial(analyze_page, img_bytes, feature_types),
-                    provider_name="textract",
-                    page_number=page_num + 1,
-                )
+                attempts: list[dict[str, object]] = []
+                try:
+                    response = run_page_with_retries(
+                        partial(analyze_page, img_bytes, feature_types),
+                        provider_name="textract",
+                        page_number=page_num + 1,
+                        attempt_ledger=attempts,
+                    )
+                except ProviderRetryExhaustedError as error:
+                    payload = dict(error.debug_payload or {})
+                    payload["attempts"] = [*api_attempts, *attempts]
+                    error.debug_payload = payload
+                    raise
+                api_attempts.extend(attempts)
                 for block in response.get("Blocks", []):
                     block["Page"] = page_num + 1
                     all_blocks.append(block)
 
                 current_page = page_num + 1
 
-        return {
-            "Blocks": all_blocks,
-            "DocumentMetadata": {"Pages": current_page},
-        }
+        return (
+            {
+                "Blocks": all_blocks,
+                "DocumentMetadata": {"Pages": current_page},
+            },
+            api_attempts,
+        )
 
     def _convert_to_markdown(self, textract_response: dict[str, Any]) -> dict[str, Any]:
         """
@@ -454,7 +484,7 @@ class TextractProvider(Provider):
 
         try:
             # Analyze the document
-            textract_response = self._analyze_multipage_document(str(source_path))
+            textract_response, api_attempts = self._analyze_multipage_document(str(source_path))
 
             completed_at = datetime.now()
             latency_ms = int((completed_at - started_at).total_seconds() * 1000)
@@ -466,6 +496,8 @@ class TextractProvider(Provider):
                 product_type=request.product_type,
                 raw_output={
                     "textract_response": textract_response,
+                    "num_api_calls": len(api_attempts),
+                    "api_attempts": api_attempts,
                     "config": {
                         "output_tables_as_html": self._output_tables_as_html,
                         "detect_tables": self._detect_tables,

--- a/src/parse_bench/inference/providers/parse/textract.py
+++ b/src/parse_bench/inference/providers/parse/textract.py
@@ -3,8 +3,9 @@
 import os
 from contextlib import ExitStack
 from datetime import datetime
+from functools import partial
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from parse_bench.inference.providers.base import (
     Provider,
@@ -12,7 +13,10 @@ from parse_bench.inference.providers.base import (
     ProviderPermanentError,
     ProviderTransientError,
 )
-from parse_bench.inference.providers.parse._multipage_image import open_document_page_images
+from parse_bench.inference.providers.parse._multipage_image import (
+    open_document_page_images,
+    run_page_with_retries,
+)
 from parse_bench.inference.providers.registry import register_provider
 from parse_bench.schemas.parse_output import (
     LayoutItemIR,
@@ -244,6 +248,32 @@ class TextractProvider(Provider):
         all_blocks: list[dict[str, Any]] = []
         current_page = 0
 
+        def analyze_page(img_bytes: bytes, feature_types: list[str]) -> dict[str, Any]:
+            from botocore.exceptions import ClientError
+
+            try:
+                if feature_types:
+                    return cast(
+                        dict[str, Any],
+                        self._textract_client.analyze_document(
+                            Document={"Bytes": img_bytes},
+                            FeatureTypes=feature_types,
+                        ),
+                    )
+                return cast(
+                    dict[str, Any],
+                    self._textract_client.detect_document_text(Document={"Bytes": img_bytes}),
+                )
+            except ClientError as exc:
+                error_code = exc.response.get("Error", {}).get("Code", "")
+                error_message = exc.response.get("Error", {}).get("Message", str(exc))
+
+                if error_code in ("ThrottlingException", "ProvisionedThroughputExceededException"):
+                    raise ProviderTransientError(f"Rate limit exceeded: {error_message}") from exc
+                if error_code in ("InvalidParameterException", "UnsupportedDocumentException"):
+                    raise ProviderPermanentError(f"Invalid document: {error_message}") from exc
+                raise ProviderTransientError(f"AWS Textract error: {error_message}") from exc
+
         with open_document_page_images(path, dpi=300) as images:
             for page_num, image in enumerate(images):
                 # Convert PIL image to bytes, resizing if needed for Textract limits
@@ -256,34 +286,16 @@ class TextractProvider(Provider):
                 if self._detect_forms:
                     feature_types.append("FORMS")
 
-                try:
-                    from botocore.exceptions import ClientError
+                response = run_page_with_retries(
+                    partial(analyze_page, img_bytes, feature_types),
+                    provider_name="textract",
+                    page_number=page_num + 1,
+                )
+                for block in response.get("Blocks", []):
+                    block["Page"] = page_num + 1
+                    all_blocks.append(block)
 
-                    if feature_types:
-                        response = self._textract_client.analyze_document(
-                            Document={"Bytes": img_bytes},
-                            FeatureTypes=feature_types,
-                        )
-                    else:
-                        response = self._textract_client.detect_document_text(Document={"Bytes": img_bytes})
-
-                    # Add page number to blocks and accumulate
-                    for block in response.get("Blocks", []):
-                        block["Page"] = page_num + 1
-                        all_blocks.append(block)
-
-                    current_page = page_num + 1
-
-                except ClientError as e:
-                    error_code = e.response.get("Error", {}).get("Code", "")
-                    error_message = e.response.get("Error", {}).get("Message", str(e))
-
-                    if error_code in ("ThrottlingException", "ProvisionedThroughputExceededException"):
-                        raise ProviderTransientError(f"Rate limit exceeded: {error_message}") from e
-                    elif error_code in ("InvalidParameterException", "UnsupportedDocumentException"):
-                        raise ProviderPermanentError(f"Invalid document: {error_message}") from e
-                    else:
-                        raise ProviderTransientError(f"AWS Textract error: {error_message}") from e
+                current_page = page_num + 1
 
         return {
             "Blocks": all_blocks,

--- a/src/parse_bench/inference/providers/parse/textract.py
+++ b/src/parse_bench/inference/providers/parse/textract.py
@@ -172,6 +172,10 @@ class TextractProvider(Provider):
                     break
                 scale *= 0.9
 
+            if len(img_bytes) > self._MAX_BYTES:
+                raise ProviderPermanentError(
+                    f"Textract image remains above the {self._MAX_BYTES}-byte API limit after resizing"
+                )
             return img_bytes
         finally:
             if candidate is not None:

--- a/src/parse_bench/inference/providers/parse/unlimitedocr.py
+++ b/src/parse_bench/inference/providers/parse/unlimitedocr.py
@@ -52,6 +52,8 @@ class UnlimitedOCRProvider(Provider):
         - dpi (int, default=300): DPI for PDF to image conversion
     """
 
+    PDF_RENDER_DPI = 300
+
     def __init__(self, provider_name: str, base_config: dict[str, Any] | None = None):
         super().__init__(provider_name, base_config)
 
@@ -62,7 +64,7 @@ class UnlimitedOCRProvider(Provider):
 
         # Match the model's reference config: PDF_DPI=300, REQUEST_TIMEOUT=1200.
         self._timeout = self.base_config.get("timeout", 1200)
-        self._dpi = self.base_config.get("dpi", 300)
+        self._dpi = self.base_config.get("dpi", self.PDF_RENDER_DPI)
 
     def _pdf_to_image(self, pdf_path: Path) -> bytes:
         try:

--- a/src/parse_bench/inference/providers/parse/unlimitedocr.py
+++ b/src/parse_bench/inference/providers/parse/unlimitedocr.py
@@ -27,6 +27,7 @@ from parse_bench.inference.providers.base import (
     ProviderTransientError,
 )
 from parse_bench.inference.providers.parse._layout_utils import build_layout_pages
+from parse_bench.inference.providers.parse._multipage_image import normalize_pdf_pages, run_pdf_pages
 from parse_bench.inference.providers.parse.mistral_ocr import _convert_pipe_tables_to_html
 from parse_bench.inference.providers.registry import register_provider
 from parse_bench.schemas.parse_output import ParseOutput
@@ -130,6 +131,10 @@ class UnlimitedOCRProvider(Provider):
         }
 
     def run_inference(self, pipeline: PipelineSpec, request: InferenceRequest) -> RawInferenceResult:
+        multipage_result = run_pdf_pages(pipeline, request, dpi=self._dpi, run_single_image=self.run_inference)
+        if multipage_result is not None:
+            return multipage_result
+
         if request.product_type != ProductType.PARSE:
             raise ProviderPermanentError(
                 f"UnlimitedOCRProvider only supports PARSE product type, got {request.product_type}"
@@ -265,6 +270,10 @@ class UnlimitedOCRProvider(Provider):
     }
 
     def normalize(self, raw_result: RawInferenceResult) -> InferenceResult:
+        multipage_result = normalize_pdf_pages(raw_result, normalize_single_image=self.normalize)
+        if multipage_result is not None:
+            return multipage_result
+
         if raw_result.product_type != ProductType.PARSE:
             raise ProviderPermanentError(
                 f"UnlimitedOCRProvider only supports PARSE product type, got {raw_result.product_type}"

--- a/src/parse_bench/inference/providers/registry.py
+++ b/src/parse_bench/inference/providers/registry.py
@@ -30,6 +30,11 @@ def register_provider(provider_name: str) -> Callable[[type[Provider]], type[Pro
     return decorator
 
 
+def registered_providers() -> dict[str, type[Provider]]:
+    """Return a snapshot of the authoritative runtime provider registry."""
+    return dict(_PROVIDER_REGISTRY)
+
+
 def create_provider(pipeline: PipelineSpec) -> Provider:
     """
     Instantiate a Provider for the given PipelineSpec.

--- a/src/parse_bench/inference/runner.py
+++ b/src/parse_bench/inference/runner.py
@@ -3,6 +3,7 @@
 import asyncio
 import concurrent.futures
 import json
+import math
 import os
 import shutil
 import subprocess
@@ -11,7 +12,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeGuard
 from urllib import error as urllib_error
 from urllib import request as urllib_request
 
@@ -48,6 +49,29 @@ from parse_bench.test_cases.schema import TestCase
 MAX_RETRIES = 5
 INITIAL_BACKOFF_S = 2.0  # seconds
 BACKOFF_MULTIPLIER = 2.0  # exponential backoff factor
+
+_RETRY_ADDITIVE_FIELDS = (
+    "credits_used",
+    "cost_usd",
+    "input_cost_usd",
+    "tool_use_prompt_cost_usd",
+    "cached_input_cost_usd",
+    "output_and_thinking_cost_usd",
+    "cache_storage_cost_usd",
+    "input_tokens",
+    "tool_use_prompt_tokens",
+    "cached_content_tokens",
+    "output_tokens",
+    "total_tokens",
+    "thinking_tokens",
+)
+_RETRY_PER_PAGE_FIELDS = {
+    "cost_per_page_usd": "cost_usd",
+    "input_tokens_per_page": "input_tokens",
+    "tool_use_prompt_tokens_per_page": "tool_use_prompt_tokens",
+    "cached_content_tokens_per_page": "cached_content_tokens",
+    "output_tokens_per_page": "output_tokens",
+}
 
 # Per-file timeout and retry configuration
 DEFAULT_PER_FILE_TIMEOUT_S = 600.0  # 10 minutes per file
@@ -237,25 +261,129 @@ class InferenceRunner:
         self,
         example_id: str,
         future: concurrent.futures.Future[Any],
-    ) -> None:
-        """Cancel cooperatively and wait until no prior worker can overlap a retry."""
+    ) -> Any | None:
+        """Cancel cooperatively, drain the worker, and preserve a late outcome."""
         self._signal_cancel_and_cancel_future(example_id, future)
         try:
-            future.result()
-        except (concurrent.futures.CancelledError, Exception):
-            pass
+            return future.result()
+        except Exception:
+            return None
 
     async def _cancel_inflight_and_drain_async(
         self,
         example_id: str,
         future: concurrent.futures.Future[Any],
-    ) -> None:
-        """Cancel cooperatively and await termination before any async retry."""
+    ) -> Any | None:
+        """Cancel cooperatively, await termination, and preserve a late outcome."""
         self._signal_cancel_and_cancel_future(example_id, future)
         try:
-            await asyncio.shield(asyncio.wrap_future(future))
+            return await asyncio.shield(asyncio.wrap_future(future))
         except (concurrent.futures.CancelledError, asyncio.CancelledError, Exception):
-            pass
+            return None
+
+    @staticmethod
+    def _is_finite_number(value: object) -> TypeGuard[int | float]:
+        return isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value)
+
+    def _attempt_stats_with_cost(self, error: ProviderError) -> dict[str, int | float]:
+        """Return public stats for one failed physical call, deriving model cost."""
+        stats = {key: value for key, value in dict(error.attempt_stats or {}).items() if self._is_finite_number(value)}
+        if "cost_usd" in stats:
+            return stats
+
+        pricing = getattr(self.provider, "_get_pricing", None)
+        if not callable(pricing):
+            return stats
+        try:
+            input_rate, output_rate = pricing()
+        except Exception:  # pragma: no cover - provider-specific defensive path
+            return stats
+        input_tokens = stats.get("input_tokens")
+        output_tokens = stats.get("output_tokens")
+        thinking_tokens = stats.get("thinking_tokens", 0)
+        if not self._is_finite_number(input_rate) or not self._is_finite_number(output_rate):
+            return stats
+        if not self._is_finite_number(input_tokens) or not self._is_finite_number(output_tokens):
+            return stats
+        if not self._is_finite_number(thinking_tokens):
+            return stats
+        stats["cost_usd"] = (input_tokens * input_rate + (output_tokens + thinking_tokens) * output_rate) / 1_000_000
+        return stats
+
+    def _merge_retry_attempts(
+        self,
+        raw_result: RawInferenceResult,
+        failed_attempts: list[dict[str, object]],
+    ) -> None:
+        """Merge runner-owned failures into the successful provider result."""
+        if not failed_attempts:
+            return
+
+        raw_output = raw_result.raw_output
+        existing = raw_output.get("api_attempts")
+        successful_attempts = (
+            [dict(attempt) for attempt in existing if isinstance(attempt, dict)] if isinstance(existing, list) else []
+        )
+        successful_call_count = raw_output.get("num_api_calls")
+        if not self._is_finite_number(successful_call_count):
+            successful_call_count = len(successful_attempts) or 1
+        if not successful_attempts:
+            successful_attempts = [
+                {
+                    "runner_attempt": len(failed_attempts) + 1,
+                    "status": "succeeded",
+                    "stats": {
+                        field: raw_output[field]
+                        for field in _RETRY_ADDITIVE_FIELDS
+                        if self._is_finite_number(raw_output.get(field))
+                    },
+                }
+            ]
+
+        failed_stats = [attempt["stats"] for attempt in failed_attempts]
+        for stat_field in _RETRY_ADDITIVE_FIELDS:
+            current = raw_output.get(stat_field)
+            prior_values = [stats.get(stat_field) if isinstance(stats, dict) else None for stats in failed_stats]
+            if self._is_finite_number(current) and all(self._is_finite_number(value) for value in prior_values):
+                raw_output[stat_field] = current + sum(prior_values)  # type: ignore[arg-type,operator]
+            elif stat_field in raw_output:
+                # A partial total is more misleading than an explicit omission.
+                del raw_output[stat_field]
+
+        raw_output["num_api_calls"] = len(failed_attempts) + int(successful_call_count)
+        raw_output["api_attempts"] = [*failed_attempts, *successful_attempts]
+
+        num_pages = raw_output.get("num_pages")
+        for per_page_field, total_field in _RETRY_PER_PAGE_FIELDS.items():
+            total = raw_output.get(total_field)
+            if self._is_finite_number(total) and self._is_finite_number(num_pages) and num_pages > 0:
+                raw_output[per_page_field] = total / num_pages
+            else:
+                raw_output.pop(per_page_field, None)
+
+    def _run_inference_with_retries(self, request: InferenceRequest) -> RawInferenceResult:
+        """Run a document provider and account every runner-owned API attempt."""
+        failed_attempts: list[dict[str, object]] = []
+        for attempt in range(MAX_RETRIES + 1):
+            try:
+                raw_result = self.provider.run_inference(self.pipeline, request)
+            except (ProviderTransientError, ProviderRateLimitError) as error:
+                failed_attempts.append(
+                    {
+                        "runner_attempt": attempt + 1,
+                        "status": "failed",
+                        "stats": self._attempt_stats_with_cost(error),
+                        "error_type": type(error).__name__,
+                        "error": str(error),
+                    }
+                )
+                if attempt == MAX_RETRIES:
+                    raise
+                time.sleep(INITIAL_BACKOFF_S * (BACKOFF_MULTIPLIER**attempt))
+            else:
+                self._merge_retry_attempts(raw_result, failed_attempts)
+                return raw_result
+        raise AssertionError("unreachable")
 
     def _is_already_processed(self, example_id: str) -> bool:
         """Check if a file has already been processed."""
@@ -581,21 +709,7 @@ class InferenceRunner:
                 product_type=product_type,
             )
 
-            # Run inference with retry for transient / rate-limit errors
-            last_error: Exception | None = None
-            for attempt in range(MAX_RETRIES + 1):
-                try:
-                    raw_result = self.provider.run_inference(self.pipeline, request)
-                    break
-                except (ProviderTransientError, ProviderRateLimitError) as e:
-                    last_error = e
-                    if attempt < MAX_RETRIES:
-                        backoff = INITIAL_BACKOFF_S * (BACKOFF_MULTIPLIER**attempt)
-                        time.sleep(backoff)
-                    else:
-                        raise
-            else:
-                raise last_error  # type: ignore[misc]
+            raw_result = self._run_inference_with_retries(request)
 
             # Fetch parse jobLogs + extract token usage BEFORE normalize, so that
             # token fields land in the InferenceResult that evaluation reads.
@@ -675,21 +789,7 @@ class InferenceRunner:
                 config_override=getattr(test_case, "config", None),
             )
 
-            # Run inference with retry for transient / rate-limit errors
-            last_error: Exception | None = None
-            for attempt in range(MAX_RETRIES + 1):
-                try:
-                    raw_result = self.provider.run_inference(self.pipeline, request)
-                    break
-                except (ProviderTransientError, ProviderRateLimitError) as e:
-                    last_error = e
-                    if attempt < MAX_RETRIES:
-                        backoff = INITIAL_BACKOFF_S * (BACKOFF_MULTIPLIER**attempt)
-                        time.sleep(backoff)
-                    else:
-                        raise
-            else:
-                raise last_error  # type: ignore[misc]
+            raw_result = self._run_inference_with_retries(request)
 
             # Fetch parse jobLogs + extract token usage BEFORE normalize, so that
             # token fields land in the InferenceResult that evaluation reads.
@@ -971,7 +1071,10 @@ class InferenceRunner:
                     raw_result, normalized_result, error_info = future.result(timeout=self.per_file_timeout)
                     break  # Success (or handled provider error) - exit retry loop
                 except concurrent.futures.TimeoutError:
-                    self._cancel_inflight_and_drain(test_case.test_id, future)
+                    drained_outcome = self._cancel_inflight_and_drain(test_case.test_id, future)
+                    if drained_outcome is not None:
+                        raw_result, normalized_result, error_info = drained_outcome
+                        break
                     remaining = self.timeout_retries - timeout_attempt
                     if remaining > 0:
                         print(
@@ -1111,7 +1214,10 @@ class InferenceRunner:
                     )
                     break  # Success (or handled provider error) - exit retry loop
                 except TimeoutError:
-                    await self._cancel_inflight_and_drain_async(test_case.test_id, future)
+                    drained_outcome = await self._cancel_inflight_and_drain_async(test_case.test_id, future)
+                    if drained_outcome is not None:
+                        raw_result, normalized_result, error_info = drained_outcome
+                        break
                     remaining = self.timeout_retries - timeout_attempt
                     if remaining > 0:
                         print(
@@ -1211,7 +1317,10 @@ class InferenceRunner:
                     )
                     break  # Success (or handled provider error) - exit retry loop
                 except TimeoutError:
-                    await self._cancel_inflight_and_drain_async(example_id, future)
+                    drained_outcome = await self._cancel_inflight_and_drain_async(example_id, future)
+                    if drained_outcome is not None:
+                        raw_result, normalized_result, error_info = drained_outcome
+                        break
                     remaining = self.timeout_retries - timeout_attempt
                     if remaining > 0:
                         print(f"  Timeout after {self.per_file_timeout}s for {example_id}, retrying ({remaining} left)")

--- a/src/parse_bench/inference/runner.py
+++ b/src/parse_bench/inference/runner.py
@@ -237,28 +237,24 @@ class InferenceRunner:
         self,
         example_id: str,
         future: concurrent.futures.Future[Any],
-        *,
-        drain_timeout_seconds: float = 5.0,
     ) -> None:
-        """Best-effort timeout cancel for synchronous retry loops."""
+        """Cancel cooperatively and wait until no prior worker can overlap a retry."""
         self._signal_cancel_and_cancel_future(example_id, future)
         try:
-            future.result(timeout=drain_timeout_seconds)
-        except (concurrent.futures.TimeoutError, concurrent.futures.CancelledError, Exception):
+            future.result()
+        except (concurrent.futures.CancelledError, Exception):
             pass
 
     async def _cancel_inflight_and_drain_async(
         self,
         example_id: str,
         future: concurrent.futures.Future[Any],
-        *,
-        drain_timeout_seconds: float = 5.0,
     ) -> None:
-        """Best-effort timeout cancel for async retry loops without blocking the event loop."""
+        """Cancel cooperatively and await termination before any async retry."""
         self._signal_cancel_and_cancel_future(example_id, future)
         try:
-            await asyncio.wait_for(asyncio.wrap_future(future), timeout=drain_timeout_seconds)
-        except (TimeoutError, concurrent.futures.CancelledError, asyncio.CancelledError, Exception):
+            await asyncio.shield(asyncio.wrap_future(future))
+        except (concurrent.futures.CancelledError, asyncio.CancelledError, Exception):
             pass
 
     def _is_already_processed(self, example_id: str) -> bool:

--- a/src/parse_bench/inference/runner.py
+++ b/src/parse_bench/inference/runner.py
@@ -278,6 +278,10 @@ class InferenceRunner:
         self._signal_cancel_and_cancel_future(example_id, future)
         try:
             return await asyncio.shield(asyncio.wrap_future(future))
+        except asyncio.CancelledError:
+            if future.cancelled():
+                return None
+            raise
         except Exception:
             return None
 
@@ -738,6 +742,11 @@ class InferenceRunner:
             error_msg = f"Provider error: {str(e)}"
             if raw_result is not None:
                 self._save_result(raw_result, None)
+            debug_payload = getattr(e, "debug_payload", None)
+            if isinstance(debug_payload, dict):
+                debug_payload_path = self._save_error_debug_payload(example_id, debug_payload)
+                if debug_payload_path:
+                    error_msg += f" [debug payload: {debug_payload_path}]"
             error_traceback = traceback.format_exc()
             if self.use_rich and example_id in self.job_statuses:
                 self.job_statuses[example_id].status = "failed"

--- a/src/parse_bench/inference/runner.py
+++ b/src/parse_bench/inference/runner.py
@@ -382,6 +382,13 @@ class InferenceRunner:
                     }
                 )
                 if attempt == MAX_RETRIES:
+                    payload = dict(error.debug_payload or {})
+                    current_attempts = payload.get("attempts")
+                    payload["attempts"] = [
+                        *failed_attempts,
+                        *(current_attempts if isinstance(current_attempts, list) else []),
+                    ]
+                    error.debug_payload = payload
                     raise
                 time.sleep(INITIAL_BACKOFF_S * (BACKOFF_MULTIPLIER**attempt))
             else:
@@ -1246,6 +1253,9 @@ class InferenceRunner:
                             "TimeoutError",
                         )
                         raw_result, normalized_result = None, None
+                except asyncio.CancelledError:
+                    await self._cancel_inflight_and_drain_async(test_case.test_id, future)
+                    raise
 
             summary.total += 1
 
@@ -1346,6 +1356,9 @@ class InferenceRunner:
                             "TimeoutError",
                         )
                         raw_result, normalized_result = None, None
+                except asyncio.CancelledError:
+                    await self._cancel_inflight_and_drain_async(example_id, future)
+                    raise
 
             summary.total += 1
 

--- a/src/parse_bench/inference/runner.py
+++ b/src/parse_bench/inference/runner.py
@@ -286,6 +286,26 @@ class InferenceRunner:
             return None
 
     @staticmethod
+    def _drained_outcome_is_retryable(outcome: Any) -> bool:
+        """Whether a cooperatively cancelled worker returned a retryable failure."""
+        if not isinstance(outcome, tuple) or len(outcome) != 3:
+            return False
+        error_info = outcome[2]
+        return (
+            isinstance(error_info, tuple)
+            and len(error_info) == 3
+            and error_info[2] in {"ProviderTransientError", "ProviderRateLimitError"}
+        )
+
+    @staticmethod
+    async def _cancel_child_tasks_and_wait(tasks: list[asyncio.Task[None]]) -> None:
+        """Cancel every batch child and wait for its provider worker to drain."""
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+    @staticmethod
     def _is_finite_number(value: object) -> TypeGuard[int | float]:
         return isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value)
 
@@ -1088,7 +1108,10 @@ class InferenceRunner:
                     break  # Success (or handled provider error) - exit retry loop
                 except concurrent.futures.TimeoutError:
                     drained_outcome = self._cancel_inflight_and_drain(test_case.test_id, future)
-                    if drained_outcome is not None:
+                    if drained_outcome is not None and (
+                        not self._drained_outcome_is_retryable(drained_outcome)
+                        or timeout_attempt == self.timeout_retries
+                    ):
                         raw_result, normalized_result, error_info = drained_outcome
                         break
                     remaining = self.timeout_retries - timeout_attempt
@@ -1231,7 +1254,10 @@ class InferenceRunner:
                     break  # Success (or handled provider error) - exit retry loop
                 except TimeoutError:
                     drained_outcome = await self._cancel_inflight_and_drain_async(test_case.test_id, future)
-                    if drained_outcome is not None:
+                    if drained_outcome is not None and (
+                        not self._drained_outcome_is_retryable(drained_outcome)
+                        or timeout_attempt == self.timeout_retries
+                    ):
                         raw_result, normalized_result, error_info = drained_outcome
                         break
                     remaining = self.timeout_retries - timeout_attempt
@@ -1337,7 +1363,10 @@ class InferenceRunner:
                     break  # Success (or handled provider error) - exit retry loop
                 except TimeoutError:
                     drained_outcome = await self._cancel_inflight_and_drain_async(example_id, future)
-                    if drained_outcome is not None:
+                    if drained_outcome is not None and (
+                        not self._drained_outcome_is_retryable(drained_outcome)
+                        or timeout_attempt == self.timeout_retries
+                    ):
                         raw_result, normalized_result, error_info = drained_outcome
                         break
                     remaining = self.timeout_retries - timeout_attempt
@@ -1581,14 +1610,16 @@ class InferenceRunner:
 
         # Create tasks
         tasks = [
-            self._process_with_semaphore(
-                semaphore,
-                pdf_path,
-                example_id_fn(pdf_path),
-                product_type,
-                summary,
-                progress,
-                task_id,
+            asyncio.create_task(
+                self._process_with_semaphore(
+                    semaphore,
+                    pdf_path,
+                    example_id_fn(pdf_path),
+                    product_type,
+                    summary,
+                    progress,
+                    task_id,
+                )
             )
             for pdf_path in pdf_files
         ]
@@ -1687,6 +1718,9 @@ class InferenceRunner:
                                     status_table,
                                 )
                             )
+                except asyncio.CancelledError:
+                    await self._cancel_child_tasks_and_wait(tasks)
+                    raise
                 finally:
                     # Cancel background UI update task
                     ui_update_task.cancel()
@@ -1709,17 +1743,21 @@ class InferenceRunner:
                 )
         else:
             # Fallback to simple processing
-            for coro in asyncio.as_completed(tasks):
-                try:
-                    await coro
-                except Exception as e:
-                    summary.failed += 1
-                    summary.errors.append(
-                        {
-                            "error": f"Task execution error: {str(e)}",
-                            "timestamp": datetime.now().isoformat(),
-                        }
-                    )
+            try:
+                for coro in asyncio.as_completed(tasks):
+                    try:
+                        await coro
+                    except Exception as e:
+                        summary.failed += 1
+                        summary.errors.append(
+                            {
+                                "error": f"Task execution error: {str(e)}",
+                                "timestamp": datetime.now().isoformat(),
+                            }
+                        )
+            except asyncio.CancelledError:
+                await self._cancel_child_tasks_and_wait(tasks)
+                raise
 
         # Finalize summary
         summary.completed_at = datetime.now()
@@ -1841,13 +1879,15 @@ class InferenceRunner:
 
         # Create tasks
         tasks = [
-            self._process_test_case_with_semaphore(
-                semaphore,
-                test_case,
-                product_type,
-                summary,
-                progress,
-                task_id,
+            asyncio.create_task(
+                self._process_test_case_with_semaphore(
+                    semaphore,
+                    test_case,
+                    product_type,
+                    summary,
+                    progress,
+                    task_id,
+                )
             )
             for test_case in test_cases
         ]
@@ -1944,6 +1984,9 @@ class InferenceRunner:
                                     status_table,
                                 )
                             )
+                except asyncio.CancelledError:
+                    await self._cancel_child_tasks_and_wait(tasks)
+                    raise
                 finally:
                     # Cancel background UI update task
                     ui_update_task.cancel()
@@ -1974,37 +2017,41 @@ class InferenceRunner:
             # Print every 10% or every 10 items, whichever is more frequent
             progress_interval = max(10, total // 10)
 
-            for coro in asyncio.as_completed(tasks):
-                try:
-                    await coro
-                    completed_count += 1
+            try:
+                for coro in asyncio.as_completed(tasks):
+                    try:
+                        await coro
+                        completed_count += 1
 
-                    # Print progress periodically
-                    if completed_count - last_progress_print >= progress_interval or completed_count == total:
-                        percentage = (completed_count / total) * 100
-                        print(
-                            f"Progress: {completed_count}/{total} ({percentage:.1f}%) - "
-                            f"Successful: {summary.successful}, Failed: {summary.failed}"
+                        # Print progress periodically
+                        if completed_count - last_progress_print >= progress_interval or completed_count == total:
+                            percentage = (completed_count / total) * 100
+                            print(
+                                f"Progress: {completed_count}/{total} ({percentage:.1f}%) - "
+                                f"Successful: {summary.successful}, Failed: {summary.failed}"
+                            )
+                            last_progress_print = completed_count
+                    except Exception as e:
+                        summary.failed += 1
+                        completed_count += 1
+                        summary.errors.append(
+                            {
+                                "error": f"Task execution error: {str(e)}",
+                                "timestamp": datetime.now().isoformat(),
+                            }
                         )
-                        last_progress_print = completed_count
-                except Exception as e:
-                    summary.failed += 1
-                    completed_count += 1
-                    summary.errors.append(
-                        {
-                            "error": f"Task execution error: {str(e)}",
-                            "timestamp": datetime.now().isoformat(),
-                        }
-                    )
 
-                    # Print progress on error too
-                    if completed_count - last_progress_print >= progress_interval or completed_count == total:
-                        percentage = (completed_count / total) * 100
-                        print(
-                            f"Progress: {completed_count}/{total} ({percentage:.1f}%) - "
-                            f"Successful: {summary.successful}, Failed: {summary.failed}"
-                        )
-                        last_progress_print = completed_count
+                        # Print progress on error too
+                        if completed_count - last_progress_print >= progress_interval or completed_count == total:
+                            percentage = (completed_count / total) * 100
+                            print(
+                                f"Progress: {completed_count}/{total} ({percentage:.1f}%) - "
+                                f"Successful: {summary.successful}, Failed: {summary.failed}"
+                            )
+                            last_progress_print = completed_count
+            except asyncio.CancelledError:
+                await self._cancel_child_tasks_and_wait(tasks)
+                raise
 
             # Print final summary
             print(f"\nCompleted processing {total} test cases:")

--- a/src/parse_bench/inference/runner.py
+++ b/src/parse_bench/inference/runner.py
@@ -278,7 +278,7 @@ class InferenceRunner:
         self._signal_cancel_and_cancel_future(example_id, future)
         try:
             return await asyncio.shield(asyncio.wrap_future(future))
-        except (concurrent.futures.CancelledError, asyncio.CancelledError, Exception):
+        except Exception:
             return None
 
     @staticmethod
@@ -686,7 +686,7 @@ class InferenceRunner:
 
     def _process_document(
         self, pdf_path: Path, example_id: str, product_type: ProductType
-    ) -> tuple[RawInferenceResult | None, InferenceResult | None, str | None]:
+    ) -> tuple[RawInferenceResult | None, InferenceResult | None, str | tuple[str, str, str] | None]:
         """
         Process a single document (synchronous).
 
@@ -743,7 +743,7 @@ class InferenceRunner:
                 self.job_statuses[example_id].status = "failed"
                 self.job_statuses[example_id].error = error_msg
                 self.job_statuses[example_id].completed_at = datetime.now()
-            return None, None, (error_msg, error_traceback, type(e).__name__)  # type: ignore[return-value]
+            return None, None, (error_msg, error_traceback, type(e).__name__)
         except Exception as e:
             import traceback
 
@@ -755,11 +755,11 @@ class InferenceRunner:
                 self.job_statuses[example_id].status = "failed"
                 self.job_statuses[example_id].error = error_msg
                 self.job_statuses[example_id].completed_at = datetime.now()
-            return None, None, (error_msg, error_traceback, type(e).__name__)  # type: ignore[return-value]
+            return None, None, (error_msg, error_traceback, type(e).__name__)
 
     def _process_test_case(
         self, test_case: TestCase, product_type: ProductType
-    ) -> tuple[RawInferenceResult | None, InferenceResult | None, str | None]:
+    ) -> tuple[RawInferenceResult | None, InferenceResult | None, str | tuple[str, str, str] | None]:
         """
         Process a single test case (synchronous).
 
@@ -829,7 +829,7 @@ class InferenceRunner:
                 self.job_statuses[test_case.test_id].status = "failed"
                 self.job_statuses[test_case.test_id].error = error_msg
                 self.job_statuses[test_case.test_id].completed_at = datetime.now()
-            return None, None, (error_msg, error_traceback, type(e).__name__)  # type: ignore[return-value]
+            return None, None, (error_msg, error_traceback, type(e).__name__)
         except Exception as e:
             import traceback
 
@@ -841,7 +841,7 @@ class InferenceRunner:
                 self.job_statuses[test_case.test_id].status = "failed"
                 self.job_statuses[test_case.test_id].error = error_msg
                 self.job_statuses[test_case.test_id].completed_at = datetime.now()
-            return None, None, (error_msg, error_traceback, type(e).__name__)  # type: ignore[return-value]
+            return None, None, (error_msg, error_traceback, type(e).__name__)
 
     def _run_files_sync(
         self,

--- a/tests/parse_bench/inference/providers/parse/test_amazon_nova.py
+++ b/tests/parse_bench/inference/providers/parse/test_amazon_nova.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -12,6 +13,9 @@ from parse_bench.inference.providers.parse._layout_utils import (
     parse_layout_blocks,
 )
 from parse_bench.inference.providers.parse.amazon_nova import AmazonNovaProvider
+from parse_bench.schemas.pipeline import PipelineSpec
+from parse_bench.schemas.pipeline_io import InferenceRequest
+from parse_bench.schemas.product import ProductType
 
 
 class _FakeBedrockClient:
@@ -42,6 +46,22 @@ def _provider(**attrs: Any) -> AmazonNovaProvider:
     for key, value in defaults.items():
         setattr(provider, key, value)
     return provider
+
+
+def _pipeline() -> PipelineSpec:
+    return PipelineSpec(
+        pipeline_name="amazon_nova_test",
+        provider_name="amazon_nova",
+        product_type=ProductType.PARSE,
+    )
+
+
+def _request(source: Path) -> InferenceRequest:
+    return InferenceRequest(
+        example_id="document",
+        source_file_path=str(source),
+        product_type=ProductType.PARSE,
+    )
 
 
 def test_geo_profile_is_priced_at_the_regional_rate() -> None:
@@ -157,6 +177,90 @@ def test_empty_response_is_rejected_rather_than_parsed_as_a_blank_page() -> None
 
     with pytest.raises(ProviderTransientError, match="no text"):
         provider._converse(Image.new("RGB", (64, 64), "white"), "system", "user")
+
+
+def test_pdf_run_inference_renders_and_calls_bedrock_one_page_at_a_time(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "document.pdf"
+    source.touch()
+    rendered_pages: list[Image.Image] = []
+    render_calls: list[int] = []
+
+    monkeypatch.setattr("pdf2image.pdfinfo_from_path", lambda path: {"Pages": 2})
+
+    def render_page(path: str, dpi: int, first_page: int, last_page: int) -> list[Image.Image]:
+        assert Path(path) == source
+        assert dpi == 150
+        assert first_page == last_page
+        if rendered_pages:
+            with pytest.raises(ValueError, match="Operation on closed image"):
+                rendered_pages[-1].getpixel((0, 0))
+        render_calls.append(first_page)
+        image = Image.new("RGB", (10 + first_page, 20), "white")
+        rendered_pages.append(image)
+        return [image]
+
+    monkeypatch.setattr("pdf2image.convert_from_path", render_page)
+    provider = _provider()
+    provider._client = _FakeBedrockClient(
+        {
+            "output": {"message": {"content": [{"text": '<div data-bbox="[0,0,10,10]" data-label="Text">page</div>'}]}},
+            "usage": {"inputTokens": 2, "outputTokens": 1, "totalTokens": 3},
+            "stopReason": "end_turn",
+        }
+    )
+
+    result = provider.run_inference(_pipeline(), _request(source))
+
+    assert render_calls == [1, 2]
+    assert len(provider._client.calls) == 2
+    assert result.raw_output["num_pages"] == 2
+    assert [page["width"] for page in result.raw_output["pages"]] == [11, 12]
+    with pytest.raises(ValueError, match="Operation on closed image"):
+        rendered_pages[-1].getpixel((0, 0))
+
+
+def test_single_image_run_inference_calls_bedrock_without_pdf_rasterization(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "page.png"
+    Image.new("RGB", (13, 17), "white").save(source)
+    real_open = Image.open
+    close_calls = 0
+
+    class TrackedImageContext:
+        def __init__(self, path: str | Path, *args: Any, **kwargs: Any) -> None:
+            self.image = real_open(path, *args, **kwargs)
+
+        def __enter__(self) -> Image.Image:
+            return self.image
+
+        def __exit__(self, *args: object) -> None:
+            nonlocal close_calls
+            close_calls += 1
+            self.image.close()
+
+    monkeypatch.setattr(Image, "open", TrackedImageContext)
+    monkeypatch.setattr(
+        "pdf2image.convert_from_path",
+        lambda *args, **kwargs: pytest.fail("single images must not be rasterized as PDFs"),
+    )
+    provider = _provider()
+    provider._client = _FakeBedrockClient(
+        {
+            "output": {"message": {"content": [{"text": '<div data-bbox="[0,0,10,10]" data-label="Text">page</div>'}]}},
+            "usage": {"inputTokens": 2, "outputTokens": 1, "totalTokens": 3},
+            "stopReason": "end_turn",
+        }
+    )
+
+    result = provider.run_inference(_pipeline(), _request(source))
+
+    assert len(provider._client.calls) == 1
+    assert result.raw_output["num_pages"] == 1
+    assert result.raw_output["pages"][0]["width"] == 13
+    assert close_calls == 1
 
 
 NESTED_LAYOUT = (

--- a/tests/parse_bench/inference/providers/parse/test_amazon_nova.py
+++ b/tests/parse_bench/inference/providers/parse/test_amazon_nova.py
@@ -244,6 +244,43 @@ def test_pdf_run_inference_renders_and_calls_bedrock_one_page_at_a_time(
         rendered_pages[-1].getpixel((0, 0))
 
 
+def test_failed_attempt_without_usage_omits_precise_document_totals(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "document.pdf"
+    source.touch()
+    monkeypatch.setattr("pdf2image.pdfinfo_from_path", lambda path: {"Pages": 1})
+    monkeypatch.setattr(
+        "pdf2image.convert_from_path",
+        lambda path, dpi, first_page, last_page: [Image.new("RGB", (10, 20), "white")],
+    )
+    monkeypatch.setattr("parse_bench.inference.providers.parse._multipage_image.time.sleep", lambda delay: None)
+    provider = _provider()
+    calls = 0
+
+    def parse_page(image: Image.Image) -> tuple[list[dict[str, object]], str, dict[str, int], str]:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise ProviderTransientError("transport failed before usage was reported")
+        return (
+            [{"bbox": [0, 0, 10, 10], "label": "Text", "text": "page"}],
+            '<div data-bbox="[0,0,10,10]" data-label="Text">page</div>',
+            {"input_tokens": 2, "output_tokens": 1, "thinking_tokens": 0, "total_tokens": 3},
+            "end_turn",
+        )
+
+    provider._parse_image_with_layout = parse_page
+
+    result = provider.run_inference(_pipeline(), _request(source))
+
+    assert calls == 2
+    assert result.raw_output["num_api_calls"] == 2
+    assert "total_tokens" not in result.raw_output
+    assert "cost_usd" not in result.raw_output
+    assert "page_usages" not in result.raw_output
+
+
 def test_single_image_run_inference_calls_bedrock_without_pdf_rasterization(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/parse_bench/inference/providers/parse/test_amazon_nova.py
+++ b/tests/parse_bench/inference/providers/parse/test_amazon_nova.py
@@ -77,6 +77,29 @@ def test_unknown_model_falls_back_to_zero_pricing() -> None:
     assert _provider(_model="us.amazon.nova-9-mystery-v1:0")._get_pricing() == (0.0, 0.0)
 
 
+def test_constructor_disables_botocore_retries_and_uses_declared_dpi(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import boto3
+
+    captured: dict[str, Any] = {}
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "test-key")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "test-secret")
+
+    def client(service_name: str, **kwargs: Any) -> object:
+        captured["service_name"] = service_name
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(boto3, "client", client)
+
+    provider = AmazonNovaProvider("amazon_nova")
+
+    assert provider._dpi == AmazonNovaProvider.PDF_RENDER_DPI == 150
+    assert captured["service_name"] == "bedrock-runtime"
+    assert captured["config"].retries == {"total_max_attempts": 1, "mode": "standard"}
+
+
 def test_converse_sends_temperature_and_no_reasoning_by_default() -> None:
     provider = _provider()
     provider._client = _FakeBedrockClient(

--- a/tests/parse_bench/inference/providers/parse/test_amazon_nova.py
+++ b/tests/parse_bench/inference/providers/parse/test_amazon_nova.py
@@ -229,6 +229,42 @@ def test_empty_response_is_rejected_rather_than_parsed_as_a_blank_page() -> None
         provider._converse(Image.new("RGB", (64, 64), "white"), "system", "user")
 
 
+@pytest.mark.parametrize("malformed", ["not layout markup", "[ ]", "[] trailing text"])
+def test_nonempty_malformed_layout_is_not_accepted_as_blank(malformed: str) -> None:
+    provider = _provider()
+    provider._converse = lambda *args: (
+        malformed,
+        {"input_tokens": 3, "output_tokens": 2, "thinking_tokens": 0, "total_tokens": 5},
+        "end_turn",
+    )
+
+    with pytest.raises(ProviderTransientError, match="malformed non-empty layout") as caught:
+        provider._parse_image_with_layout(Image.new("RGB", (64, 64), "white"))
+
+    assert caught.value.attempt_stats == {
+        "input_tokens": 3,
+        "output_tokens": 2,
+        "thinking_tokens": 0,
+        "total_tokens": 5,
+    }
+
+
+def test_exact_empty_array_is_the_only_blank_layout_representation() -> None:
+    provider = _provider()
+    provider._converse = lambda *args: (
+        "  []\n",
+        {"input_tokens": 3, "output_tokens": 1, "thinking_tokens": 0, "total_tokens": 4},
+        "end_turn",
+    )
+
+    items, raw_text, usage, stop_reason = provider._parse_image_with_layout(Image.new("RGB", (64, 64), "white"))
+
+    assert items == []
+    assert raw_text == "  []\n"
+    assert usage["total_tokens"] == 4
+    assert stop_reason == "end_turn"
+
+
 def test_pdf_run_inference_renders_and_calls_bedrock_one_page_at_a_time(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/parse_bench/inference/providers/parse/test_amazon_nova.py
+++ b/tests/parse_bench/inference/providers/parse/test_amazon_nova.py
@@ -73,8 +73,35 @@ def test_global_profile_is_priced_at_the_cross_region_global_rate() -> None:
     assert _provider(_model="global.amazon.nova-2-lite-v1:0")._get_pricing() == (0.30, 2.50)
 
 
-def test_unknown_model_falls_back_to_zero_pricing() -> None:
-    assert _provider(_model="us.amazon.nova-9-mystery-v1:0")._get_pricing() == (0.0, 0.0)
+def test_unknown_model_pricing_remains_unknown() -> None:
+    assert _provider(_model="us.amazon.nova-9-mystery-v1:0")._get_pricing() is None
+
+
+def test_unknown_pricing_does_not_abort_completed_inference(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "document.pdf"
+    source.touch()
+    monkeypatch.setattr("pdf2image.pdfinfo_from_path", lambda path: {"Pages": 1})
+    monkeypatch.setattr(
+        "pdf2image.convert_from_path",
+        lambda path, dpi, first_page, last_page: [Image.new("RGB", (10, 20), "white")],
+    )
+    provider = _provider(_model="us.amazon.nova-9-mystery-v1:0")
+    provider._parse_image_with_layout = lambda image: (
+        [],
+        "[]",
+        {"input_tokens": 1, "output_tokens": 1, "thinking_tokens": 0, "total_tokens": 2},
+        "end_turn",
+    )
+
+    result = provider.run_inference(_pipeline(), _request(source))
+
+    assert result.raw_output["num_api_calls"] == 1
+    assert result.raw_output["total_tokens"] == 2
+    assert "cost_usd" not in result.raw_output
+    assert "cost_per_page_usd" not in result.raw_output
 
 
 def test_constructor_disables_botocore_retries_and_uses_declared_dpi(

--- a/tests/parse_bench/inference/providers/parse/test_dots_ocr_status_classification.py
+++ b/tests/parse_bench/inference/providers/parse/test_dots_ocr_status_classification.py
@@ -10,6 +10,7 @@ from PIL import Image
 from parse_bench.inference.providers.base import (
     ProviderPermanentError,
     ProviderRateLimitError,
+    ProviderRetryExhaustedError,
     ProviderTransientError,
 )
 from parse_bench.inference.providers.parse.dots_ocr import DotsOcrParseProvider
@@ -68,3 +69,51 @@ def test_dots_other_real_4xx_statuses_are_permanent(status_code: int) -> None:
 
     with pytest.raises(ProviderPermanentError):
         provider._call_endpoint(Image.new("RGB", (1, 1)))
+
+
+def test_dots_layout_failure_retries_with_usage_in_terminal_ledger(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = object.__new__(DotsOcrParseProvider)
+    provider._is_layout_mode = True
+    monkeypatch.setattr(
+        provider,
+        "_call_endpoint",
+        lambda image: (
+            "not layout json",
+            {"input_tokens": 7, "output_tokens": 3, "total_tokens": 10},
+        ),
+    )
+    monkeypatch.setattr("parse_bench.inference.providers.parse._multipage_image.time.sleep", lambda delay: None)
+    attempts: list[dict[str, object]] = []
+
+    with Image.new("RGB", (8, 8), "white") as image:
+        with pytest.raises(ProviderRetryExhaustedError) as caught:
+            provider._call_page_with_retries(image, 1, attempts, [])
+
+    assert len(attempts) == 3
+    assert [attempt["status"] for attempt in attempts] == ["failed", "failed", "failed"]
+    assert [attempt["stats"]["total_tokens"] for attempt in attempts] == [10, 10, 10]
+    assert caught.value.debug_payload["attempts"] == attempts
+
+
+def test_dots_successful_page_attempt_records_response_usage(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = object.__new__(DotsOcrParseProvider)
+    provider._is_layout_mode = True
+    monkeypatch.setattr(
+        provider,
+        "_call_endpoint",
+        lambda image: (
+            "[]",
+            {"input_tokens": 7, "output_tokens": 1, "total_tokens": 8},
+        ),
+    )
+    attempts: list[dict[str, object]] = []
+
+    with Image.new("RGB", (8, 8), "white") as image:
+        raw_text, usage, items = provider._call_page_with_retries(image, 1, attempts, [])
+
+    assert raw_text == "[]"
+    assert usage["total_tokens"] == 8
+    assert items == []
+    assert attempts[0]["stats"]["total_tokens"] == 8

--- a/tests/parse_bench/inference/providers/parse/test_dots_ocr_status_classification.py
+++ b/tests/parse_bench/inference/providers/parse/test_dots_ocr_status_classification.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import httpx
+import pytest
+from openai import APIConnectionError, APIStatusError, APITimeoutError, RateLimitError
+from PIL import Image
+
+from parse_bench.inference.providers.base import (
+    ProviderPermanentError,
+    ProviderRateLimitError,
+    ProviderTransientError,
+)
+from parse_bench.inference.providers.parse.dots_ocr import DotsOcrParseProvider
+
+
+def _provider_raising(exc: Exception) -> DotsOcrParseProvider:
+    provider = object.__new__(DotsOcrParseProvider)
+
+    def create(**kwargs: object) -> None:
+        raise exc
+
+    provider._client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create)))
+    provider._model = "dots-ocr"
+    provider._prompt = "parse"
+    provider._max_tokens = 100
+    provider._temperature = 0.1
+    provider._top_p = 0.9
+    return provider
+
+
+def _status_error(status_code: int) -> APIStatusError:
+    request = httpx.Request("POST", "https://dots.invalid/v1/chat/completions")
+    response = httpx.Response(status_code, request=request)
+    if status_code == 429:
+        return RateLimitError("rate limited", response=response, body=None)
+    return APIStatusError("request failed", response=response, body=None)
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        APITimeoutError(request=httpx.Request("POST", "https://dots.invalid")),
+        APIConnectionError(request=httpx.Request("POST", "https://dots.invalid")),
+        _status_error(408),
+        _status_error(500),
+        _status_error(503),
+    ],
+)
+def test_dots_real_transport_and_transient_status_errors_are_retryable(exc: Exception) -> None:
+    provider = _provider_raising(exc)
+
+    with pytest.raises(ProviderTransientError):
+        provider._call_endpoint(Image.new("RGB", (1, 1)))
+
+
+def test_dots_real_429_is_rate_limited() -> None:
+    provider = _provider_raising(_status_error(429))
+
+    with pytest.raises(ProviderRateLimitError):
+        provider._call_endpoint(Image.new("RGB", (1, 1)))
+
+
+@pytest.mark.parametrize("status_code", [400, 401, 403, 404, 422])
+def test_dots_other_real_4xx_statuses_are_permanent(status_code: int) -> None:
+    provider = _provider_raising(_status_error(status_code))
+
+    with pytest.raises(ProviderPermanentError):
+        provider._call_endpoint(Image.new("RGB", (1, 1)))

--- a/tests/parse_bench/inference/providers/parse/test_google_multipage_failures.py
+++ b/tests/parse_bench/inference/providers/parse/test_google_multipage_failures.py
@@ -6,7 +6,7 @@ from types import SimpleNamespace
 import pytest
 from PIL import Image
 
-from parse_bench.inference.providers.base import ProviderTransientError
+from parse_bench.inference.providers.base import ProviderRetryExhaustedError
 from parse_bench.inference.providers.parse.google import GoogleProvider
 from parse_bench.schemas.pipeline import PipelineSpec
 from parse_bench.schemas.pipeline_io import InferenceRequest
@@ -81,11 +81,11 @@ def _provider(mode: str, responses: list[SimpleNamespace]) -> tuple[GoogleProvid
 @pytest.mark.parametrize(
     ("mode", "page_one", "message"),
     [
-        ("image", "page one", "returned no text after 2 attempts"),
+        ("image", "page one", "returned no text"),
         (
             "parse_with_layout",
             '<div data-bbox="[0,0,1000,1000]" data-label="Text">page one</div>',
-            "returned no layout text after 2 attempts",
+            "returned no layout text",
         ),
     ],
 )
@@ -109,14 +109,15 @@ def test_google_page_two_empty_responses_abort_without_partial_payload(
         return [image]
 
     monkeypatch.setattr("pdf2image.convert_from_path", render_page)
-    provider, models = _provider(mode, [_response(page_one), _response(None), _response(None)])
+    provider, models = _provider(mode, [_response(page_one), *[_response(None) for _ in range(3)]])
+    monkeypatch.setattr("time.sleep", lambda delay: None)
     successful_result = None
 
-    with pytest.raises(ProviderTransientError, match=message):
+    with pytest.raises(ProviderRetryExhaustedError, match=message):
         successful_result = provider.run_inference(_pipeline(), _request(source))
 
     assert successful_result is None
-    assert models.calls == 3
+    assert models.calls == 4
     assert len(rendered) == 2
     for image in rendered:
         with pytest.raises(ValueError, match="Operation on closed image"):

--- a/tests/parse_bench/inference/providers/parse/test_google_multipage_failures.py
+++ b/tests/parse_bench/inference/providers/parse/test_google_multipage_failures.py
@@ -4,10 +4,20 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+from google.api_core import exceptions as google_exceptions
 from PIL import Image
 
-from parse_bench.inference.providers.base import ProviderRetryExhaustedError
+from parse_bench.inference.providers.base import (
+    ProviderPermanentError,
+    ProviderRetryExhaustedError,
+    ProviderTransientError,
+)
 from parse_bench.inference.providers.parse.google import GoogleProvider
+from parse_bench.inference.providers.parse.google_agentic_vision import (
+    USER_PROMPT_AGENTIC_VISION_PREFIX,
+    classify_gemini_api_exception,
+    parse_page_response,
+)
 from parse_bench.schemas.pipeline import PipelineSpec
 from parse_bench.schemas.pipeline_io import InferenceRequest
 from parse_bench.schemas.product import ProductType
@@ -250,3 +260,89 @@ def test_google_agentic_mixed_failures_can_succeed_on_final_owned_attempt(
     assert [call["attempt"] for call in calls] == [1, 2, 3]
     assert [call["usage"]["total_tokens"] for call in calls] == [8, 0, 10]
     assert calls[1]["error"]["type"] == "ProviderTransientError"
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        google_exceptions.InternalServerError("internal"),
+        google_exceptions.ServiceUnavailable("unavailable"),
+        google_exceptions.GatewayTimeout("deadline"),
+        TimeoutError(),
+        ConnectionError(),
+    ],
+)
+def test_google_agentic_classifies_real_transient_errors(error: Exception) -> None:
+    assert isinstance(classify_gemini_api_exception(error), ProviderTransientError)
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        google_exceptions.BadRequest("bad request"),
+        google_exceptions.Unauthorized("unauthorized"),
+        google_exceptions.Forbidden("forbidden"),
+        google_exceptions.NotFound("not found"),
+    ],
+)
+def test_google_agentic_classifies_real_permanent_errors(error: Exception) -> None:
+    assert isinstance(classify_gemini_api_exception(error), ProviderPermanentError)
+
+
+def test_google_agentic_blank_middle_page_preserves_page_identity_and_raw_calls(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "document.pdf"
+    source.touch()
+    rendered: list[Image.Image] = []
+    monkeypatch.setattr("pdf2image.pdfinfo_from_path", lambda path: {"Pages": 3})
+
+    def render_page(path: str, dpi: int, first_page: int, last_page: int) -> list[Image.Image]:
+        assert Path(path) == source
+        assert first_page == last_page
+        image = Image.new("RGB", (8 + first_page, 8), "white")
+        rendered.append(image)
+        return [image]
+
+    monkeypatch.setattr("pdf2image.convert_from_path", render_page)
+    first = '<div data-bbox="[0,0,1000,1000]" data-label="Text">page one</div>'
+    third = '<div data-bbox="[0,0,1000,1000]" data-label="Text">page three</div>'
+    provider, models = _agentic_provider([_response(first), _response("[]"), _response(third)])
+
+    raw_result = provider.run_inference(_pipeline(), _request(source))
+    result = provider.normalize(raw_result)
+
+    assert models.calls == 3
+    assert raw_result.raw_output["num_api_calls"] == 3
+    assert [page["page_index"] for page in raw_result.raw_output["pages"]] == [0, 1, 2]
+    blank = raw_result.raw_output["pages"][1]
+    assert blank["items"] == []
+    assert blank["markdown"] == ""
+    assert blank["raw_content"] == ""
+    assert len(blank["api_calls"]) == 1
+    assert blank["api_calls"][0]["final_text"] == "[]"
+    assert [page.page_index for page in result.output.pages] == [0, 1, 2]
+    assert [page.markdown for page in result.output.pages] == ["page one", "", "page three"]
+    assert [page.page_number for page in result.output.layout_pages] == [1, 2, 3]
+    assert result.output.layout_pages[1].items == []
+    assert "exactly []" in USER_PROMPT_AGENTIC_VISION_PREFIX
+    for image in rendered:
+        with pytest.raises(ValueError, match="Operation on closed image"):
+            image.getpixel((0, 0))
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        _response(None),
+        _response(""),
+        _response("not wrapped"),
+        _response("[ ]"),
+        _response("[] trailing text"),
+    ],
+    ids=["missing", "empty", "malformed", "non-exact-array", "array-with-trailing-text"],
+)
+def test_google_agentic_missing_empty_and_malformed_are_not_blank(response: SimpleNamespace) -> None:
+    with pytest.raises(ValueError, match="No (valid )?wrapped layout payload"):
+        parse_page_response(response)

--- a/tests/parse_bench/inference/providers/parse/test_google_multipage_failures.py
+++ b/tests/parse_bench/inference/providers/parse/test_google_multipage_failures.py
@@ -71,6 +71,20 @@ class _Models:
         return response
 
 
+class _Caches:
+    def __init__(self) -> None:
+        self.deleted: list[str] = []
+
+    def create(self, **kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(
+            name="cachedContents/document-prefix",
+            usage_metadata=SimpleNamespace(total_token_count=2048),
+        )
+
+    def delete(self, *, name: str) -> None:
+        self.deleted.append(name)
+
+
 def _provider(mode: str, responses: list[object]) -> tuple[GoogleProvider, _Models]:
     provider = object.__new__(GoogleProvider)
     models = _Models(responses)
@@ -148,6 +162,47 @@ def test_google_page_two_empty_responses_abort_without_partial_payload(
     for image in rendered:
         with pytest.raises(ValueError, match="Operation on closed image"):
             image.getpixel((0, 0))
+
+
+def test_google_retry_ledger_accounts_billed_malformed_response_usage_and_cost(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "page.png"
+    with Image.new("RGB", (8, 8), "white") as image:
+        image.save(source)
+    malformed = _response(None)
+    malformed.usage_metadata = SimpleNamespace(
+        prompt_token_count=10,
+        tool_use_prompt_token_count=0,
+        cached_content_token_count=0,
+        candidates_token_count=4,
+        thoughts_token_count=1,
+        total_token_count=15,
+    )
+    success = _response("parsed")
+    success.usage_metadata = SimpleNamespace(
+        prompt_token_count=11,
+        tool_use_prompt_token_count=0,
+        cached_content_token_count=0,
+        candidates_token_count=5,
+        thoughts_token_count=1,
+        total_token_count=17,
+    )
+    provider, models = _provider("image", [malformed, success])
+    monkeypatch.setattr("parse_bench.inference.providers.parse._multipage_image.time.sleep", lambda delay: None)
+
+    result = provider.run_inference(_pipeline(), _request(source))
+
+    assert models.calls == 2
+    assert result.raw_output["num_api_calls"] == 2
+    assert result.raw_output["input_tokens"] == 21
+    assert result.raw_output["output_tokens"] == 9
+    assert result.raw_output["thinking_tokens"] == 2
+    assert result.raw_output["total_tokens"] == 32
+    assert len(result.raw_output["api_attempts"]) == 2
+    assert result.raw_output["api_attempts"][0]["status"] == "failed"
+    assert result.raw_output["cost_usd"] > 0
 
 
 def test_google_agentic_page_two_malformed_then_transient_exhausts_one_page_budget(
@@ -330,6 +385,43 @@ def test_google_agentic_blank_middle_page_preserves_page_identity_and_raw_calls(
     for image in rendered:
         with pytest.raises(ValueError, match="Operation on closed image"):
             image.getpixel((0, 0))
+
+
+@pytest.mark.parametrize("terminal_failure", [False, True], ids=["success", "failure"])
+def test_google_agentic_document_finally_deletes_server_cache(
+    terminal_failure: bool,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "document.pdf"
+    source.touch()
+    monkeypatch.setattr("pdf2image.pdfinfo_from_path", lambda path: {"Pages": 2})
+    monkeypatch.setattr(
+        "pdf2image.convert_from_path",
+        lambda path, dpi, first_page, last_page: [Image.new("RGB", (8, 8), "white")],
+    )
+    monkeypatch.setattr(
+        "parse_bench.inference.providers.parse.google_agentic_vision.time.sleep",
+        lambda delay: None,
+    )
+    valid = '<div data-bbox="[0,0,1000,1000]" data-label="Text">page</div>'
+    responses = [_response(valid), _response(valid)]
+    if terminal_failure:
+        responses = [_response(valid), _response("bad"), _response("bad"), _response("bad")]
+    provider, _ = _agentic_provider(responses)
+    caches = _Caches()
+    provider._client.caches = caches
+    provider._types.CreateCachedContentConfig = lambda **kwargs: SimpleNamespace(**kwargs)
+    provider._enable_explicit_context_cache = True
+
+    if terminal_failure:
+        with pytest.raises(ProviderRetryExhaustedError):
+            provider.run_inference(_pipeline(), _request(source))
+    else:
+        result = provider.run_inference(_pipeline(), _request(source))
+        assert result.raw_output["explicit_context_cache"]["deleted"] is True
+
+    assert caches.deleted == ["cachedContents/document-prefix"]
 
 
 @pytest.mark.parametrize(

--- a/tests/parse_bench/inference/providers/parse/test_google_multipage_failures.py
+++ b/tests/parse_bench/inference/providers/parse/test_google_multipage_failures.py
@@ -440,3 +440,49 @@ def test_google_agentic_document_finally_deletes_server_cache(
 def test_google_agentic_missing_empty_and_malformed_are_not_blank(response: SimpleNamespace) -> None:
     with pytest.raises(ValueError, match="No (valid )?wrapped layout payload"):
         parse_page_response(response)
+
+
+def test_google_agentic_permanent_api_failure_persists_physical_call() -> None:
+    provider, models = _agentic_provider([google_exceptions.BadRequest("bad request")])
+    runner = provider._build_agentic_vision_runner(expected_page_calls=1)
+    image = Image.new("RGB", (8, 8), "white")
+
+    with pytest.raises(ProviderPermanentError) as caught:
+        runner.parse_page(
+            page_index=0,
+            image=image,
+            image_bytes=b"image",
+            image_mime_type="image/jpeg",
+        )
+
+    payload = caught.value.debug_payload
+    assert isinstance(payload, dict)
+    assert models.calls == 1
+    assert len(payload["api_calls"]) == 1
+    assert payload["api_calls"][0]["error"]["type"] == "ProviderPermanentError"
+    image.close()
+
+
+def test_google_agentic_permanent_page_two_failure_keeps_page_one_accounting(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "document.pdf"
+    source.touch()
+    monkeypatch.setattr("pdf2image.pdfinfo_from_path", lambda path: {"Pages": 2})
+    monkeypatch.setattr(
+        "pdf2image.convert_from_path",
+        lambda path, dpi, first_page, last_page: [Image.new("RGB", (8, 8), "white")],
+    )
+    valid = '<div data-bbox="[0,0,1000,1000]" data-label="Text">page one</div>'
+    provider, models = _agentic_provider([_response(valid), google_exceptions.BadRequest("bad request")])
+
+    with pytest.raises(ProviderPermanentError) as caught:
+        provider.run_inference(_pipeline(), _request(source))
+
+    payload = caught.value.debug_payload
+    assert isinstance(payload, dict)
+    assert models.calls == 2
+    assert len(payload["api_calls"]) == 2
+    assert payload["api_calls"][0]["final_text"] == valid
+    assert payload["api_calls"][1]["error"]["type"] == "ProviderPermanentError"

--- a/tests/parse_bench/inference/providers/parse/test_google_multipage_failures.py
+++ b/tests/parse_bench/inference/providers/parse/test_google_multipage_failures.py
@@ -263,7 +263,7 @@ def test_google_agentic_page_two_malformed_then_transient_exhausts_one_page_budg
     calls = debug_payload["api_calls"]
     assert [call["page_index"] for call in calls] == [1, 1, 1]
     assert [call["attempt"] for call in calls] == [1, 2, 3]
-    assert [call["usage"]["total_tokens"] for call in calls] == [11, 0, 13]
+    assert [call["usage"].get("total_tokens") for call in calls] == [11, None, 13]
     assert calls[0]["response"] is not None
     assert calls[1]["error"]["type"] == "ProviderTransientError"
     assert calls[2]["response"] is not None
@@ -308,12 +308,13 @@ def test_google_agentic_mixed_failures_can_succeed_on_final_owned_attempt(
 
     assert models.calls == 3
     assert result.raw_output["num_api_calls"] == 3
-    assert result.raw_output["total_tokens"] == 18
+    assert "total_tokens" not in result.raw_output
+    assert "cost_usd" not in result.raw_output
     page = result.raw_output["pages"][0]
     assert page["markdown"] == "success"
     calls = page["api_calls"]
     assert [call["attempt"] for call in calls] == [1, 2, 3]
-    assert [call["usage"]["total_tokens"] for call in calls] == [8, 0, 10]
+    assert [call["usage"].get("total_tokens") for call in calls] == [8, None, 10]
     assert calls[1]["error"]["type"] == "ProviderTransientError"
 
 

--- a/tests/parse_bench/inference/providers/parse/test_google_multipage_failures.py
+++ b/tests/parse_bench/inference/providers/parse/test_google_multipage_failures.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from PIL import Image
+
+from parse_bench.inference.providers.base import ProviderTransientError
+from parse_bench.inference.providers.parse.google import GoogleProvider
+from parse_bench.schemas.pipeline import PipelineSpec
+from parse_bench.schemas.pipeline_io import InferenceRequest
+from parse_bench.schemas.product import ProductType
+
+
+def _pipeline() -> PipelineSpec:
+    return PipelineSpec(
+        pipeline_name="google_test",
+        provider_name="google",
+        product_type=ProductType.PARSE,
+    )
+
+
+def _request(source: Path) -> InferenceRequest:
+    return InferenceRequest(
+        example_id="document",
+        source_file_path=str(source),
+        product_type=ProductType.PARSE,
+    )
+
+
+def _response(text: str | None) -> SimpleNamespace:
+    candidates = []
+    if text is not None:
+        candidates = [
+            SimpleNamespace(
+                content=SimpleNamespace(parts=[SimpleNamespace(text=text)]),
+                finish_reason=None,
+            )
+        ]
+    return SimpleNamespace(
+        candidates=candidates,
+        prompt_feedback=SimpleNamespace(block_reason=None),
+        usage_metadata=None,
+    )
+
+
+class _Models:
+    def __init__(self, responses: list[SimpleNamespace]) -> None:
+        self._responses = iter(responses)
+        self.calls = 0
+
+    def generate_content(self, **kwargs: object) -> SimpleNamespace:
+        self.calls += 1
+        return next(self._responses)
+
+
+def _provider(mode: str, responses: list[SimpleNamespace]) -> tuple[GoogleProvider, _Models]:
+    provider = object.__new__(GoogleProvider)
+    models = _Models(responses)
+    provider._client = SimpleNamespace(models=models)
+    provider._types = SimpleNamespace(
+        Part=SimpleNamespace(
+            from_bytes=lambda **kwargs: kwargs,
+            from_text=lambda **kwargs: kwargs,
+        ),
+        GenerateContentConfig=lambda **kwargs: SimpleNamespace(**kwargs),
+        Content=lambda **kwargs: SimpleNamespace(**kwargs),
+    )
+    provider._model = "gemini-3-flash"
+    provider._dpi = 144
+    provider._max_tokens = 1024
+    provider._thinking_level = None
+    provider._mode = mode
+    provider._bbox_scale = 1000
+    provider._layout_system_prompt = "layout system prompt"
+    provider._layout_user_prompt = "layout user prompt"
+    return provider, models
+
+
+@pytest.mark.parametrize(
+    ("mode", "page_one", "message"),
+    [
+        ("image", "page one", "returned no text after 2 attempts"),
+        (
+            "parse_with_layout",
+            '<div data-bbox="[0,0,1000,1000]" data-label="Text">page one</div>',
+            "returned no layout text after 2 attempts",
+        ),
+    ],
+)
+def test_google_page_two_empty_responses_abort_without_partial_payload(
+    mode: str,
+    page_one: str,
+    message: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "document.pdf"
+    source.touch()
+    rendered: list[Image.Image] = []
+    monkeypatch.setattr("pdf2image.pdfinfo_from_path", lambda path: {"Pages": 2})
+
+    def render_page(path: str, dpi: int, first_page: int, last_page: int) -> list[Image.Image]:
+        assert Path(path) == source
+        assert first_page == last_page
+        image = Image.new("RGB", (8 + first_page, 8), "white")
+        rendered.append(image)
+        return [image]
+
+    monkeypatch.setattr("pdf2image.convert_from_path", render_page)
+    provider, models = _provider(mode, [_response(page_one), _response(None), _response(None)])
+    successful_result = None
+
+    with pytest.raises(ProviderTransientError, match=message):
+        successful_result = provider.run_inference(_pipeline(), _request(source))
+
+    assert successful_result is None
+    assert models.calls == 3
+    assert len(rendered) == 2
+    for image in rendered:
+        with pytest.raises(ValueError, match="Operation on closed image"):
+            image.getpixel((0, 0))

--- a/tests/parse_bench/inference/providers/parse/test_google_multipage_failures.py
+++ b/tests/parse_bench/inference/providers/parse/test_google_multipage_failures.py
@@ -46,16 +46,22 @@ def _response(text: str | None) -> SimpleNamespace:
 
 
 class _Models:
-    def __init__(self, responses: list[SimpleNamespace]) -> None:
+    def __init__(self, responses: list[object]) -> None:
         self._responses = iter(responses)
         self.calls = 0
+        self.requests: list[dict[str, object]] = []
 
     def generate_content(self, **kwargs: object) -> SimpleNamespace:
         self.calls += 1
-        return next(self._responses)
+        self.requests.append(kwargs)
+        response = next(self._responses)
+        if isinstance(response, Exception):
+            raise response
+        assert isinstance(response, SimpleNamespace)
+        return response
 
 
-def _provider(mode: str, responses: list[SimpleNamespace]) -> tuple[GoogleProvider, _Models]:
+def _provider(mode: str, responses: list[object]) -> tuple[GoogleProvider, _Models]:
     provider = object.__new__(GoogleProvider)
     models = _Models(responses)
     provider._client = SimpleNamespace(models=models)
@@ -75,6 +81,16 @@ def _provider(mode: str, responses: list[SimpleNamespace]) -> tuple[GoogleProvid
     provider._bbox_scale = 1000
     provider._layout_system_prompt = "layout system prompt"
     provider._layout_user_prompt = "layout user prompt"
+    return provider, models
+
+
+def _agentic_provider(responses: list[object]) -> tuple[GoogleProvider, _Models]:
+    provider, models = _provider("parse_with_layout_agentic_vision", responses)
+    provider._types.ToolCodeExecution = lambda: SimpleNamespace()
+    provider._types.Tool = lambda **kwargs: SimpleNamespace(**kwargs)
+    provider._enable_explicit_context_cache = False
+    provider._context_cache_ttl_seconds = 900
+    provider._min_cacheable_tokens = 1024
     return provider, models
 
 
@@ -122,3 +138,115 @@ def test_google_page_two_empty_responses_abort_without_partial_payload(
     for image in rendered:
         with pytest.raises(ValueError, match="Operation on closed image"):
             image.getpixel((0, 0))
+
+
+def test_google_agentic_page_two_malformed_then_transient_exhausts_one_page_budget(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "document.pdf"
+    source.touch()
+    rendered: list[Image.Image] = []
+    monkeypatch.setattr("pdf2image.pdfinfo_from_path", lambda path: {"Pages": 2})
+
+    def render_page(path: str, dpi: int, first_page: int, last_page: int) -> list[Image.Image]:
+        assert Path(path) == source
+        assert first_page == last_page
+        image = Image.new("RGB", (8 + first_page, 8), "white")
+        rendered.append(image)
+        return [image]
+
+    monkeypatch.setattr("pdf2image.convert_from_path", render_page)
+    monkeypatch.setattr(
+        "parse_bench.inference.providers.parse.google_agentic_vision.time.sleep",
+        lambda delay: None,
+    )
+    valid = '<div data-bbox="[0,0,1000,1000]" data-label="Text">page one</div>'
+    malformed_one = _response("not wrapped")
+    malformed_one.usage_metadata = SimpleNamespace(
+        prompt_token_count=7,
+        tool_use_prompt_token_count=0,
+        cached_content_token_count=0,
+        candidates_token_count=3,
+        thoughts_token_count=1,
+        total_token_count=11,
+    )
+    malformed_three = _response("still not wrapped")
+    malformed_three.usage_metadata = SimpleNamespace(
+        prompt_token_count=8,
+        tool_use_prompt_token_count=0,
+        cached_content_token_count=0,
+        candidates_token_count=4,
+        thoughts_token_count=1,
+        total_token_count=13,
+    )
+    provider, models = _agentic_provider(
+        [_response(valid), malformed_one, TimeoutError("connection timeout"), malformed_three]
+    )
+
+    with pytest.raises(
+        ProviderRetryExhaustedError,
+        match="Google Agentic Vision page 2 failed after 3 attempts",
+    ) as exc_info:
+        provider.run_inference(_pipeline(), _request(source))
+
+    assert models.calls == 4
+    assert len(models.requests) == 4
+    assert len(rendered) == 2
+    debug_payload = exc_info.value.debug_payload
+    assert isinstance(debug_payload, dict)
+    calls = debug_payload["api_calls"]
+    assert [call["page_index"] for call in calls] == [1, 1, 1]
+    assert [call["attempt"] for call in calls] == [1, 2, 3]
+    assert [call["usage"]["total_tokens"] for call in calls] == [11, 0, 13]
+    assert calls[0]["response"] is not None
+    assert calls[1]["error"]["type"] == "ProviderTransientError"
+    assert calls[2]["response"] is not None
+    for image in rendered:
+        with pytest.raises(ValueError, match="Operation on closed image"):
+            image.getpixel((0, 0))
+
+
+def test_google_agentic_mixed_failures_can_succeed_on_final_owned_attempt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "page.png"
+    with Image.new("RGB", (9, 8), "white") as image:
+        image.save(source)
+    monkeypatch.setattr(
+        "parse_bench.inference.providers.parse.google_agentic_vision.time.sleep",
+        lambda delay: None,
+    )
+    malformed = _response("not wrapped")
+    malformed.usage_metadata = SimpleNamespace(
+        prompt_token_count=5,
+        tool_use_prompt_token_count=0,
+        cached_content_token_count=0,
+        candidates_token_count=2,
+        thoughts_token_count=1,
+        total_token_count=8,
+    )
+    valid = '<div data-bbox="[0,0,1000,1000]" data-label="Text">success</div>'
+    successful = _response(valid)
+    successful.usage_metadata = SimpleNamespace(
+        prompt_token_count=6,
+        tool_use_prompt_token_count=0,
+        cached_content_token_count=0,
+        candidates_token_count=3,
+        thoughts_token_count=1,
+        total_token_count=10,
+    )
+    provider, models = _agentic_provider([malformed, TimeoutError("network reset"), successful])
+
+    result = provider.run_inference(_pipeline(), _request(source))
+
+    assert models.calls == 3
+    assert result.raw_output["num_api_calls"] == 3
+    assert result.raw_output["total_tokens"] == 18
+    page = result.raw_output["pages"][0]
+    assert page["markdown"] == "success"
+    calls = page["api_calls"]
+    assert [call["attempt"] for call in calls] == [1, 2, 3]
+    assert [call["usage"]["total_tokens"] for call in calls] == [8, 0, 10]
+    assert calls[1]["error"]["type"] == "ProviderTransientError"

--- a/tests/parse_bench/inference/providers/parse/test_google_multipage_failures.py
+++ b/tests/parse_bench/inference/providers/parse/test_google_multipage_failures.py
@@ -261,12 +261,13 @@ def test_google_agentic_page_two_malformed_then_transient_exhausts_one_page_budg
     debug_payload = exc_info.value.debug_payload
     assert isinstance(debug_payload, dict)
     calls = debug_payload["api_calls"]
-    assert [call["page_index"] for call in calls] == [1, 1, 1]
-    assert [call["attempt"] for call in calls] == [1, 2, 3]
-    assert [call["usage"].get("total_tokens") for call in calls] == [11, None, 13]
+    assert [call["page_index"] for call in calls] == [0, 1, 1, 1]
+    assert [call["attempt"] for call in calls] == [1, 1, 2, 3]
+    assert [call["usage"].get("total_tokens") for call in calls] == [None, 11, None, 13]
     assert calls[0]["response"] is not None
-    assert calls[1]["error"]["type"] == "ProviderTransientError"
-    assert calls[2]["response"] is not None
+    assert calls[1]["response"] is not None
+    assert calls[2]["error"]["type"] == "ProviderTransientError"
+    assert calls[3]["response"] is not None
     for image in rendered:
         with pytest.raises(ValueError, match="Operation on closed image"):
             image.getpixel((0, 0))

--- a/tests/parse_bench/inference/providers/parse/test_image_ownership.py
+++ b/tests/parse_bench/inference/providers/parse/test_image_ownership.py
@@ -340,13 +340,62 @@ def test_infinity_deep_parsing_closes_every_crop(fail: bool, tmp_path: Path, mon
         return f"table {call_count - 1}"
 
     provider = _infinity_provider(Mock(side_effect=parse), deep_parsing=True)
-    result = provider._parse_document(str(source))["result"]
-
     if fail:
-        assert result == shallow
+        with pytest.raises(ProviderPermanentError, match="Error during deep parsing: deep parse failed") as caught:
+            provider._parse_document(str(source))
+        assert isinstance(caught.value.__cause__, RuntimeError)
     else:
+        result = provider._parse_document(str(source))["result"]
         assert [element["text"] for element in json.loads(result)] == ["table 1", "table 2"]
     assert len(crops) == 2
     assert all(isinstance(image.close, Mock) and image.close.call_count == 1 for image in crops)
+    assert isinstance(opened_image.close, Mock) and opened_image.close.call_count == 1
+    assert isinstance(converted_image.close, Mock) and converted_image.close.call_count == 1
+
+
+def test_infinity_deep_parsing_preserves_classified_error_and_closes_crop(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from parse_bench.inference.providers.base import ProviderTransientError
+    from parse_bench.inference.providers.parse import infinity_parser2 as infinity_module
+
+    source = tmp_path / "page.png"
+    source.touch()
+    opened_image = Image.new("RGB", (8, 8), "white")
+    converted_image = Image.new("RGB", (8, 8), "white")
+    opened_image.close = Mock(wraps=opened_image.close)
+    converted_image.close = Mock(wraps=converted_image.close)
+
+    class OpenedImageContext:
+        def __enter__(self) -> Image.Image:
+            return opened_image
+
+        def __exit__(self, *args: object) -> None:
+            opened_image.close()
+
+    monkeypatch.setattr(infinity_module.PILImage, "open", lambda path: OpenedImageContext())
+    monkeypatch.setattr(Image.Image, "convert", lambda image, *args, **kwargs: converted_image)
+    crops: list[Image.Image] = []
+    real_crop = Image.Image.crop
+
+    def crop(image: Image.Image, *args: Any, **kwargs: Any) -> Image.Image:
+        derived = real_crop(image, *args, **kwargs)
+        derived.close = Mock(wraps=derived.close)
+        crops.append(derived)
+        return derived
+
+    monkeypatch.setattr(Image.Image, "crop", crop)
+    shallow = json.dumps([{"category": "figure", "bbox": [0, 0, 4, 4], "text": "figure"}])
+    classified = ProviderTransientError("deep provider timed out")
+    parser = Mock(side_effect=[shallow, classified])
+    provider = _infinity_provider(parser, deep_parsing=True)
+
+    with pytest.raises(ProviderTransientError, match="deep provider timed out") as caught:
+        provider._parse_document(str(source))
+
+    assert caught.value is classified
+    assert len(crops) == 1
+    assert isinstance(crops[0].close, Mock) and crops[0].close.call_count == 1
     assert isinstance(opened_image.close, Mock) and opened_image.close.call_count == 1
     assert isinstance(converted_image.close, Mock) and converted_image.close.call_count == 1

--- a/tests/parse_bench/inference/providers/parse/test_image_ownership.py
+++ b/tests/parse_bench/inference/providers/parse/test_image_ownership.py
@@ -399,3 +399,47 @@ def test_infinity_deep_parsing_preserves_classified_error_and_closes_crop(
     assert isinstance(crops[0].close, Mock) and crops[0].close.call_count == 1
     assert isinstance(opened_image.close, Mock) and opened_image.close.call_count == 1
     assert isinstance(converted_image.close, Mock) and converted_image.close.call_count == 1
+
+
+@pytest.mark.parametrize(
+    "response",
+    [json.dumps({"error": "model diagnostic"}), "", "[]"],
+    ids=["diagnostic-dict", "empty", "empty-list"],
+)
+def test_infinity_deep_parsing_rejects_invalid_layout_response(response: str) -> None:
+    provider = _infinity_provider(Mock(), deep_parsing=True)
+    with Image.new("RGB", (8, 8), "white") as image:
+        with pytest.raises(ProviderPermanentError, match="deep-parsing input"):
+            provider._apply_deep_parsing(response, image)
+
+
+@pytest.mark.parametrize("deep_response", ["", "   ", None, {"error": "diagnostic"}])
+def test_infinity_deep_parsing_rejects_empty_or_non_text_figure_result(
+    deep_response: object,
+) -> None:
+    shallow = json.dumps([{"category": "figure", "bbox": [0, 0, 4, 4], "text": "shallow figure"}])
+    provider = _infinity_provider(Mock(return_value=deep_response), deep_parsing=True)
+
+    with Image.new("RGB", (8, 8), "white") as image:
+        with pytest.raises(ProviderPermanentError, match="deep response for figure 1"):
+            provider._apply_deep_parsing(shallow, image)
+
+
+@pytest.mark.parametrize(
+    "result",
+    [json.dumps({"error": "diagnostic"}), "not json", "[]", json.dumps(["invalid element"])],
+    ids=["diagnostic-dict", "malformed-json", "empty-list", "non-object-element"],
+)
+def test_infinity_normalize_rejects_invalid_results(result: str) -> None:
+    provider = _infinity_provider(Mock())
+    raw_result = SimpleNamespace(
+        raw_output={
+            "result": result,
+            "_config": {"page_width": 8, "page_height": 8},
+        },
+        pipeline_name="infinity-test",
+        request=SimpleNamespace(example_id="document"),
+    )
+
+    with pytest.raises(ProviderPermanentError):
+        provider._normalize(raw_result)

--- a/tests/parse_bench/inference/providers/parse/test_image_ownership.py
+++ b/tests/parse_bench/inference/providers/parse/test_image_ownership.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+from PIL import Image
+
+from parse_bench.inference.providers.base import ProviderPermanentError
+from parse_bench.inference.providers.parse.amazon_nova import AmazonNovaProvider
+from parse_bench.inference.providers.parse.anthropic import AnthropicProvider
+from parse_bench.inference.providers.parse.google import GoogleProvider
+from parse_bench.inference.providers.parse.openai import OpenAIProvider
+from parse_bench.inference.providers.parse.tesseract import TesseractProvider
+from parse_bench.inference.providers.parse.textract import TextractProvider
+
+ENCODERS = [
+    (AmazonNovaProvider, "_image_to_jpeg_bytes"),
+    (AnthropicProvider, "_image_to_base64"),
+    (GoogleProvider, "_image_to_bytes"),
+    (OpenAIProvider, "_image_to_base64"),
+]
+
+
+@pytest.mark.parametrize(("provider_class", "method_name"), ENCODERS)
+@pytest.mark.parametrize("fail", [False, True], ids=["success", "exception"])
+def test_vision_encoders_close_derived_images_but_not_caller_image(
+    provider_class: type[Any],
+    method_name: str,
+    fail: bool,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = object.__new__(provider_class)
+    provider.MAX_IMAGE_DIMENSION = 4
+    provider.MAX_IMAGE_SIZE_BYTES = 1024 * 1024
+    original = Image.new("RGBA", (8, 8), "white")
+    derived: list[Image.Image] = []
+    real_resize = Image.Image.resize
+    real_convert = Image.Image.convert
+    real_save = Image.Image.save
+    inside_pillow_operation = False
+
+    def track(image: Image.Image) -> Image.Image:
+        image.close = Mock(wraps=image.close)
+        derived.append(image)
+        return image
+
+    def resize(image: Image.Image, *args: Any, **kwargs: Any) -> Image.Image:
+        nonlocal inside_pillow_operation
+        if inside_pillow_operation:
+            return real_resize(image, *args, **kwargs)
+        inside_pillow_operation = True
+        try:
+            resized = real_resize(image, *args, **kwargs)
+        finally:
+            inside_pillow_operation = False
+        return track(resized)
+
+    def convert(image: Image.Image, *args: Any, **kwargs: Any) -> Image.Image:
+        nonlocal inside_pillow_operation
+        if inside_pillow_operation:
+            return real_convert(image, *args, **kwargs)
+        inside_pillow_operation = True
+        try:
+            converted = real_convert(image, *args, **kwargs)
+        finally:
+            inside_pillow_operation = False
+        return track(converted)
+
+    def save(image: Image.Image, *args: Any, **kwargs: Any) -> None:
+        if fail:
+            raise RuntimeError("encoding failed")
+        real_save(image, *args, **kwargs)
+
+    monkeypatch.setattr(Image.Image, "resize", resize)
+    monkeypatch.setattr(Image.Image, "convert", convert)
+    monkeypatch.setattr(Image.Image, "save", save)
+
+    if fail:
+        with pytest.raises(RuntimeError, match="encoding failed"):
+            getattr(provider, method_name)(original)
+    else:
+        assert getattr(provider, method_name)(original)
+
+    assert len(derived) == 2
+    assert all(isinstance(image.close, Mock) and image.close.call_count == 1 for image in derived)
+    assert original.getpixel((0, 0)) == (255, 255, 255, 255)
+    original.close()
+
+
+@pytest.mark.parametrize("fail", [False, True], ids=["success", "exception"])
+def test_textract_closes_all_resizes_but_not_caller_image(fail: bool, monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = object.__new__(TextractProvider)
+    provider._MAX_DIMENSION = 4
+    provider._TARGET_BYTES = 0
+    original = Image.new("RGB", (8, 8), "white")
+    derived: list[Image.Image] = []
+    real_resize = Image.Image.resize
+    real_save = Image.Image.save
+
+    def resize(image: Image.Image, *args: Any, **kwargs: Any) -> Image.Image:
+        resized = real_resize(image, *args, **kwargs)
+        resized.close = Mock(wraps=resized.close)
+        derived.append(resized)
+        return resized
+
+    save_calls = 0
+
+    def save(image: Image.Image, *args: Any, **kwargs: Any) -> None:
+        nonlocal save_calls
+        save_calls += 1
+        if fail and save_calls == 2:
+            raise RuntimeError("encoding failed")
+        real_save(image, *args, **kwargs)
+
+    monkeypatch.setattr(Image.Image, "resize", resize)
+    monkeypatch.setattr(Image.Image, "save", save)
+
+    if fail:
+        with pytest.raises(RuntimeError, match="encoding failed"):
+            provider._resize_image_for_textract(original)
+    else:
+        assert provider._resize_image_for_textract(original)
+
+    assert derived
+    assert all(isinstance(image.close, Mock) and image.close.call_count == 1 for image in derived)
+    assert original.getpixel((0, 0)) == (255, 255, 255)
+    original.close()
+
+
+@pytest.mark.parametrize("fail", [False, True], ids=["success", "exception"])
+def test_tesseract_single_image_is_closed_on_success_and_failure(
+    tmp_path: Path, fail: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "page.png"
+    Image.new("RGB", (8, 6), "white").save(source)
+    provider = object.__new__(TesseractProvider)
+    provider._output_type = "text"
+    provider._lang = "eng"
+    provider._config = ""
+    real_open = Image.open
+    opened: list[Image.Image] = []
+
+    class TrackedImageContext:
+        def __init__(self, path: str | Path) -> None:
+            self.image = real_open(path)
+            self.image.close = Mock(wraps=self.image.close)
+            opened.append(self.image)
+
+        def __enter__(self) -> Image.Image:
+            return self.image
+
+        def __exit__(self, *args: object) -> None:
+            self.image.close()
+
+    def image_to_string(*args: Any, **kwargs: Any) -> str:
+        if fail:
+            raise RuntimeError("ocr failed")
+        return "page text"
+
+    import pytesseract
+
+    monkeypatch.setattr(Image, "open", TrackedImageContext)
+    monkeypatch.setattr(pytesseract, "image_to_string", image_to_string)
+    monkeypatch.setattr(pytesseract, "Output", SimpleNamespace(DICT="dict"))
+
+    if fail:
+        with pytest.raises(ProviderPermanentError, match="Error during OCR: ocr failed"):
+            provider._ocr_image(str(source))
+    else:
+        result = provider._ocr_image(str(source))
+        assert result["pages"][0]["text"] == "page text"
+        assert result["pages"][0]["width"] == 8
+
+    assert len(opened) == 1
+    assert isinstance(opened[0].close, Mock)
+    assert opened[0].close.call_count == 1

--- a/tests/parse_bench/inference/providers/parse/test_image_ownership.py
+++ b/tests/parse_bench/inference/providers/parse/test_image_ownership.py
@@ -403,8 +403,8 @@ def test_infinity_deep_parsing_preserves_classified_error_and_closes_crop(
 
 @pytest.mark.parametrize(
     "response",
-    [json.dumps({"error": "model diagnostic"}), "", "[]"],
-    ids=["diagnostic-dict", "empty", "empty-list"],
+    [json.dumps({"error": "model diagnostic"}), ""],
+    ids=["diagnostic-dict", "empty"],
 )
 def test_infinity_deep_parsing_rejects_invalid_layout_response(response: str) -> None:
     provider = _infinity_provider(Mock(), deep_parsing=True)
@@ -427,8 +427,8 @@ def test_infinity_deep_parsing_rejects_empty_or_non_text_figure_result(
 
 @pytest.mark.parametrize(
     "result",
-    [json.dumps({"error": "diagnostic"}), "not json", "[]", json.dumps(["invalid element"])],
-    ids=["diagnostic-dict", "malformed-json", "empty-list", "non-object-element"],
+    [json.dumps({"error": "diagnostic"}), "not json", json.dumps(["invalid element"])],
+    ids=["diagnostic-dict", "malformed-json", "non-object-element"],
 )
 def test_infinity_normalize_rejects_invalid_results(result: str) -> None:
     provider = _infinity_provider(Mock())

--- a/tests/parse_bench/inference/providers/parse/test_image_ownership.py
+++ b/tests/parse_bench/inference/providers/parse/test_image_ownership.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -11,8 +12,12 @@ from PIL import Image
 from parse_bench.inference.providers.base import ProviderPermanentError
 from parse_bench.inference.providers.parse.amazon_nova import AmazonNovaProvider
 from parse_bench.inference.providers.parse.anthropic import AnthropicProvider
+from parse_bench.inference.providers.parse.gemma4 import Gemma4Provider
 from parse_bench.inference.providers.parse.google import GoogleProvider
+from parse_bench.inference.providers.parse.infinity_parser2 import InfinityParser2Provider
+from parse_bench.inference.providers.parse.nemotron_omni import NemotronOmniProvider
 from parse_bench.inference.providers.parse.openai import OpenAIProvider
+from parse_bench.inference.providers.parse.qwen3_5 import Qwen35Provider
 from parse_bench.inference.providers.parse.tesseract import TesseractProvider
 from parse_bench.inference.providers.parse.textract import TextractProvider
 
@@ -22,6 +27,8 @@ ENCODERS = [
     (GoogleProvider, "_image_to_bytes"),
     (OpenAIProvider, "_image_to_base64"),
 ]
+
+SINGLE_IMAGE_READERS = [Gemma4Provider, NemotronOmniProvider, Qwen35Provider]
 
 
 @pytest.mark.parametrize(("provider_class", "method_name"), ENCODERS)
@@ -177,3 +184,169 @@ def test_tesseract_single_image_is_closed_on_success_and_failure(
     assert len(opened) == 1
     assert isinstance(opened[0].close, Mock)
     assert opened[0].close.call_count == 1
+
+
+@pytest.mark.parametrize("provider_class", SINGLE_IMAGE_READERS)
+@pytest.mark.parametrize("fail", [False, True], ids=["success", "exception"])
+def test_vllm_single_image_reader_closes_opened_image(
+    provider_class: type[Any], tmp_path: Path, fail: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "page.png"
+    Image.new("RGB", (8, 6), "white").save(source)
+    provider = object.__new__(provider_class)
+    real_open = Image.open
+    opened: list[Image.Image] = []
+
+    class TrackedImageContext:
+        def __init__(self, path: str | Path) -> None:
+            self.image = real_open(path)
+            self.image.close = Mock(wraps=self.image.close)
+            opened.append(self.image)
+
+        def __enter__(self) -> Image.Image:
+            return self.image
+
+        def __exit__(self, *args: object) -> None:
+            self.image.close()
+
+    monkeypatch.setattr(Image, "open", TrackedImageContext)
+    if fail:
+        monkeypatch.setattr(Path, "read_bytes", lambda self: (_ for _ in ()).throw(RuntimeError("read failed")))
+
+    if fail:
+        with pytest.raises(ProviderPermanentError, match="Error reading image file: read failed"):
+            provider._read_image_with_size(source)
+    else:
+        image_bytes, width, height = provider._read_image_with_size(source)
+        assert image_bytes
+        assert (width, height) == (8, 6)
+
+    assert len(opened) == 1
+    assert isinstance(opened[0].close, Mock)
+    assert opened[0].close.call_count == 1
+
+
+def _infinity_provider(parser: Mock, *, deep_parsing: bool = False) -> InfinityParser2Provider:
+    provider = object.__new__(InfinityParser2Provider)
+    provider._parser = SimpleNamespace(parse=parser)
+    provider._task_type = "doc2json"
+    provider._batch_size = 1
+    provider._output_format = "json"
+    provider._max_new_tokens = None
+    provider._temperature = 0.0
+    provider._deep_parsing_mode = deep_parsing
+    provider._model_name = "test-model"
+    provider._api_url = "http://provider.invalid"
+    provider._base_config = {}
+    return provider
+
+
+@pytest.mark.parametrize("source_kind", ["image", "pdf"])
+@pytest.mark.parametrize("fail", [False, True], ids=["success", "exception"])
+def test_infinity_parser_closes_opened_and_converted_images(
+    source_kind: str, fail: bool, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from parse_bench.inference.providers.parse import infinity_parser2 as infinity_module
+
+    source = tmp_path / f"page.{source_kind if source_kind == 'pdf' else 'png'}"
+    source.touch()
+    opened_image = Image.new("RGBA", (8, 6), "white")
+    opened_image.close = Mock(wraps=opened_image.close)
+    converted: list[Image.Image] = []
+    real_convert = Image.Image.convert
+
+    def convert(image: Image.Image, *args: Any, **kwargs: Any) -> Image.Image:
+        derived = real_convert(image, *args, **kwargs)
+        derived.close = Mock(wraps=derived.close)
+        converted.append(derived)
+        return derived
+
+    monkeypatch.setattr(Image.Image, "convert", convert)
+    if source_kind == "pdf":
+        monkeypatch.setattr(infinity_module, "convert_from_path", lambda *args, **kwargs: [opened_image])
+    else:
+
+        class OpenedImageContext:
+            def __enter__(self) -> Image.Image:
+                return opened_image
+
+            def __exit__(self, *args: object) -> None:
+                opened_image.close()
+
+        monkeypatch.setattr(infinity_module.PILImage, "open", lambda path: OpenedImageContext())
+
+    parser = Mock(side_effect=RuntimeError("parse failed")) if fail else Mock(return_value="[]")
+    provider = _infinity_provider(parser)
+
+    if fail:
+        with pytest.raises(ProviderPermanentError, match="Error parsing document: parse failed"):
+            provider._parse_document(str(source))
+    else:
+        assert provider._parse_document(str(source))["result"] == "[]"
+
+    assert isinstance(opened_image.close, Mock)
+    assert opened_image.close.call_count == 1
+    assert len(converted) == 1
+    assert isinstance(converted[0].close, Mock)
+    assert converted[0].close.call_count == 1
+
+
+@pytest.mark.parametrize("fail", [False, True], ids=["success", "exception"])
+def test_infinity_deep_parsing_closes_every_crop(fail: bool, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from parse_bench.inference.providers.parse import infinity_parser2 as infinity_module
+
+    source = tmp_path / "page.png"
+    source.touch()
+    opened_image = Image.new("RGB", (8, 8), "white")
+    converted_image = Image.new("RGB", (8, 8), "white")
+    converted_image.close = Mock(wraps=converted_image.close)
+    opened_image.close = Mock(wraps=opened_image.close)
+
+    class OpenedImageContext:
+        def __enter__(self) -> Image.Image:
+            return opened_image
+
+        def __exit__(self, *args: object) -> None:
+            opened_image.close()
+
+    monkeypatch.setattr(infinity_module.PILImage, "open", lambda path: OpenedImageContext())
+    monkeypatch.setattr(Image.Image, "convert", lambda image, *args, **kwargs: converted_image)
+
+    crops: list[Image.Image] = []
+    real_crop = Image.Image.crop
+
+    def crop(image: Image.Image, *args: Any, **kwargs: Any) -> Image.Image:
+        derived = real_crop(image, *args, **kwargs)
+        derived.close = Mock(wraps=derived.close)
+        crops.append(derived)
+        return derived
+
+    monkeypatch.setattr(Image.Image, "crop", crop)
+    shallow = json.dumps(
+        [
+            {"category": "figure", "bbox": [0, 0, 4, 4], "text": "first"},
+            {"category": "figure", "bbox": [4, 4, 8, 8], "text": "second"},
+        ]
+    )
+    call_count = 0
+
+    def parse(image: Image.Image, **kwargs: Any) -> str:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return shallow
+        if fail and call_count == 3:
+            raise RuntimeError("deep parse failed")
+        return f"table {call_count - 1}"
+
+    provider = _infinity_provider(Mock(side_effect=parse), deep_parsing=True)
+    result = provider._parse_document(str(source))["result"]
+
+    if fail:
+        assert result == shallow
+    else:
+        assert [element["text"] for element in json.loads(result)] == ["table 1", "table 2"]
+    assert len(crops) == 2
+    assert all(isinstance(image.close, Mock) and image.close.call_count == 1 for image in crops)
+    assert isinstance(opened_image.close, Mock) and opened_image.close.call_count == 1
+    assert isinstance(converted_image.close, Mock) and converted_image.close.call_count == 1

--- a/tests/parse_bench/inference/providers/parse/test_image_ownership.py
+++ b/tests/parse_bench/inference/providers/parse/test_image_ownership.py
@@ -108,6 +108,9 @@ def test_textract_closes_all_resizes_but_not_caller_image(fail: bool, monkeypatc
     real_save = Image.Image.save
 
     def resize(image: Image.Image, *args: Any, **kwargs: Any) -> Image.Image:
+        if len(derived) >= 2:
+            previous = derived[-1]
+            assert isinstance(previous.close, Mock) and previous.close.call_count == 1
         resized = real_resize(image, *args, **kwargs)
         resized.close = Mock(wraps=resized.close)
         derived.append(resized)

--- a/tests/parse_bench/inference/providers/parse/test_infinity_parser2.py
+++ b/tests/parse_bench/inference/providers/parse/test_infinity_parser2.py
@@ -7,11 +7,18 @@ regress them.
 
 from __future__ import annotations
 
+import json
 import unittest
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
 
+import pytest
 from bs4 import BeautifulSoup
 
+from parse_bench.inference.providers.base import ProviderPermanentError
 from parse_bench.inference.providers.parse.infinity_parser2 import (
+    InfinityParser2Provider,
     _convert_nonstandard_table,
     _convert_table_header,
     _determine_header_row_count,
@@ -22,6 +29,107 @@ from parse_bench.inference.providers.parse.infinity_parser2 import (
     _is_pure_text_cell,
     _is_year_cell,
 )
+from parse_bench.schemas.pipeline import PipelineSpec
+from parse_bench.schemas.pipeline_io import InferenceRequest, RawInferenceResult
+from parse_bench.schemas.product import ProductType
+
+
+def _provider() -> InfinityParser2Provider:
+    provider = object.__new__(InfinityParser2Provider)
+    provider._base_config = {}
+    return provider
+
+
+def _raw_result(raw_output: dict[str, object]) -> RawInferenceResult:
+    now = datetime.now()
+    pipeline = PipelineSpec(
+        pipeline_name="infinity-test",
+        provider_name="infinity_parser2",
+        product_type=ProductType.PARSE,
+    )
+    request = InferenceRequest(
+        example_id="document",
+        source_file_path=str(Path("document.pdf")),
+        product_type=ProductType.PARSE,
+    )
+    return RawInferenceResult(
+        request=request,
+        pipeline=pipeline,
+        pipeline_name=pipeline.pipeline_name,
+        product_type=ProductType.PARSE,
+        raw_output=raw_output,
+        started_at=now,
+        completed_at=now,
+        latency_in_ms=1,
+    )
+
+
+def _page_output(result: str) -> dict[str, object]:
+    return {
+        "result": result,
+        "_config": {"page_width": 100, "page_height": 200},
+    }
+
+
+def test_structured_empty_layout_normalizes_as_blank_page() -> None:
+    output = _provider()._normalize(_raw_result(_page_output("[]")))
+
+    assert [(page.page_index, page.markdown) for page in output.pages] == [(0, "")]
+    assert [(page.page_number, page.items) for page in output.layout_pages] == [(1, [])]
+    assert output.markdown == ""
+
+
+def test_blank_middle_page_preserves_document_page_identities() -> None:
+    page_one = json.dumps([{"page": 1, "category": "text", "bbox": [0, 0, 10, 10], "text": "one"}])
+    page_three = json.dumps([{"page": 1, "category": "text", "bbox": [0, 0, 10, 10], "text": "three"}])
+    raw_result = _raw_result(
+        {
+            "_parse_bench_multipage": {
+                "version": 1,
+                "num_pages": 3,
+                "pages": [
+                    {"page_index": 0, "raw_output": _page_output(page_one)},
+                    {"page_index": 1, "raw_output": _page_output("[]")},
+                    {"page_index": 2, "raw_output": _page_output(page_three)},
+                ],
+            }
+        }
+    )
+
+    output = _provider().normalize(raw_result).output
+
+    assert [page.page_index + 1 for page in output.pages] == [1, 2, 3]
+    assert [page.page_number for page in output.layout_pages] == [1, 2, 3]
+    assert [page.markdown for page in output.pages] == ["one", "", "three"]
+    assert output.markdown == "one\n\n\n\nthree"
+
+
+@pytest.mark.parametrize(
+    ("raw_output", "message"),
+    [
+        ({"_config": {"page_width": 100, "page_height": 200}}, "Empty result"),
+        (_page_output(""), "Empty result"),
+        (_page_output("not json"), "not valid JSON"),
+        (_page_output(json.dumps({"error": "model diagnostic"})), "must decode to a list"),
+        (_page_output(json.dumps(["bad element"])), "non-object layout element"),
+    ],
+    ids=["missing", "empty-text", "malformed-json", "diagnostic-dict", "invalid-element"],
+)
+def test_empty_and_malformed_results_remain_distinct_from_blank_layout(
+    raw_output: dict[str, object],
+    message: str,
+) -> None:
+    with pytest.raises(ProviderPermanentError, match=message):
+        _provider()._normalize(_raw_result(raw_output))
+
+
+def test_deep_parsing_passes_through_structured_blank_layout() -> None:
+    provider = _provider()
+    provider._parser = SimpleNamespace(parse=lambda *args, **kwargs: pytest.fail("blank page must not deep-parse"))
+    from PIL import Image
+
+    with Image.new("RGB", (8, 8), "white") as image:
+        assert provider._apply_deep_parsing("[]", image) == "[]"
 
 
 class TestCellClassifiers(unittest.TestCase):
@@ -132,12 +240,7 @@ class TestConvertTableHeader(unittest.TestCase):
     """End-to-end: <td> in detected header rows is rewritten to <th>."""
 
     def test_td_to_th_in_header_row(self) -> None:
-        html = (
-            "<table>"
-            "<tr><td>2022</td><td>2023</td></tr>"
-            "<tr><td>10</td><td>20</td></tr>"
-            "</table>"
-        )
+        html = "<table><tr><td>2022</td><td>2023</td></tr><tr><td>10</td><td>20</td></tr></table>"
         out = _convert_table_header(html)
         soup = BeautifulSoup(out, "html.parser")
         rows = soup.find_all("tr")

--- a/tests/parse_bench/inference/providers/parse/test_kdl_frontier_nano_multipage.py
+++ b/tests/parse_bench/inference/providers/parse/test_kdl_frontier_nano_multipage.py
@@ -334,6 +334,8 @@ def test_kdl_streams_pdf_pages_in_order_and_closes_owned_images(
     ) -> list[dict[str, object]]:
         assert image.mode == "RGB"
         events.append(("infer", page_number))
+        if page_number == 2:
+            return []
         return [
             {
                 "category": "Text",
@@ -348,7 +350,14 @@ def test_kdl_streams_pdf_pages_in_order_and_closes_owned_images(
 
     raw_result = _provider().run_inference(_pipeline(), _request(source))
 
-    assert raw_result.raw_output["markdown"] == "page 1\n\n---\n\n**Page 2**\n\npage 2\n\n---\n\n**Page 3**\n\npage 3"
+    assert raw_result.raw_output["markdown"] == ("page 1\n\n---\n\n**Page 2**\n\n---\n\n**Page 3**\n\npage 3")
+    assert [page["page_number"] for page in raw_result.raw_output["pages"]] == [1, 2, 3]
+    assert [page["page_number"] for page in raw_result.raw_output["markdown_pages"]] == [1, 2, 3]
+    assert raw_result.raw_output["pages"][1]["elements"] == []
+    assert raw_result.raw_output["markdown_pages"][1]["content"] == ""
+    normalized_result = _provider().normalize(raw_result)
+    assert [page.page_index for page in normalized_result.output.pages] == [0, 1, 2]
+    assert [page.page_number for page in normalized_result.output.layout_pages] == [1, 2, 3]
     assert events == [
         ("render", 1),
         ("infer", 1),
@@ -361,6 +370,53 @@ def test_kdl_streams_pdf_pages_in_order_and_closes_owned_images(
     assert len(opened) == len(normalized) == 3
     for image in [*opened, *normalized]:
         _assert_closed(image)
+
+
+def test_kdl_non_native_layout_aborts_page(monkeypatch: pytest.MonkeyPatch) -> None:
+    engine = kdl._NanoEngine("http://provider.invalid", "test-model", 1, 30)
+
+    async def non_native_layout(*args: object, **kwargs: object) -> str:
+        return "diagnostic response instead of layout tokens"
+
+    monkeypatch.setattr(kdl, "_nano_chat", non_native_layout)
+    monkeypatch.setattr(kdl, "analyze_page_content", lambda image: SimpleNamespace(is_blank=False))
+    with Image.new("RGB", (64, 64), "white") as image:
+        with pytest.raises(ProviderPermanentError, match="non-native layout response"):
+            asyncio.run(engine._parse_page(object(), asyncio.Semaphore(1), image, 2))
+
+
+@pytest.mark.parametrize("failure_stage", ["crop", "preprocess"])
+def test_kdl_crop_or_preprocess_failure_is_classified(failure_stage: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    with Image.new("RGB", (64, 64), "white") as image:
+        if failure_stage == "crop":
+            monkeypatch.setattr(
+                Image.Image,
+                "crop",
+                lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("crop failed")),
+            )
+        else:
+            monkeypatch.setattr(
+                kdl,
+                "preprocess_for_vlm",
+                lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("preprocess failed")),
+            )
+
+        with pytest.raises(
+            ProviderPermanentError,
+            match=f"Failed to crop or preprocess layout item 0: {failure_stage} failed",
+        ):
+            kdl._nano_group_by_bucket(
+                [
+                    {
+                        "category": "Text",
+                        "bbox": [0.0, 0.0, 0.5, 0.5],
+                        "layout_order": 0,
+                        "page_number": 1,
+                    }
+                ],
+                image,
+                lambda derived: derived,
+            )
 
 
 @pytest.mark.parametrize(

--- a/tests/parse_bench/inference/providers/parse/test_kdl_frontier_nano_multipage.py
+++ b/tests/parse_bench/inference/providers/parse/test_kdl_frontier_nano_multipage.py
@@ -312,6 +312,113 @@ def test_kdl_exhausted_page_two_retry_is_terminal_without_replaying_page_one(
         page.close()
 
 
+def test_kdl_recognition_failure_settles_cancelled_sibling_before_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    layout = (
+        "<|box_start|>50 50 450 450<|box_end|><|ref_start|>text<|ref_end|>"
+        "<|box_start|>550 550 950 950<|box_end|><|ref_start|>text<|ref_end|>"
+    )
+    attempt = 0
+    recognition_calls = 0
+    sibling_started = asyncio.Event()
+    sibling_settled = asyncio.Event()
+    release_success = asyncio.Event()
+
+    async def chat(client: object, url: str, payload: dict[str, object], semaphore: object) -> str:
+        nonlocal attempt, recognition_calls
+        prompt = payload["messages"][0]["content"][1]["text"]  # type: ignore[index]
+        if prompt == kdl._NANO_PROMPTS["layout"]:
+            if attempt:
+                assert sibling_settled.is_set(), "retry began before the failed attempt's sibling settled"
+            attempt += 1
+            return layout
+
+        recognition_calls += 1
+        if attempt == 1:
+            if recognition_calls == 1:
+                await sibling_started.wait()
+                raise ProviderTransientError("recognition failed")
+            sibling_started.set()
+            try:
+                await asyncio.Event().wait()
+            finally:
+                sibling_settled.set()
+
+        release_success.set()
+        await release_success.wait()
+        return "recognized"
+
+    async def no_sleep(delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(kdl, "_nano_chat", chat)
+    monkeypatch.setattr(kdl, "analyze_page_content", lambda image: SimpleNamespace(is_blank=False))
+    monkeypatch.setattr(kdl.asyncio, "sleep", no_sleep)
+    engine = kdl._NanoEngine("http://provider.invalid", "test-model", 2, 30)
+
+    with _content_image() as page:
+        result = asyncio.run(engine._parse_page(object(), asyncio.Semaphore(2), page, 1))
+
+    assert result
+    assert attempt == 2
+    assert sibling_settled.is_set()
+
+
+def test_kdl_terminal_exhaustion_leaves_no_recognition_siblings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    layout = (
+        "<|box_start|>50 50 450 450<|box_end|><|ref_start|>text<|ref_end|>"
+        "<|box_start|>550 550 950 950<|box_end|><|ref_start|>text<|ref_end|>"
+    )
+    attempt = 0
+    calls_in_attempt = 0
+    active_recognitions = 0
+    sibling_started = [asyncio.Event() for _ in range(3)]
+    sibling_settled = [asyncio.Event() for _ in range(3)]
+
+    async def chat(client: object, url: str, payload: dict[str, object], semaphore: object) -> str:
+        nonlocal attempt, calls_in_attempt, active_recognitions
+        prompt = payload["messages"][0]["content"][1]["text"]  # type: ignore[index]
+        if prompt == kdl._NANO_PROMPTS["layout"]:
+            if attempt:
+                assert sibling_settled[attempt - 1].is_set(), "next attempt began before sibling settlement"
+            attempt += 1
+            calls_in_attempt = 0
+            return layout
+
+        calls_in_attempt += 1
+        active_recognitions += 1
+        try:
+            if calls_in_attempt == 1:
+                await sibling_started[attempt - 1].wait()
+                raise ProviderTransientError("recognition failed")
+            sibling_started[attempt - 1].set()
+            await asyncio.Event().wait()
+            raise AssertionError("unreachable")
+        finally:
+            active_recognitions -= 1
+            if calls_in_attempt > 1:
+                sibling_settled[attempt - 1].set()
+
+    async def no_sleep(delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(kdl, "_nano_chat", chat)
+    monkeypatch.setattr(kdl, "analyze_page_content", lambda image: SimpleNamespace(is_blank=False))
+    monkeypatch.setattr(kdl.asyncio, "sleep", no_sleep)
+    engine = kdl._NanoEngine("http://provider.invalid", "test-model", 2, 30)
+
+    with _content_image() as page:
+        with pytest.raises(ProviderRetryExhaustedError, match="KDL page 1 failed after 3 attempts"):
+            asyncio.run(engine._parse_page(object(), asyncio.Semaphore(2), page, 1))
+
+    assert attempt == 3
+    assert active_recognitions == 0
+    assert all(event.is_set() for event in sibling_settled)
+
+
 @pytest.mark.parametrize("fail", [False, True], ids=["success", "encoding-failure"])
 def test_nano_data_uri_closes_rgb_conversion(
     fail: bool,

--- a/tests/parse_bench/inference/providers/parse/test_kdl_frontier_nano_multipage.py
+++ b/tests/parse_bench/inference/providers/parse/test_kdl_frontier_nano_multipage.py
@@ -9,9 +9,12 @@ from PIL import Image
 
 from parse_bench.inference.providers.base import ProviderPermanentError, ProviderTransientError
 from parse_bench.inference.providers.parse import kdl_frontier_nano as kdl
+from parse_bench.inference.providers.parse._multipage_image import IMAGE_BACKED_PDF_PROVIDERS
 from parse_bench.schemas.pipeline import PipelineSpec
 from parse_bench.schemas.pipeline_io import InferenceRequest
 from parse_bench.schemas.product import ProductType
+
+KDL_SPEC = next(spec for spec in IMAGE_BACKED_PDF_PROVIDERS if spec.execution == "kdl")
 
 
 def _pipeline() -> PipelineSpec:
@@ -32,7 +35,7 @@ def _request(source: Path) -> InferenceRequest:
 
 def _provider() -> kdl.KdlFrontierNanoProvider:
     provider = object.__new__(kdl.KdlFrontierNanoProvider)
-    provider._dpi = 144
+    provider._dpi = KDL_SPEC.dpi
     provider._endpoint_url = "http://provider.invalid/v1"
     provider._model = "test-model"
     provider._max_concurrent = 1

--- a/tests/parse_bench/inference/providers/parse/test_kdl_frontier_nano_multipage.py
+++ b/tests/parse_bench/inference/providers/parse/test_kdl_frontier_nano_multipage.py
@@ -50,6 +50,8 @@ def _provider() -> kdl.KdlFrontierNanoProvider:
     provider._max_concurrent = 1
     provider._timeout = 30
     provider._max_pages = 10
+    provider._input_cost_per_million = None
+    provider._output_cost_per_million = None
     return provider
 
 
@@ -266,6 +268,69 @@ def test_nano_chat_retries_invalid_responses_and_preserves_last_failure(
     assert isinstance(caught.value.__cause__, IndexError)
 
 
+def test_kdl_persists_every_stage_attempt_and_known_usage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    page = _content_image()
+    monkeypatch.setattr(kdl, "analyze_page_content", lambda image: SimpleNamespace(is_blank=False))
+    layout = "<|box_start|>100 100 900 900<|box_end|><|ref_start|>text<|ref_end|>"
+    responses = [
+        {"choices": [], "usage": {"prompt_tokens": 2, "completion_tokens": 0, "total_tokens": 2}},
+        {
+            "choices": [{"message": {"content": layout}}],
+            "usage": {"prompt_tokens": 3, "completion_tokens": 4, "total_tokens": 7},
+        },
+        {
+            "choices": [{"message": {"content": "recognized text"}}],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 6, "total_tokens": 11},
+        },
+    ]
+
+    class Client:
+        async def post(self, url: str, **kwargs: object) -> httpx.Response:
+            request = httpx.Request("POST", url)
+            return httpx.Response(200, request=request, json=responses.pop(0))
+
+    class ClientContext:
+        async def __aenter__(self) -> Client:
+            return Client()
+
+        async def __aexit__(self, *args: object) -> None:
+            return None
+
+    async def no_sleep(delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(kdl.httpx, "AsyncClient", lambda **kwargs: ClientContext())
+    monkeypatch.setattr(kdl.asyncio, "sleep", no_sleep)
+    engine = kdl._NanoEngine(
+        "http://provider.invalid",
+        "test-model",
+        1,
+        30,
+        input_cost_per_million=1.0,
+        output_cost_per_million=2.0,
+    )
+
+    result = asyncio.run(engine.parse_pages([page]))
+
+    assert result["num_api_calls"] == 3
+    assert [(attempt["stage"], attempt["attempt"], attempt["status"]) for attempt in result["api_attempts"]] == [
+        ("layout", 1, "failed"),
+        ("layout", 2, "succeeded"),
+        ("text recognition", 1, "succeeded"),
+    ]
+    assert result["input_tokens"] == 10
+    assert result["output_tokens"] == 10
+    assert result["total_tokens"] == 20
+    assert [attempt["stats"]["cost_usd"] for attempt in result["api_attempts"]] == pytest.approx(
+        [2 / 1_000_000, 11 / 1_000_000, 17 / 1_000_000]
+    )
+    assert result["cost_usd"] == pytest.approx(30 / 1_000_000)
+    assert result["cost_per_page_usd"] == pytest.approx(30 / 1_000_000)
+    page.close()
+
+
 @pytest.mark.parametrize("fail_recognition", [False, True], ids=["monochromatic-skip", "gather-failure"])
 def test_kdl_real_page_stage_closes_every_derivative(
     fail_recognition: bool,
@@ -365,10 +430,18 @@ def test_kdl_exhausted_page_two_retry_is_terminal_without_replaying_page_one(
     monkeypatch.setattr(kdl.asyncio, "sleep", no_sleep)
     engine = kdl._NanoEngine("http://provider.invalid", "test-model", 1, 30)
 
-    with pytest.raises(ProviderRetryExhaustedError, match="KDL page 2 failed after 3 attempts"):
+    with pytest.raises(ProviderRetryExhaustedError, match="KDL page 2 failed after 3 attempts") as caught:
         asyncio.run(engine.parse_pages(pages))
 
     assert calls == 5
+    attempts = caught.value.debug_payload["attempts"]
+    assert [(attempt["page_number"], attempt["status"]) for attempt in attempts] == [
+        (1, "succeeded"),
+        (1, "succeeded"),
+        (2, "failed"),
+        (2, "failed"),
+        (2, "failed"),
+    ]
     for page in pages:
         page.close()
 

--- a/tests/parse_bench/inference/providers/parse/test_kdl_frontier_nano_multipage.py
+++ b/tests/parse_bench/inference/providers/parse/test_kdl_frontier_nano_multipage.py
@@ -1,0 +1,286 @@
+from __future__ import annotations
+
+import io
+from pathlib import Path
+from typing import Any
+
+import pytest
+from PIL import Image
+
+from parse_bench.inference.providers.base import ProviderPermanentError, ProviderTransientError
+from parse_bench.inference.providers.parse import kdl_frontier_nano as kdl
+from parse_bench.schemas.pipeline import PipelineSpec
+from parse_bench.schemas.pipeline_io import InferenceRequest
+from parse_bench.schemas.product import ProductType
+
+
+def _pipeline() -> PipelineSpec:
+    return PipelineSpec(
+        pipeline_name="kdl_frontier_nano_test",
+        provider_name="kdl_frontier_nano",
+        product_type=ProductType.PARSE,
+    )
+
+
+def _request(source: Path) -> InferenceRequest:
+    return InferenceRequest(
+        example_id="document",
+        source_file_path=str(source),
+        product_type=ProductType.PARSE,
+    )
+
+
+def _provider() -> kdl.KdlFrontierNanoProvider:
+    provider = object.__new__(kdl.KdlFrontierNanoProvider)
+    provider._dpi = 144
+    provider._endpoint_url = "http://provider.invalid/v1"
+    provider._model = "test-model"
+    provider._max_concurrent = 1
+    provider._timeout = 30
+    provider._max_pages = 10
+    return provider
+
+
+def _png_bytes(page_number: int) -> bytes:
+    with Image.new("RGBA", (8 + page_number, 8), (page_number, 0, 0, 255)) as image:
+        buffer = io.BytesIO()
+        image.save(buffer, format="PNG")
+        return buffer.getvalue()
+
+
+class _FakePixmap:
+    def __init__(self, page_number: int) -> None:
+        self._page_number = page_number
+
+    def tobytes(self, output: str) -> bytes:
+        assert output == "png"
+        return _png_bytes(self._page_number)
+
+
+class _FakePage:
+    def __init__(self, page_number: int, render: Any) -> None:
+        self._page_number = page_number
+        self._render = render
+
+    def get_pixmap(self, **kwargs: object) -> _FakePixmap:
+        self._render(self._page_number)
+        return _FakePixmap(self._page_number)
+
+
+class _FakeDocument:
+    def __init__(self, page_count: int, render: Any, events: list[tuple[str, int]]) -> None:
+        self.page_count = page_count
+        self._render = render
+        self._events = events
+
+    def __enter__(self) -> _FakeDocument:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self._events.append(("close_document", 0))
+
+    def __iter__(self):
+        return iter(_FakePage(page_number, self._render) for page_number in range(1, self.page_count + 1))
+
+
+def _track_opened_and_normalized_images(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[list[Image.Image], list[Image.Image]]:
+    opened: list[Image.Image] = []
+    normalized: list[Image.Image] = []
+    real_open = Image.open
+    real_normalize = kdl.normalize_image_mode
+
+    def tracked_open(*args: object, **kwargs: object) -> Image.Image:
+        image = real_open(*args, **kwargs)
+        opened.append(image)
+        return image
+
+    def tracked_normalize(image: Image.Image, target_mode: str = "RGB") -> Image.Image:
+        result = real_normalize(image, target_mode)
+        if result is not image:
+            normalized.append(result)
+        return result
+
+    monkeypatch.setattr(kdl.Image, "open", tracked_open)
+    monkeypatch.setattr(kdl, "normalize_image_mode", tracked_normalize)
+    return opened, normalized
+
+
+def _assert_closed(image: Image.Image) -> None:
+    with pytest.raises(ValueError, match="Operation on closed image"):
+        image.getpixel((0, 0))
+
+
+def test_kdl_streams_pdf_pages_in_order_and_closes_owned_images(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "document.pdf"
+    source.touch()
+    events: list[tuple[str, int]] = []
+    opened, normalized = _track_opened_and_normalized_images(monkeypatch)
+
+    def render(page_number: int) -> None:
+        if opened:
+            _assert_closed(opened[-1])
+            _assert_closed(normalized[-1])
+        events.append(("render", page_number))
+
+    monkeypatch.setattr(
+        "fitz.open",
+        lambda path: _FakeDocument(3, render, events),
+    )
+
+    async def parse_page(
+        self: object,
+        client: object,
+        semaphore: object,
+        image: Image.Image,
+        page_number: int,
+    ) -> list[dict[str, object]]:
+        assert image.mode == "RGB"
+        events.append(("infer", page_number))
+        return [
+            {
+                "category": "Text",
+                "bbox": [0.0, 0.0, 1.0, 1.0],
+                "content": f"page {page_number}",
+                "layout_order": 0,
+                "page_number": page_number,
+            }
+        ]
+
+    monkeypatch.setattr(kdl._NanoEngine, "_parse_page", parse_page)
+
+    raw_result = _provider().run_inference(_pipeline(), _request(source))
+
+    assert raw_result.raw_output["markdown"] == "page 1\n\n---\n\n**Page 2**\n\npage 2\n\n---\n\n**Page 3**\n\npage 3"
+    assert events == [
+        ("render", 1),
+        ("infer", 1),
+        ("render", 2),
+        ("infer", 2),
+        ("render", 3),
+        ("infer", 3),
+        ("close_document", 0),
+    ]
+    assert len(opened) == len(normalized) == 3
+    for image in [*opened, *normalized]:
+        _assert_closed(image)
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        ProviderPermanentError("invalid page"),
+        ProviderTransientError("page timed out"),
+    ],
+    ids=["permanent", "transient"],
+)
+def test_kdl_page_two_failure_aborts_and_closes_images(
+    failure: Exception,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "document.pdf"
+    source.touch()
+    events: list[tuple[str, int]] = []
+    opened, normalized = _track_opened_and_normalized_images(monkeypatch)
+    monkeypatch.setattr(
+        "fitz.open",
+        lambda path: _FakeDocument(3, lambda page: events.append(("render", page)), events),
+    )
+
+    async def parse_page(
+        self: object,
+        client: object,
+        semaphore: object,
+        image: Image.Image,
+        page_number: int,
+    ) -> list[dict[str, object]]:
+        events.append(("infer", page_number))
+        if page_number == 2:
+            raise failure
+        return []
+
+    monkeypatch.setattr(kdl._NanoEngine, "_parse_page", parse_page)
+    successful_result = None
+
+    with pytest.raises(type(failure), match=str(failure)):
+        successful_result = _provider().run_inference(_pipeline(), _request(source))
+
+    assert successful_result is None
+    assert events == [
+        ("render", 1),
+        ("infer", 1),
+        ("render", 2),
+        ("infer", 2),
+        ("close_document", 0),
+    ]
+    assert len(opened) == len(normalized) == 2
+    for image in [*opened, *normalized]:
+        _assert_closed(image)
+
+
+def test_kdl_render_failure_closes_prior_page_and_document(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    source = tmp_path / "document.pdf"
+    source.touch()
+    events: list[tuple[str, int]] = []
+    opened, normalized = _track_opened_and_normalized_images(monkeypatch)
+
+    def render(page_number: int) -> None:
+        events.append(("render", page_number))
+        if page_number == 2:
+            raise RuntimeError("renderer failed")
+
+    monkeypatch.setattr("fitz.open", lambda path: _FakeDocument(3, render, events))
+
+    async def parse_page(*args: object, **kwargs: object) -> list[dict[str, object]]:
+        events.append(("infer", len(opened)))
+        return []
+
+    monkeypatch.setattr(kdl._NanoEngine, "_parse_page", parse_page)
+
+    with pytest.raises(ProviderPermanentError, match="Failed to render document page 2: renderer failed"):
+        _provider().run_inference(_pipeline(), _request(source))
+
+    assert events == [
+        ("render", 1),
+        ("infer", 1),
+        ("render", 2),
+        ("close_document", 0),
+    ]
+    assert len(opened) == len(normalized) == 1
+    _assert_closed(opened[0])
+    _assert_closed(normalized[0])
+
+
+def test_kdl_single_image_path_preserves_one_page_behavior_and_closes_images(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "page.png"
+    with Image.new("RGBA", (8, 8), "white") as image:
+        image.save(source)
+    opened, normalized = _track_opened_and_normalized_images(monkeypatch)
+    page_numbers: list[int] = []
+    monkeypatch.setattr("fitz.open", lambda path: pytest.fail("single images must not open as PDFs"))
+
+    async def parse_page(
+        self: object,
+        client: object,
+        semaphore: object,
+        image: Image.Image,
+        page_number: int,
+    ) -> list[dict[str, object]]:
+        page_numbers.append(page_number)
+        return []
+
+    monkeypatch.setattr(kdl._NanoEngine, "_parse_page", parse_page)
+
+    raw_result = _provider().run_inference(_pipeline(), _request(source))
+
+    assert raw_result.raw_output["markdown"] == ""
+    assert page_numbers == [1]
+    assert len(opened) == len(normalized) == 1
+    _assert_closed(opened[0])
+    _assert_closed(normalized[0])

--- a/tests/parse_bench/inference/providers/parse/test_kdl_frontier_nano_multipage.py
+++ b/tests/parse_bench/inference/providers/parse/test_kdl_frontier_nano_multipage.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import io
+from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -19,7 +20,7 @@ from parse_bench.inference.providers.base import (
 from parse_bench.inference.providers.parse import kdl_frontier_nano as kdl
 from parse_bench.inference.providers.parse._multipage_image import IMAGE_BACKED_PDF_PROVIDERS
 from parse_bench.schemas.pipeline import PipelineSpec
-from parse_bench.schemas.pipeline_io import InferenceRequest
+from parse_bench.schemas.pipeline_io import InferenceRequest, RawInferenceResult
 from parse_bench.schemas.product import ProductType
 
 KDL_SPEC = next(spec for spec in IMAGE_BACKED_PDF_PROVIDERS if spec.execution == "kdl")
@@ -50,6 +51,66 @@ def _provider() -> kdl.KdlFrontierNanoProvider:
     provider._timeout = 30
     provider._max_pages = 10
     return provider
+
+
+def _raw_kdl_result(raw_output: dict[str, object]) -> RawInferenceResult:
+    now = datetime.now()
+    request = InferenceRequest(
+        example_id="document",
+        source_file_path="document.pdf",
+        product_type=ProductType.PARSE,
+    )
+    return RawInferenceResult(
+        request=request,
+        pipeline=_pipeline(),
+        pipeline_name="kdl_frontier_nano_test",
+        product_type=ProductType.PARSE,
+        raw_output=raw_output,
+        started_at=now,
+        completed_at=now,
+        latency_in_ms=1,
+    )
+
+
+def test_kdl_normalize_rejects_non_contiguous_page_identities() -> None:
+    raw = _raw_kdl_result(
+        {
+            "markdown": "untrusted",
+            "pages": [
+                {"page_number": 2, "elements": []},
+                {"page_number": 3, "elements": []},
+            ],
+            "markdown_pages": [
+                {"page_number": 2, "content": "two"},
+                {"page_number": 3, "content": "three"},
+            ],
+        }
+    )
+
+    with pytest.raises(ProviderPermanentError, match="page identities are inconsistent"):
+        _provider().normalize(raw)
+
+
+def test_kdl_normalize_rebuilds_document_markdown_from_canonical_pages() -> None:
+    raw = _raw_kdl_result(
+        {
+            "markdown": "three before two",
+            "pages": [
+                {"page_number": 1, "elements": []},
+                {"page_number": 2, "elements": []},
+            ],
+            "markdown_pages": [
+                {"page_number": 1, "content": "one"},
+                {"page_number": 2, "content": "two"},
+            ],
+        }
+    )
+
+    output = _provider().normalize(raw).output
+
+    assert [page.page_index for page in output.pages] == [0, 1]
+    assert [page.page_number for page in output.layout_pages] == [1, 2]
+    assert output.markdown == "one\n\n---\n\n**Page 2**\n\ntwo"
 
 
 def _png_bytes(page_number: int) -> bytes:

--- a/tests/parse_bench/inference/providers/parse/test_kdl_frontier_nano_multipage.py
+++ b/tests/parse_bench/inference/providers/parse/test_kdl_frontier_nano_multipage.py
@@ -312,42 +312,34 @@ def test_kdl_exhausted_page_two_retry_is_terminal_without_replaying_page_one(
         page.close()
 
 
-def test_kdl_recognition_failure_settles_cancelled_sibling_before_retry(
+def test_kdl_recognition_retry_preserves_layout_and_successful_sibling(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     layout = (
         "<|box_start|>50 50 450 450<|box_end|><|ref_start|>text<|ref_end|>"
         "<|box_start|>550 550 950 950<|box_end|><|ref_start|>text<|ref_end|>"
     )
-    attempt = 0
+    layout_calls = 0
     recognition_calls = 0
-    sibling_started = asyncio.Event()
-    sibling_settled = asyncio.Event()
-    release_success = asyncio.Event()
+    failed_task: asyncio.Task[object] | None = None
+    task_attempts: dict[asyncio.Task[object], int] = {}
 
     async def chat(client: object, url: str, payload: dict[str, object], semaphore: object) -> str:
-        nonlocal attempt, recognition_calls
+        nonlocal failed_task, layout_calls, recognition_calls
         prompt = payload["messages"][0]["content"][1]["text"]  # type: ignore[index]
         if prompt == kdl._NANO_PROMPTS["layout"]:
-            if attempt:
-                assert sibling_settled.is_set(), "retry began before the failed attempt's sibling settled"
-            attempt += 1
+            layout_calls += 1
             return layout
 
         recognition_calls += 1
-        if attempt == 1:
-            if recognition_calls == 1:
-                await sibling_started.wait()
-                raise ProviderTransientError("recognition failed")
-            sibling_started.set()
-            try:
-                await asyncio.Event().wait()
-            finally:
-                sibling_settled.set()
-
-        release_success.set()
-        await release_success.wait()
-        return "recognized"
+        task = asyncio.current_task()
+        assert task is not None
+        task_attempts[task] = task_attempts.get(task, 0) + 1
+        if failed_task is None:
+            failed_task = task
+        if task is failed_task and task_attempts[task] == 1:
+            raise ProviderTransientError("recognition failed once")
+        return f"recognized {recognition_calls}"
 
     async def no_sleep(delay: float) -> None:
         return None
@@ -360,47 +352,42 @@ def test_kdl_recognition_failure_settles_cancelled_sibling_before_retry(
     with _content_image() as page:
         result = asyncio.run(engine._parse_page(object(), asyncio.Semaphore(2), page, 1))
 
-    assert result
-    assert attempt == 2
-    assert sibling_settled.is_set()
+    assert len(result) == 2
+    assert layout_calls == 1
+    assert recognition_calls == 3
 
 
-def test_kdl_terminal_exhaustion_leaves_no_recognition_siblings(
+def test_kdl_terminal_recognition_exhaustion_does_not_replay_successful_sibling(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     layout = (
         "<|box_start|>50 50 450 450<|box_end|><|ref_start|>text<|ref_end|>"
         "<|box_start|>550 550 950 950<|box_end|><|ref_start|>text<|ref_end|>"
     )
-    attempt = 0
-    calls_in_attempt = 0
+    layout_calls = 0
+    recognition_calls = 0
     active_recognitions = 0
-    sibling_started = [asyncio.Event() for _ in range(3)]
-    sibling_settled = [asyncio.Event() for _ in range(3)]
+    failed_task: asyncio.Task[object] | None = None
 
     async def chat(client: object, url: str, payload: dict[str, object], semaphore: object) -> str:
-        nonlocal attempt, calls_in_attempt, active_recognitions
+        nonlocal active_recognitions, failed_task, layout_calls, recognition_calls
         prompt = payload["messages"][0]["content"][1]["text"]  # type: ignore[index]
         if prompt == kdl._NANO_PROMPTS["layout"]:
-            if attempt:
-                assert sibling_settled[attempt - 1].is_set(), "next attempt began before sibling settlement"
-            attempt += 1
-            calls_in_attempt = 0
+            layout_calls += 1
             return layout
 
-        calls_in_attempt += 1
+        recognition_calls += 1
+        task = asyncio.current_task()
+        assert task is not None
+        if failed_task is None:
+            failed_task = task
         active_recognitions += 1
         try:
-            if calls_in_attempt == 1:
-                await sibling_started[attempt - 1].wait()
+            if task is failed_task:
                 raise ProviderTransientError("recognition failed")
-            sibling_started[attempt - 1].set()
-            await asyncio.Event().wait()
-            raise AssertionError("unreachable")
+            return "successful sibling"
         finally:
             active_recognitions -= 1
-            if calls_in_attempt > 1:
-                sibling_settled[attempt - 1].set()
 
     async def no_sleep(delay: float) -> None:
         return None
@@ -414,9 +401,9 @@ def test_kdl_terminal_exhaustion_leaves_no_recognition_siblings(
         with pytest.raises(ProviderRetryExhaustedError, match="KDL page 1 failed after 3 attempts"):
             asyncio.run(engine._parse_page(object(), asyncio.Semaphore(2), page, 1))
 
-    assert attempt == 3
+    assert layout_calls == 1
+    assert recognition_calls == 4
     assert active_recognitions == 0
-    assert all(event.is_set() for event in sibling_settled)
 
 
 @pytest.mark.parametrize("fail", [False, True], ids=["success", "encoding-failure"])

--- a/tests/parse_bench/inference/providers/parse/test_kdl_frontier_nano_multipage.py
+++ b/tests/parse_bench/inference/providers/parse/test_kdl_frontier_nano_multipage.py
@@ -209,10 +209,7 @@ def test_kdl_real_page_stage_closes_every_derivative(
     page = _content_image()
     derived = _track_pillow_derivatives(monkeypatch)
     monkeypatch.setattr(kdl, "analyze_page_content", lambda image: SimpleNamespace(is_blank=False))
-    layout = (
-        "<|box_start|>100 100 900 900<|box_end|>"
-        "<|ref_start|>text<|ref_end|>"
-    )
+    layout = "<|box_start|>100 100 900 900<|box_end|><|ref_start|>text<|ref_end|>"
     calls = 0
 
     async def chat(*args: object, **kwargs: object) -> str:
@@ -247,10 +244,7 @@ def test_kdl_real_page_two_stage_failure_aborts_document(
     pages = [_content_image(), _content_image()]
     derived = _track_pillow_derivatives(monkeypatch)
     monkeypatch.setattr(kdl, "analyze_page_content", lambda image: SimpleNamespace(is_blank=False))
-    layout = (
-        "<|box_start|>100 100 900 900<|box_end|>"
-        "<|ref_start|>text<|ref_end|>"
-    )
+    layout = "<|box_start|>100 100 900 900<|box_end|><|ref_start|>text<|ref_end|>"
     calls = 0
 
     async def chat(*args: object, **kwargs: object) -> str:

--- a/tests/parse_bench/inference/providers/parse/test_kdl_frontier_nano_multipage.py
+++ b/tests/parse_bench/inference/providers/parse/test_kdl_frontier_nano_multipage.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import asyncio
 import io
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
+from unittest.mock import Mock
 
+import httpx
 import pytest
 from PIL import Image
 
@@ -113,6 +117,199 @@ def _track_opened_and_normalized_images(
 def _assert_closed(image: Image.Image) -> None:
     with pytest.raises(ValueError, match="Operation on closed image"):
         image.getpixel((0, 0))
+
+
+def _content_image() -> Image.Image:
+    image = Image.new("RGB", (64, 64), "white")
+    for coordinate in range(8, 56):
+        image.putpixel((coordinate, coordinate), (0, 0, 0))
+    return image
+
+
+def _track_pillow_derivatives(monkeypatch: pytest.MonkeyPatch) -> list[Image.Image]:
+    derived: list[Image.Image] = []
+
+    def wrap(method_name: str) -> None:
+        real_method = getattr(Image.Image, method_name)
+
+        def tracked(image: Image.Image, *args: Any, **kwargs: Any) -> Image.Image:
+            result = real_method(image, *args, **kwargs)
+            result.close = Mock(wraps=result.close)
+            derived.append(result)
+            return result
+
+        monkeypatch.setattr(Image.Image, method_name, tracked)
+
+    for method_name in ("convert", "resize", "crop"):
+        wrap(method_name)
+    return derived
+
+
+@pytest.mark.parametrize(
+    ("status_code", "error_type", "attempts"),
+    [(400, ProviderPermanentError, 1), (429, ProviderTransientError, 3), (503, ProviderTransientError, 3)],
+)
+def test_nano_chat_classifies_http_failures(
+    status_code: int,
+    error_type: type[Exception],
+    attempts: int,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
+
+    class Client:
+        async def post(self, url: str, **kwargs: object) -> httpx.Response:
+            nonlocal calls
+            calls += 1
+            request = httpx.Request("POST", url)
+            return httpx.Response(status_code, request=request, text="provider failure")
+
+    async def no_sleep(delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(kdl.asyncio, "sleep", no_sleep)
+
+    with pytest.raises(error_type, match=f"HTTP {status_code}|{status_code}") as caught:
+        asyncio.run(kdl._nano_chat(Client(), "http://provider.invalid", {}, asyncio.Semaphore(1)))
+
+    assert calls == attempts
+    if status_code >= 500 or status_code == 429:
+        assert isinstance(caught.value.__cause__, httpx.HTTPStatusError)
+
+
+def test_nano_chat_retries_invalid_responses_and_preserves_last_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
+
+    class Client:
+        async def post(self, url: str, **kwargs: object) -> httpx.Response:
+            nonlocal calls
+            calls += 1
+            request = httpx.Request("POST", url)
+            return httpx.Response(200, request=request, json={"choices": []})
+
+    async def no_sleep(delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(kdl.asyncio, "sleep", no_sleep)
+
+    with pytest.raises(ProviderTransientError, match="failed after 3 attempts") as caught:
+        asyncio.run(kdl._nano_chat(Client(), "http://provider.invalid", {}, asyncio.Semaphore(1)))
+
+    assert calls == 3
+    assert isinstance(caught.value.__cause__, IndexError)
+
+
+@pytest.mark.parametrize("fail_recognition", [False, True], ids=["monochromatic-skip", "gather-failure"])
+def test_kdl_real_page_stage_closes_every_derivative(
+    fail_recognition: bool,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    page = _content_image()
+    derived = _track_pillow_derivatives(monkeypatch)
+    monkeypatch.setattr(kdl, "analyze_page_content", lambda image: SimpleNamespace(is_blank=False))
+    layout = (
+        "<|box_start|>100 100 900 900<|box_end|>"
+        "<|ref_start|>text<|ref_end|>"
+    )
+    calls = 0
+
+    async def chat(*args: object, **kwargs: object) -> str:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return layout
+        if fail_recognition:
+            raise ProviderTransientError("recognition exhausted")
+        return "recognized text"
+
+    if not fail_recognition:
+        page.paste("white", (6, 6, 58, 58))
+    monkeypatch.setattr(kdl, "_nano_chat", chat)
+    engine = kdl._NanoEngine("http://provider.invalid", "test-model", 1, 30)
+
+    if fail_recognition:
+        with pytest.raises(ProviderTransientError, match="recognition exhausted"):
+            asyncio.run(engine._parse_page(object(), asyncio.Semaphore(1), page, 1))
+    else:
+        assert asyncio.run(engine._parse_page(object(), asyncio.Semaphore(1), page, 1)) == []
+
+    assert derived
+    assert all(isinstance(image.close, Mock) and image.close.call_count == 1 for image in derived)
+    assert page.getpixel((0, 0)) == (255, 255, 255)
+    page.close()
+
+
+def test_kdl_real_page_two_stage_failure_aborts_document(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pages = [_content_image(), _content_image()]
+    derived = _track_pillow_derivatives(monkeypatch)
+    monkeypatch.setattr(kdl, "analyze_page_content", lambda image: SimpleNamespace(is_blank=False))
+    layout = (
+        "<|box_start|>100 100 900 900<|box_end|>"
+        "<|ref_start|>text<|ref_end|>"
+    )
+    calls = 0
+
+    async def chat(*args: object, **kwargs: object) -> str:
+        nonlocal calls
+        calls += 1
+        if calls == 3:
+            raise ProviderTransientError("page two layout exhausted")
+        return layout if calls == 1 else "page one text"
+
+    monkeypatch.setattr(kdl, "_nano_chat", chat)
+    engine = kdl._NanoEngine("http://provider.invalid", "test-model", 1, 30)
+    successful_result = None
+
+    with pytest.raises(ProviderTransientError, match="page two layout exhausted"):
+        successful_result = asyncio.run(engine.parse_pages(pages))
+
+    assert successful_result is None
+    assert calls == 3
+    assert derived
+    assert all(isinstance(image.close, Mock) and image.close.call_count == 1 for image in derived)
+    for page in pages:
+        assert page.getpixel((0, 0)) == (255, 255, 255)
+        page.close()
+
+
+@pytest.mark.parametrize("fail", [False, True], ids=["success", "encoding-failure"])
+def test_nano_data_uri_closes_rgb_conversion(
+    fail: bool,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original = Image.new("HSV", (8, 8), (0, 0, 255))
+    real_convert = Image.Image.convert
+    real_save = Image.Image.save
+    converted: list[Image.Image] = []
+
+    def convert(image: Image.Image, *args: Any, **kwargs: Any) -> Image.Image:
+        result = real_convert(image, *args, **kwargs)
+        result.close = Mock(wraps=result.close)
+        converted.append(result)
+        return result
+
+    def save(image: Image.Image, *args: Any, **kwargs: Any) -> None:
+        if fail:
+            raise RuntimeError("encoding failed")
+        real_save(image, *args, **kwargs)
+
+    monkeypatch.setattr(Image.Image, "convert", convert)
+    monkeypatch.setattr(Image.Image, "save", save)
+
+    if fail:
+        with pytest.raises(RuntimeError, match="encoding failed"):
+            kdl._nano_image_to_data_uri(original)
+    else:
+        assert kdl._nano_image_to_data_uri(original).startswith("data:image/jpeg;base64,")
+
+    assert len(converted) == 1
+    assert isinstance(converted[0].close, Mock) and converted[0].close.call_count == 1
+    assert original.getpixel((0, 0)) == (0, 0, 255)
+    original.close()
 
 
 def test_kdl_streams_pdf_pages_in_order_and_closes_owned_images(

--- a/tests/parse_bench/inference/providers/parse/test_kdl_frontier_nano_multipage.py
+++ b/tests/parse_bench/inference/providers/parse/test_kdl_frontier_nano_multipage.py
@@ -11,7 +11,11 @@ import httpx
 import pytest
 from PIL import Image
 
-from parse_bench.inference.providers.base import ProviderPermanentError, ProviderTransientError
+from parse_bench.inference.providers.base import (
+    ProviderPermanentError,
+    ProviderRetryExhaustedError,
+    ProviderTransientError,
+)
 from parse_bench.inference.providers.parse import kdl_frontier_nano as kdl
 from parse_bench.inference.providers.parse._multipage_image import IMAGE_BACKED_PDF_PROVIDERS
 from parse_bench.schemas.pipeline import PipelineSpec
@@ -147,7 +151,7 @@ def _track_pillow_derivatives(monkeypatch: pytest.MonkeyPatch) -> list[Image.Ima
 
 @pytest.mark.parametrize(
     ("status_code", "error_type", "attempts"),
-    [(400, ProviderPermanentError, 1), (429, ProviderTransientError, 3), (503, ProviderTransientError, 3)],
+    [(400, ProviderPermanentError, 1), (429, ProviderTransientError, 1), (503, ProviderTransientError, 1)],
 )
 def test_nano_chat_classifies_http_failures(
     status_code: int,
@@ -194,10 +198,10 @@ def test_nano_chat_retries_invalid_responses_and_preserves_last_failure(
 
     monkeypatch.setattr(kdl.asyncio, "sleep", no_sleep)
 
-    with pytest.raises(ProviderTransientError, match="failed after 3 attempts") as caught:
+    with pytest.raises(ProviderTransientError, match="Stage request failed") as caught:
         asyncio.run(kdl._nano_chat(Client(), "http://provider.invalid", {}, asyncio.Semaphore(1)))
 
-    assert calls == 3
+    assert calls == 1
     assert isinstance(caught.value.__cause__, IndexError)
 
 
@@ -223,11 +227,16 @@ def test_kdl_real_page_stage_closes_every_derivative(
 
     if not fail_recognition:
         page.paste("white", (6, 6, 58, 58))
+
+    async def no_sleep(delay: float) -> None:
+        return None
+
     monkeypatch.setattr(kdl, "_nano_chat", chat)
+    monkeypatch.setattr(kdl.asyncio, "sleep", no_sleep)
     engine = kdl._NanoEngine("http://provider.invalid", "test-model", 1, 30)
 
     if fail_recognition:
-        with pytest.raises(ProviderTransientError, match="recognition exhausted"):
+        with pytest.raises(ProviderRetryExhaustedError, match="KDL page 1 failed after 3 attempts"):
             asyncio.run(engine._parse_page(object(), asyncio.Semaphore(1), page, 1))
     else:
         assert asyncio.run(engine._parse_page(object(), asyncio.Semaphore(1), page, 1)) == []
@@ -238,7 +247,7 @@ def test_kdl_real_page_stage_closes_every_derivative(
     page.close()
 
 
-def test_kdl_real_page_two_stage_failure_aborts_document(
+def test_kdl_real_page_two_stage_failure_retries_only_page_two(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     pages = [_content_image(), _content_image()]
@@ -251,22 +260,55 @@ def test_kdl_real_page_two_stage_failure_aborts_document(
         nonlocal calls
         calls += 1
         if calls == 3:
-            raise ProviderTransientError("page two layout exhausted")
-        return layout if calls == 1 else "page one text"
+            raise ProviderTransientError("page two layout timed out")
+        return layout if calls in {1, 4} else f"page text {calls}"
 
     monkeypatch.setattr(kdl, "_nano_chat", chat)
+
+    async def no_sleep(delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(kdl.asyncio, "sleep", no_sleep)
     engine = kdl._NanoEngine("http://provider.invalid", "test-model", 1, 30)
-    successful_result = None
 
-    with pytest.raises(ProviderTransientError, match="page two layout exhausted"):
-        successful_result = asyncio.run(engine.parse_pages(pages))
+    result = asyncio.run(engine.parse_pages(pages))
 
-    assert successful_result is None
-    assert calls == 3
+    assert calls == 5
+    assert [page["page_number"] for page in result["pages"]] == [1, 2]
     assert derived
     assert all(isinstance(image.close, Mock) and image.close.call_count == 1 for image in derived)
     for page in pages:
         assert page.getpixel((0, 0)) == (255, 255, 255)
+        page.close()
+
+
+def test_kdl_exhausted_page_two_retry_is_terminal_without_replaying_page_one(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pages = [_content_image(), _content_image()]
+    monkeypatch.setattr(kdl, "analyze_page_content", lambda image: SimpleNamespace(is_blank=False))
+    layout = "<|box_start|>100 100 900 900<|box_end|><|ref_start|>text<|ref_end|>"
+    calls = 0
+
+    async def chat(*args: object, **kwargs: object) -> str:
+        nonlocal calls
+        calls += 1
+        if calls >= 3:
+            raise ProviderTransientError("page two unavailable")
+        return layout if calls == 1 else "page one text"
+
+    async def no_sleep(delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(kdl, "_nano_chat", chat)
+    monkeypatch.setattr(kdl.asyncio, "sleep", no_sleep)
+    engine = kdl._NanoEngine("http://provider.invalid", "test-model", 1, 30)
+
+    with pytest.raises(ProviderRetryExhaustedError, match="KDL page 2 failed after 3 attempts"):
+        asyncio.run(engine.parse_pages(pages))
+
+    assert calls == 5
+    for page in pages:
         page.close()
 
 

--- a/tests/parse_bench/inference/providers/parse/test_kdl_frontier_nano_multipage.py
+++ b/tests/parse_bench/inference/providers/parse/test_kdl_frontier_nano_multipage.py
@@ -331,6 +331,34 @@ def test_kdl_persists_every_stage_attempt_and_known_usage(
     page.close()
 
 
+def test_kdl_retries_semantically_invalid_layout_inside_stage_owner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    page = _content_image()
+    monkeypatch.setattr(kdl, "analyze_page_content", lambda image: SimpleNamespace(is_blank=False))
+
+    async def invalid_layout(*args: object, **kwargs: object) -> kdl._NanoStageResponse:
+        return kdl._NanoStageResponse(
+            content="not native layout",
+            usage={"input_tokens": 5, "output_tokens": 2, "total_tokens": 7},
+        )
+
+    async def no_sleep(delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(kdl, "_nano_chat", invalid_layout)
+    monkeypatch.setattr(kdl.asyncio, "sleep", no_sleep)
+    engine = kdl._NanoEngine("http://provider.invalid", "test-model", 1, 30)
+
+    with pytest.raises(ProviderRetryExhaustedError) as caught:
+        asyncio.run(engine._parse_page(SimpleNamespace(), asyncio.Semaphore(1), page, 1))
+
+    attempts = caught.value.debug_payload["attempts"]
+    assert [attempt["status"] for attempt in attempts] == ["failed", "failed", "failed"]
+    assert [attempt["stats"]["total_tokens"] for attempt in attempts] == [7, 7, 7]
+    page.close()
+
+
 @pytest.mark.parametrize("fail_recognition", [False, True], ids=["monochromatic-skip", "gather-failure"])
 def test_kdl_real_page_stage_closes_every_derivative(
     fail_recognition: bool,

--- a/tests/parse_bench/inference/providers/parse/test_llm_page_retry_and_responses.py
+++ b/tests/parse_bench/inference/providers/parse/test_llm_page_retry_and_responses.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import importlib
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from PIL import Image
@@ -329,3 +329,65 @@ def test_layout_file_malformed_page_two_aborts_document_atomically_through_respo
         successful_result = provider.run_inference(_pipeline(module_name), _request(source))
 
     assert successful_result is None
+
+
+def test_openai_and_anthropic_sdk_retries_are_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, dict[str, object]] = {}
+    openai_sdk = importlib.import_module("openai")
+    anthropic_sdk = importlib.import_module("anthropic")
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setattr(
+        openai_sdk,
+        "OpenAI",
+        lambda **kwargs: captured.setdefault("openai", kwargs),
+    )
+    monkeypatch.setattr(
+        anthropic_sdk,
+        "Anthropic",
+        lambda **kwargs: captured.setdefault("anthropic", kwargs),
+    )
+
+    openai_module = importlib.import_module("parse_bench.inference.providers.parse.openai")
+    anthropic_module = importlib.import_module("parse_bench.inference.providers.parse.anthropic")
+    openai_provider = openai_module.OpenAIProvider("openai")
+    anthropic_provider = anthropic_module.AnthropicProvider("anthropic")
+
+    assert captured["openai"]["max_retries"] == 0
+    assert captured["anthropic"]["max_retries"] == 0
+    assert openai_provider._dpi == openai_module.OpenAIProvider.PDF_RENDER_DPI == 150
+    assert anthropic_provider._dpi == anthropic_module.AnthropicProvider.PDF_RENDER_DPI == 150
+
+
+def test_google_sdk_and_dots_compatible_client_use_one_attempt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, dict[str, object]] = {}
+    google_module = importlib.import_module("parse_bench.inference.providers.parse.google")
+    dots_module = importlib.import_module("parse_bench.inference.providers.parse.dots_ocr")
+    genai = importlib.import_module("google.genai")
+
+    monkeypatch.setenv("GOOGLE_GEMINI_API_KEY", "test-key")
+    monkeypatch.setattr(
+        genai,
+        "Client",
+        lambda **kwargs: captured.setdefault("google", kwargs),
+    )
+    monkeypatch.setattr(
+        dots_module,
+        "OpenAI",
+        lambda **kwargs: captured.setdefault("dots", kwargs),
+    )
+
+    google_provider = google_module.GoogleProvider("google")
+    dots_provider = dots_module.DotsOcrParseProvider(
+        "dots_ocr_parse",
+        {"endpoint_url": "https://dots.invalid/v1"},
+    )
+
+    http_options = cast(Any, captured["google"]["http_options"])
+    assert http_options.retry_options.attempts == 1
+    assert captured["dots"]["max_retries"] == 0
+    assert google_provider._dpi == google_module.GoogleProvider.PDF_RENDER_DPI == 150
+    assert dots_provider._dpi == dots_module.DotsOcrParseProvider.PDF_RENDER_DPI == 150

--- a/tests/parse_bench/inference/providers/parse/test_llm_page_retry_and_responses.py
+++ b/tests/parse_bench/inference/providers/parse/test_llm_page_retry_and_responses.py
@@ -10,9 +10,11 @@ import pytest
 from PIL import Image
 
 from parse_bench.inference.providers.base import (
+    ProviderPermanentError,
     ProviderRetryExhaustedError,
     ProviderTransientError,
 )
+from parse_bench.inference.providers.parse._multipage_image import annotate_attempt_costs, run_page_once
 from parse_bench.inference.providers.parse.google_agentic_vision import extract_usage_from_response
 from parse_bench.inference.runner import InferenceRunner
 from parse_bench.schemas.pipeline import PipelineSpec
@@ -200,6 +202,98 @@ def test_missing_success_usage_remains_unknown(module_name: str, class_name: str
     )
 
     assert provider_class._extract_usage(response) == {}
+
+
+@pytest.mark.parametrize(
+    ("module_name", "class_name"),
+    [
+        ("google", "GoogleProvider"),
+        ("openai", "OpenAIProvider"),
+        ("anthropic", "AnthropicProvider"),
+    ],
+)
+def test_native_file_success_without_usage_keeps_output_and_physical_ledger(
+    module_name: str,
+    class_name: str,
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "document.pdf"
+    source.touch()
+    provider = _layout_file_provider(module_name, class_name)
+    provider._mode = "file"
+    provider._get_pricing = lambda: None
+    provider._parse_pdf_file = lambda path: ("parsed", {})
+
+    result = provider.run_inference(_pipeline(module_name), _request(source))
+
+    assert result.raw_output["pages"][0]["markdown"] == "parsed"
+    assert result.raw_output["num_api_calls"] == 1
+    assert result.raw_output["api_attempts"] == [{"page_number": 1, "attempt": 1, "status": "succeeded", "stats": {}}]
+    assert "input_tokens" not in result.raw_output
+    assert "cost_usd" not in result.raw_output
+
+
+def test_permanent_physical_call_persists_attempt_before_reraising() -> None:
+    attempts: list[dict[str, object]] = []
+
+    def fail() -> None:
+        raise ProviderPermanentError("submitted bad request", attempt_stats={"input_tokens": 3})
+
+    with pytest.raises(ProviderPermanentError) as caught:
+        run_page_once(fail, page_number=2, attempt_ledger=attempts)
+
+    assert attempts == [
+        {
+            "page_number": 2,
+            "attempt": 1,
+            "status": "failed",
+            "stats": {"input_tokens": 3},
+            "error_type": "ProviderPermanentError",
+            "error": "submitted bad request",
+        }
+    ]
+    assert caught.value.debug_payload == {"attempts": attempts}
+
+
+def test_openai_reasoning_is_not_double_billed_and_cached_input_is_not_full_price() -> None:
+    module = importlib.import_module("parse_bench.inference.providers.parse.openai")
+    provider = object.__new__(module.OpenAIProvider)
+    response = SimpleNamespace(
+        usage=SimpleNamespace(
+            prompt_tokens=100,
+            completion_tokens=40,
+            total_tokens=140,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=60),
+            completion_tokens_details=SimpleNamespace(reasoning_tokens=10),
+        )
+    )
+
+    usage = provider._extract_usage(response)
+
+    assert usage == {
+        "input_tokens": 100,
+        "cached_content_tokens": 60,
+        "output_tokens": 40,
+        "thinking_tokens": 10,
+        "total_tokens": 140,
+    }
+    attempts: list[dict[str, object]] = [{"stats": dict(usage)}]
+    annotate_attempt_costs(
+        attempts,
+        input_rate_per_million=1.0,
+        output_rate_per_million=2.0,
+        output_tokens_include_thinking=True,
+    )
+    assert "cost_usd" not in attempts[0]["stats"]
+
+    uncached_attempts: list[dict[str, object]] = [{"stats": {**usage, "cached_content_tokens": 0}}]
+    annotate_attempt_costs(
+        uncached_attempts,
+        input_rate_per_million=1.0,
+        output_rate_per_million=2.0,
+        output_tokens_include_thinking=True,
+    )
+    assert uncached_attempts[0]["stats"]["cost_usd"] == pytest.approx(0.00018)
 
 
 def test_agentic_missing_or_partial_success_usage_remains_incomplete() -> None:

--- a/tests/parse_bench/inference/providers/parse/test_llm_page_retry_and_responses.py
+++ b/tests/parse_bench/inference/providers/parse/test_llm_page_retry_and_responses.py
@@ -13,6 +13,7 @@ from parse_bench.inference.providers.base import (
     ProviderRetryExhaustedError,
     ProviderTransientError,
 )
+from parse_bench.inference.providers.parse.google_agentic_vision import extract_usage_from_response
 from parse_bench.inference.runner import InferenceRunner
 from parse_bench.schemas.pipeline import PipelineSpec
 from parse_bench.schemas.pipeline_io import InferenceRequest
@@ -59,6 +60,7 @@ def _layout_file_provider(module_name: str, class_name: str) -> Any:
     provider._supports_temperature = True
     provider._enable_explicit_context_cache = False
     provider._get_pricing = lambda: (0.0, 0.0)
+    provider._get_context_cache_pricing = lambda: (0.0, 0.0)
     return provider
 
 
@@ -181,6 +183,102 @@ def _anthropic_response(content: list[object] | None = None) -> SimpleNamespace:
         content=content if content is not None else [SimpleNamespace(type="text", text="page")],
         usage=None,
     )
+
+
+@pytest.mark.parametrize(
+    ("module_name", "class_name", "response"),
+    [
+        ("google", "GoogleProvider", SimpleNamespace(usage_metadata=None)),
+        ("openai", "OpenAIProvider", SimpleNamespace(usage=None)),
+        ("anthropic", "AnthropicProvider", SimpleNamespace(usage=None)),
+        ("amazon_nova", "AmazonNovaProvider", {}),
+    ],
+)
+def test_missing_success_usage_remains_unknown(module_name: str, class_name: str, response: object) -> None:
+    provider_class = getattr(
+        importlib.import_module(f"parse_bench.inference.providers.parse.{module_name}"), class_name
+    )
+
+    assert provider_class._extract_usage(response) == {}
+
+
+def test_agentic_missing_or_partial_success_usage_remains_incomplete() -> None:
+    assert extract_usage_from_response(SimpleNamespace(usage_metadata=None)) == {}
+    partial = extract_usage_from_response(SimpleNamespace(usage_metadata=SimpleNamespace(prompt_token_count=7)))
+
+    assert partial == {"input_tokens": 7}
+
+
+@pytest.mark.parametrize(
+    ("module_name", "class_name"),
+    [
+        ("google", "GoogleProvider"),
+        ("openai", "OpenAIProvider"),
+        ("anthropic", "AnthropicProvider"),
+        ("amazon_nova", "AmazonNovaProvider"),
+    ],
+)
+def test_unknown_model_pricing_remains_unknown(module_name: str, class_name: str) -> None:
+    provider = object.__new__(
+        getattr(importlib.import_module(f"parse_bench.inference.providers.parse.{module_name}"), class_name)
+    )
+    provider._model = "future-unknown-model"
+
+    assert provider._get_pricing() is None
+
+
+def test_google_unknown_pricing_preserves_complete_usage_without_cost() -> None:
+    google = importlib.import_module("parse_bench.inference.providers.parse.google")
+    provider = object.__new__(google.GoogleProvider)
+    provider._model = "future-unknown-model"
+
+    summary = provider._compute_usage_cost_summary([dict(_USAGE)], num_pages=1)
+
+    assert summary == {
+        "input_tokens": 1,
+        "tool_use_prompt_tokens": 0,
+        "cached_content_tokens": 0,
+        "output_tokens": 1,
+        "thinking_tokens": 0,
+        "total_tokens": 2,
+        "num_api_calls": 1,
+        "input_tokens_per_page": 1.0,
+        "tool_use_prompt_tokens_per_page": 0.0,
+        "cached_content_tokens_per_page": 0.0,
+        "output_tokens_per_page": 1.0,
+    }
+
+
+@pytest.mark.parametrize(
+    ("module_name", "class_name"),
+    [
+        ("google", "GoogleProvider"),
+        ("openai", "OpenAIProvider"),
+        ("anthropic", "AnthropicProvider"),
+    ],
+)
+def test_unknown_pricing_does_not_abort_completed_file_inference(
+    module_name: str,
+    class_name: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "document.pdf"
+    source.touch()
+    module = importlib.import_module(f"parse_bench.inference.providers.parse.{module_name}")
+    monkeypatch.setattr(module, "split_pdf_to_pages", lambda path: [(b"1", 10, 10)])
+    provider = _layout_file_provider(module_name, class_name)
+    provider._get_pricing = lambda: None
+    if module_name == "google":
+        provider._get_context_cache_pricing = lambda: None
+    provider._parse_pdf_page_with_layout = lambda pdf_bytes: ([], "[]", dict(_USAGE))
+
+    result = provider.run_inference(_pipeline(module_name), _request(source))
+
+    assert result.raw_output["num_api_calls"] == 1
+    assert result.raw_output["total_tokens"] == 2
+    assert "cost_usd" not in result.raw_output
+    assert "cost_per_page_usd" not in result.raw_output
 
 
 @pytest.mark.parametrize(

--- a/tests/parse_bench/inference/providers/parse/test_llm_page_retry_and_responses.py
+++ b/tests/parse_bench/inference/providers/parse/test_llm_page_retry_and_responses.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import json
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
@@ -97,6 +98,9 @@ def test_layout_file_page_two_retry_never_replays_page_one(
     assert raw_result.raw_output["num_pages"] == 2
     assert raw_result.raw_output["num_api_calls"] == 3
     assert len(raw_result.raw_output["api_attempts"]) == 3
+    assert "total_tokens" not in raw_result.raw_output
+    assert "cost_usd" not in raw_result.raw_output
+    assert "page_usages" not in raw_result.raw_output
     assert calls == [1, 2, 2]
 
 
@@ -140,6 +144,7 @@ def test_layout_file_exhaustion_is_terminal_to_document_runner(
 
     provider.run_inference = counted_run_inference
     runner = object.__new__(InferenceRunner)
+    runner.output_dir = tmp_path
     runner.use_rich = False
     runner.job_statuses = {}
     runner.pipeline = _pipeline(module_name)
@@ -155,6 +160,13 @@ def test_layout_file_exhaustion_is_terminal_to_document_runner(
     assert error is not None and error[2] == ProviderRetryExhaustedError.__name__
     assert document_attempts == 1
     assert calls == [1, 2, 2, 2]
+    payload = json.loads((tmp_path / "document.error.raw.json").read_text())
+    assert [(attempt["page_number"], attempt["status"]) for attempt in payload["attempts"]] == [
+        (1, "succeeded"),
+        (2, "failed"),
+        (2, "failed"),
+        (2, "failed"),
+    ]
 
 
 def _openai_response(content: object = "page") -> SimpleNamespace:

--- a/tests/parse_bench/inference/providers/parse/test_llm_page_retry_and_responses.py
+++ b/tests/parse_bench/inference/providers/parse/test_llm_page_retry_and_responses.py
@@ -95,6 +95,8 @@ def test_layout_file_page_two_retry_never_replays_page_one(
     raw_result = provider.run_inference(_pipeline(module_name), _request(source))
 
     assert raw_result.raw_output["num_pages"] == 2
+    assert raw_result.raw_output["num_api_calls"] == 3
+    assert len(raw_result.raw_output["api_attempts"]) == 3
     assert calls == [1, 2, 2]
 
 

--- a/tests/parse_bench/inference/providers/parse/test_llm_page_retry_and_responses.py
+++ b/tests/parse_bench/inference/providers/parse/test_llm_page_retry_and_responses.py
@@ -1,0 +1,331 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from PIL import Image
+
+from parse_bench.inference.providers.base import (
+    ProviderRetryExhaustedError,
+    ProviderTransientError,
+)
+from parse_bench.inference.runner import InferenceRunner
+from parse_bench.schemas.pipeline import PipelineSpec
+from parse_bench.schemas.pipeline_io import InferenceRequest
+from parse_bench.schemas.product import ProductType
+
+_USAGE = {
+    "input_tokens": 1,
+    "output_tokens": 1,
+    "thinking_tokens": 0,
+    "total_tokens": 2,
+}
+
+
+def _pipeline(provider_name: str) -> PipelineSpec:
+    return PipelineSpec(
+        pipeline_name=f"{provider_name}_layout_file_test",
+        provider_name=provider_name,
+        product_type=ProductType.PARSE,
+    )
+
+
+def _request(source: Path) -> InferenceRequest:
+    return InferenceRequest(
+        example_id="document",
+        source_file_path=str(source),
+        product_type=ProductType.PARSE,
+    )
+
+
+def _layout_file_provider(module_name: str, class_name: str) -> Any:
+    module = importlib.import_module(f"parse_bench.inference.providers.parse.{module_name}")
+    provider = object.__new__(getattr(module, class_name))
+    provider._mode = "parse_with_layout_file"
+    provider._model = "test-model"
+    provider._dpi = 150
+    provider._max_tokens = 100
+    provider._bbox_scale = 1000
+    provider._layout_system_prompt = "layout system"
+    provider._layout_user_prompt = "layout user"
+    provider._reasoning_effort = None
+    provider._thinking_level = None
+    provider._thinking = None
+    provider._effort = None
+    provider._supports_temperature = True
+    provider._enable_explicit_context_cache = False
+    provider._get_pricing = lambda: (0.0, 0.0)
+    return provider
+
+
+@pytest.mark.parametrize(
+    ("module_name", "class_name"),
+    [
+        ("google", "GoogleProvider"),
+        ("openai", "OpenAIProvider"),
+        ("anthropic", "AnthropicProvider"),
+    ],
+)
+def test_layout_file_page_two_retry_never_replays_page_one(
+    module_name: str,
+    class_name: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "document.pdf"
+    source.touch()
+    module = importlib.import_module(f"parse_bench.inference.providers.parse.{module_name}")
+    monkeypatch.setattr(module, "split_pdf_to_pages", lambda path: [(b"1", 10, 10), (b"2", 10, 10)])
+    monkeypatch.setattr("parse_bench.inference.providers.parse._multipage_image.time.sleep", lambda delay: None)
+    provider = _layout_file_provider(module_name, class_name)
+    calls: list[int] = []
+
+    def parse_page(pdf_bytes: bytes) -> tuple[list[dict[str, object]], str, dict[str, int]]:
+        page_number = int(pdf_bytes)
+        calls.append(page_number)
+        if calls == [1, 2]:
+            raise ProviderTransientError("page two timed out")
+        text = f'<div data-bbox="[0,0,10,10]" data-label="Text">page {page_number}</div>'
+        return ([{"bbox": [0, 0, 10, 10], "label": "Text", "text": f"page {page_number}"}], text, _USAGE)
+
+    provider._parse_pdf_page_with_layout = parse_page
+    raw_result = provider.run_inference(_pipeline(module_name), _request(source))
+
+    assert raw_result.raw_output["num_pages"] == 2
+    assert calls == [1, 2, 2]
+
+
+@pytest.mark.parametrize(
+    ("module_name", "class_name"),
+    [
+        ("google", "GoogleProvider"),
+        ("openai", "OpenAIProvider"),
+        ("anthropic", "AnthropicProvider"),
+    ],
+)
+def test_layout_file_exhaustion_is_terminal_to_document_runner(
+    module_name: str,
+    class_name: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "document.pdf"
+    source.touch()
+    module = importlib.import_module(f"parse_bench.inference.providers.parse.{module_name}")
+    monkeypatch.setattr(module, "split_pdf_to_pages", lambda path: [(b"1", 10, 10), (b"2", 10, 10)])
+    monkeypatch.setattr("parse_bench.inference.providers.parse._multipage_image.time.sleep", lambda delay: None)
+    provider = _layout_file_provider(module_name, class_name)
+    calls: list[int] = []
+    document_attempts = 0
+
+    def parse_page(pdf_bytes: bytes) -> tuple[list[dict[str, object]], str, dict[str, int]]:
+        page_number = int(pdf_bytes)
+        calls.append(page_number)
+        if page_number == 2:
+            raise ProviderTransientError("page two unavailable")
+        return ([], "[]", _USAGE)
+
+    provider._parse_pdf_page_with_layout = parse_page
+    original_run_inference = provider.run_inference
+
+    def counted_run_inference(pipeline: PipelineSpec, request: InferenceRequest):  # type: ignore[no-untyped-def]
+        nonlocal document_attempts
+        document_attempts += 1
+        return original_run_inference(pipeline, request)
+
+    provider.run_inference = counted_run_inference
+    runner = object.__new__(InferenceRunner)
+    runner.use_rich = False
+    runner.job_statuses = {}
+    runner.pipeline = _pipeline(module_name)
+    runner.provider = provider
+    runner._prepare_source_file_for_provider = lambda example_id, path: path
+    runner._fetch_parse_job_logs = lambda raw_result, example_id: None
+    runner._save_result = lambda raw_result, normalized_result: None
+
+    raw_result, normalized_result, error = runner._process_document(source, "document", ProductType.PARSE)
+
+    assert raw_result is None
+    assert normalized_result is None
+    assert error is not None and error[2] == ProviderRetryExhaustedError.__name__
+    assert document_attempts == 1
+    assert calls == [1, 2, 2, 2]
+
+
+def _openai_response(content: object = "page") -> SimpleNamespace:
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=content))],
+        usage=None,
+    )
+
+
+def _anthropic_response(content: list[object] | None = None) -> SimpleNamespace:
+    return SimpleNamespace(
+        content=content if content is not None else [SimpleNamespace(type="text", text="page")],
+        usage=None,
+    )
+
+
+@pytest.mark.parametrize(
+    "bad_response", [SimpleNamespace(choices=[], usage=None), _openai_response(None), _openai_response("")]
+)
+def test_openai_normal_image_rejects_missing_or_empty_text(bad_response: object) -> None:
+    provider = object.__new__(importlib.import_module("parse_bench.inference.providers.parse.openai").OpenAIProvider)
+    provider._client = SimpleNamespace(
+        chat=SimpleNamespace(completions=SimpleNamespace(create=lambda **kwargs: bad_response))
+    )
+    provider._model = "test-model"
+    provider._max_tokens = 100
+    provider._reasoning_effort = None
+    provider._image_to_base64 = lambda image: "image"
+
+    with pytest.raises(ProviderTransientError, match="no choices|no message content|empty message content"):
+        provider._parse_image(Image.new("RGB", (1, 1)))
+
+
+@pytest.mark.parametrize(
+    "bad_response",
+    [
+        _anthropic_response([]),
+        _anthropic_response([SimpleNamespace(type="thinking", thinking="...")]),
+        _anthropic_response([SimpleNamespace(type="text", text="")]),
+    ],
+)
+def test_anthropic_normal_image_rejects_missing_or_empty_text(bad_response: object) -> None:
+    provider = object.__new__(
+        importlib.import_module("parse_bench.inference.providers.parse.anthropic").AnthropicProvider
+    )
+    provider._client = SimpleNamespace(messages=SimpleNamespace(create=lambda **kwargs: bad_response))
+    provider._model = "test-model"
+    provider._max_tokens = 100
+    provider._thinking = None
+    provider._effort = None
+    provider._supports_temperature = True
+    provider._image_to_base64 = lambda image: "image"
+
+    with pytest.raises(ProviderTransientError, match="no content blocks|no non-empty text content"):
+        provider._parse_image(Image.new("RGB", (1, 1)))
+
+
+@pytest.mark.parametrize(
+    ("module_name", "class_name", "response"),
+    [
+        ("openai", "OpenAIProvider", _openai_response("not layout markup")),
+        (
+            "anthropic",
+            "AnthropicProvider",
+            _anthropic_response([SimpleNamespace(type="text", text="not layout markup")]),
+        ),
+    ],
+)
+def test_layout_image_rejects_malformed_output_through_response_parser(
+    module_name: str,
+    class_name: str,
+    response: object,
+) -> None:
+    provider = object.__new__(
+        getattr(importlib.import_module(f"parse_bench.inference.providers.parse.{module_name}"), class_name)
+    )
+    if module_name == "openai":
+        provider._client = SimpleNamespace(
+            chat=SimpleNamespace(completions=SimpleNamespace(create=lambda **kwargs: response))
+        )
+        provider._reasoning_effort = None
+    else:
+        provider._client = SimpleNamespace(messages=SimpleNamespace(create=lambda **kwargs: response))
+        provider._thinking = None
+        provider._effort = None
+        provider._supports_temperature = True
+    provider._model = "test-model"
+    provider._max_tokens = 100
+    provider._layout_system_prompt = "system"
+    provider._layout_user_prompt = "user"
+    provider._image_to_base64 = lambda image: "image"
+
+    with pytest.raises(ProviderTransientError, match="malformed layout output"):
+        provider._parse_image_with_layout(Image.new("RGB", (1, 1)))
+
+
+@pytest.mark.parametrize(
+    ("provider_class", "response"),
+    [
+        (
+            "OpenAIProvider",
+            _openai_response("[]"),
+        ),
+        (
+            "AnthropicProvider",
+            _anthropic_response([SimpleNamespace(type="text", text="[]")]),
+        ),
+    ],
+)
+def test_layout_parser_accepts_only_explicit_structured_blank(provider_class: str, response: object) -> None:
+    module_name = "openai" if provider_class == "OpenAIProvider" else "anthropic"
+    provider = object.__new__(
+        getattr(importlib.import_module(f"parse_bench.inference.providers.parse.{module_name}"), provider_class)
+    )
+    if module_name == "openai":
+        provider._client = SimpleNamespace(
+            chat=SimpleNamespace(completions=SimpleNamespace(create=lambda **kwargs: response))
+        )
+        provider._reasoning_effort = None
+    else:
+        provider._client = SimpleNamespace(messages=SimpleNamespace(create=lambda **kwargs: response))
+        provider._thinking = None
+        provider._effort = None
+        provider._supports_temperature = True
+    provider._model = "test-model"
+    provider._max_tokens = 100
+    provider._layout_system_prompt = "system"
+    provider._layout_user_prompt = "user"
+    provider._image_to_base64 = lambda image: "image"
+
+    items, text, _ = provider._parse_image_with_layout(Image.new("RGB", (1, 1)))
+
+    assert items == []
+    assert text == "[]"
+
+
+@pytest.mark.parametrize(
+    ("module_name", "class_name"),
+    [("openai", "OpenAIProvider"), ("anthropic", "AnthropicProvider")],
+)
+def test_layout_file_malformed_page_two_aborts_document_atomically_through_response_parser(
+    module_name: str,
+    class_name: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "document.pdf"
+    source.touch()
+    module = importlib.import_module(f"parse_bench.inference.providers.parse.{module_name}")
+    monkeypatch.setattr(module, "split_pdf_to_pages", lambda path: [(b"1", 10, 10), (b"2", 10, 10)])
+    monkeypatch.setattr("parse_bench.inference.providers.parse._multipage_image.time.sleep", lambda delay: None)
+    good = '<div data-bbox="[0,0,10,10]" data-label="Text">page one</div>'
+    if module_name == "openai":
+        responses = iter([_openai_response(good), *[_openai_response("") for _ in range(3)]])
+    else:
+        responses = iter(
+            [
+                _anthropic_response([SimpleNamespace(type="text", text=good)]),
+                *[_anthropic_response([SimpleNamespace(type="text", text="")]) for _ in range(3)],
+            ]
+        )
+    provider = _layout_file_provider(module_name, class_name)
+    if module_name == "openai":
+        provider._client = SimpleNamespace(
+            chat=SimpleNamespace(completions=SimpleNamespace(create=lambda **kwargs: next(responses)))
+        )
+    else:
+        provider._client = SimpleNamespace(
+            beta=SimpleNamespace(messages=SimpleNamespace(create=lambda **kwargs: next(responses)))
+        )
+    successful_result = None
+
+    with pytest.raises(ProviderRetryExhaustedError, match="page 2 failed after 3 attempts"):
+        successful_result = provider.run_inference(_pipeline(module_name), _request(source))
+
+    assert successful_result is None

--- a/tests/parse_bench/inference/providers/parse/test_multipage_image.py
+++ b/tests/parse_bench/inference/providers/parse/test_multipage_image.py
@@ -59,9 +59,6 @@ def test_partial_attempt_usage_is_not_treated_as_exact_zero_buckets() -> None:
     assert usages == [
         {
             "input_tokens": 4,
-            "output_tokens": 0,
-            "thinking_tokens": 0,
-            "total_tokens": 0,
             "_usage_known": 0,
         }
     ]
@@ -290,6 +287,93 @@ def test_external_cancellation_signals_and_drains_running_worker(tmp_path: Path)
 
     assert cancel_calls == ["document"]
     assert release.is_set()
+
+
+def test_top_level_batch_cancellation_signals_and_drains_every_running_worker(tmp_path: Path) -> None:
+    both_started = threading.Event()
+    release = threading.Event()
+    cancel_calls: list[str] = []
+    started = 0
+    started_lock = threading.Lock()
+    runner = object.__new__(InferenceRunner)
+    runner.provider = SimpleNamespace(cancel=lambda example_id: (cancel_calls.append(example_id), release.set()))
+    runner.pipeline = _pipeline()
+    runner.output_dir = tmp_path
+    runner.use_rich = False
+    runner.console = None
+    runner.job_statuses = {}
+    runner.timeout_retries = 0
+    runner.per_file_timeout = 60
+    runner.max_concurrent = 2
+    runner._thread_pool = concurrent.futures.ThreadPoolExecutor(max_workers=2)
+    runner._is_already_processed = lambda example_id: False
+
+    def process(pdf_path: Path, example_id: str, product_type: ProductType) -> tuple[None, None, None]:
+        nonlocal started
+        with started_lock:
+            started += 1
+            if started == 2:
+                both_started.set()
+        release.wait()
+        return None, None, None
+
+    runner._process_document = process
+
+    async def exercise() -> None:
+        task = asyncio.create_task(runner.run_files([tmp_path / "a.pdf", tmp_path / "b.pdf"], ProductType.PARSE))
+        while not both_started.is_set():
+            await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    try:
+        asyncio.run(exercise())
+    finally:
+        release.set()
+        runner._thread_pool.shutdown(wait=True)
+
+    assert sorted(cancel_calls) == ["a", "b"]
+
+
+def test_timeout_retries_after_cancelled_worker_returns_transient_failure(tmp_path: Path) -> None:
+    release = threading.Event()
+    calls = 0
+    runner = object.__new__(InferenceRunner)
+    runner.provider = SimpleNamespace(cancel=lambda example_id: release.set())
+    runner.use_rich = False
+    runner.job_statuses = {}
+    runner.timeout_retries = 1
+    runner.per_file_timeout = 0.01
+    runner._thread_pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    runner._is_already_processed = lambda example_id: False
+
+    def process(pdf_path: Path, example_id: str, product_type: ProductType) -> tuple[None, None, tuple[str, str, str]]:
+        nonlocal calls
+        calls += 1
+        release.wait()
+        return None, None, ("cancelled provider request", "", "ProviderTransientError")
+
+    runner._process_document = process
+
+    async def exercise() -> RunSummary:
+        summary = RunSummary()
+        await runner._process_with_semaphore(
+            asyncio.Semaphore(1),
+            tmp_path / "document.pdf",
+            "document",
+            ProductType.PARSE,
+            summary,
+        )
+        return summary
+
+    try:
+        summary = asyncio.run(exercise())
+    finally:
+        runner._thread_pool.shutdown(wait=True)
+
+    assert calls == 2
+    assert summary.failed == 1
 
 
 @pytest.mark.parametrize("provider_name", ["google", "openai", "anthropic"])

--- a/tests/parse_bench/inference/providers/parse/test_multipage_image.py
+++ b/tests/parse_bench/inference/providers/parse/test_multipage_image.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+from PIL import Image
+
+from parse_bench.inference.providers.parse._multipage_image import (
+    normalize_pdf_pages,
+    run_pdf_pages,
+)
+from parse_bench.schemas.parse_output import ParseLayoutPageIR, ParseOutput
+from parse_bench.schemas.pipeline import PipelineSpec
+from parse_bench.schemas.pipeline_io import InferenceRequest, InferenceResult, RawInferenceResult
+from parse_bench.schemas.product import ProductType
+
+
+def _pipeline() -> PipelineSpec:
+    return PipelineSpec(
+        pipeline_name="test_image_provider",
+        provider_name="test",
+        product_type=ProductType.PARSE,
+    )
+
+
+def _request(source: Path) -> InferenceRequest:
+    return InferenceRequest(
+        example_id="document",
+        source_file_path=str(source),
+        product_type=ProductType.PARSE,
+    )
+
+
+def test_pdf_pages_are_processed_and_combined_in_document_order(tmp_path: Path, monkeypatch) -> None:
+    source = tmp_path / "document.pdf"
+    source.touch()
+    rendered_pages = [Image.new("RGB", (20 + page_index, 30), (page_index, 0, 0)) for page_index in (1, 2, 3)]
+    monkeypatch.setattr(
+        "pdf2image.convert_from_path",
+        lambda path, dpi: rendered_pages,
+    )
+
+    observed_pages: list[tuple[str, int]] = []
+
+    def run_single_image(pipeline: PipelineSpec, request: InferenceRequest) -> RawInferenceResult:
+        image_path = Path(request.source_file_path)
+        with Image.open(image_path) as image:
+            page_number = image.getpixel((0, 0))[0]
+        observed_pages.append((image_path.name, page_number))
+        now = datetime.now()
+        return RawInferenceResult(
+            request=request,
+            pipeline=pipeline,
+            pipeline_name=pipeline.pipeline_name,
+            product_type=request.product_type,
+            raw_output={"markdown": f"page {page_number}"},
+            started_at=now,
+            completed_at=now,
+            latency_in_ms=page_number,
+        )
+
+    raw_result = run_pdf_pages(
+        _pipeline(),
+        _request(source),
+        dpi=144,
+        run_single_image=run_single_image,
+    )
+
+    assert raw_result is not None
+    assert observed_pages == [
+        ("page-000001.png", 1),
+        ("page-000002.png", 2),
+        ("page-000003.png", 3),
+    ]
+    # Raw artifacts must remain checkpoint-safe after temporary images disappear.
+    json.dumps(raw_result.model_dump(mode="json"))
+
+    def normalize_single_image(raw: RawInferenceResult) -> InferenceResult:
+        markdown = raw.raw_output["markdown"]
+        output = ParseOutput(
+            example_id=raw.request.example_id,
+            pipeline_name=raw.pipeline_name,
+            markdown=markdown,
+            layout_pages=[ParseLayoutPageIR(page_number=1, md=markdown)],
+        )
+        return InferenceResult(
+            request=raw.request,
+            pipeline_name=raw.pipeline_name,
+            product_type=raw.product_type,
+            raw_output=raw.raw_output,
+            output=output,
+            started_at=raw.started_at,
+            completed_at=raw.completed_at,
+            latency_in_ms=raw.latency_in_ms,
+        )
+
+    result = normalize_pdf_pages(raw_result, normalize_single_image=normalize_single_image)
+
+    assert result is not None
+    assert result.output.markdown == "page 1\n\npage 2\n\npage 3"
+    assert [(page.page_index, page.markdown) for page in result.output.pages] == [
+        (0, "page 1"),
+        (1, "page 2"),
+        (2, "page 3"),
+    ]
+    assert [page.page_number for page in result.output.layout_pages] == [1, 2, 3]
+
+
+def test_single_image_input_stays_on_the_provider_path(tmp_path: Path) -> None:
+    source = tmp_path / "image.png"
+    Image.new("RGB", (8, 8), "white").save(source)
+    called = False
+
+    def run_single_image(pipeline: PipelineSpec, request: InferenceRequest) -> RawInferenceResult:
+        nonlocal called
+        called = True
+        raise AssertionError("the adapter must not intercept a single image")
+
+    result = run_pdf_pages(
+        _pipeline(),
+        _request(source),
+        dpi=144,
+        run_single_image=run_single_image,
+    )
+
+    assert result is None
+    assert called is False

--- a/tests/parse_bench/inference/providers/parse/test_multipage_image.py
+++ b/tests/parse_bench/inference/providers/parse/test_multipage_image.py
@@ -4,8 +4,10 @@ import json
 from datetime import datetime
 from pathlib import Path
 
+import pytest
 from PIL import Image
 
+from parse_bench.inference.providers.base import ProviderPermanentError
 from parse_bench.inference.providers.parse._multipage_image import (
     normalize_pdf_pages,
     run_pdf_pages,
@@ -35,10 +37,26 @@ def _request(source: Path) -> InferenceRequest:
 def test_pdf_pages_are_processed_and_combined_in_document_order(tmp_path: Path, monkeypatch) -> None:
     source = tmp_path / "document.pdf"
     source.touch()
-    rendered_pages = [Image.new("RGB", (20 + page_index, 30), (page_index, 0, 0)) for page_index in (1, 2, 3)]
+    events: list[tuple[str, int]] = []
+    rendered_pages: list[Image.Image] = []
+
+    monkeypatch.setattr("pdf2image.pdfinfo_from_path", lambda path: {"Pages": 3})
+
+    def render_page(path: str, dpi: int, first_page: int, last_page: int) -> list[Image.Image]:
+        assert Path(path) == source
+        assert dpi == 144
+        assert first_page == last_page
+        if rendered_pages:
+            with pytest.raises(ValueError, match="Operation on closed image"):
+                rendered_pages[-1].getpixel((0, 0))
+        events.append(("render", first_page))
+        image = Image.new("RGB", (20 + first_page, 30), (first_page, 0, 0))
+        rendered_pages.append(image)
+        return [image]
+
     monkeypatch.setattr(
         "pdf2image.convert_from_path",
-        lambda path, dpi: rendered_pages,
+        render_page,
     )
 
     observed_pages: list[tuple[str, int]] = []
@@ -47,6 +65,7 @@ def test_pdf_pages_are_processed_and_combined_in_document_order(tmp_path: Path, 
         image_path = Path(request.source_file_path)
         with Image.open(image_path) as image:
             page_number = image.getpixel((0, 0))[0]
+        events.append(("infer", page_number))
         observed_pages.append((image_path.name, page_number))
         now = datetime.now()
         return RawInferenceResult(
@@ -73,6 +92,17 @@ def test_pdf_pages_are_processed_and_combined_in_document_order(tmp_path: Path, 
         ("page-000002.png", 2),
         ("page-000003.png", 3),
     ]
+    # Rendering and inference alternate, so later pages cannot be retained eagerly.
+    assert events == [
+        ("render", 1),
+        ("infer", 1),
+        ("render", 2),
+        ("infer", 2),
+        ("render", 3),
+        ("infer", 3),
+    ]
+    with pytest.raises(ValueError, match="Operation on closed image"):
+        rendered_pages[-1].getpixel((0, 0))
     # Raw artifacts must remain checkpoint-safe after temporary images disappear.
     json.dumps(raw_result.model_dump(mode="json"))
 
@@ -98,6 +128,7 @@ def test_pdf_pages_are_processed_and_combined_in_document_order(tmp_path: Path, 
     result = normalize_pdf_pages(raw_result, normalize_single_image=normalize_single_image)
 
     assert result is not None
+    assert isinstance(result.output, ParseOutput)
     assert result.output.markdown == "page 1\n\npage 2\n\npage 3"
     assert [(page.page_index, page.markdown) for page in result.output.pages] == [
         (0, "page 1"),
@@ -105,6 +136,45 @@ def test_pdf_pages_are_processed_and_combined_in_document_order(tmp_path: Path, 
         (2, "page 3"),
     ]
     assert [page.page_number for page in result.output.layout_pages] == [1, 2, 3]
+
+
+def test_pdf_render_failure_identifies_page_and_stops(tmp_path: Path, monkeypatch) -> None:
+    source = tmp_path / "document.pdf"
+    source.touch()
+    render_calls: list[int] = []
+
+    monkeypatch.setattr("pdf2image.pdfinfo_from_path", lambda path: {"Pages": 3})
+
+    def render_page(path: str, dpi: int, first_page: int, last_page: int) -> list[Image.Image]:
+        render_calls.append(first_page)
+        if first_page == 2:
+            raise RuntimeError("poppler failed")
+        return [Image.new("RGB", (8, 8), "white")]
+
+    monkeypatch.setattr("pdf2image.convert_from_path", render_page)
+
+    def run_single_image(pipeline: PipelineSpec, request: InferenceRequest) -> RawInferenceResult:
+        now = datetime.now()
+        return RawInferenceResult(
+            request=request,
+            pipeline=pipeline,
+            pipeline_name=pipeline.pipeline_name,
+            product_type=request.product_type,
+            raw_output={"markdown": "page 1"},
+            started_at=now,
+            completed_at=now,
+            latency_in_ms=1,
+        )
+
+    with pytest.raises(ProviderPermanentError, match="Failed to render PDF page 2: poppler failed"):
+        run_pdf_pages(
+            _pipeline(),
+            _request(source),
+            dpi=144,
+            run_single_image=run_single_image,
+        )
+
+    assert render_calls == [1, 2]
 
 
 def test_single_image_input_stays_on_the_provider_path(tmp_path: Path) -> None:

--- a/tests/parse_bench/inference/providers/parse/test_multipage_image.py
+++ b/tests/parse_bench/inference/providers/parse/test_multipage_image.py
@@ -8,12 +8,17 @@ import pytest
 from PIL import Image
 
 from parse_bench.evaluation.stats import build_operational_stats
-from parse_bench.inference.providers.base import ProviderPermanentError
+from parse_bench.inference.providers.base import (
+    ProviderPermanentError,
+    ProviderRetryExhaustedError,
+    ProviderTransientError,
+)
 from parse_bench.inference.providers.parse._multipage_image import (
     normalize_pdf_pages,
     open_document_page_images,
     run_pdf_pages,
 )
+from parse_bench.inference.runner import InferenceRunner
 from parse_bench.schemas.parse_output import ParseLayoutPageIR, ParseOutput
 from parse_bench.schemas.pipeline import PipelineSpec
 from parse_bench.schemas.pipeline_io import InferenceRequest, InferenceResult, RawInferenceResult
@@ -167,6 +172,107 @@ def test_pdf_pages_are_processed_and_combined_in_document_order(tmp_path: Path, 
     assert stats["input_tokens"].value == 60
     assert stats["input_tokens_per_page"].value == 20
     assert stats["num_api_calls"].value == 3
+
+
+def test_transient_page_retry_does_not_replay_prior_page_or_duplicate_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "document.pdf"
+    source.touch()
+    monkeypatch.setattr("pdf2image.pdfinfo_from_path", lambda path: {"Pages": 3})
+    monkeypatch.setattr(
+        "pdf2image.convert_from_path",
+        lambda path, dpi, first_page, last_page: [Image.new("RGB", (8, 8), (first_page, 0, 0))],
+    )
+    monkeypatch.setattr("parse_bench.inference.providers.parse._multipage_image.time.sleep", lambda delay: None)
+    requested_pages: list[int] = []
+
+    def run_single_image(pipeline: PipelineSpec, request: InferenceRequest) -> RawInferenceResult:
+        with Image.open(request.source_file_path) as image:
+            page_number = image.getpixel((0, 0))[0]
+        requested_pages.append(page_number)
+        if requested_pages == [1, 2]:
+            raise ProviderTransientError("page two timed out")
+        now = datetime.now()
+        return RawInferenceResult(
+            request=request,
+            pipeline=pipeline,
+            pipeline_name=pipeline.pipeline_name,
+            product_type=request.product_type,
+            raw_output={"markdown": f"page {page_number}", "num_api_calls": 1},
+            started_at=now,
+            completed_at=now,
+            latency_in_ms=1,
+        )
+
+    raw_result = run_pdf_pages(_pipeline(), _request(source), dpi=144, run_single_image=run_single_image)
+
+    assert raw_result is not None
+    assert requested_pages == [1, 2, 2, 3]
+    assert raw_result.raw_output["num_api_calls"] == 3
+    envelope = raw_result.raw_output["_parse_bench_multipage"]
+    assert isinstance(envelope, dict)
+    assert [page["page_index"] for page in envelope["pages"]] == [0, 1, 2]
+
+
+def test_exhausted_page_retry_is_terminal_to_document_runner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "document.pdf"
+    source.touch()
+    monkeypatch.setattr("pdf2image.pdfinfo_from_path", lambda path: {"Pages": 2})
+    monkeypatch.setattr(
+        "pdf2image.convert_from_path",
+        lambda path, dpi, first_page, last_page: [Image.new("RGB", (8, 8), (first_page, 0, 0))],
+    )
+    monkeypatch.setattr("parse_bench.inference.providers.parse._multipage_image.time.sleep", lambda delay: None)
+    requested_pages: list[int] = []
+    document_attempts = 0
+
+    def run_single_image(pipeline: PipelineSpec, request: InferenceRequest) -> RawInferenceResult:
+        with Image.open(request.source_file_path) as image:
+            page_number = image.getpixel((0, 0))[0]
+        requested_pages.append(page_number)
+        if page_number == 2:
+            raise ProviderTransientError("still unavailable")
+        now = datetime.now()
+        return RawInferenceResult(
+            request=request,
+            pipeline=pipeline,
+            pipeline_name=pipeline.pipeline_name,
+            product_type=request.product_type,
+            raw_output={"markdown": "page 1", "num_api_calls": 1},
+            started_at=now,
+            completed_at=now,
+            latency_in_ms=1,
+        )
+
+    class AdapterProvider:
+        def run_inference(self, pipeline: PipelineSpec, request: InferenceRequest) -> RawInferenceResult:
+            nonlocal document_attempts
+            document_attempts += 1
+            result = run_pdf_pages(pipeline, request, dpi=144, run_single_image=run_single_image)
+            assert result is not None
+            return result
+
+    runner = object.__new__(InferenceRunner)
+    runner.use_rich = False
+    runner.job_statuses = {}
+    runner.pipeline = _pipeline()
+    runner.provider = AdapterProvider()
+    runner._prepare_source_file_for_provider = lambda example_id, path: path
+    runner._fetch_parse_job_logs = lambda raw_result, example_id: None
+    runner._save_result = lambda raw_result, normalized_result: None
+
+    raw_result, normalized_result, error = runner._process_document(source, "document", ProductType.PARSE)
+
+    assert raw_result is None
+    assert normalized_result is None
+    assert error is not None and error[2] == ProviderRetryExhaustedError.__name__
+    assert document_attempts == 1
+    assert requested_pages == [1, 2, 2, 2]
 
 
 def test_multipage_aggregation_omits_partial_or_invalid_provider_metadata(tmp_path: Path, monkeypatch) -> None:

--- a/tests/parse_bench/inference/providers/parse/test_multipage_image.py
+++ b/tests/parse_bench/inference/providers/parse/test_multipage_image.py
@@ -247,6 +247,51 @@ def test_async_timeout_adopts_late_success_without_resubmission(tmp_path: Path) 
     assert run_summary.total_latency_ms == 9
 
 
+def test_external_cancellation_signals_and_drains_running_worker(tmp_path: Path) -> None:
+    started = threading.Event()
+    release = threading.Event()
+    cancel_calls: list[str] = []
+    runner = object.__new__(InferenceRunner)
+    runner.provider = SimpleNamespace(cancel=lambda example_id: (cancel_calls.append(example_id), release.set()))
+    runner.use_rich = False
+    runner.job_statuses = {}
+    runner.timeout_retries = 0
+    runner.per_file_timeout = 60
+    runner._thread_pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    runner._is_already_processed = lambda example_id: False
+
+    def process(pdf_path: Path, example_id: str, product_type: ProductType) -> tuple[None, None, None]:
+        started.set()
+        release.wait()
+        return None, None, None
+
+    runner._process_document = process
+
+    async def exercise() -> None:
+        task = asyncio.create_task(
+            runner._process_with_semaphore(
+                asyncio.Semaphore(1),
+                tmp_path / "document.pdf",
+                "document",
+                ProductType.PARSE,
+                RunSummary(),
+            )
+        )
+        while not started.is_set():
+            await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    try:
+        asyncio.run(exercise())
+    finally:
+        runner._thread_pool.shutdown(wait=True)
+
+    assert cancel_calls == ["document"]
+    assert release.is_set()
+
+
 @pytest.mark.parametrize("provider_name", ["google", "openai", "anthropic"])
 def test_runner_file_retry_accounts_failed_usage_cost_and_success(
     provider_name: str,
@@ -317,6 +362,33 @@ def test_runner_file_retry_accounts_failed_usage_cost_and_success(
     attempts = result.raw_output["api_attempts"]
     assert [attempt["status"] for attempt in attempts] == ["failed", "succeeded"]
     assert attempts[0]["stats"]["cost_usd"] == pytest.approx(9 / 1_000_000)
+
+
+def test_runner_terminal_retry_persists_every_failed_attempt(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    request = _request(tmp_path / "document.pdf")
+
+    class FileProvider:
+        def _get_pricing(self) -> tuple[float, float]:
+            return 1.0, 2.0
+
+        def run_inference(self, pipeline: PipelineSpec, current_request: InferenceRequest) -> RawInferenceResult:
+            raise ProviderTransientError(
+                "unavailable",
+                attempt_stats={"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+            )
+
+    runner = object.__new__(InferenceRunner)
+    runner.provider = FileProvider()
+    runner.pipeline = _pipeline()
+    monkeypatch.setattr("parse_bench.inference.runner.time.sleep", lambda delay: None)
+
+    with pytest.raises(ProviderTransientError) as exc_info:
+        runner._run_inference_with_retries(request)
+
+    payload = exc_info.value.debug_payload
+    assert isinstance(payload, dict)
+    assert len(payload["attempts"]) == 6
+    assert [attempt["runner_attempt"] for attempt in payload["attempts"]] == [1, 2, 3, 4, 5, 6]
 
 
 def test_pdf_pages_are_processed_and_combined_in_document_order(tmp_path: Path, monkeypatch) -> None:

--- a/tests/parse_bench/inference/providers/parse/test_multipage_image.py
+++ b/tests/parse_bench/inference/providers/parse/test_multipage_image.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 from PIL import Image
 
+from parse_bench.evaluation.stats import build_operational_stats
 from parse_bench.inference.providers.base import ProviderPermanentError
 from parse_bench.inference.providers.parse._multipage_image import (
     normalize_pdf_pages,
@@ -74,7 +75,16 @@ def test_pdf_pages_are_processed_and_combined_in_document_order(tmp_path: Path, 
             pipeline=pipeline,
             pipeline_name=pipeline.pipeline_name,
             product_type=request.product_type,
-            raw_output={"markdown": f"page {page_number}"},
+            raw_output={
+                "markdown": f"page {page_number}",
+                "cost_usd": page_number / 10,
+                "cost_per_page_usd": page_number / 10,
+                "input_tokens": page_number * 10,
+                "input_tokens_per_page": page_number * 10,
+                "output_tokens": page_number,
+                "total_tokens": page_number * 11,
+                "num_api_calls": 1,
+            },
             started_at=now,
             completed_at=now,
             latency_in_ms=page_number,
@@ -106,6 +116,18 @@ def test_pdf_pages_are_processed_and_combined_in_document_order(tmp_path: Path, 
         rendered_pages[-1].getpixel((0, 0))
     # Raw artifacts must remain checkpoint-safe after temporary images disappear.
     json.dumps(raw_result.model_dump(mode="json"))
+    assert raw_result.raw_output["num_pages"] == 3
+    assert raw_result.raw_output["cost_usd"] == pytest.approx(0.6)
+    assert raw_result.raw_output["cost_per_page_usd"] == pytest.approx(0.2)
+    assert raw_result.raw_output["input_tokens"] == 60
+    assert raw_result.raw_output["input_tokens_per_page"] == 20
+    assert raw_result.raw_output["output_tokens"] == 6
+    assert raw_result.raw_output["total_tokens"] == 66
+    assert raw_result.raw_output["num_api_calls"] == 3
+
+    envelope = raw_result.raw_output["_parse_bench_multipage"]
+    assert isinstance(envelope, dict)
+    assert [page["raw_output"]["input_tokens"] for page in envelope["pages"]] == [10, 20, 30]
 
     def normalize_single_image(raw: RawInferenceResult) -> InferenceResult:
         markdown = raw.raw_output["markdown"]
@@ -137,6 +159,57 @@ def test_pdf_pages_are_processed_and_combined_in_document_order(tmp_path: Path, 
         (2, "page 3"),
     ]
     assert [page.page_number for page in result.output.layout_pages] == [1, 2, 3]
+
+    stats = {stat.name: stat for stat in build_operational_stats(result)}
+    assert stats["latency_ms_per_page"].value == pytest.approx(result.latency_in_ms / 3)
+    assert stats["cost_usd"].value == pytest.approx(0.6)
+    assert stats["cost_per_page_usd"].value == pytest.approx(0.2)
+    assert stats["input_tokens"].value == 60
+    assert stats["input_tokens_per_page"].value == 20
+    assert stats["num_api_calls"].value == 3
+
+
+def test_multipage_aggregation_omits_partial_or_invalid_provider_metadata(tmp_path: Path, monkeypatch) -> None:
+    source = tmp_path / "document.pdf"
+    source.touch()
+    monkeypatch.setattr("pdf2image.pdfinfo_from_path", lambda path: {"Pages": 2})
+    monkeypatch.setattr(
+        "pdf2image.convert_from_path",
+        lambda path, dpi, first_page, last_page: [Image.new("RGB", (8, 8), "white")],
+    )
+    page_number = 0
+
+    def run_single_image(pipeline: PipelineSpec, request: InferenceRequest) -> RawInferenceResult:
+        nonlocal page_number
+        page_number += 1
+        now = datetime.now()
+        raw_output: dict[str, object] = {
+            "markdown": f"page {page_number}",
+            "input_tokens": 10 if page_number == 1 else "unknown",
+            "output_tokens": page_number,
+            "cost_usd": 0.1 if page_number == 1 else float("nan"),
+        }
+        if page_number == 1:
+            raw_output["num_api_calls"] = 1
+        return RawInferenceResult(
+            request=request,
+            pipeline=pipeline,
+            pipeline_name=pipeline.pipeline_name,
+            product_type=request.product_type,
+            raw_output=raw_output,
+            started_at=now,
+            completed_at=now,
+            latency_in_ms=1,
+        )
+
+    result = run_pdf_pages(_pipeline(), _request(source), dpi=144, run_single_image=run_single_image)
+
+    assert result is not None
+    assert result.raw_output["num_pages"] == 2
+    assert result.raw_output["output_tokens"] == 3
+    assert "input_tokens" not in result.raw_output
+    assert "cost_usd" not in result.raw_output
+    assert "num_api_calls" not in result.raw_output
 
 
 def test_pdf_render_failure_identifies_page_and_stops(tmp_path: Path, monkeypatch) -> None:

--- a/tests/parse_bench/inference/providers/parse/test_multipage_image.py
+++ b/tests/parse_bench/inference/providers/parse/test_multipage_image.py
@@ -19,6 +19,8 @@ from parse_bench.inference.providers.base import (
     ProviderTransientError,
 )
 from parse_bench.inference.providers.parse._multipage_image import (
+    append_attempt_usages,
+    attempt_usages_complete,
     normalize_pdf_pages,
     open_document_page_images,
     run_pdf_pages,
@@ -44,6 +46,26 @@ def _request(source: Path) -> InferenceRequest:
         source_file_path=str(source),
         product_type=ProductType.PARSE,
     )
+
+
+def test_partial_attempt_usage_is_not_treated_as_exact_zero_buckets() -> None:
+    usages: list[dict[str, int]] = []
+
+    append_attempt_usages(
+        usages,
+        [{"stats": {"input_tokens": 4}, "page_number": 1, "attempt": 1, "status": "failed"}],
+    )
+
+    assert usages == [
+        {
+            "input_tokens": 4,
+            "output_tokens": 0,
+            "thinking_tokens": 0,
+            "total_tokens": 0,
+            "_usage_known": 0,
+        }
+    ]
+    assert not attempt_usages_complete(usages)
 
 
 def test_timeout_drain_blocks_resubmission_until_running_worker_terminates() -> None:
@@ -127,6 +149,24 @@ def test_async_timeout_drain_propagates_caller_cancellation() -> None:
         future = executor.submit(worker)
         assert started.wait(timeout=1)
         asyncio.run(exercise(future))
+
+
+def test_async_timeout_drain_treats_queued_future_cancellation_as_retryable() -> None:
+    runner = object.__new__(InferenceRunner)
+    runner.provider = SimpleNamespace()
+    release = threading.Event()
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        blocker = executor.submit(release.wait)
+        future = executor.submit(lambda: "must not run")
+        try:
+            outcome = asyncio.run(runner._cancel_inflight_and_drain_async("document", future))
+        finally:
+            release.set()
+            blocker.result(timeout=1)
+
+    assert outcome is None
+    assert future.cancelled()
 
 
 def test_sync_timeout_adopts_late_success_without_resubmission(tmp_path: Path) -> None:
@@ -557,6 +597,7 @@ def test_exhausted_page_retry_is_terminal_to_document_runner(
     runner.job_statuses = {}
     runner.pipeline = _pipeline()
     runner.provider = AdapterProvider()
+    runner.output_dir = tmp_path
     runner._prepare_source_file_for_provider = lambda example_id, path: path
     runner._fetch_parse_job_logs = lambda raw_result, example_id: None
     runner._save_result = lambda raw_result, normalized_result: None
@@ -568,6 +609,13 @@ def test_exhausted_page_retry_is_terminal_to_document_runner(
     assert error is not None and error[2] == ProviderRetryExhaustedError.__name__
     assert document_attempts == 1
     assert requested_pages == [1, 2, 2, 2]
+    payload = json.loads((tmp_path / "document.error.raw.json").read_text())
+    assert [(attempt["page_number"], attempt["status"]) for attempt in payload["attempts"]] == [
+        (1, "succeeded"),
+        (2, "failed"),
+        (2, "failed"),
+        (2, "failed"),
+    ]
 
 
 def test_multipage_aggregation_omits_partial_or_invalid_provider_metadata(tmp_path: Path, monkeypatch) -> None:

--- a/tests/parse_bench/inference/providers/parse/test_multipage_image.py
+++ b/tests/parse_bench/inference/providers/parse/test_multipage_image.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import asyncio
+import concurrent.futures
 import json
+import threading
 from datetime import datetime
 from pathlib import Path
 
@@ -39,6 +42,55 @@ def _request(source: Path) -> InferenceRequest:
         source_file_path=str(source),
         product_type=ProductType.PARSE,
     )
+
+
+def test_timeout_drain_blocks_resubmission_until_running_worker_terminates() -> None:
+    runner = object.__new__(InferenceRunner)
+    runner.provider = object()
+    started = threading.Event()
+    release = threading.Event()
+    drain_returned = threading.Event()
+
+    def worker() -> None:
+        started.set()
+        release.wait()
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(worker)
+        assert started.wait(timeout=1)
+        drain_thread = threading.Thread(
+            target=lambda: (runner._cancel_inflight_and_drain("document", future), drain_returned.set())
+        )
+        drain_thread.start()
+        assert not drain_returned.wait(timeout=0.05)
+        release.set()
+        drain_thread.join(timeout=1)
+        assert drain_returned.is_set()
+
+
+def test_async_timeout_drain_awaits_running_worker_termination() -> None:
+    runner = object.__new__(InferenceRunner)
+    runner.provider = object()
+    started = threading.Event()
+    release = threading.Event()
+
+    def worker() -> None:
+        started.set()
+        release.wait()
+
+    async def exercise(future: concurrent.futures.Future[None]) -> None:
+        with pytest.raises(TimeoutError):
+            await asyncio.wait_for(asyncio.wrap_future(future), timeout=0.01)
+        drain = asyncio.create_task(runner._cancel_inflight_and_drain_async("document", future))
+        await asyncio.sleep(0.05)
+        assert not drain.done()
+        release.set()
+        await asyncio.wait_for(drain, timeout=1)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(worker)
+        assert started.wait(timeout=1)
+        asyncio.run(exercise(future))
 
 
 def test_pdf_pages_are_processed_and_combined_in_document_order(tmp_path: Path, monkeypatch) -> None:
@@ -210,10 +262,67 @@ def test_transient_page_retry_does_not_replay_prior_page_or_duplicate_output(
 
     assert raw_result is not None
     assert requested_pages == [1, 2, 2, 3]
-    assert raw_result.raw_output["num_api_calls"] == 3
+    assert raw_result.raw_output["num_api_calls"] == 4
     envelope = raw_result.raw_output["_parse_bench_multipage"]
     assert isinstance(envelope, dict)
     assert [page["page_index"] for page in envelope["pages"]] == [0, 1, 2]
+
+
+def test_multipage_retry_ledger_aggregates_failed_attempt_usage_and_cost(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "document.pdf"
+    source.touch()
+    monkeypatch.setattr("pdf2image.pdfinfo_from_path", lambda path: {"Pages": 1})
+    monkeypatch.setattr(
+        "pdf2image.convert_from_path",
+        lambda path, dpi, first_page, last_page: [Image.new("RGB", (8, 8), "white")],
+    )
+    monkeypatch.setattr("parse_bench.inference.providers.parse._multipage_image.time.sleep", lambda delay: None)
+    calls = 0
+
+    def run_single_image(pipeline: PipelineSpec, request: InferenceRequest) -> RawInferenceResult:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise ProviderTransientError(
+                "malformed billed response",
+                attempt_stats={
+                    "input_tokens": 5,
+                    "output_tokens": 2,
+                    "total_tokens": 7,
+                    "cost_usd": 0.05,
+                },
+            )
+        now = datetime.now()
+        return RawInferenceResult(
+            request=request,
+            pipeline=pipeline,
+            pipeline_name=pipeline.pipeline_name,
+            product_type=request.product_type,
+            raw_output={
+                "markdown": "success",
+                "input_tokens": 10,
+                "output_tokens": 4,
+                "total_tokens": 14,
+                "cost_usd": 0.1,
+                "num_api_calls": 1,
+            },
+            started_at=now,
+            completed_at=now,
+            latency_in_ms=1,
+        )
+
+    result = run_pdf_pages(_pipeline(), _request(source), dpi=144, run_single_image=run_single_image)
+
+    assert result is not None
+    assert result.raw_output["num_api_calls"] == 2
+    assert result.raw_output["input_tokens"] == 15
+    assert result.raw_output["output_tokens"] == 6
+    assert result.raw_output["total_tokens"] == 21
+    assert result.raw_output["cost_usd"] == pytest.approx(0.15)
+    assert result.raw_output["cost_per_page_usd"] == pytest.approx(0.15)
 
 
 def test_exhausted_page_retry_is_terminal_to_document_runner(
@@ -315,7 +424,7 @@ def test_multipage_aggregation_omits_partial_or_invalid_provider_metadata(tmp_pa
     assert result.raw_output["output_tokens"] == 3
     assert "input_tokens" not in result.raw_output
     assert "cost_usd" not in result.raw_output
-    assert "num_api_calls" not in result.raw_output
+    assert result.raw_output["num_api_calls"] == 2
 
 
 def test_pdf_render_failure_identifies_page_and_stops(tmp_path: Path, monkeypatch) -> None:

--- a/tests/parse_bench/inference/providers/parse/test_multipage_image.py
+++ b/tests/parse_bench/inference/providers/parse/test_multipage_image.py
@@ -10,6 +10,7 @@ from PIL import Image
 from parse_bench.inference.providers.base import ProviderPermanentError
 from parse_bench.inference.providers.parse._multipage_image import (
     normalize_pdf_pages,
+    open_document_page_images,
     run_pdf_pages,
 )
 from parse_bench.schemas.parse_output import ParseLayoutPageIR, ParseOutput
@@ -177,6 +178,61 @@ def test_pdf_render_failure_identifies_page_and_stops(tmp_path: Path, monkeypatc
     assert render_calls == [1, 2]
 
 
+def test_inference_failure_closes_current_page_and_stops_rendering(tmp_path: Path, monkeypatch) -> None:
+    source = tmp_path / "document.pdf"
+    source.touch()
+    rendered_pages: list[Image.Image] = []
+    render_calls: list[int] = []
+
+    monkeypatch.setattr("pdf2image.pdfinfo_from_path", lambda path: {"Pages": 2})
+
+    def render_page(path: str, dpi: int, first_page: int, last_page: int) -> list[Image.Image]:
+        render_calls.append(first_page)
+        image = Image.new("RGB", (8, 8), "white")
+        rendered_pages.append(image)
+        return [image]
+
+    monkeypatch.setattr("pdf2image.convert_from_path", render_page)
+
+    def fail_inference(pipeline: PipelineSpec, request: InferenceRequest) -> RawInferenceResult:
+        raise RuntimeError("inference failed")
+
+    with pytest.raises(RuntimeError, match="inference failed"):
+        run_pdf_pages(_pipeline(), _request(source), dpi=144, run_single_image=fail_inference)
+
+    assert render_calls == [1]
+    with pytest.raises(ValueError, match="Operation on closed image"):
+        rendered_pages[0].getpixel((0, 0))
+
+
+def test_single_image_context_closes_the_image_after_inference(tmp_path: Path, monkeypatch) -> None:
+    source = tmp_path / "image.png"
+    Image.new("RGB", (8, 8), "white").save(source)
+    real_open = Image.open
+    close_calls = 0
+
+    class TrackedImageContext:
+        def __init__(self, path: str | Path) -> None:
+            self.image = real_open(path)
+
+        def __enter__(self) -> Image.Image:
+            return self.image
+
+        def __exit__(self, *args: object) -> None:
+            nonlocal close_calls
+            close_calls += 1
+            self.image.close()
+
+    monkeypatch.setattr(Image, "open", TrackedImageContext)
+
+    with open_document_page_images(source, dpi=144) as images:
+        (image,) = list(images)
+        assert len(images) == 1
+        assert image.getpixel((0, 0)) == (255, 255, 255)
+
+    assert close_calls == 1
+
+
 def test_single_image_input_stays_on_the_provider_path(tmp_path: Path) -> None:
     source = tmp_path / "image.png"
     Image.new("RGB", (8, 8), "white").save(source)
@@ -196,3 +252,33 @@ def test_single_image_input_stays_on_the_provider_path(tmp_path: Path) -> None:
 
     assert result is None
     assert called is False
+
+
+@pytest.mark.parametrize(
+    "envelope",
+    [
+        {},
+        {"version": 2, "num_pages": 1, "pages": []},
+        {"version": 1, "num_pages": True, "pages": []},
+        {"version": 1, "num_pages": 0, "pages": []},
+        {"version": 1, "num_pages": 1, "pages": "not-a-list"},
+        {"version": 1, "num_pages": 2, "pages": [{"page_index": 0, "raw_output": {}}]},
+        {"version": 1, "num_pages": 1, "pages": [{"page_index": True, "raw_output": {}}]},
+        {"version": 1, "num_pages": 1, "pages": [{"page_index": 0, "raw_output": []}]},
+    ],
+)
+def test_malformed_multipage_envelopes_are_rejected(envelope: dict[str, object]) -> None:
+    now = datetime.now()
+    raw_result = RawInferenceResult(
+        request=_request(Path("document.pdf")),
+        pipeline=_pipeline(),
+        pipeline_name="test_image_provider",
+        product_type=ProductType.PARSE,
+        raw_output={"_parse_bench_multipage": envelope},
+        started_at=now,
+        completed_at=now,
+        latency_in_ms=1,
+    )
+
+    with pytest.raises(ProviderPermanentError, match="Invalid multipage raw output"):
+        normalize_pdf_pages(raw_result, normalize_single_image=lambda raw: pytest.fail("must not normalize a page"))

--- a/tests/parse_bench/inference/providers/parse/test_multipage_image.py
+++ b/tests/parse_bench/inference/providers/parse/test_multipage_image.py
@@ -102,6 +102,33 @@ def test_async_timeout_drain_awaits_running_worker_termination() -> None:
         asyncio.run(exercise(future))
 
 
+def test_async_timeout_drain_propagates_caller_cancellation() -> None:
+    runner = object.__new__(InferenceRunner)
+    runner.provider = SimpleNamespace()
+    started = threading.Event()
+    release = threading.Event()
+
+    def worker() -> str:
+        started.set()
+        release.wait()
+        return "late-success"
+
+    async def exercise(future: concurrent.futures.Future[str]) -> None:
+        drain = asyncio.create_task(runner._cancel_inflight_and_drain_async("document", future))
+        await asyncio.sleep(0.05)
+        assert not drain.done()
+        drain.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await drain
+        release.set()
+        assert await asyncio.wrap_future(future) == "late-success"
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(worker)
+        assert started.wait(timeout=1)
+        asyncio.run(exercise(future))
+
+
 def test_sync_timeout_adopts_late_success_without_resubmission(tmp_path: Path) -> None:
     runner = object.__new__(InferenceRunner)
     runner.provider = SimpleNamespace()

--- a/tests/parse_bench/inference/providers/parse/test_multipage_image.py
+++ b/tests/parse_bench/inference/providers/parse/test_multipage_image.py
@@ -4,8 +4,10 @@ import asyncio
 import concurrent.futures
 import json
 import threading
+import time
 from datetime import datetime
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from PIL import Image
@@ -21,7 +23,7 @@ from parse_bench.inference.providers.parse._multipage_image import (
     open_document_page_images,
     run_pdf_pages,
 )
-from parse_bench.inference.runner import InferenceRunner
+from parse_bench.inference.runner import InferenceRunner, RunSummary
 from parse_bench.schemas.parse_output import ParseLayoutPageIR, ParseOutput
 from parse_bench.schemas.pipeline import PipelineSpec
 from parse_bench.schemas.pipeline_io import InferenceRequest, InferenceResult, RawInferenceResult
@@ -51,21 +53,27 @@ def test_timeout_drain_blocks_resubmission_until_running_worker_terminates() -> 
     release = threading.Event()
     drain_returned = threading.Event()
 
-    def worker() -> None:
+    def worker() -> str:
         started.set()
         release.wait()
+        return "late-success"
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
         future = executor.submit(worker)
         assert started.wait(timeout=1)
-        drain_thread = threading.Thread(
-            target=lambda: (runner._cancel_inflight_and_drain("document", future), drain_returned.set())
-        )
+        outcomes: list[object] = []
+
+        def drain() -> None:
+            outcomes.append(runner._cancel_inflight_and_drain("document", future))
+            drain_returned.set()
+
+        drain_thread = threading.Thread(target=drain)
         drain_thread.start()
         assert not drain_returned.wait(timeout=0.05)
         release.set()
         drain_thread.join(timeout=1)
         assert drain_returned.is_set()
+        assert outcomes == ["late-success"]
 
 
 def test_async_timeout_drain_awaits_running_worker_termination() -> None:
@@ -74,9 +82,10 @@ def test_async_timeout_drain_awaits_running_worker_termination() -> None:
     started = threading.Event()
     release = threading.Event()
 
-    def worker() -> None:
+    def worker() -> str:
         started.set()
         release.wait()
+        return "late-success"
 
     async def exercise(future: concurrent.futures.Future[None]) -> None:
         with pytest.raises(TimeoutError):
@@ -85,12 +94,162 @@ def test_async_timeout_drain_awaits_running_worker_termination() -> None:
         await asyncio.sleep(0.05)
         assert not drain.done()
         release.set()
-        await asyncio.wait_for(drain, timeout=1)
+        assert await asyncio.wait_for(drain, timeout=1) == "late-success"
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
         future = executor.submit(worker)
         assert started.wait(timeout=1)
         asyncio.run(exercise(future))
+
+
+def test_sync_timeout_adopts_late_success_without_resubmission(tmp_path: Path) -> None:
+    runner = object.__new__(InferenceRunner)
+    runner.provider = SimpleNamespace()
+    runner.pipeline = _pipeline()
+    runner.output_dir = tmp_path
+    runner.use_rich = False
+    runner.console = None
+    runner.job_statuses = {}
+    runner.timeout_retries = 2
+    runner.per_file_timeout = 0.01
+    runner.max_concurrent = 1
+    runner.save_raw = True
+    runner.save_normalized = True
+    runner.force = True
+    runner.tags = []
+    runner._is_already_processed = lambda example_id: False
+    calls = 0
+    late_raw = SimpleNamespace(latency_in_ms=7)
+
+    def process(test_case: object, product_type: ProductType) -> tuple[object, None, None]:
+        nonlocal calls
+        calls += 1
+        time.sleep(0.03)
+        return late_raw, None, None
+
+    runner._process_test_case = process
+    test_case = SimpleNamespace(test_id="document", file_path=tmp_path / "document.pdf")
+
+    summary = runner._run_test_cases_sync([test_case], ProductType.PARSE)
+
+    assert calls == 1
+    assert summary.successful == 1
+    assert summary.failed == 0
+    assert summary.total_latency_ms == 7
+
+
+def test_async_timeout_adopts_late_success_without_resubmission(tmp_path: Path) -> None:
+    runner = object.__new__(InferenceRunner)
+    runner.provider = SimpleNamespace()
+    runner.use_rich = False
+    runner.job_statuses = {}
+    runner.timeout_retries = 2
+    runner.per_file_timeout = 0.01
+    runner._thread_pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    runner._is_already_processed = lambda example_id: False
+    calls = 0
+    late_raw = SimpleNamespace(latency_in_ms=9)
+
+    def process(pdf_path: Path, example_id: str, product_type: ProductType) -> tuple[object, None, None]:
+        nonlocal calls
+        calls += 1
+        time.sleep(0.03)
+        return late_raw, None, None
+
+    runner._process_document = process
+
+    async def exercise() -> RunSummary:
+        run_summary = RunSummary()
+        await runner._process_with_semaphore(
+            asyncio.Semaphore(1),
+            tmp_path / "document.pdf",
+            "document",
+            ProductType.PARSE,
+            run_summary,
+        )
+        return run_summary
+
+    try:
+        run_summary = asyncio.run(exercise())
+    finally:
+        runner._thread_pool.shutdown(wait=True)
+
+    assert calls == 1
+    assert run_summary.successful == 1
+    assert run_summary.failed == 0
+    assert run_summary.total_latency_ms == 9
+
+
+@pytest.mark.parametrize("provider_name", ["google", "openai", "anthropic"])
+def test_runner_file_retry_accounts_failed_usage_cost_and_success(
+    provider_name: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = _request(tmp_path / "document.pdf")
+    calls = 0
+
+    class FileProvider:
+        def _get_pricing(self) -> tuple[float, float]:
+            return 1.0, 2.0
+
+        def run_inference(self, pipeline: PipelineSpec, current_request: InferenceRequest) -> RawInferenceResult:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise ProviderTransientError(
+                    "malformed billed file response",
+                    attempt_stats={
+                        "input_tokens": 5,
+                        "output_tokens": 2,
+                        "thinking_tokens": 0,
+                        "total_tokens": 7,
+                    },
+                )
+            now = datetime.now()
+            return RawInferenceResult(
+                request=current_request,
+                pipeline=pipeline,
+                pipeline_name=pipeline.pipeline_name,
+                product_type=current_request.product_type,
+                raw_output={
+                    "pages": [{"page_index": 0, "markdown": "success"}],
+                    "num_pages": 1,
+                    "input_tokens": 10,
+                    "output_tokens": 4,
+                    "thinking_tokens": 0,
+                    "total_tokens": 14,
+                    "cost_usd": 18 / 1_000_000,
+                    "cost_per_page_usd": 18 / 1_000_000,
+                    "num_api_calls": 1,
+                    "api_attempts": [],
+                },
+                started_at=now,
+                completed_at=now,
+                latency_in_ms=1,
+            )
+
+    runner = object.__new__(InferenceRunner)
+    runner.provider = FileProvider()
+    runner.pipeline = PipelineSpec(
+        pipeline_name=f"{provider_name}_file",
+        provider_name=provider_name,
+        product_type=ProductType.PARSE,
+    )
+    monkeypatch.setattr("parse_bench.inference.runner.time.sleep", lambda delay: None)
+
+    result = runner._run_inference_with_retries(request)
+
+    assert calls == 2
+    assert result.raw_output["num_api_calls"] == 2
+    assert result.raw_output["input_tokens"] == 15
+    assert result.raw_output["output_tokens"] == 6
+    assert result.raw_output["total_tokens"] == 21
+    assert result.raw_output["cost_usd"] == pytest.approx(27 / 1_000_000)
+    assert result.raw_output["cost_per_page_usd"] == pytest.approx(27 / 1_000_000)
+    attempts = result.raw_output["api_attempts"]
+    assert [attempt["status"] for attempt in attempts] == ["failed", "succeeded"]
+    assert attempts[0]["stats"]["cost_usd"] == pytest.approx(9 / 1_000_000)
 
 
 def test_pdf_pages_are_processed_and_combined_in_document_order(tmp_path: Path, monkeypatch) -> None:

--- a/tests/parse_bench/inference/providers/parse/test_multipage_provider_hooks.py
+++ b/tests/parse_bench/inference/providers/parse/test_multipage_provider_hooks.py
@@ -3,10 +3,18 @@ from __future__ import annotations
 import ast
 import importlib
 import inspect
+import json
 from pathlib import Path
 from typing import Any
 
 import pytest
+from PIL import Image
+
+from parse_bench.inference.providers.base import ProviderPermanentError
+from parse_bench.schemas.parse_output import ParseOutput
+from parse_bench.schemas.pipeline import PipelineSpec
+from parse_bench.schemas.pipeline_io import InferenceRequest
+from parse_bench.schemas.product import ProductType
 
 ADAPTER_PROVIDERS = [
     ("chandra2", "Chandra2Provider", 144),
@@ -26,64 +34,190 @@ ADAPTER_PROVIDERS = [
 ]
 
 
+def _pipeline(module_name: str) -> PipelineSpec:
+    return PipelineSpec(
+        pipeline_name=f"{module_name}_test",
+        provider_name=module_name,
+        product_type=ProductType.PARSE,
+    )
+
+
+def _request(source: Path) -> InferenceRequest:
+    return InferenceRequest(
+        example_id="document",
+        source_file_path=str(source),
+        product_type=ProductType.PARSE,
+    )
+
+
+def _provider(module_name: str, class_name: str, dpi: int) -> Any:
+    module = importlib.import_module(f"parse_bench.inference.providers.parse.{module_name}")
+    provider = object.__new__(getattr(module, class_name))
+    defaults = {
+        "_dpi": dpi,
+        "_timeout": 30,
+        "_server_url": "http://provider.invalid",
+        "_api_format": "openai",
+        "_task": "parse",
+        "_model": "test-model",
+        "_served_model_name": "test-model",
+        "_prompt_mode": "parse",
+    }
+    for name, value in defaults.items():
+        setattr(provider, name, value)
+    return provider
+
+
+def _install_local_boundary(provider: Any, module_name: str) -> list[int]:
+    calls: list[int] = []
+
+    def raw_output(page_number: int) -> dict[str, object]:
+        if module_name == "infinity_parser2":
+            return {
+                "result": json.dumps(
+                    [
+                        {
+                            "page": 1,
+                            "category": "text",
+                            "text": f"page {page_number}",
+                            "bbox": [0, 0, 8, 8],
+                        }
+                    ]
+                ),
+                "_config": {"page_width": 8, "page_height": 8},
+                "input_tokens": page_number * 10,
+                "cost_usd": page_number / 10,
+                "num_api_calls": 1,
+            }
+        return {
+            "markdown": f"page {page_number}",
+            "input_tokens": page_number * 10,
+            "cost_usd": page_number / 10,
+            "num_api_calls": 1,
+        }
+
+    if module_name == "infinity_parser2":
+
+        def parse_document(path: str) -> dict[str, object]:
+            calls.append(len(calls) + 1)
+            return raw_output(calls[-1])
+
+        provider._parse_document = parse_document
+    else:
+
+        async def run_inference_async(*args: object, **kwargs: object) -> dict[str, object]:
+            calls.append(len(calls) + 1)
+            return raw_output(calls[-1])
+
+        provider._run_inference_async = run_inference_async
+
+    return calls
+
+
+def _mock_two_page_pdf(source: Path, monkeypatch: pytest.MonkeyPatch) -> list[Image.Image]:
+    rendered: list[Image.Image] = []
+    monkeypatch.setattr("pdf2image.pdfinfo_from_path", lambda path: {"Pages": 2})
+
+    def render_page(path: str, dpi: int, first_page: int, last_page: int) -> list[Image.Image]:
+        assert Path(path) == source
+        assert first_page == last_page
+        image = Image.new("RGB", (8 + first_page, 8), "white")
+        rendered.append(image)
+        return [image]
+
+    monkeypatch.setattr("pdf2image.convert_from_path", render_page)
+    return rendered
+
+
 @pytest.mark.parametrize(("module_name", "class_name", "expected_dpi"), ADAPTER_PROVIDERS)
-def test_provider_run_inference_uses_multipage_adapter(
+def test_adapter_provider_runs_and_normalizes_actual_pdf_pages(
     module_name: str,
     class_name: str,
     expected_dpi: int,
+    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    module = importlib.import_module(f"parse_bench.inference.providers.parse.{module_name}")
-    provider_class = getattr(module, class_name)
-    provider = object.__new__(provider_class)
-    if expected_dpi != 300 or module_name != "infinity_parser2":
-        provider._dpi = expected_dpi
+    source = tmp_path / "document.pdf"
+    source.touch()
+    rendered = _mock_two_page_pdf(source, monkeypatch)
+    provider = _provider(module_name, class_name, expected_dpi)
+    boundary_calls = _install_local_boundary(provider, module_name)
 
-    sentinel = object()
-    pipeline = object()
-    request = object()
+    raw_result = provider.run_inference(_pipeline(module_name), _request(source))
+    result = provider.normalize(raw_result)
 
-    def fake_run_pdf_pages(
-        actual_pipeline: object,
-        actual_request: object,
-        *,
-        dpi: int,
-        run_single_image: Any,
-    ) -> object:
-        assert actual_pipeline is pipeline
-        assert actual_request is request
-        assert dpi == expected_dpi
-        assert run_single_image.__self__ is provider
-        assert run_single_image.__func__ is provider_class.run_inference
-        return sentinel
+    assert boundary_calls == [1, 2]
+    assert raw_result.raw_output["num_pages"] == 2
+    assert raw_result.raw_output["input_tokens"] == 30
+    assert raw_result.raw_output["cost_usd"] == pytest.approx(0.3)
+    assert raw_result.raw_output["num_api_calls"] == 2
+    envelope = raw_result.raw_output["_parse_bench_multipage"]
+    assert isinstance(envelope, dict)
+    assert [page["page_index"] for page in envelope["pages"]] == [0, 1]
+    assert isinstance(result.output, ParseOutput)
+    assert result.output.markdown == "page 1\n\npage 2"
+    assert [(page.page_index, page.markdown) for page in result.output.pages] == [
+        (0, "page 1"),
+        (1, "page 2"),
+    ]
+    assert len(rendered) == 2
+    for image in rendered:
+        with pytest.raises(ValueError, match="Operation on closed image"):
+            image.getpixel((0, 0))
 
-    monkeypatch.setattr(module, "run_pdf_pages", fake_run_pdf_pages)
 
-    assert provider.run_inference(pipeline, request) is sentinel
-
-
-@pytest.mark.parametrize(("module_name", "class_name", "_expected_dpi"), ADAPTER_PROVIDERS)
-def test_provider_normalize_uses_multipage_adapter(
+@pytest.mark.parametrize(("module_name", "class_name", "expected_dpi"), ADAPTER_PROVIDERS)
+def test_adapter_provider_preserves_single_image_path(
     module_name: str,
     class_name: str,
-    _expected_dpi: int,
+    expected_dpi: int,
+    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    module = importlib.import_module(f"parse_bench.inference.providers.parse.{module_name}")
-    provider_class = getattr(module, class_name)
-    provider = object.__new__(provider_class)
-    sentinel = object()
-    raw_result = object()
+    source = tmp_path / "page.png"
+    Image.new("RGB", (8, 8), "white").save(source)
+    provider = _provider(module_name, class_name, expected_dpi)
+    boundary_calls = _install_local_boundary(provider, module_name)
+    monkeypatch.setattr(
+        "pdf2image.convert_from_path",
+        lambda *args, **kwargs: pytest.fail("single-image inference must not rasterize a PDF"),
+    )
 
-    def fake_normalize_pdf_pages(actual_raw_result: object, *, normalize_single_image: Any) -> object:
-        assert actual_raw_result is raw_result
-        assert normalize_single_image.__self__ is provider
-        assert normalize_single_image.__func__ is provider_class.normalize
-        return sentinel
+    raw_result = provider.run_inference(_pipeline(module_name), _request(source))
+    result = provider.normalize(raw_result)
 
-    monkeypatch.setattr(module, "normalize_pdf_pages", fake_normalize_pdf_pages)
+    assert boundary_calls == [1]
+    assert "_parse_bench_multipage" not in raw_result.raw_output
+    assert isinstance(result.output, ParseOutput)
+    assert result.output.markdown == "page 1"
 
-    assert provider.normalize(raw_result) is sentinel
+
+@pytest.mark.parametrize(("module_name", "class_name", "expected_dpi"), ADAPTER_PROVIDERS)
+def test_adapter_provider_closes_rendered_page_when_persistence_fails(
+    module_name: str,
+    class_name: str,
+    expected_dpi: int,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "document.pdf"
+    source.touch()
+    rendered = _mock_two_page_pdf(source, monkeypatch)
+    provider = _provider(module_name, class_name, expected_dpi)
+    _install_local_boundary(provider, module_name)
+    multipage_module = importlib.import_module("parse_bench.inference.providers.parse._multipage_image")
+
+    def fail_save(image: Image.Image, destination: Path) -> None:
+        raise ProviderPermanentError("save failed")
+
+    monkeypatch.setattr(multipage_module, "_save_png", fail_save)
+
+    with pytest.raises(ProviderPermanentError, match="save failed"):
+        provider.run_inference(_pipeline(module_name), _request(source))
+
+    assert len(rendered) == 1
+    with pytest.raises(ValueError, match="Operation on closed image"):
+        rendered[0].getpixel((0, 0))
 
 
 @pytest.mark.parametrize(

--- a/tests/parse_bench/inference/providers/parse/test_multipage_provider_hooks.py
+++ b/tests/parse_bench/inference/providers/parse/test_multipage_provider_hooks.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import ast
+import importlib
+import inspect
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+ADAPTER_PROVIDERS = [
+    ("chandra2", "Chandra2Provider", 144),
+    ("deepseekocr2", "DeepSeekOCR2Provider", 144),
+    ("falconocr", "FalconOcrProvider", 144),
+    ("gemma4", "Gemma4Provider", 144),
+    ("granite_vision", "GraniteVisionProvider", 144),
+    ("infinity_parser2", "InfinityParser2Provider", 300),
+    ("mineru25", "MinerU25Provider", 144),
+    ("mineru2605pro", "MinerU2605ProProvider", 144),
+    ("mineru_diffusion", "MinerUDiffusionProvider", 144),
+    ("nemotron_omni", "NemotronOmniProvider", 144),
+    ("paddleocr", "PaddleOCRProvider", 144),
+    ("qwen3_5", "Qwen35Provider", 144),
+    ("surya2", "Surya2Provider", 144),
+    ("unlimitedocr", "UnlimitedOCRProvider", 144),
+]
+
+
+@pytest.mark.parametrize(("module_name", "class_name", "expected_dpi"), ADAPTER_PROVIDERS)
+def test_provider_run_inference_uses_multipage_adapter(
+    module_name: str,
+    class_name: str,
+    expected_dpi: int,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = importlib.import_module(f"parse_bench.inference.providers.parse.{module_name}")
+    provider_class = getattr(module, class_name)
+    provider = object.__new__(provider_class)
+    if expected_dpi != 300 or module_name != "infinity_parser2":
+        provider._dpi = expected_dpi
+
+    sentinel = object()
+    pipeline = object()
+    request = object()
+
+    def fake_run_pdf_pages(
+        actual_pipeline: object,
+        actual_request: object,
+        *,
+        dpi: int,
+        run_single_image: Any,
+    ) -> object:
+        assert actual_pipeline is pipeline
+        assert actual_request is request
+        assert dpi == expected_dpi
+        assert run_single_image.__self__ is provider
+        assert run_single_image.__func__ is provider_class.run_inference
+        return sentinel
+
+    monkeypatch.setattr(module, "run_pdf_pages", fake_run_pdf_pages)
+
+    assert provider.run_inference(pipeline, request) is sentinel
+
+
+@pytest.mark.parametrize(("module_name", "class_name", "_expected_dpi"), ADAPTER_PROVIDERS)
+def test_provider_normalize_uses_multipage_adapter(
+    module_name: str,
+    class_name: str,
+    _expected_dpi: int,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = importlib.import_module(f"parse_bench.inference.providers.parse.{module_name}")
+    provider_class = getattr(module, class_name)
+    provider = object.__new__(provider_class)
+    sentinel = object()
+    raw_result = object()
+
+    def fake_normalize_pdf_pages(actual_raw_result: object, *, normalize_single_image: Any) -> object:
+        assert actual_raw_result is raw_result
+        assert normalize_single_image.__self__ is provider
+        assert normalize_single_image.__func__ is provider_class.normalize
+        return sentinel
+
+    monkeypatch.setattr(module, "normalize_pdf_pages", fake_normalize_pdf_pages)
+
+    assert provider.normalize(raw_result) is sentinel
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    ["amazon_nova", "dots_ocr", "anthropic", "google", "openai", "tesseract", "textract"],
+)
+def test_refactored_providers_do_not_call_pdf2image_eagerly(module_name: str) -> None:
+    module = importlib.import_module(f"parse_bench.inference.providers.parse.{module_name}")
+    tree = ast.parse(inspect.getsource(module))
+
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, (ast.Name, ast.Attribute))
+        and getattr(node.func, "id", getattr(node.func, "attr", None)) == "convert_from_path"
+    ]
+
+    assert calls == []
+
+
+def test_shared_rasterizer_bounds_every_convert_from_path_call() -> None:
+    module = importlib.import_module("parse_bench.inference.providers.parse._multipage_image")
+    source_path = Path(inspect.getsourcefile(module) or "")
+    tree = ast.parse(source_path.read_text())
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "convert_from_path"
+    ]
+
+    assert len(calls) == 1
+    assert {keyword.arg for keyword in calls[0].keywords} >= {"first_page", "last_page"}

--- a/tests/parse_bench/inference/providers/parse/test_multipage_provider_hooks.py
+++ b/tests/parse_bench/inference/providers/parse/test_multipage_provider_hooks.py
@@ -223,16 +223,7 @@ def test_adapter_provider_closes_rendered_page_when_persistence_fails(
         rendered[0].getpixel((0, 0))
 
 
-@pytest.mark.parametrize(
-    "failure",
-    [
-        ProviderPermanentError("page two is invalid"),
-        ProviderTransientError("page two timed out"),
-    ],
-    ids=["permanent", "transient"],
-)
 def test_paddleocr_page_two_failure_aborts_without_partial_result(
-    failure: Exception,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -247,12 +238,12 @@ def test_paddleocr_page_two_failure_aborts_without_partial_result(
         nonlocal calls
         calls += 1
         if calls == 2:
-            raise failure
+            raise ProviderPermanentError("page two is invalid")
         return {"markdown": "page 1"}
 
     provider._run_inference_async = run_inference_async
 
-    with pytest.raises(type(failure), match=str(failure)):
+    with pytest.raises(ProviderPermanentError, match="page two is invalid"):
         successful_result = provider.run_inference(_pipeline("paddleocr"), _request(source))
 
     assert successful_result is None
@@ -265,18 +256,20 @@ def test_paddleocr_page_two_failure_aborts_without_partial_result(
 
 @pytest.mark.parametrize(("module_name", "class_name", "expected_dpi"), ADAPTER_PROVIDERS)
 @pytest.mark.parametrize(
-    "failure",
+    ("failure", "expected_error", "expected_calls"),
     [
-        ProviderPermanentError("page two is invalid"),
-        ProviderTransientError("page two timed out"),
+        (ProviderPermanentError("page two is invalid"), ProviderPermanentError, [1, 2]),
+        (ProviderTransientError("page two timed out"), None, [1, 2, 3]),
     ],
     ids=["permanent", "transient"],
 )
-def test_adapter_provider_page_failure_aborts_without_partial_result(
+def test_adapter_provider_owns_page_failure_handling(
     module_name: str,
     class_name: str,
     expected_dpi: int,
     failure: Exception,
+    expected_error: type[Exception] | None,
+    expected_calls: list[int],
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -285,13 +278,15 @@ def test_adapter_provider_page_failure_aborts_without_partial_result(
     rendered = _mock_two_page_pdf(source, monkeypatch)
     provider = _provider(module_name, class_name, expected_dpi)
     calls = _install_local_boundary(provider, module_name, failure=failure, fail_on_call=2)
-    successful_result = None
+    monkeypatch.setattr("parse_bench.inference.providers.parse._multipage_image.time.sleep", lambda delay: None)
 
-    with pytest.raises(type(failure), match=str(failure)):
-        successful_result = provider.run_inference(_pipeline(module_name), _request(source))
+    if expected_error is not None:
+        with pytest.raises(expected_error, match=str(failure)):
+            provider.run_inference(_pipeline(module_name), _request(source))
+    else:
+        assert provider.run_inference(_pipeline(module_name), _request(source)) is not None
 
-    assert successful_result is None
-    assert calls == [1, 2]
+    assert calls == expected_calls
     assert len(rendered) == 2
     for image in rendered:
         with pytest.raises(ValueError, match="Operation on closed image"):

--- a/tests/parse_bench/inference/providers/parse/test_multipage_provider_hooks.py
+++ b/tests/parse_bench/inference/providers/parse/test_multipage_provider_hooks.py
@@ -11,10 +11,12 @@ import pytest
 from PIL import Image
 
 from parse_bench.inference.providers.base import ProviderPermanentError, ProviderTransientError
+from parse_bench.inference.providers.parse import PARSE_PROVIDER_MODULES
 from parse_bench.inference.providers.parse._multipage_image import (
     IMAGE_BACKED_PDF_PROVIDERS,
     PARSE_PROVIDER_PDF_CLASSIFICATIONS,
 )
+from parse_bench.inference.providers.registry import registered_providers
 from parse_bench.schemas.parse_output import ParseOutput
 from parse_bench.schemas.pipeline import PipelineSpec
 from parse_bench.schemas.pipeline_io import InferenceRequest
@@ -128,48 +130,6 @@ def _mock_two_page_pdf(source: Path, monkeypatch: pytest.MonkeyPatch) -> list[Im
 
     monkeypatch.setattr("pdf2image.convert_from_path", render_page)
     return rendered
-
-
-def _qualified_name(expression: ast.expr, bindings: dict[str, str]) -> str | None:
-    if isinstance(expression, ast.Name):
-        return bindings.get(expression.id, expression.id)
-    if isinstance(expression, ast.Attribute):
-        parent = _qualified_name(expression.value, bindings)
-        return f"{parent}.{expression.attr}" if parent is not None else None
-    return None
-
-
-def _registered_provider_classes(tree: ast.Module) -> list[tuple[str, str]]:
-    bindings: dict[str, str] = {}
-    for node in tree.body:
-        if isinstance(node, ast.Import):
-            for alias in node.names:
-                local_name = alias.asname or alias.name.split(".")[0]
-                bindings[local_name] = alias.name if alias.asname else local_name
-        elif isinstance(node, ast.ImportFrom) and node.module is not None:
-            for alias in node.names:
-                bindings[alias.asname or alias.name] = f"{node.module}.{alias.name}"
-
-    registrations: list[tuple[str, str]] = []
-    for node in tree.body:
-        if not isinstance(node, ast.ClassDef):
-            continue
-        for decorator in node.decorator_list:
-            if not isinstance(decorator, ast.Call):
-                continue
-            target = _qualified_name(decorator.func, bindings)
-            if target not in {
-                "parse_bench.inference.register_provider",
-                "parse_bench.inference.providers.register_provider",
-                "parse_bench.inference.providers.registry.register_provider",
-            }:
-                continue
-            if not decorator.args or not isinstance(decorator.args[0], ast.Constant):
-                continue
-            provider_name = decorator.args[0].value
-            if isinstance(provider_name, str):
-                registrations.append((provider_name, node.name))
-    return registrations
 
 
 @pytest.mark.parametrize(("module_name", "class_name", "expected_dpi"), ADAPTER_PROVIDERS)
@@ -371,35 +331,16 @@ def test_shared_rasterizer_bounds_every_convert_from_path_call() -> None:
     assert {keyword.arg for keyword in calls[0].keywords} >= {"first_page", "last_page"}
 
 
-@pytest.mark.parametrize(
-    "source",
-    [
-        "from parse_bench.inference.providers.registry import register_provider\n"
-        "@register_provider('sample')\nclass Sample: pass\n",
-        "from parse_bench.inference.providers.registry import register_provider as register\n"
-        "@register('sample')\nclass Sample: pass\n",
-        "import parse_bench.inference.providers.registry as registry\n"
-        "@registry.register_provider('sample')\nclass Sample: pass\n",
-        "from parse_bench.inference.providers import registry as provider_registry\n"
-        "@provider_registry.register_provider('sample')\nclass Sample: pass\n",
-    ],
-)
-def test_registered_provider_discovery_resolves_import_aliases(source: str) -> None:
-    assert _registered_provider_classes(ast.parse(source)) == [("sample", "Sample")]
-
-
 def test_every_registered_parse_provider_has_explicit_pdf_classification() -> None:
-    provider_dir = Path(__file__).parents[5] / "src/parse_bench/inference/providers/parse"
-    registered: dict[str, tuple[str, str]] = {}
-
-    for source_path in provider_dir.glob("*.py"):
-        tree = ast.parse(source_path.read_text())
-        for provider_name, class_name in _registered_provider_classes(tree):
-            assert provider_name not in registered
-            registered[provider_name] = (source_path.stem, class_name)
+    registered = {
+        provider_name: (provider_class.__module__.rsplit(".", 1)[-1], provider_class.__name__)
+        for provider_name, provider_class in registered_providers().items()
+        if provider_class.__module__.startswith("parse_bench.inference.providers.parse.")
+    }
 
     classified = {spec.provider_name: spec for spec in PARSE_PROVIDER_PDF_CLASSIFICATIONS}
     assert len(classified) == len(PARSE_PROVIDER_PDF_CLASSIFICATIONS)
+    assert set(PARSE_PROVIDER_MODULES) == {spec.module_name for spec in classified.values()}
     assert set(classified) == set(registered)
     assert {
         provider_name: (spec.module_name, spec.class_name) for provider_name, spec in classified.items()

--- a/tests/parse_bench/inference/providers/parse/test_multipage_provider_hooks.py
+++ b/tests/parse_bench/inference/providers/parse/test_multipage_provider_hooks.py
@@ -346,10 +346,8 @@ def test_every_registered_parse_provider_has_explicit_pdf_classification() -> No
     }
     for spec in classified.values():
         if spec.pdf_handling == "local-page-raster":
-            assert spec.dpi is not None
             assert spec.execution in {"adapter", "direct", "kdl"}
         else:
-            assert spec.dpi is None
             assert spec.execution is None
 
     local_raster = {
@@ -361,3 +359,36 @@ def test_every_registered_parse_provider_has_explicit_pdf_classification() -> No
         spec.provider_name: (spec.module_name, spec.class_name) for spec in IMAGE_BACKED_PDF_PROVIDERS
     } == local_raster
     assert {spec.execution for spec in IMAGE_BACKED_PDF_PROVIDERS} == {"adapter", "direct", "kdl"}
+
+
+def test_local_raster_metadata_reads_declared_provider_defaults() -> None:
+    expected_defaults = {
+        "amazon_nova": 150,
+        "anthropic": 150,
+        "chandra2": 192,
+        "deepseekocr2": 150,
+        "dots_ocr_parse": 150,
+        "falconocr": 200,
+        "gemma4": 150,
+        "google": 150,
+        "granite_vision": 150,
+        "infinity_parser2": 300,
+        "kdl_frontier_nano": 144,
+        "mineru25": 150,
+        "mineru2605pro": 150,
+        "mineru_diffusion": 150,
+        "nemotron_omni": 150,
+        "openai": 150,
+        "paddleocr": 150,
+        "qwen3_5": 150,
+        "surya2": 192,
+        "tesseract": 300,
+        "textract": 300,
+        "unlimitedocr": 300,
+    }
+
+    assert {spec.provider_name: spec.dpi for spec in IMAGE_BACKED_PDF_PROVIDERS} == expected_defaults
+    for spec in IMAGE_BACKED_PDF_PROVIDERS:
+        module = importlib.import_module(f"parse_bench.inference.providers.parse.{spec.module_name}")
+        provider_class = getattr(module, spec.class_name)
+        assert provider_class.PDF_RENDER_DPI == expected_defaults[spec.provider_name]

--- a/tests/parse_bench/inference/providers/parse/test_multipage_provider_hooks.py
+++ b/tests/parse_bench/inference/providers/parse/test_multipage_provider_hooks.py
@@ -10,7 +10,7 @@ from typing import Any
 import pytest
 from PIL import Image
 
-from parse_bench.inference.providers.base import ProviderPermanentError
+from parse_bench.inference.providers.base import ProviderPermanentError, ProviderTransientError
 from parse_bench.schemas.parse_output import ParseOutput
 from parse_bench.schemas.pipeline import PipelineSpec
 from parse_bench.schemas.pipeline_io import InferenceRequest
@@ -218,6 +218,46 @@ def test_adapter_provider_closes_rendered_page_when_persistence_fails(
     assert len(rendered) == 1
     with pytest.raises(ValueError, match="Operation on closed image"):
         rendered[0].getpixel((0, 0))
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        ProviderPermanentError("page two is invalid"),
+        ProviderTransientError("page two timed out"),
+    ],
+    ids=["permanent", "transient"],
+)
+def test_paddleocr_page_two_failure_aborts_without_partial_result(
+    failure: Exception,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "document.pdf"
+    source.touch()
+    rendered = _mock_two_page_pdf(source, monkeypatch)
+    provider = _provider("paddleocr", "PaddleOCRProvider", 144)
+    calls = 0
+    successful_result = None
+
+    async def run_inference_async(*args: object, **kwargs: object) -> dict[str, object]:
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise failure
+        return {"markdown": "page 1"}
+
+    provider._run_inference_async = run_inference_async
+
+    with pytest.raises(type(failure), match=str(failure)):
+        successful_result = provider.run_inference(_pipeline("paddleocr"), _request(source))
+
+    assert successful_result is None
+    assert calls == 2
+    assert len(rendered) == 2
+    for image in rendered:
+        with pytest.raises(ValueError, match="Operation on closed image"):
+            image.getpixel((0, 0))
 
 
 @pytest.mark.parametrize(

--- a/tests/parse_bench/inference/providers/parse/test_multipage_provider_hooks.py
+++ b/tests/parse_bench/inference/providers/parse/test_multipage_provider_hooks.py
@@ -11,26 +11,14 @@ import pytest
 from PIL import Image
 
 from parse_bench.inference.providers.base import ProviderPermanentError, ProviderTransientError
+from parse_bench.inference.providers.parse._multipage_image import IMAGE_BACKED_PDF_PROVIDERS
 from parse_bench.schemas.parse_output import ParseOutput
 from parse_bench.schemas.pipeline import PipelineSpec
 from parse_bench.schemas.pipeline_io import InferenceRequest
 from parse_bench.schemas.product import ProductType
 
 ADAPTER_PROVIDERS = [
-    ("chandra2", "Chandra2Provider", 144),
-    ("deepseekocr2", "DeepSeekOCR2Provider", 144),
-    ("falconocr", "FalconOcrProvider", 144),
-    ("gemma4", "Gemma4Provider", 144),
-    ("granite_vision", "GraniteVisionProvider", 144),
-    ("infinity_parser2", "InfinityParser2Provider", 300),
-    ("mineru25", "MinerU25Provider", 144),
-    ("mineru2605pro", "MinerU2605ProProvider", 144),
-    ("mineru_diffusion", "MinerUDiffusionProvider", 144),
-    ("nemotron_omni", "NemotronOmniProvider", 144),
-    ("paddleocr", "PaddleOCRProvider", 144),
-    ("qwen3_5", "Qwen35Provider", 144),
-    ("surya2", "Surya2Provider", 144),
-    ("unlimitedocr", "UnlimitedOCRProvider", 144),
+    (spec.module_name, spec.class_name, spec.dpi) for spec in IMAGE_BACKED_PDF_PROVIDERS if spec.execution == "adapter"
 ]
 
 
@@ -68,7 +56,13 @@ def _provider(module_name: str, class_name: str, dpi: int) -> Any:
     return provider
 
 
-def _install_local_boundary(provider: Any, module_name: str) -> list[int]:
+def _install_local_boundary(
+    provider: Any,
+    module_name: str,
+    *,
+    failure: Exception | None = None,
+    fail_on_call: int = 1,
+) -> list[int]:
     calls: list[int] = []
 
     def raw_output(page_number: int) -> dict[str, object]:
@@ -100,6 +94,8 @@ def _install_local_boundary(provider: Any, module_name: str) -> list[int]:
 
         def parse_document(path: str) -> dict[str, object]:
             calls.append(len(calls) + 1)
+            if failure is not None and calls[-1] == fail_on_call:
+                raise failure
             return raw_output(calls[-1])
 
         provider._parse_document = parse_document
@@ -107,6 +103,8 @@ def _install_local_boundary(provider: Any, module_name: str) -> list[int]:
 
         async def run_inference_async(*args: object, **kwargs: object) -> dict[str, object]:
             calls.append(len(calls) + 1)
+            if failure is not None and calls[-1] == fail_on_call:
+                raise failure
             return raw_output(calls[-1])
 
         provider._run_inference_async = run_inference_async
@@ -260,9 +258,44 @@ def test_paddleocr_page_two_failure_aborts_without_partial_result(
             image.getpixel((0, 0))
 
 
+@pytest.mark.parametrize(("module_name", "class_name", "expected_dpi"), ADAPTER_PROVIDERS)
+@pytest.mark.parametrize(
+    "failure",
+    [
+        ProviderPermanentError("page two is invalid"),
+        ProviderTransientError("page two timed out"),
+    ],
+    ids=["permanent", "transient"],
+)
+def test_adapter_provider_page_failure_aborts_without_partial_result(
+    module_name: str,
+    class_name: str,
+    expected_dpi: int,
+    failure: Exception,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "document.pdf"
+    source.touch()
+    rendered = _mock_two_page_pdf(source, monkeypatch)
+    provider = _provider(module_name, class_name, expected_dpi)
+    calls = _install_local_boundary(provider, module_name, failure=failure, fail_on_call=2)
+    successful_result = None
+
+    with pytest.raises(type(failure), match=str(failure)):
+        successful_result = provider.run_inference(_pipeline(module_name), _request(source))
+
+    assert successful_result is None
+    assert calls == [1, 2]
+    assert len(rendered) == 2
+    for image in rendered:
+        with pytest.raises(ValueError, match="Operation on closed image"):
+            image.getpixel((0, 0))
+
+
 @pytest.mark.parametrize(
     "module_name",
-    ["amazon_nova", "dots_ocr", "anthropic", "google", "openai", "tesseract", "textract"],
+    [spec.module_name for spec in IMAGE_BACKED_PDF_PROVIDERS if spec.execution == "direct"],
 )
 def test_refactored_providers_do_not_call_pdf2image_eagerly(module_name: str) -> None:
     module = importlib.import_module(f"parse_bench.inference.providers.parse.{module_name}")
@@ -291,3 +324,43 @@ def test_shared_rasterizer_bounds_every_convert_from_path_call() -> None:
 
     assert len(calls) == 1
     assert {keyword.arg for keyword in calls[0].keywords} >= {"first_page", "last_page"}
+
+
+def test_every_registered_local_pdf_raster_provider_is_classified() -> None:
+    provider_dir = Path(__file__).parents[5] / "src/parse_bench/inference/providers/parse"
+    registered: dict[str, tuple[str, str]] = {}
+    raster_provider_names: set[str] = set()
+
+    for source_path in provider_dir.glob("*.py"):
+        tree = ast.parse(source_path.read_text())
+        module_registrations: list[tuple[str, str]] = []
+        for node in tree.body:
+            if not isinstance(node, ast.ClassDef):
+                continue
+            for decorator in node.decorator_list:
+                if (
+                    isinstance(decorator, ast.Call)
+                    and isinstance(decorator.func, ast.Name)
+                    and decorator.func.id == "register_provider"
+                    and decorator.args
+                    and isinstance(decorator.args[0], ast.Constant)
+                    and isinstance(decorator.args[0].value, str)
+                ):
+                    registration = (decorator.args[0].value, node.name)
+                    module_registrations.append(registration)
+                    registered[registration[0]] = (source_path.stem, registration[1])
+
+        local_raster_calls = {
+            getattr(node.func, "id", getattr(node.func, "attr", None))
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call) and isinstance(node.func, (ast.Name, ast.Attribute))
+        }
+        if local_raster_calls & {"run_pdf_pages", "open_document_page_images", "get_pixmap"}:
+            raster_provider_names.update(provider_name for provider_name, _ in module_registrations)
+
+    classified = {spec.provider_name for spec in IMAGE_BACKED_PDF_PROVIDERS}
+    assert classified == raster_provider_names
+    assert {spec.provider_name: (spec.module_name, spec.class_name) for spec in IMAGE_BACKED_PDF_PROVIDERS} == {
+        provider_name: registered[provider_name] for provider_name in classified
+    }
+    assert {spec.execution for spec in IMAGE_BACKED_PDF_PROVIDERS} == {"adapter", "direct", "kdl"}

--- a/tests/parse_bench/inference/providers/parse/test_multipage_provider_hooks.py
+++ b/tests/parse_bench/inference/providers/parse/test_multipage_provider_hooks.py
@@ -11,7 +11,10 @@ import pytest
 from PIL import Image
 
 from parse_bench.inference.providers.base import ProviderPermanentError, ProviderTransientError
-from parse_bench.inference.providers.parse._multipage_image import IMAGE_BACKED_PDF_PROVIDERS
+from parse_bench.inference.providers.parse._multipage_image import (
+    IMAGE_BACKED_PDF_PROVIDERS,
+    PARSE_PROVIDER_PDF_CLASSIFICATIONS,
+)
 from parse_bench.schemas.parse_output import ParseOutput
 from parse_bench.schemas.pipeline import PipelineSpec
 from parse_bench.schemas.pipeline_io import InferenceRequest
@@ -125,6 +128,48 @@ def _mock_two_page_pdf(source: Path, monkeypatch: pytest.MonkeyPatch) -> list[Im
 
     monkeypatch.setattr("pdf2image.convert_from_path", render_page)
     return rendered
+
+
+def _qualified_name(expression: ast.expr, bindings: dict[str, str]) -> str | None:
+    if isinstance(expression, ast.Name):
+        return bindings.get(expression.id, expression.id)
+    if isinstance(expression, ast.Attribute):
+        parent = _qualified_name(expression.value, bindings)
+        return f"{parent}.{expression.attr}" if parent is not None else None
+    return None
+
+
+def _registered_provider_classes(tree: ast.Module) -> list[tuple[str, str]]:
+    bindings: dict[str, str] = {}
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                local_name = alias.asname or alias.name.split(".")[0]
+                bindings[local_name] = alias.name if alias.asname else local_name
+        elif isinstance(node, ast.ImportFrom) and node.module is not None:
+            for alias in node.names:
+                bindings[alias.asname or alias.name] = f"{node.module}.{alias.name}"
+
+    registrations: list[tuple[str, str]] = []
+    for node in tree.body:
+        if not isinstance(node, ast.ClassDef):
+            continue
+        for decorator in node.decorator_list:
+            if not isinstance(decorator, ast.Call):
+                continue
+            target = _qualified_name(decorator.func, bindings)
+            if target not in {
+                "parse_bench.inference.register_provider",
+                "parse_bench.inference.providers.register_provider",
+                "parse_bench.inference.providers.registry.register_provider",
+            }:
+                continue
+            if not decorator.args or not isinstance(decorator.args[0], ast.Constant):
+                continue
+            provider_name = decorator.args[0].value
+            if isinstance(provider_name, str):
+                registrations.append((provider_name, node.name))
+    return registrations
 
 
 @pytest.mark.parametrize(("module_name", "class_name", "expected_dpi"), ADAPTER_PROVIDERS)
@@ -326,41 +371,57 @@ def test_shared_rasterizer_bounds_every_convert_from_path_call() -> None:
     assert {keyword.arg for keyword in calls[0].keywords} >= {"first_page", "last_page"}
 
 
-def test_every_registered_local_pdf_raster_provider_is_classified() -> None:
+@pytest.mark.parametrize(
+    "source",
+    [
+        "from parse_bench.inference.providers.registry import register_provider\n"
+        "@register_provider('sample')\nclass Sample: pass\n",
+        "from parse_bench.inference.providers.registry import register_provider as register\n"
+        "@register('sample')\nclass Sample: pass\n",
+        "import parse_bench.inference.providers.registry as registry\n"
+        "@registry.register_provider('sample')\nclass Sample: pass\n",
+        "from parse_bench.inference.providers import registry as provider_registry\n"
+        "@provider_registry.register_provider('sample')\nclass Sample: pass\n",
+    ],
+)
+def test_registered_provider_discovery_resolves_import_aliases(source: str) -> None:
+    assert _registered_provider_classes(ast.parse(source)) == [("sample", "Sample")]
+
+
+def test_every_registered_parse_provider_has_explicit_pdf_classification() -> None:
     provider_dir = Path(__file__).parents[5] / "src/parse_bench/inference/providers/parse"
     registered: dict[str, tuple[str, str]] = {}
-    raster_provider_names: set[str] = set()
 
     for source_path in provider_dir.glob("*.py"):
         tree = ast.parse(source_path.read_text())
-        module_registrations: list[tuple[str, str]] = []
-        for node in tree.body:
-            if not isinstance(node, ast.ClassDef):
-                continue
-            for decorator in node.decorator_list:
-                if (
-                    isinstance(decorator, ast.Call)
-                    and isinstance(decorator.func, ast.Name)
-                    and decorator.func.id == "register_provider"
-                    and decorator.args
-                    and isinstance(decorator.args[0], ast.Constant)
-                    and isinstance(decorator.args[0].value, str)
-                ):
-                    registration = (decorator.args[0].value, node.name)
-                    module_registrations.append(registration)
-                    registered[registration[0]] = (source_path.stem, registration[1])
+        for provider_name, class_name in _registered_provider_classes(tree):
+            assert provider_name not in registered
+            registered[provider_name] = (source_path.stem, class_name)
 
-        local_raster_calls = {
-            getattr(node.func, "id", getattr(node.func, "attr", None))
-            for node in ast.walk(tree)
-            if isinstance(node, ast.Call) and isinstance(node.func, (ast.Name, ast.Attribute))
-        }
-        if local_raster_calls & {"run_pdf_pages", "open_document_page_images", "get_pixmap"}:
-            raster_provider_names.update(provider_name for provider_name, _ in module_registrations)
-
-    classified = {spec.provider_name for spec in IMAGE_BACKED_PDF_PROVIDERS}
-    assert classified == raster_provider_names
-    assert {spec.provider_name: (spec.module_name, spec.class_name) for spec in IMAGE_BACKED_PDF_PROVIDERS} == {
-        provider_name: registered[provider_name] for provider_name in classified
+    classified = {spec.provider_name: spec for spec in PARSE_PROVIDER_PDF_CLASSIFICATIONS}
+    assert len(classified) == len(PARSE_PROVIDER_PDF_CLASSIFICATIONS)
+    assert set(classified) == set(registered)
+    assert {
+        provider_name: (spec.module_name, spec.class_name) for provider_name, spec in classified.items()
+    } == registered
+    assert {spec.pdf_handling for spec in classified.values()} == {
+        "local-page-raster",
+        "no-local-page-raster",
     }
+    for spec in classified.values():
+        if spec.pdf_handling == "local-page-raster":
+            assert spec.dpi is not None
+            assert spec.execution in {"adapter", "direct", "kdl"}
+        else:
+            assert spec.dpi is None
+            assert spec.execution is None
+
+    local_raster = {
+        provider_name: (spec.module_name, spec.class_name)
+        for provider_name, spec in classified.items()
+        if spec.pdf_handling == "local-page-raster"
+    }
+    assert {
+        spec.provider_name: (spec.module_name, spec.class_name) for spec in IMAGE_BACKED_PDF_PROVIDERS
+    } == local_raster
     assert {spec.execution for spec in IMAGE_BACKED_PDF_PROVIDERS} == {"adapter", "direct", "kdl"}

--- a/tests/parse_bench/inference/providers/parse/test_normalized_page_invariants.py
+++ b/tests/parse_bench/inference/providers/parse/test_normalized_page_invariants.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import importlib
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from parse_bench.inference.providers.base import ProviderPermanentError
+from parse_bench.schemas.pipeline import PipelineSpec
+from parse_bench.schemas.pipeline_io import InferenceRequest, RawInferenceResult
+from parse_bench.schemas.product import ProductType
+
+PROVIDERS = [
+    ("google", "GoogleProvider"),
+    ("openai", "OpenAIProvider"),
+    ("anthropic", "AnthropicProvider"),
+    ("amazon_nova", "AmazonNovaProvider"),
+    ("dots_ocr", "DotsOcrParseProvider"),
+]
+
+
+def _raw_result(module_name: str, pages: list[dict[str, Any]]) -> RawInferenceResult:
+    now = datetime.now()
+    pipeline = PipelineSpec(
+        pipeline_name=f"{module_name}_test",
+        provider_name=module_name,
+        product_type=ProductType.PARSE,
+    )
+    request = InferenceRequest(
+        example_id="document",
+        source_file_path=str(Path("document.pdf")),
+        product_type=ProductType.PARSE,
+    )
+    raw_output: dict[str, Any] = {"pages": pages, "mode": "parse_with_layout", "bbox_scale": 1000}
+    if module_name == "dots_ocr":
+        raw_output["prompt_mode"] = "prompt_layout_all_en_v1_5"
+    return RawInferenceResult(
+        request=request,
+        pipeline=pipeline,
+        pipeline_name=pipeline.pipeline_name,
+        product_type=ProductType.PARSE,
+        raw_output=raw_output,
+        started_at=now,
+        completed_at=now,
+        latency_in_ms=1,
+    )
+
+
+def _page(module_name: str, page_index: int, text: str) -> dict[str, Any]:
+    if module_name == "dots_ocr":
+        layout_items = [{"category": "Text", "bbox": [0, 0, 50, 50], "text": text}] if text else []
+        return {
+            "page_index": page_index,
+            "width": 100,
+            "height": 100,
+            "markdown": text,
+            "layout_items": layout_items,
+        }
+    items = [{"label": "Text", "bbox": [0, 0, 500, 500], "text": text}] if text else []
+    return {"page_index": page_index, "width": 100, "height": 100, "items": items}
+
+
+@pytest.mark.parametrize(("module_name", "class_name"), PROVIDERS)
+def test_normalization_sorts_once_and_preserves_explicit_blank_layout_page(
+    module_name: str,
+    class_name: str,
+) -> None:
+    provider_class = getattr(
+        importlib.import_module(f"parse_bench.inference.providers.parse.{module_name}"), class_name
+    )
+    provider = object.__new__(provider_class)
+    raw = _raw_result(
+        module_name,
+        [_page(module_name, 2, "third"), _page(module_name, 1, ""), _page(module_name, 0, "first")],
+    )
+
+    result = provider.normalize(raw)
+
+    assert [(page.page_index, page.markdown) for page in result.output.pages] == [
+        (0, "first"),
+        (1, ""),
+        (2, "third"),
+    ]
+    assert result.output.markdown == "first\n\n\n\nthird"
+    assert [page.page_number for page in result.output.layout_pages] == [1, 2, 3]
+    assert result.output.layout_pages[1].items == []
+
+
+@pytest.mark.parametrize(("module_name", "class_name"), PROVIDERS)
+def test_normalization_rejects_duplicate_raw_page_indices(module_name: str, class_name: str) -> None:
+    provider_class = getattr(
+        importlib.import_module(f"parse_bench.inference.providers.parse.{module_name}"), class_name
+    )
+    provider = object.__new__(provider_class)
+    raw = _raw_result(module_name, [_page(module_name, 0, "first"), _page(module_name, 0, "duplicate")])
+
+    with pytest.raises(ProviderPermanentError, match="unique, contiguous, and zero-based"):
+        provider.normalize(raw)

--- a/tests/parse_bench/inference/providers/parse/test_normalized_page_invariants.py
+++ b/tests/parse_bench/inference/providers/parse/test_normalized_page_invariants.py
@@ -20,6 +20,11 @@ PROVIDERS = [
     ("dots_ocr", "DotsOcrParseProvider"),
 ]
 
+TEXT_PAGE_PROVIDERS = [
+    ("pymupdf4llm", "PyMuPDF4LLMProvider"),
+    ("tesseract", "TesseractProvider"),
+]
+
 
 def _raw_result(module_name: str, pages: list[dict[str, Any]]) -> RawInferenceResult:
     now = datetime.now()
@@ -95,6 +100,47 @@ def test_normalization_rejects_duplicate_raw_page_indices(module_name: str, clas
     )
     provider = object.__new__(provider_class)
     raw = _raw_result(module_name, [_page(module_name, 0, "first"), _page(module_name, 0, "duplicate")])
+
+    with pytest.raises(ProviderPermanentError, match="unique, contiguous, and zero-based"):
+        provider.normalize(raw)
+
+
+@pytest.mark.parametrize(("module_name", "class_name"), TEXT_PAGE_PROVIDERS)
+def test_text_normalization_sorts_raw_pages_before_all_views(module_name: str, class_name: str) -> None:
+    provider_class = getattr(
+        importlib.import_module(f"parse_bench.inference.providers.parse.{module_name}"), class_name
+    )
+    provider = object.__new__(provider_class)
+    raw = _raw_result(
+        module_name,
+        [
+            {"page_index": 1, "text": "second", "width": 100, "height": 100, "blocks": []},
+            {"page_index": 0, "text": "first", "width": 100, "height": 100, "blocks": []},
+        ],
+    )
+
+    result = provider.normalize(raw)
+
+    assert [(page.page_index, page.markdown) for page in result.output.pages] == [
+        (0, "first"),
+        (1, "second"),
+    ]
+    assert result.output.markdown == "first\n\nsecond"
+
+
+@pytest.mark.parametrize(("module_name", "class_name"), TEXT_PAGE_PROVIDERS)
+def test_text_normalization_rejects_duplicate_raw_page_indices(module_name: str, class_name: str) -> None:
+    provider_class = getattr(
+        importlib.import_module(f"parse_bench.inference.providers.parse.{module_name}"), class_name
+    )
+    provider = object.__new__(provider_class)
+    raw = _raw_result(
+        module_name,
+        [
+            {"page_index": 0, "text": "first"},
+            {"page_index": 0, "text": "duplicate"},
+        ],
+    )
 
     with pytest.raises(ProviderPermanentError, match="unique, contiguous, and zero-based"):
         provider.normalize(raw)

--- a/tests/parse_bench/inference/providers/parse/test_refactored_provider_paths.py
+++ b/tests/parse_bench/inference/providers/parse/test_refactored_provider_paths.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -13,7 +14,7 @@ from parse_bench.inference.providers.base import (
     ProviderTransientError,
 )
 from parse_bench.inference.providers.parse._multipage_image import IMAGE_BACKED_PDF_PROVIDERS
-from parse_bench.inference.providers.parse.textract import TextractProvider
+from parse_bench.inference.providers.parse.textract import TextractProvider, _build_layout_pages
 from parse_bench.schemas.parse_output import ParseOutput
 from parse_bench.schemas.pipeline import PipelineSpec
 from parse_bench.schemas.pipeline_io import InferenceRequest
@@ -441,6 +442,75 @@ def test_textract_success_persists_every_physical_retry_attempt(
         (1, 1, "failed"),
         (1, 2, "succeeded"),
     ]
+
+
+def test_textract_retries_botocore_transport_failures(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from botocore.exceptions import EndpointConnectionError
+
+    source = tmp_path / "document.pdf"
+    source.touch()
+    _mock_pdf(source, monkeypatch)
+    provider = _provider("textract", "TextractProvider", 300)
+    provider._textract_client = _TextractClient(
+        failure=EndpointConnectionError(endpoint_url="https://textract.invalid"),
+        fail_on_call=1,
+    )
+    monkeypatch.setattr("time.sleep", lambda delay: None)
+
+    result = provider.run_inference(_pipeline("textract"), _request(source))
+
+    assert provider._textract_client.calls == 3
+    assert result.raw_output["num_api_calls"] == 3
+    assert [
+        (attempt["page_number"], attempt["attempt"], attempt["status"]) for attempt in result.raw_output["api_attempts"]
+    ] == [
+        (1, 1, "failed"),
+        (1, 2, "succeeded"),
+        (2, 1, "succeeded"),
+    ]
+
+
+def test_textract_preserves_blank_physical_pages_in_all_normalized_views(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = _provider("textract", "TextractProvider", 300)
+    provider._detect_tables = False
+    fake_pages = [
+        SimpleNamespace(
+            page_num=1,
+            lines=[SimpleNamespace(text="one", bbox=SimpleNamespace(y=0.1))],
+            tables=[],
+        ),
+        SimpleNamespace(
+            page_num=3,
+            lines=[SimpleNamespace(text="three", bbox=SimpleNamespace(y=0.1))],
+            tables=[],
+        ),
+    ]
+    monkeypatch.setattr(
+        "textractor.parsers.response_parser.parse",
+        lambda response: SimpleNamespace(pages=fake_pages),
+    )
+    blocks = [
+        {"Id": "p1", "BlockType": "LAYOUT_TEXT", "Page": 1},
+        {"Id": "p3", "BlockType": "LAYOUT_TEXT", "Page": 3},
+    ]
+    response = {"DocumentMetadata": {"Pages": 3}, "Blocks": blocks}
+
+    markdown = TextractProvider._convert_to_markdown(provider, response)
+    layout_pages = _build_layout_pages(blocks, num_pages=3)
+
+    assert [(page["page_index"], page["markdown"]) for page in markdown["pages"]] == [
+        (0, "one"),
+        (1, ""),
+        (2, "three"),
+    ]
+    assert markdown["markdown"] == "one\n\n\n\nthree"
+    assert [page.page_number for page in layout_pages] == [1, 2, 3]
+    assert layout_pages[1].items == []
 
 
 def test_dots_ocr_malformed_layout_aborts_document(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/parse_bench/inference/providers/parse/test_refactored_provider_paths.py
+++ b/tests/parse_bench/inference/providers/parse/test_refactored_provider_paths.py
@@ -41,14 +41,15 @@ def _request(source: Path) -> InferenceRequest:
 
 
 class _TextractClient:
-    def __init__(self, fail: bool = False) -> None:
+    def __init__(self, failure: Exception | None = None, fail_on_call: int = 1) -> None:
         self.calls = 0
-        self.fail = fail
+        self.failure = failure
+        self.fail_on_call = fail_on_call
 
     def analyze_document(self, **kwargs: object) -> dict[str, object]:
         self.calls += 1
-        if self.fail:
-            raise RuntimeError("textract failed")
+        if self.failure is not None and self.calls == self.fail_on_call:
+            raise self.failure
         return {
             "Blocks": [
                 {
@@ -105,15 +106,16 @@ def _install_boundary(
     module_name: str,
     monkeypatch: pytest.MonkeyPatch,
     *,
-    fail: bool = False,
+    failure: Exception | None = None,
+    fail_on_call: int = 1,
 ) -> list[int]:
     calls: list[int] = []
 
     def next_page() -> int:
         page_number = len(calls) + 1
         calls.append(page_number)
-        if fail:
-            raise ProviderPermanentError("provider boundary failed")
+        if failure is not None and page_number == fail_on_call:
+            raise failure
         return page_number
 
     def usage(page_number: int) -> dict[str, int]:
@@ -145,7 +147,7 @@ def _install_boundary(
 
         monkeypatch.setattr(pytesseract, "image_to_string", lambda *args, **kwargs: f"page {next_page()}")
     elif module_name == "textract":
-        provider._textract_client = _TextractClient(fail=fail)
+        provider._textract_client = _TextractClient(failure=failure, fail_on_call=fail_on_call)
     return calls
 
 
@@ -231,7 +233,7 @@ def test_refactored_provider_preserves_single_image_behavior(
 
 
 @pytest.mark.parametrize(("module_name", "class_name", "dpi"), LEGACY_PROVIDERS)
-def test_refactored_provider_closes_pages_when_provider_boundary_fails(
+def test_refactored_provider_propagates_permanent_failure_without_partial_document(
     module_name: str,
     class_name: str,
     dpi: int,
@@ -242,15 +244,57 @@ def test_refactored_provider_closes_pages_when_provider_boundary_fails(
     source.touch()
     rendered = _mock_pdf(source, monkeypatch)
     provider = _provider(module_name, class_name, dpi)
-    _install_boundary(provider, module_name, monkeypatch, fail=True)
-    monkeypatch.setattr("time.sleep", lambda seconds: None)
+    calls = _install_boundary(
+        provider,
+        module_name,
+        monkeypatch,
+        failure=ProviderPermanentError("provider boundary failed"),
+        fail_on_call=2,
+    )
+    delays: list[int] = []
+    monkeypatch.setattr("time.sleep", delays.append)
 
-    try:
+    with pytest.raises(ProviderPermanentError, match="provider boundary failed"):
         provider.run_inference(_pipeline(module_name), _request(source))
-    except (ProviderPermanentError, ProviderTransientError):
-        pass
 
-    assert rendered
+    boundary_calls = provider._textract_client.calls if module_name == "textract" else calls
+    assert boundary_calls == 2 if module_name == "textract" else [1, 2]
+    assert delays == []
+    assert len(rendered) == 2
+    for image in rendered:
+        with pytest.raises(ValueError, match="Operation on closed image"):
+            image.getpixel((0, 0))
+
+
+@pytest.mark.parametrize(
+    ("module_name", "class_name", "dpi"),
+    [provider for provider in LEGACY_PROVIDERS if provider[0] != "dots_ocr"],
+)
+def test_refactored_provider_propagates_transient_page_failure_for_document_retry(
+    module_name: str,
+    class_name: str,
+    dpi: int,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "document.pdf"
+    source.touch()
+    rendered = _mock_pdf(source, monkeypatch)
+    provider = _provider(module_name, class_name, dpi)
+    calls = _install_boundary(
+        provider,
+        module_name,
+        monkeypatch,
+        failure=ProviderTransientError("timeout on page two"),
+        fail_on_call=2,
+    )
+
+    with pytest.raises(ProviderTransientError, match="timeout on page two"):
+        provider.run_inference(_pipeline(module_name), _request(source))
+
+    boundary_calls = provider._textract_client.calls if module_name == "textract" else calls
+    assert boundary_calls == 2 if module_name == "textract" else [1, 2]
+    assert len(rendered) == 2
     for image in rendered:
         with pytest.raises(ValueError, match="Operation on closed image"):
             image.getpixel((0, 0))
@@ -263,14 +307,13 @@ def test_dots_ocr_retries_the_document_after_transient_page_failure(
     source.touch()
     _mock_pdf(source, monkeypatch)
     provider = _provider("dots_ocr", "DotsOcrParseProvider", 144)
-    calls = 0
+    page_widths: list[int] = []
 
     def call_endpoint(image: Image.Image) -> str:
-        nonlocal calls
-        calls += 1
-        if calls == 1:
+        page_widths.append(image.width)
+        if len(page_widths) == 2:
             raise ProviderTransientError("retry me")
-        return f"page {calls - 1}"
+        return f"page {image.width - 8}"
 
     provider._call_endpoint = call_endpoint
     delays: list[int] = []
@@ -279,6 +322,30 @@ def test_dots_ocr_retries_the_document_after_transient_page_failure(
     raw_result = provider.run_inference(_pipeline("dots_ocr"), _request(source))
     result = provider.normalize(raw_result)
 
-    assert calls == 3
+    assert page_widths == [9, 10, 9, 10]
     assert delays == [15]
     assert result.output.markdown == "page 1\n\npage 2"
+
+
+def test_dots_ocr_propagates_transient_failure_after_document_retries_exhausted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "document.pdf"
+    source.touch()
+    _mock_pdf(source, monkeypatch)
+    provider = _provider("dots_ocr", "DotsOcrParseProvider", 144)
+    page_widths: list[int] = []
+
+    def call_endpoint(image: Image.Image) -> str:
+        page_widths.append(image.width)
+        raise ProviderTransientError("retry me")
+
+    provider._call_endpoint = call_endpoint
+    delays: list[int] = []
+    monkeypatch.setattr("time.sleep", delays.append)
+
+    with pytest.raises(ProviderTransientError, match="retry me"):
+        provider.run_inference(_pipeline("dots_ocr"), _request(source))
+
+    assert page_widths == [9, 9, 9]
+    assert delays == [15, 30]

--- a/tests/parse_bench/inference/providers/parse/test_refactored_provider_paths.py
+++ b/tests/parse_bench/inference/providers/parse/test_refactored_provider_paths.py
@@ -91,6 +91,28 @@ def test_textract_client_disables_hidden_sdk_retries(monkeypatch: pytest.MonkeyP
     assert config.retries["mode"] == "standard"  # type: ignore[attr-defined]
 
 
+def test_textract_resize_rejects_payload_still_above_hard_limit() -> None:
+    provider = object.__new__(TextractProvider)
+    provider._TARGET_BYTES = 10
+    provider._MAX_BYTES = 12
+    provider._MAX_DIMENSION = 10_000
+
+    class OversizeImage:
+        size = (100, 100)
+
+        def resize(self, size: tuple[int, int], resampling: object) -> OversizeImage:
+            return OversizeImage()
+
+        def save(self, buffer: object, **kwargs: object) -> None:
+            buffer.write(b"x" * 13)  # type: ignore[attr-defined]
+
+        def close(self) -> None:
+            return None
+
+    with pytest.raises(ProviderPermanentError, match="above the 12-byte API limit"):
+        provider._resize_image_for_textract(OversizeImage())
+
+
 def _provider(module_name: str, class_name: str, dpi: int) -> Any:
     module = importlib.import_module(f"parse_bench.inference.providers.parse.{module_name}")
     provider = object.__new__(getattr(module, class_name))

--- a/tests/parse_bench/inference/providers/parse/test_refactored_provider_paths.py
+++ b/tests/parse_bench/inference/providers/parse/test_refactored_provider_paths.py
@@ -414,6 +414,35 @@ def test_textract_page_retry_budget_is_exactly_three_billable_calls(
     assert delays == [2.0, 4.0]
 
 
+def test_textract_success_persists_every_physical_retry_attempt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "document.pdf"
+    source.touch()
+    monkeypatch.setattr("pdf2image.pdfinfo_from_path", lambda path: {"Pages": 1})
+    monkeypatch.setattr(
+        "pdf2image.convert_from_path",
+        lambda path, dpi, first_page, last_page: [Image.new("RGB", (8, 8), "white")],
+    )
+    provider = _provider("textract", "TextractProvider", 300)
+    provider._textract_client = _TextractClient(
+        failure=ProviderTransientError("first call unavailable"),
+        fail_on_call=1,
+    )
+    monkeypatch.setattr("time.sleep", lambda delay: None)
+
+    result = provider.run_inference(_pipeline("textract"), _request(source))
+
+    assert provider._textract_client.calls == 2
+    assert result.raw_output["num_api_calls"] == 2
+    attempts = result.raw_output["api_attempts"]
+    assert [(attempt["page_number"], attempt["attempt"], attempt["status"]) for attempt in attempts] == [
+        (1, 1, "failed"),
+        (1, 2, "succeeded"),
+    ]
+
+
 def test_dots_ocr_malformed_layout_aborts_document(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     source = tmp_path / "document.pdf"
     source.touch()

--- a/tests/parse_bench/inference/providers/parse/test_refactored_provider_paths.py
+++ b/tests/parse_bench/inference/providers/parse/test_refactored_provider_paths.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from typing import Any
+
+import pytest
+from PIL import Image
+
+from parse_bench.inference.providers.base import ProviderPermanentError, ProviderTransientError
+from parse_bench.schemas.parse_output import ParseOutput
+from parse_bench.schemas.pipeline import PipelineSpec
+from parse_bench.schemas.pipeline_io import InferenceRequest
+from parse_bench.schemas.product import ProductType
+
+LEGACY_PROVIDERS = [
+    ("amazon_nova", "AmazonNovaProvider", 150),
+    ("anthropic", "AnthropicProvider", 144),
+    ("dots_ocr", "DotsOcrParseProvider", 144),
+    ("google", "GoogleProvider", 144),
+    ("openai", "OpenAIProvider", 144),
+    ("tesseract", "TesseractProvider", 144),
+    ("textract", "TextractProvider", 300),
+]
+
+
+def _pipeline(module_name: str) -> PipelineSpec:
+    return PipelineSpec(
+        pipeline_name=f"{module_name}_test",
+        provider_name=module_name,
+        product_type=ProductType.PARSE,
+    )
+
+
+def _request(source: Path) -> InferenceRequest:
+    return InferenceRequest(
+        example_id="document",
+        source_file_path=str(source),
+        product_type=ProductType.PARSE,
+    )
+
+
+class _TextractClient:
+    def __init__(self, fail: bool = False) -> None:
+        self.calls = 0
+        self.fail = fail
+
+    def analyze_document(self, **kwargs: object) -> dict[str, object]:
+        self.calls += 1
+        if self.fail:
+            raise RuntimeError("textract failed")
+        return {
+            "Blocks": [
+                {
+                    "Id": f"line-{self.calls}",
+                    "BlockType": "LINE",
+                    "Text": f"page {self.calls}",
+                }
+            ]
+        }
+
+
+def _provider(module_name: str, class_name: str, dpi: int) -> Any:
+    module = importlib.import_module(f"parse_bench.inference.providers.parse.{module_name}")
+    provider = object.__new__(getattr(module, class_name))
+    defaults = {
+        "_dpi": dpi,
+        "_mode": "image",
+        "_bbox_scale": 1000,
+        "_model": "test-model",
+        "_max_tokens": 100,
+        "_reasoning_effort": None,
+        "_thinking_level": None,
+        "_temperature": None,
+        "_top_p": None,
+        "_region": "test-region",
+        "_prompt_mode": "parse",
+        "_is_layout_mode": False,
+        "_timeout": 30,
+        "_lang": "eng",
+        "_config": "",
+        "_output_type": "text",
+        "_detect_tables": False,
+        "_detect_forms": False,
+        "_output_tables_as_html": True,
+    }
+    for name, value in defaults.items():
+        setattr(provider, name, value)
+    if module_name in {"amazon_nova", "anthropic", "google", "openai"}:
+        provider._get_pricing = lambda: (1.0, 2.0)
+    if module_name == "textract":
+        provider._textract_client = _TextractClient()
+
+        def convert_to_markdown(response: dict[str, object]) -> dict[str, object]:
+            page_count = response.get("DocumentMetadata", {}).get("Pages", 1)
+            pages = [{"page_index": page - 1, "markdown": f"page {page}"} for page in range(1, int(page_count) + 1)]
+            return {"pages": pages, "markdown": "\n\n".join(page["markdown"] for page in pages)}
+
+        provider._convert_to_markdown = convert_to_markdown
+    return provider
+
+
+def _install_boundary(
+    provider: Any,
+    module_name: str,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    fail: bool = False,
+) -> list[int]:
+    calls: list[int] = []
+
+    def next_page() -> int:
+        page_number = len(calls) + 1
+        calls.append(page_number)
+        if fail:
+            raise ProviderPermanentError("provider boundary failed")
+        return page_number
+
+    def usage(page_number: int) -> dict[str, int]:
+        return {
+            "input_tokens": page_number * 10,
+            "output_tokens": page_number,
+            "thinking_tokens": 0,
+            "total_tokens": page_number * 11,
+        }
+
+    if module_name == "amazon_nova":
+        provider._parse_image_with_layout = lambda image: (
+            [{"label": "Text", "text": f"page {(page := next_page())}", "bbox": [0, 0, 8, 8]}],
+            f"page {page}",
+            usage(page),
+            "end_turn",
+        )
+    elif module_name in {"anthropic", "google", "openai"}:
+
+        def parse_image(image: Image.Image) -> tuple[str, dict[str, int]]:
+            page = next_page()
+            return f"page {page}", usage(page)
+
+        provider._parse_image = parse_image
+    elif module_name == "dots_ocr":
+        provider._call_endpoint = lambda image: f"page {next_page()}"
+    elif module_name == "tesseract":
+        import pytesseract
+
+        monkeypatch.setattr(pytesseract, "image_to_string", lambda *args, **kwargs: f"page {next_page()}")
+    elif module_name == "textract":
+        provider._textract_client = _TextractClient(fail=fail)
+    return calls
+
+
+def _mock_pdf(source: Path, monkeypatch: pytest.MonkeyPatch) -> list[Image.Image]:
+    rendered: list[Image.Image] = []
+    monkeypatch.setattr("pdf2image.pdfinfo_from_path", lambda path: {"Pages": 2})
+
+    def render(path: str, dpi: int, first_page: int, last_page: int) -> list[Image.Image]:
+        assert Path(path) == source
+        image = Image.new("RGB", (8 + first_page, 8), "white")
+        rendered.append(image)
+        return [image]
+
+    monkeypatch.setattr("pdf2image.convert_from_path", render)
+    return rendered
+
+
+@pytest.mark.parametrize(("module_name", "class_name", "dpi"), LEGACY_PROVIDERS)
+def test_refactored_provider_runs_and_normalizes_ordered_pdf_pages(
+    module_name: str,
+    class_name: str,
+    dpi: int,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "document.pdf"
+    source.touch()
+    rendered = _mock_pdf(source, monkeypatch)
+    provider = _provider(module_name, class_name, dpi)
+    calls = _install_boundary(provider, module_name, monkeypatch)
+
+    raw_result = provider.run_inference(_pipeline(module_name), _request(source))
+    result = provider.normalize(raw_result)
+
+    boundary_calls = provider._textract_client.calls if module_name == "textract" else calls
+    assert boundary_calls == 2 if module_name == "textract" else [1, 2]
+    assert (
+        raw_result.raw_output.get("num_pages") == 2
+        or raw_result.raw_output.get("textract_response", {}).get("DocumentMetadata", {}).get("Pages") == 2
+    )
+    assert isinstance(result.output, ParseOutput)
+    assert result.output.markdown == "page 1\n\npage 2"
+    assert [(page.page_index, page.markdown) for page in result.output.pages] == [
+        (0, "page 1"),
+        (1, "page 2"),
+    ]
+    if module_name in {"amazon_nova", "anthropic", "google", "openai"}:
+        assert raw_result.raw_output["input_tokens"] == 30
+        assert raw_result.raw_output["output_tokens"] == 3
+        assert raw_result.raw_output["cost_per_page_usd"] == pytest.approx(18 / 1_000_000)
+    if module_name == "amazon_nova":
+        assert [page.page_number for page in result.output.layout_pages] == [1, 2]
+    assert len(rendered) == 2
+    for image in rendered:
+        with pytest.raises(ValueError, match="Operation on closed image"):
+            image.getpixel((0, 0))
+
+
+@pytest.mark.parametrize(("module_name", "class_name", "dpi"), LEGACY_PROVIDERS)
+def test_refactored_provider_preserves_single_image_behavior(
+    module_name: str,
+    class_name: str,
+    dpi: int,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "page.png"
+    Image.new("RGB", (8, 8), "white").save(source)
+    provider = _provider(module_name, class_name, dpi)
+    calls = _install_boundary(provider, module_name, monkeypatch)
+    monkeypatch.setattr(
+        "pdf2image.convert_from_path",
+        lambda *args, **kwargs: pytest.fail("single images must not use PDF rasterization"),
+    )
+
+    raw_result = provider.run_inference(_pipeline(module_name), _request(source))
+    result = provider.normalize(raw_result)
+
+    boundary_calls = provider._textract_client.calls if module_name == "textract" else calls
+    assert boundary_calls == 1 if module_name == "textract" else [1]
+    assert isinstance(result.output, ParseOutput)
+    assert result.output.markdown == "page 1"
+
+
+@pytest.mark.parametrize(("module_name", "class_name", "dpi"), LEGACY_PROVIDERS)
+def test_refactored_provider_closes_pages_when_provider_boundary_fails(
+    module_name: str,
+    class_name: str,
+    dpi: int,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "document.pdf"
+    source.touch()
+    rendered = _mock_pdf(source, monkeypatch)
+    provider = _provider(module_name, class_name, dpi)
+    _install_boundary(provider, module_name, monkeypatch, fail=True)
+    monkeypatch.setattr("time.sleep", lambda seconds: None)
+
+    try:
+        provider.run_inference(_pipeline(module_name), _request(source))
+    except (ProviderPermanentError, ProviderTransientError):
+        pass
+
+    assert rendered
+    for image in rendered:
+        with pytest.raises(ValueError, match="Operation on closed image"):
+            image.getpixel((0, 0))
+
+
+def test_dots_ocr_retries_the_document_after_transient_page_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "document.pdf"
+    source.touch()
+    _mock_pdf(source, monkeypatch)
+    provider = _provider("dots_ocr", "DotsOcrParseProvider", 144)
+    calls = 0
+
+    def call_endpoint(image: Image.Image) -> str:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise ProviderTransientError("retry me")
+        return f"page {calls - 1}"
+
+    provider._call_endpoint = call_endpoint
+    delays: list[int] = []
+    monkeypatch.setattr("time.sleep", delays.append)
+
+    raw_result = provider.run_inference(_pipeline("dots_ocr"), _request(source))
+    result = provider.normalize(raw_result)
+
+    assert calls == 3
+    assert delays == [15]
+    assert result.output.markdown == "page 1\n\npage 2"

--- a/tests/parse_bench/inference/providers/parse/test_refactored_provider_paths.py
+++ b/tests/parse_bench/inference/providers/parse/test_refactored_provider_paths.py
@@ -7,8 +7,13 @@ from typing import Any
 import pytest
 from PIL import Image
 
-from parse_bench.inference.providers.base import ProviderPermanentError, ProviderTransientError
+from parse_bench.inference.providers.base import (
+    ProviderPermanentError,
+    ProviderRetryExhaustedError,
+    ProviderTransientError,
+)
 from parse_bench.inference.providers.parse._multipage_image import IMAGE_BACKED_PDF_PROVIDERS
+from parse_bench.inference.providers.parse.textract import TextractProvider
 from parse_bench.schemas.parse_output import ParseOutput
 from parse_bench.schemas.pipeline import PipelineSpec
 from parse_bench.schemas.pipeline_io import InferenceRequest
@@ -54,6 +59,35 @@ class _TextractClient:
                 }
             ]
         }
+
+
+def test_textract_client_disables_hidden_sdk_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    import boto3
+
+    client = object()
+    captured: dict[str, object] = {}
+
+    def build_client(service_name: str, **kwargs: object) -> object:
+        captured["service_name"] = service_name
+        captured.update(kwargs)
+        return client
+
+    monkeypatch.setattr(boto3, "client", build_client)
+
+    provider = TextractProvider(
+        "textract",
+        {
+            "aws_access_key_id": "test-access-key",
+            "aws_secret_access_key": "test-secret-key",
+            "aws_region": "us-test-1",
+        },
+    )
+
+    assert provider._textract_client is client
+    assert captured["service_name"] == "textract"
+    config = captured["config"]
+    assert config.retries["total_max_attempts"] == 1  # type: ignore[attr-defined]
+    assert config.retries["mode"] == "standard"  # type: ignore[attr-defined]
 
 
 def _provider(module_name: str, class_name: str, dpi: int) -> Any:
@@ -348,6 +382,35 @@ def test_dots_ocr_raises_terminal_error_after_page_retries_exhausted(
         provider.run_inference(_pipeline("dots_ocr"), _request(source))
 
     assert page_widths == [9, 9, 9]
+    assert delays == [2.0, 4.0]
+
+
+def test_textract_page_retry_budget_is_exactly_three_billable_calls(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "document.pdf"
+    source.touch()
+    _mock_pdf(source, monkeypatch)
+    provider = _provider("textract", "TextractProvider", 300)
+
+    class AlwaysTransientClient:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def analyze_document(self, **kwargs: object) -> dict[str, object]:
+            self.calls += 1
+            raise ProviderTransientError("retry me")
+
+    client = AlwaysTransientClient()
+    provider._textract_client = client
+    delays: list[float] = []
+    monkeypatch.setattr("time.sleep", delays.append)
+
+    with pytest.raises(ProviderRetryExhaustedError, match="textract page 1 failed after 3 attempts"):
+        provider.run_inference(_pipeline("textract"), _request(source))
+
+    assert client.calls == 3
     assert delays == [2.0, 4.0]
 
 

--- a/tests/parse_bench/inference/providers/parse/test_refactored_provider_paths.py
+++ b/tests/parse_bench/inference/providers/parse/test_refactored_provider_paths.py
@@ -119,6 +119,8 @@ def _provider(module_name: str, class_name: str, dpi: int) -> Any:
         setattr(provider, name, value)
     if module_name in {"amazon_nova", "anthropic", "google", "openai"}:
         provider._get_pricing = lambda: (1.0, 2.0)
+    if module_name == "google":
+        provider._get_context_cache_pricing = lambda: (0.0, 0.0)
     if module_name == "textract":
         provider._textract_client = _TextractClient()
 

--- a/tests/parse_bench/inference/providers/parse/test_refactored_provider_paths.py
+++ b/tests/parse_bench/inference/providers/parse/test_refactored_provider_paths.py
@@ -295,7 +295,7 @@ def test_refactored_provider_propagates_transient_page_failure_for_document_retr
             image.getpixel((0, 0))
 
 
-def test_dots_ocr_retries_the_document_after_transient_page_failure(
+def test_dots_ocr_retries_only_the_failed_page_after_transient_failure(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     source = tmp_path / "document.pdf"
@@ -317,12 +317,13 @@ def test_dots_ocr_retries_the_document_after_transient_page_failure(
     raw_result = provider.run_inference(_pipeline("dots_ocr"), _request(source))
     result = provider.normalize(raw_result)
 
-    assert page_widths == [9, 10, 9, 10]
+    assert page_widths == [9, 10, 10]
     assert delays == [15]
     assert result.output.markdown == "page 1\n\npage 2"
+    assert [page.page_index for page in result.output.pages] == [0, 1]
 
 
-def test_dots_ocr_propagates_transient_failure_after_document_retries_exhausted(
+def test_dots_ocr_raises_terminal_error_after_page_retries_exhausted(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     source = tmp_path / "document.pdf"
@@ -339,8 +340,23 @@ def test_dots_ocr_propagates_transient_failure_after_document_retries_exhausted(
     delays: list[int] = []
     monkeypatch.setattr("time.sleep", delays.append)
 
-    with pytest.raises(ProviderTransientError, match="retry me"):
+    from parse_bench.inference.providers.base import ProviderRetryExhaustedError
+
+    with pytest.raises(ProviderRetryExhaustedError, match="page 1 failed after 3 attempts: retry me"):
         provider.run_inference(_pipeline("dots_ocr"), _request(source))
 
     assert page_widths == [9, 9, 9]
     assert delays == [15, 30]
+
+
+def test_dots_ocr_malformed_layout_aborts_document(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    source = tmp_path / "document.pdf"
+    source.touch()
+    _mock_pdf(source, monkeypatch)
+    provider = _provider("dots_ocr", "DotsOcrParseProvider", 144)
+    provider._prompt_mode = "prompt_layout_all_en_v1_5"
+    provider._is_layout_mode = True
+    provider._call_endpoint = lambda image: "not layout json"
+
+    with pytest.raises(ProviderPermanentError, match="Could not parse layout items"):
+        provider.run_inference(_pipeline("dots_ocr"), _request(source))

--- a/tests/parse_bench/inference/providers/parse/test_refactored_provider_paths.py
+++ b/tests/parse_bench/inference/providers/parse/test_refactored_provider_paths.py
@@ -265,7 +265,7 @@ def test_refactored_provider_propagates_permanent_failure_without_partial_docume
     ("module_name", "class_name", "dpi"),
     [provider for provider in LEGACY_PROVIDERS if provider[0] != "dots_ocr"],
 )
-def test_refactored_provider_propagates_transient_page_failure_for_document_retry(
+def test_refactored_provider_retries_only_the_failed_page(
     module_name: str,
     class_name: str,
     dpi: int,
@@ -283,12 +283,14 @@ def test_refactored_provider_propagates_transient_page_failure_for_document_retr
         failure=ProviderTransientError("timeout on page two"),
         fail_on_call=2,
     )
+    delays: list[float] = []
+    monkeypatch.setattr("time.sleep", delays.append)
 
-    with pytest.raises(ProviderTransientError, match="timeout on page two"):
-        provider.run_inference(_pipeline(module_name), _request(source))
+    assert provider.run_inference(_pipeline(module_name), _request(source)) is not None
 
     boundary_calls = provider._textract_client.calls if module_name == "textract" else calls
-    assert boundary_calls == 2 if module_name == "textract" else [1, 2]
+    assert boundary_calls == 3 if module_name == "textract" else [1, 2, 3]
+    assert delays == [2.0]
     assert len(rendered) == 2
     for image in rendered:
         with pytest.raises(ValueError, match="Operation on closed image"):
@@ -318,7 +320,7 @@ def test_dots_ocr_retries_only_the_failed_page_after_transient_failure(
     result = provider.normalize(raw_result)
 
     assert page_widths == [9, 10, 10]
-    assert delays == [15]
+    assert delays == [2.0]
     assert result.output.markdown == "page 1\n\npage 2"
     assert [page.page_index for page in result.output.pages] == [0, 1]
 
@@ -346,7 +348,7 @@ def test_dots_ocr_raises_terminal_error_after_page_retries_exhausted(
         provider.run_inference(_pipeline("dots_ocr"), _request(source))
 
     assert page_widths == [9, 9, 9]
-    assert delays == [15, 30]
+    assert delays == [2.0, 4.0]
 
 
 def test_dots_ocr_malformed_layout_aborts_document(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/parse_bench/inference/providers/parse/test_refactored_provider_paths.py
+++ b/tests/parse_bench/inference/providers/parse/test_refactored_provider_paths.py
@@ -8,19 +8,14 @@ import pytest
 from PIL import Image
 
 from parse_bench.inference.providers.base import ProviderPermanentError, ProviderTransientError
+from parse_bench.inference.providers.parse._multipage_image import IMAGE_BACKED_PDF_PROVIDERS
 from parse_bench.schemas.parse_output import ParseOutput
 from parse_bench.schemas.pipeline import PipelineSpec
 from parse_bench.schemas.pipeline_io import InferenceRequest
 from parse_bench.schemas.product import ProductType
 
 LEGACY_PROVIDERS = [
-    ("amazon_nova", "AmazonNovaProvider", 150),
-    ("anthropic", "AnthropicProvider", 144),
-    ("dots_ocr", "DotsOcrParseProvider", 144),
-    ("google", "GoogleProvider", 144),
-    ("openai", "OpenAIProvider", 144),
-    ("tesseract", "TesseractProvider", 144),
-    ("textract", "TextractProvider", 300),
+    (spec.module_name, spec.class_name, spec.dpi) for spec in IMAGE_BACKED_PDF_PROVIDERS if spec.execution == "direct"
 ]
 
 

--- a/tests/test_check_static_quality_delta.py
+++ b/tests/test_check_static_quality_delta.py
@@ -165,3 +165,12 @@ def test_divergent_baseline_uses_merge_base_for_diff_and_archive(tmp_path: Path)
     checker._extract_baseline(repo, merge_base, extracted)
     assert (extracted / "sample.py").read_text() == "base = 1\n"
     assert checker._added_line_ranges(repo, merge_base, ["sample.py"]) == {"sample.py": [range(1, 2)]}
+
+
+def test_github_actions_gate_runs_checker_against_fetched_origin_main() -> None:
+    workflow = Path(__file__).parents[1] / ".github/workflows/static-quality-delta.yml"
+    content = workflow.read_text()
+
+    assert "fetch-depth: 0" in content
+    assert "git fetch --no-tags origin main:refs/remotes/origin/main" in content
+    assert "scripts/check_static_quality_delta.py --baseline origin/main" in content

--- a/tests/test_check_static_quality_delta.py
+++ b/tests/test_check_static_quality_delta.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from collections import Counter
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+def _load_checker() -> ModuleType:
+    script = Path(__file__).parents[1] / "scripts/check_static_quality_delta.py"
+    spec = importlib.util.spec_from_file_location("check_static_quality_delta", script)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+checker = _load_checker()
+
+
+def _result(returncode: int = 0, stdout: str = "", stderr: str = "") -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(["tool"], returncode, stdout, stderr)
+
+
+@pytest.mark.parametrize(
+    ("function_name", "returncode", "stdout", "stderr", "message"),
+    [
+        ("_ruff_diagnostics", 2, "", "invalid config", "Ruff check failed"),
+        ("_ruff_diagnostics", 0, "[]", "warning", "Ruff check wrote to stderr"),
+        ("_ruff_diagnostics", 0, "not json", "", "malformed JSON"),
+        ("_ruff_diagnostics", 0, "{}", "", "not a list"),
+        ("_mypy_diagnostics", 2, "", "invalid config", "mypy failed"),
+        ("_mypy_diagnostics", 0, "", "warning", "mypy wrote to stderr"),
+        ("_mypy_diagnostics", 1, "mypy internal surprise", "", "unrecognized output"),
+    ],
+)
+def test_diagnostic_tools_fail_closed(
+    function_name: str,
+    returncode: int,
+    stdout: str,
+    stderr: str,
+    message: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (tmp_path / "sample.py").write_text("value = 1\n")
+    monkeypatch.setattr(checker, "_run", lambda *args, **kwargs: _result(returncode, stdout, stderr))
+
+    with pytest.raises(checker.StaticQualityError, match=message):
+        getattr(checker, function_name)(tmp_path, ["sample.py"], "tool")
+
+
+def test_ruff_rejects_malformed_diagnostic_schema(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    (tmp_path / "sample.py").write_text("value = 1\n")
+    monkeypatch.setattr(checker, "_run", lambda *args, **kwargs: _result(1, '[{"filename": "sample.py"}]'))
+
+    with pytest.raises(checker.StaticQualityError, match="invalid schema"):
+        checker._ruff_diagnostics(tmp_path, ["sample.py"], "ruff")
+
+
+def test_mypy_parses_errors_and_rejects_exit_output_mismatch(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    (tmp_path / "sample.py").write_text("value: str = 1\n")
+    output = (
+        "sample.py:1: error: Incompatible types in assignment  [assignment]\n"
+        'sample.py:1: note: expression has type "int"\n'
+        "Found 1 error in 1 file (checked 1 source file)\n"
+    )
+    monkeypatch.setattr(checker, "_run", lambda *args, **kwargs: _result(1, output))
+
+    diagnostics = checker._mypy_diagnostics(tmp_path, ["sample.py"], "mypy")
+    assert [(item.path, item.row, item.code, item.source) for item in diagnostics] == [
+        ("sample.py", 1, "assignment", "value: str = 1")
+    ]
+
+    monkeypatch.setattr(
+        checker, "_run", lambda *args, **kwargs: _result(1, "Success: no issues found in 1 source file\n")
+    )
+    with pytest.raises(checker.StaticQualityError, match="without parseable errors"):
+        checker._mypy_diagnostics(tmp_path, ["sample.py"], "mypy")
+
+
+@pytest.mark.parametrize(
+    ("result", "message"),
+    [
+        (_result(2, stderr="formatter crashed"), "Ruff formatter failed"),
+        (_result(0, stderr="config warning"), "Ruff formatter wrote to stderr"),
+        (_result(0, stdout="unexpected formatter output"), "malformed diff output"),
+    ],
+)
+def test_formatter_failures_are_terminal(
+    result: subprocess.CompletedProcess[str],
+    message: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(checker, "_run", lambda *args, **kwargs: result)
+    with pytest.raises(checker.StaticQualityError, match=message):
+        checker._format_hunks(tmp_path, ["sample.py"], "ruff")
+
+
+def test_formatter_hunks_use_current_tree_line_numbers(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    formatter_diff = """--- sample.py
++++ sample.py
+@@ -2,4 +2,7 @@
+-old
++new
+"""
+    monkeypatch.setattr(checker, "_run", lambda *args, **kwargs: _result(0, formatter_diff))
+
+    assert checker._format_hunks(tmp_path, ["sample.py"], "ruff") == [("sample.py", range(2, 9))]
+
+
+def test_baseline_comparison_tracks_source_across_line_moves() -> None:
+    baseline = checker.Diagnostic("sample.py", "E001", "problem", "bad()", 2)
+    moved = checker.Diagnostic("sample.py", "E001", "problem", "bad()", 20)
+    changed_source = checker.Diagnostic("sample.py", "E001", "problem", "worse()", 20)
+
+    assert checker._new_diagnostics(Counter([moved]), Counter([baseline])) == Counter()
+    assert checker._new_diagnostics(Counter([changed_source]), Counter([baseline])) == Counter([changed_source])
+    assert checker._on_changed_lines([moved], {"sample.py": [range(20, 21)]}) == Counter([moved])
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return result.stdout.strip()
+
+
+def test_divergent_baseline_uses_merge_base_for_diff_and_archive(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "tests@example.com")
+    _git(repo, "config", "user.name", "Tests")
+    (repo / "sample.py").write_text("base = 1\n")
+    _git(repo, "add", "sample.py")
+    _git(repo, "commit", "-qm", "base")
+    base = _git(repo, "rev-parse", "HEAD")
+
+    _git(repo, "branch", "baseline")
+    _git(repo, "checkout", "-q", "baseline")
+    (repo / "sample.py").write_text("baseline = 2\n")
+    _git(repo, "commit", "-qam", "baseline work")
+
+    _git(repo, "checkout", "-q", "-b", "feature", base)
+    (repo / "sample.py").write_text("feature = 3\n")
+    _git(repo, "commit", "-qam", "feature work")
+
+    merge_base = checker._merge_base(repo, "baseline")
+    assert merge_base == base
+    assert checker._changed_python_files(repo, merge_base) == ["sample.py"]
+
+    extracted = tmp_path / "extracted"
+    extracted.mkdir()
+    checker._extract_baseline(repo, merge_base, extracted)
+    assert (extracted / "sample.py").read_text() == "base = 1\n"
+    assert checker._added_line_ranges(repo, merge_base, ["sample.py"]) == {"sample.py": [range(1, 2)]}


### PR DESCRIPTION
## What

Fix ParseBench inference so image-backed PDF providers process every page in order instead of silently using only the first page.

This also fixes the inputs consumed by text evaluators: normalized Markdown now includes every source page in order, genuine blank pages remain explicit empty pages, and empty, malformed, or diagnostic provider responses are rejected instead of being treated as successful text. The branch also adds page-level retry and checkpoint handling, deterministic image ownership, provider-specific DPI selection, atomic document failure semantics, exhaustive provider classification checks, and a fail-closed static-quality delta gate.

## Why

Text Content and other text-based evaluations need complete, page-aligned Markdown. First-page-only output, silently partial documents, or diagnostic strings represented as successful output can produce misleading evaluation scores. At the same time, a genuinely blank page is valid document content and must not be confused with a missing or malformed response.

Retry ownership and resource-lifecycle inconsistencies could also replay billable work, leak page images, or return partially parsed documents.

## How

- Introduce a shared incremental multipage adapter for raster-backed providers.
- Render and infer one page at a time, then normalize page Markdown and layout data into source order.
- Preserve exact structured blank-page responses as empty pages with their original page identity.
- Reject missing, empty, malformed, or diagnostic text/layout responses before they reach evaluation.
- Refactor direct provider loops, including KDL, Infinity, Dots, PaddleOCR, Google, Textract, OpenAI, Anthropic, Amazon Nova, and local OCR providers.
- Bound retries at the failed page and prevent outer document replay after exhaustion.
- Close rendered and derived images deterministically.
- Validate every registered parse provider against an explicit runtime classification.
- Add focused provider, concurrency, retry-budget, ownership, checkpoint, normalization, blank-page, and failure-propagation tests.
- Add a pull-request static-quality delta workflow that rejects new Ruff, formatting, or mypy debt without conflating existing baseline debt.

## How to reproduce/test

From the repository root:

    uv sync --python 3.12 --extra dev --extra runners --frozen
    uv run --python 3.12 pytest
    uv run --python 3.12 python scripts/check_static_quality_delta.py --baseline origin/main
    git diff --check origin/main...HEAD

Expected results:

- 652 tests pass.
- Static-quality delta passes with no new Ruff, Ruff-format, or mypy issues.
- Diff check exits successfully.
