### PR TITLE
Remove internal staging pipelines

### DIFF
--- a/src/parse_bench/inference/pipelines/extract.py
+++ b/src/parse_bench/inference/pipelines/extract.py
@@ -5,16 +5,6 @@ from typing import Any
 from parse_bench.schemas.pipeline import PipelineSpec
 from parse_bench.schemas.product import ProductType
 
-GRANULAR_BBOX_OUTPUT_OPTIONS = {
-    "granular_bboxes": ["word"],
-}
-LLAMAEXTRACT_V2_AGENTIC_HOSTED_GRANULAR_PARSE_CONFIG = {
-    "tier": "agentic",
-    "version": "latest",
-    "disable_cache": True,
-    "output_options": GRANULAR_BBOX_OUTPUT_OPTIONS,
-}
-
 
 def _pipeline_spec(
     *,
@@ -32,21 +22,6 @@ def _pipeline_spec(
 
 def register_extract_pipelines(register_fn) -> None:  # type: ignore[no-untyped-def]
     """Register the implementation-target extract pipelines."""
-
-    register_fn(
-        _pipeline_spec(
-            pipeline_name="llamaextract_v2_cost_effective_parse_agentic_granular_bboxes_staging",
-            provider_name="llamaextract_v2",
-            config={
-                "tier": "cost_effective",
-                "parse_tier": "agentic",
-                "use_staging": True,
-                "timeout": 3000,
-                "cite_sources": True,
-                "parse_config": LLAMAEXTRACT_V2_AGENTIC_HOSTED_GRANULAR_PARSE_CONFIG,
-            },
-        )
-    )
 
     register_fn(
         _pipeline_spec(

--- a/src/parse_bench/inference/pipelines/layout.py
+++ b/src/parse_bench/inference/pipelines/layout.py
@@ -140,27 +140,3 @@ def register_layout_pipelines(register_fn) -> None:  # type: ignore[no-untyped-d
             config={},  # Uses LAYOUT_V3_BYOC_GPU_URL env var or localhost:8002
         )
     )
-
-    # =========================================================================
-    # LlamaParse Staging Layout Detection (uses V3 labels)
-    # =========================================================================
-
-    register_fn(
-        PipelineSpec(
-            pipeline_name="staging_ours_agentic",
-            provider_name="llamaparse",
-            product_type=ProductType.LAYOUT_DETECTION,
-            config={
-                "use_staging": True,
-                "max_pages": 25,
-                "invalidate_cache": True,
-                "tier": "agentic",
-                "version": "latest",
-                "high_res_ocr": True,
-                "adaptive_long_table": True,
-                "outlined_table_extraction": True,
-                "output_tables_as_HTML": True,
-                "precise_bounding_box": True,
-            },
-        )
-    )

--- a/src/parse_bench/inference/pipelines/parse.py
+++ b/src/parse_bench/inference/pipelines/parse.py
@@ -62,23 +62,6 @@ def register_parse_pipelines(register_fn) -> None:  # type: ignore[no-untyped-de
         )
     )
 
-    register_fn(
-        PipelineSpec(
-            pipeline_name="llamaparse_agentic_granular_bboxes_staging",
-            provider_name="llamaparse",
-            product_type=ProductType.PARSE,
-            config={
-                "use_staging": True,
-                "tier": "agentic",
-                "version": "latest",
-                "disable_cache": True,
-                "output_options": {
-                    "granular_bboxes": ["word"],
-                },
-            },
-        )
-    )
-
     # =========================================================================
     # Extend AI Parse Pipelines
     # =========================================================================

--- a/tests/test_extract_integration.py
+++ b/tests/test_extract_integration.py
@@ -95,12 +95,12 @@ def test_extract_evaluator_emits_native_extract_metrics_only(tmp_path: Path) -> 
             product_type=ProductType.EXTRACT,
             schema_override=case.data_schema,
         ),
-        pipeline_name="llamaextract_v2_cost_effective_parse_agentic_granular_bboxes_staging",
+        pipeline_name="extend_extract",
         product_type=ProductType.EXTRACT,
         raw_output={"job_id": "ext-123", "parse_config_id": "cfg-123"},
         output=ExtractOutput(
             example_id="docs/payroll_7",
-            pipeline_name="llamaextract_v2_cost_effective_parse_agentic_granular_bboxes_staging",
+            pipeline_name="extend_extract",
             extracted_data={"invoice": {"number": "INV-001", "date": "May 1, 2026"}},
             field_citations=[
                 FieldCitation(field_path="invoice.number", page=1, bbox=[0.1, 0.2, 0.3, 0.1]),
@@ -199,12 +199,12 @@ def test_extract_evaluator_scores_filtered_verified_rules(tmp_path: Path) -> Non
             product_type=ProductType.EXTRACT,
             schema_override=case.data_schema,
         ),
-        pipeline_name="llamaextract_v2_cost_effective_parse_agentic_granular_bboxes_staging",
+        pipeline_name="extend_extract",
         product_type=ProductType.EXTRACT,
         raw_output={},
         output=ExtractOutput(
             example_id="docs/payroll_7",
-            pipeline_name="llamaextract_v2_cost_effective_parse_agentic_granular_bboxes_staging",
+            pipeline_name="extend_extract",
             extracted_data={"invoice": {"number": "INV-001", "date": "2026-05-01"}},
             field_citations=[
                 FieldCitation(field_path="invoice.number", page=1, bbox=[0.1, 0.2, 0.3, 0.1]),
@@ -280,28 +280,11 @@ def test_extract_avg_micro_aggregation() -> None:
 
 def test_requested_extract_pipelines_registered() -> None:
     extend_pipeline = get_pipeline("extend_extract")
-    llamaextract_pipeline = get_pipeline("llamaextract_v2_cost_effective_parse_agentic_granular_bboxes_staging")
-    parse_pipeline = get_pipeline("llamaparse_agentic_granular_bboxes_staging")
 
     assert isinstance(extend_pipeline, PipelineSpec)
     assert extend_pipeline.product_type == ProductType.EXTRACT
     assert extend_pipeline.provider_name == "extend"
     assert extend_pipeline.config["advancedOptions"]["citationsEnabled"] is True
-
-    assert llamaextract_pipeline.product_type == ProductType.EXTRACT
-    assert llamaextract_pipeline.provider_name == "llamaextract_v2"
-    assert llamaextract_pipeline.config["tier"] == "cost_effective"
-    assert llamaextract_pipeline.config["parse_tier"] == "agentic"
-    assert llamaextract_pipeline.config["use_staging"] is True
-    assert llamaextract_pipeline.config["cite_sources"] is True
-    assert llamaextract_pipeline.config["parse_config"]["disable_cache"] is True
-    assert llamaextract_pipeline.config["parse_config"]["output_options"]["granular_bboxes"] == ["word"]
-
-    assert parse_pipeline.product_type == ProductType.PARSE
-    assert parse_pipeline.provider_name == "llamaparse"
-    assert parse_pipeline.config["use_staging"] is True
-    assert parse_pipeline.config["tier"] == "agentic"
-    assert parse_pipeline.config["output_options"]["granular_bboxes"] == ["word"]
 
 
 def test_parse_evaluator_scores_extract_field_grounding_rules(tmp_path: Path) -> None:
@@ -327,7 +310,7 @@ def test_parse_evaluator_scores_extract_field_grounding_rules(tmp_path: Path) ->
             source_file_path=str(case.file_path),
             product_type=ProductType.PARSE,
         ),
-        pipeline_name="llamaparse_agentic_granular_bboxes_staging",
+        pipeline_name="llamaparse_agentic",
         product_type=ProductType.PARSE,
         raw_output={
             "v2_grounded_items": [
@@ -360,7 +343,7 @@ def test_parse_evaluator_scores_extract_field_grounding_rules(tmp_path: Path) ->
         },
         output=ParseOutput(
             example_id="docs/payroll_7",
-            pipeline_name="llamaparse_agentic_granular_bboxes_staging",
+            pipeline_name="llamaparse_agentic",
             markdown="Invoice INV-001",
         ),
         started_at=now,
@@ -417,7 +400,7 @@ def test_parse_evaluator_scores_filtered_verified_rules(tmp_path: Path) -> None:
             source_file_path=str(case.file_path),
             product_type=ProductType.PARSE,
         ),
-        pipeline_name="llamaparse_agentic_granular_bboxes_staging",
+        pipeline_name="llamaparse_agentic",
         product_type=ProductType.PARSE,
         raw_output={
             "v2_grounded_items": [
@@ -450,7 +433,7 @@ def test_parse_evaluator_scores_filtered_verified_rules(tmp_path: Path) -> None:
         },
         output=ParseOutput(
             example_id="docs/payroll_7",
-            pipeline_name="llamaparse_agentic_granular_bboxes_staging",
+            pipeline_name="llamaparse_agentic",
             markdown="Invoice INV-001",
         ),
         started_at=now,
@@ -504,12 +487,12 @@ def test_parallel_worker_respects_verified_only_flag(tmp_path: Path) -> None:
             product_type=ProductType.EXTRACT,
             schema_override=case.data_schema,
         ),
-        pipeline_name="llamaextract_v2_cost_effective_parse_agentic_granular_bboxes_staging",
+        pipeline_name="extend_extract",
         product_type=ProductType.EXTRACT,
         raw_output={},
         output=ExtractOutput(
             example_id="docs/payroll_7",
-            pipeline_name="llamaextract_v2_cost_effective_parse_agentic_granular_bboxes_staging",
+            pipeline_name="extend_extract",
             extracted_data={"invoice": {"number": "INV-001", "date": "2026-05-01"}},
             field_citations=[
                 FieldCitation(field_path="invoice.number", page=1, bbox=[0.1, 0.2, 0.3, 0.1]),


### PR DESCRIPTION
Removes the staging-only pipelines that should not be in the public repo:

- `llamaparse_agentic_granular_bboxes_staging` (parse)
- `llamaextract_v2_cost_effective_parse_agentic_granular_bboxes_staging` (extract)
- `staging_ours_agentic` (layout)

Tests in `test_extract_integration.py` that referenced these now use public pipeline names; the registration test checks `extend_extract` only. All 9 tests pass.