### PR TITLE
fix(evaluator): include italic/underline/mark in semantic_formatting scoring

### DIFF
--- a/src/parse_bench/evaluation/evaluators/parse.py
+++ b/src/parse_bench/evaluation/evaluators/parse.py
@@ -70,6 +70,23 @@ def _has_html_tables(content: str) -> bool:
 logger = logging.getLogger(__name__)
 
 
+# Positive/negative rule-type pairs that make up the text styling category.
+# This must cover every styling kind handled by FormattingRule; a kind that is
+# missing here is still scored into its own ``rule_<type>_pass_rate`` sub-metric
+# but is silently excluded from ``normalized_text_styling`` and therefore from
+# the ``semantic_formatting`` headline. ``mark_color`` is deliberately absent:
+# it is a colour-value assertion with no positive/negative counterpart.
+_TEXT_STYLING_PAIRS: list[tuple[str, str]] = [
+    ("is_bold", "is_not_bold"),
+    ("is_italic", "is_not_italic"),
+    ("is_underline", "is_not_underline"),
+    ("is_strikeout", "is_not_strikeout"),
+    ("is_mark", "is_not_mark"),
+    ("is_sup", "is_not_sup"),
+    ("is_sub", "is_not_sub"),
+]
+
+
 def _has_extract_field_bboxes(test_case: ExtractTestCase) -> bool:
     return any(rule.bboxes for rule in test_case.get_extract_field_rules())
 
@@ -348,14 +365,8 @@ class ParseEvaluator(BaseEvaluator):
 
                     # Normalized category scores: avg of per-type averages
                     # to reduce impact of docs with many rules of one type.
-                    # Text styling: bold, strikeout, sup, sub pairs.
+                    # Text styling: see _TEXT_STYLING_PAIRS at module level.
                     # A pair is included only if the positive rule exists for this doc.
-                    _TEXT_STYLING_PAIRS = [
-                        ("is_bold", "is_not_bold"),
-                        ("is_strikeout", "is_not_strikeout"),
-                        ("is_sup", "is_not_sup"),
-                        ("is_sub", "is_not_sub"),
-                    ]
                     _TEXT_STYLING_POS_TYPES: set[str] = set()
                     _TEXT_STYLING_NEG_TYPES: set[str] = set()
                     for pos, neg in _TEXT_STYLING_PAIRS:

--- a/tests/parse_bench/evaluation/evaluators/test_parse_text_styling_categories.py
+++ b/tests/parse_bench/evaluation/evaluators/test_parse_text_styling_categories.py
@@ -1,0 +1,117 @@
+"""Tests that every FormattingRule styling kind reaches the headline scores.
+
+``_TEXT_STYLING_PAIRS`` used to list only bold/strikeout/sup/sub, so
+``is_italic``, ``is_underline`` and ``is_mark`` rules were executed and
+reported as ``rule_<type>_pass_rate`` sub-metrics but never folded into
+``normalized_text_styling`` — and therefore never into ``semantic_formatting``.
+A pipeline scoring 0% on those three kinds got the same headline as one
+scoring 100%.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from parse_bench.evaluation.evaluators.parse import _TEXT_STYLING_PAIRS, ParseEvaluator
+from parse_bench.evaluation.metrics.parse.rules_formatting import FormattingRule
+from parse_bench.schemas.parse_output import ParseOutput
+from parse_bench.schemas.pipeline_io import InferenceRequest, InferenceResult
+from parse_bench.schemas.product import ProductType
+from parse_bench.test_cases.schema import ParseTestCase
+
+# Styled so that is_italic / is_underline / is_mark all pass.
+STYLED_MD = "The *alpha* and <u>beta</u> and <mark>gamma</mark> terms."
+# Same words, no markup: the same three rules all fail.
+PLAIN_MD = "The alpha and beta and gamma terms."
+
+STYLING_RULES = [
+    {"type": "is_italic", "text": "alpha"},
+    {"type": "is_underline", "text": "beta"},
+    {"type": "is_mark", "text": "gamma"},
+]
+
+
+def _evaluate(markdown: str, rules: list[dict[str, str]]) -> dict[str, float]:
+    """Run the rule-based evaluator and return metric_name -> value."""
+    evaluator = ParseEvaluator(
+        enable_rule_based=True,
+        enable_grits=False,
+        enable_structural_consistency=False,
+        enable_table_record_match=False,
+    )
+    test_case = ParseTestCase(
+        test_id="text_styling/doc",
+        group="text_styling",
+        file_path="doc.pdf",
+        test_rules=rules,  # type: ignore[arg-type]
+    )
+    request = InferenceRequest(
+        example_id="doc",
+        source_file_path="doc.pdf",
+        product_type=ProductType.PARSE,
+    )
+    now = datetime.now(UTC)
+    inference_result = InferenceResult(
+        request=request,
+        pipeline_name="test",
+        product_type=ProductType.PARSE,
+        raw_output={},
+        output=ParseOutput(example_id="doc", pipeline_name="test", markdown=markdown),
+        started_at=now,
+        completed_at=now,
+        latency_in_ms=0,
+    )
+    result = evaluator.evaluate(inference_result, test_case)
+    return {m.metric_name: m.value for m in result.metrics}
+
+
+class TestStylingPairsCoverage:
+    def test_pairs_cover_every_formatting_kind(self):
+        """Guards against a styling kind being added to FormattingRule but not scored."""
+        scored_kinds = {pos.removeprefix("is_") for pos, _ in _TEXT_STYLING_PAIRS}
+        assert scored_kinds == set(FormattingRule._FORMATTING_PATTERNS)
+
+    def test_pairs_are_well_formed(self):
+        for pos, neg in _TEXT_STYLING_PAIRS:
+            assert neg == pos.replace("is_", "is_not_", 1)
+
+
+class TestItalicUnderlineMarkAffectHeadline:
+    def test_styling_rules_produce_headline_metrics(self):
+        metrics = _evaluate(STYLED_MD, STYLING_RULES)
+        assert "normalized_text_styling" in metrics
+        assert "semantic_formatting" in metrics
+
+    def test_all_passing_scores_full(self):
+        metrics = _evaluate(STYLED_MD, STYLING_RULES)
+        assert metrics["normalized_text_styling"] == 1.0
+        assert metrics["semantic_formatting"] == 1.0
+
+    def test_all_failing_scores_zero(self):
+        metrics = _evaluate(PLAIN_MD, STYLING_RULES)
+        assert metrics["normalized_text_styling"] == 0.0
+        assert metrics["semantic_formatting"] == 0.0
+
+    def test_headline_separates_passing_from_failing(self):
+        """The regression itself: these two used to be indistinguishable."""
+        styled = _evaluate(STYLED_MD, STYLING_RULES)
+        plain = _evaluate(PLAIN_MD, STYLING_RULES)
+        assert styled["semantic_formatting"] > plain["semantic_formatting"]
+
+    def test_each_kind_contributes_individually(self):
+        """Failing any single kind must move the headline on its own."""
+        for rule in STYLING_RULES:
+            styled = _evaluate(STYLED_MD, [rule])
+            plain = _evaluate(PLAIN_MD, [rule])
+            assert styled["normalized_text_styling"] > plain["normalized_text_styling"], rule["type"]
+
+    def test_negative_rules_are_scored(self):
+        """is_not_* counterparts must also reach the headline."""
+        negative_rules = [
+            {"type": "is_not_italic", "text": "alpha"},
+            {"type": "is_not_underline", "text": "beta"},
+            {"type": "is_not_mark", "text": "gamma"},
+        ]
+        # Plain markdown satisfies the negative rules; styled markdown violates them.
+        assert _evaluate(PLAIN_MD, negative_rules)["normalized_text_styling"] == 1.0
+        assert _evaluate(STYLED_MD, negative_rules)["normalized_text_styling"] == 0.0


### PR DESCRIPTION
Fixes #101

## Problem

`_TEXT_STYLING_PAIRS` listed only four rule-type pairs — bold, strikeout, sup, sub — so
`is_italic`, `is_underline` and `is_mark` never reached the headline
`semantic_formatting` score.

The gap is easy to miss because those three types are fully wired up everywhere else:
they are annotated in the dataset, their matchers run, and their per-type sub-metrics
(`rule_is_underline_pass_rate` and friends) are emitted. Only the headline aggregation
skips them.

| type | rules in the dataset |
|---|---|
| `is_italic` | 655 |
| `is_underline` | 405 |
| `is_mark` | 88 |

Concretely: given source text with `*alpha*`, `<u>beta</u>` and `<mark>gamma</mark>`, a
parser that preserves all three emphasis spans and a parser that flattens them to plain
text received the **same** Semantic Formatting number.

## Fix

Add the three missing positive/negative pairs and lift `_TEXT_STYLING_PAIRS` to module
level so there is a single source of truth. They then flow through the existing
`pos_rules`/`neg_rules` → F_β → `normalized_text_styling` → `semantic_formatting` path,
with no change to the weighting or aggregation logic.

`mark_color` is deliberately left out: it asserts a colour value and has no
`is_not_mark_color` counterpart, so it does not fit the positive/negative pair structure
that the F_β combination relies on. It keeps its own `rule_mark_color_pass_rate`. Happy
to fold it in if you would rather it counted toward styling.

## Scoring impact

**`semantic_formatting` and `normalized_text_score` will change** for documents carrying
italic/underline/mark rules, so previously published leaderboard numbers are not
directly comparable to post-fix runs. That is the intent of the fix, but it likely wants
a release note.

## Tests

`tests/parse_bench/evaluation/evaluators/test_parse_text_styling_categories.py`:

- a coverage guard asserting `_TEXT_STYLING_PAIRS` covers every kind in
  `FormattingRule._FORMATTING_PATTERNS`, so a future styling type cannot silently skip
  the headline again
- per-kind assertions that italic/underline/mark each move `normalized_text_styling` and
  `semantic_formatting`
- negative-rule (`is_not_*`) coverage

Verified locally: the 8 new tests pass and the full `tests/parse_bench/evaluation/` suite
is 253 passed. Reverting just the three pairs makes 7 of the 8 new tests fail, so they
genuinely pin the behaviour rather than passing vacuously.
