### PR TITLE
Add reducto_r1 parse pipeline and leaderboard entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ A **pipeline** is a document parsing tool or configuration that you want to eval
 | `google_docai_layout` | Google Cloud Document AI |
 | `reducto` | Reducto |
 | `reducto_agentic` | Reducto (Agentic) |
+| `reducto_r1` | Reducto (r-1) |
 | `extend_parse` | Extend |
 | `landingai_parse` | LandingAI |
 | `qwen3_5_4b_vllm_parse` | Qwen 3 VL |

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -132,6 +132,7 @@ These pipelines use hosted APIs. You only need an API key in your `.env` file.
 |---|---|---|
 | **`reducto`** | Default Reducto (In paper: *Reducto*) | `REDUCTO_API_KEY` |
 | **`reducto_agentic`** | Agentic mode (In paper: *Reducto (Agentic)*) | `REDUCTO_API_KEY` |
+| **`reducto_r1`** | r-1 model, `settings.model="r-1"` (In paper: *Reducto (r-1)*) | `REDUCTO_API_KEY` |
 
 ### Pulse
 

--- a/leaderboard.csv
+++ b/leaderboard.csv
@@ -39,6 +39,7 @@ Datalab Accurate,Commercial - Startup APIs,69.95,90.29,62.40,83.87,40.79,72.38,1
 Datalab Balanced,Commercial - Startup APIs,69.51,89.10,62.05,83.63,39.74,73.05,0.4,,,,,
 Datalab Fast,Commercial - Startup APIs,67.79,85.08,57.56,82.76,39.06,74.47,0.4,,,,,
 Reducto,Commercial - Startup APIs,67.83,70.33,56.99,86.37,56.75,68.71,2.38,3,1.7,2.1,2.5,
+Reducto (r-1),Commercial - Startup APIs,62.37,85.15,2.76,89.19,73.99,60.75,1,1,1,1,1,
 Pulse,Commercial - Startup APIs,65.59,82.01,39.62,82.76,51.99,71.56,1.5,,,,,
 Extend,Commercial - Startup APIs,55.75,85.05,1.59,84.08,47.36,60.67,2.5,,,,,
 Extend (2.0),Commercial - Startup APIs,75.33,84.82,78.31,84.59,60.31,68.61,2.5,,,,,

--- a/src/parse_bench/inference/pipelines/parse.py
+++ b/src/parse_bench/inference/pipelines/parse.py
@@ -1138,6 +1138,20 @@ def register_parse_pipelines(register_fn) -> None:  # type: ignore[no-untyped-de
         )
     )
 
+    register_fn(
+        PipelineSpec(
+            pipeline_name="reducto_r1",
+            provider_name="reducto",
+            product_type=ProductType.PARSE,
+            config={
+                "ocr_system": "standard",
+                "agentic": False,
+                "table_output_format": "html",
+                "model": "r-1",
+            },
+        )
+    )
+
     # =========================================================================
     # DeepSeek-OCR-2
     # =========================================================================

--- a/src/parse_bench/inference/providers/parse/reducto.py
+++ b/src/parse_bench/inference/providers/parse/reducto.py
@@ -81,6 +81,8 @@ class ReductoProvider(Provider):
               (default: [])
             - `advanced_chart_agent`: Enable advanced chart agent for figure agentic scope
               to convert charts/graphs to tabular format (default: False)
+            - `model`: Reducto parse model to select via ``settings.model`` (e.g. "r-1").
+              Omitted by default.
         """
         super().__init__(provider_name, base_config)
 
@@ -98,6 +100,7 @@ class ReductoProvider(Provider):
         self._table_output_format = self.base_config.get("table_output_format", "html")
         self._formatting_include = self.base_config.get("formatting_include", [])
         self._advanced_chart_agent = self.base_config.get("advanced_chart_agent", False)
+        self._model = self.base_config.get("model")
 
     def _is_pdf_file(self, file_path: str) -> bool:
         """
@@ -169,10 +172,12 @@ class ReductoProvider(Provider):
             if self._formatting_include:
                 formatting_config["include"] = self._formatting_include
 
-            settings_config = {
+            settings_config: dict[str, Any] = {
                 "ocr_system": self._ocr_system,
                 # Don't specify page_range - process all pages
             }
+            if self._model:
+                settings_config["model"] = self._model
 
             # Parse the document (run in executor since SDK is synchronous)
             # Build kwargs dynamically — only include enhance if non-empty,
@@ -225,6 +230,7 @@ class ReductoProvider(Provider):
                 "table_output_format": self._table_output_format,
                 "formatting_include": self._formatting_include,
                 "advanced_chart_agent": self._advanced_chart_agent,
+                "model": self._model,
                 "total_pages": num_pages,
             }
 


### PR DESCRIPTION
## What
Add a parse pipeline for Reducto's r-1 model (`reducto_r1`) and its leaderboard entry.

## Why
r-1 is Reducto's new document parsing model, priced all-in at 1¢/page with no agentic multiplier. The benchmark should cover it alongside the existing Reducto pipelines.

## How
- Add a `model` config knob to the Reducto parse provider: when set, it is forwarded into `settings.model`; omitting it keeps the legacy Parse path unchanged. The SDK forwards unknown settings keys verbatim, so this reaches the API without an SDK bump.
- Register `reducto_r1` (`provider_name="reducto"`, `model="r-1"`, agentic disabled, `ocr_system="standard"`, `table_output_format="html"`). r-1 rejects agentic scopes without a prompt and handles quality natively, so the pipeline runs it standalone.
- Add the extended-benchmark leaderboard row (Overall 62.37) and regenerate the README top-10; add the pipeline to the README and docs listings.

## Changes
- `src/parse_bench/inference/providers/parse/reducto.py`
- `src/parse_bench/inference/pipelines/parse.py`
- `leaderboard.csv`
- `README.md`
- `docs/pipelines.md`

## Testing
- `uv run parse-bench pipelines` lists `reducto_r1`.
- `uv run ruff check` passes on the changed source files.

## Notes
Requires `REDUCTO_API_KEY` (same as the other Reducto pipelines). Charts score is low (2.76) because standalone r-1 describes charts as text rather than extracting data points; advanced chart extraction remains available as a specialized augmentation but is out of scope here.
