### PR TITLE
2. Port evaluation-runner, aggregation and report fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,8 @@ with this version.
   tokens are priced. `parse-bench inference renormalize` re-prices saved runs via
   `Provider.recompute_cost` without re-running inference.
 - Leaderboard: the *LiteParse (no OCR)* row was re-run with LiteParse 2.14.3 and this release's scoring (overall 32.8 -> 36.9; visual grounding 10.7 -> 31.8 now that layout blocks are scored).
+- Aggregation: `micro_*` aggregates are emitted for standalone F1, accuracy and pass-rate
+  metrics; fractional `passed` counts are no longer dropped from `total_*` metrics.
 - `ParseTestCase` accepts layout and extract-field rules on `test_rules` and carries `metadata`.
 - Rule schemas and classes for `table_marker_cells`, `text_color`, `absent_unless_strikeout`,
   `present_as_strikeout`, `is_not_latex` and the extended `form_field` rule (`label` list,
@@ -81,7 +83,11 @@ with this version.
 - New pipelines: Reducto change-tracking / agentic table / agentic chart, GPT-5.4
   reasoning-none, Sonnet 5 parse-with-layout, Gemini 3.6 / 3.7 / 3.1 Flash Lite
   layout variants, Mistral OCR 4.1, Nemotron Omni vLLM, Qwen3.8 Flash Next.
-- `parse_bench_version` is recorded in `_metadata.json`.
+- Evaluation worker pool: a hung document is now killed and retried once instead of
+  blocking the run forever; `*.images/` artifact directories are skipped.
+- Comparison reports pick the primary metric from an ordered candidate chain and read
+  predictions from `layout_pages`; run labels keep their dataset suffix.
+- `parse_bench_version` is recorded in `_metadata.json` and `_evaluation_report.json`.
 - CI (lint, tests, wheel smoke test) and a tag-driven PyPI publish workflow.
 
 ### Changed

--- a/src/parse_bench/analysis/comparison.py
+++ b/src/parse_bench/analysis/comparison.py
@@ -32,12 +32,25 @@ class PipelineComparison:
         self.pipeline_b_dir = Path(pipeline_b_dir)
         self.test_cases_dir = Path(test_cases_dir) if test_cases_dir else None
 
-    # Metric mapping for different product types
-    METRIC_MAP: dict[str, str] = {
-        "extract": "accuracy",
-        "parse": "rule_pass_rate",
-        "layout_detection": "mAP@[.50:.95]",
+    # Ordered metric-name candidates per product type. The first name present
+    # in an evaluation result wins. Parse carries a fallback chain because
+    # layout-only parse runs (test cases with only ``LayoutTestRule`` entries)
+    # emit table-only metrics such as ``grits_trm_composite`` or layout-only
+    # metrics such as ``mAP@[.50:.95]`` instead of ``rule_pass_rate``.
+    #
+    # MUST stay in sync with
+    # ``comparison_core.py::COMPARISON_METRIC_CANDIDATES`` — enforced by
+    # ``tests/.../test_comparison_consistency.py``. ``rule_pass_rate`` is the
+    # canonical parse metric (pass/fail rule semantics from
+    # ``ParseEvaluator``); ``grits_trm_composite`` is the primary table-only
+    # parse metric. ``normalized_text_score`` is a secondary text-similarity
+    # signal and intentionally absent here.
+    METRIC_CANDIDATES: dict[str, tuple[str, ...]] = {
+        "extract": ("accuracy",),
+        "parse": ("rule_pass_rate", "grits_trm_composite", "mAP@[.50:.95]"),
+        "layout_detection": ("mAP@[.50:.95]",),
     }
+    DEFAULT_METRIC: str = "accuracy"
 
     def _detect_product_type(self, summary: EvaluationSummary) -> str:
         """Detect product type from evaluation results."""
@@ -60,8 +73,10 @@ class PipelineComparison:
         # Get the parent directory name (the run/experiment folder)
         parent_name = pipeline_dir.parent.name
 
-        # Try to extract a run ID pattern (e.g., run-21391181794)
-        run_id_match = re.search(r"run-(\d+)", parent_name)
+        # Try to extract a run ID pattern (e.g., run-21391181794). Matrix-leg
+        # dirs append a dataset suffix (run-<id>-<dataset-slug>) — keep it, or
+        # two legs of the same parent run would get identical labels.
+        run_id_match = re.search(r"run-(\d+(?:-[A-Za-z0-9._-]+)?)", parent_name)
         if run_id_match:
             return f"run-{run_id_match.group(1)}"
 
@@ -128,14 +143,34 @@ class PipelineComparison:
                 return metric.value
         return None
 
-    def _get_comparison_metric(self, eval_result: EvaluationResult, product_type: str) -> float | None:
-        """Get the primary comparison metric based on product type."""
-        target_metric = self.METRIC_MAP.get(product_type, "accuracy")
+    def _candidate_metric_names(self, product_type: str) -> tuple[str, ...]:
+        return self.METRIC_CANDIDATES.get(product_type, (self.DEFAULT_METRIC,))
 
-        for metric in eval_result.metrics:
-            if metric.metric_name == target_metric:
-                return metric.value
+    def _get_comparison_metric(self, eval_result: EvaluationResult, product_type: str) -> float | None:
+        """Return the first candidate metric emitted by ``eval_result``.
+
+        Parse emits ``rule_pass_rate`` *or* ``mAP@[.50:.95]`` depending on
+        whether the test case carries parse rules or only layout rules.
+        """
+        available = {m.metric_name: m.value for m in eval_result.metrics}
+        for name in self._candidate_metric_names(product_type):
+            if name in available:
+                return available[name]
         return None
+
+    def _resolve_comparison_metric_name(self, summary: EvaluationSummary, product_type: str) -> str:
+        """Pick the metric-name label used in stats/output headers.
+
+        Scans per-example results and returns the first candidate that at
+        least one example emitted; falls back to the first candidate so
+        empty summaries still get a sane label.
+        """
+        candidates = self._candidate_metric_names(product_type)
+        emitted = {m.metric_name for r in summary.per_example_results for m in r.metrics}
+        for name in candidates:
+            if name in emitted:
+                return name
+        return candidates[0]
 
     def _get_predictions(self, inference: InferenceResult | None) -> list[dict] | None:
         """Extract predictions as list of dicts for JSON serialization."""
@@ -195,7 +230,7 @@ class PipelineComparison:
 
         # Detect product type
         product_type = self._detect_product_type(summary_a)
-        comparison_metric = self.METRIC_MAP.get(product_type, "accuracy")
+        comparison_metric = self._resolve_comparison_metric_name(summary_a, product_type)
 
         # Create mapping of test_id -> EvaluationResult
         results_a = {r.test_id: r for r in summary_a.per_example_results}

--- a/src/parse_bench/analysis/comparison_core.py
+++ b/src/parse_bench/analysis/comparison_core.py
@@ -10,12 +10,25 @@ import re
 from pathlib import Path
 from typing import Any
 
-# Metric mapping for different product types
-COMPARISON_METRIC_MAP: dict[str, str] = {
-    "extract": "accuracy",
-    "parse": "normalized_text_score",
-    "layout_detection": "mAP@[.50:.95]",
+# Ordered metric-name candidates per product type. The first name present
+# in an evaluation result wins. Parse carries a fallback chain because
+# layout-only parse runs (test cases with only ``LayoutTestRule`` entries)
+# emit table-only metrics such as ``grits_trm_composite`` or layout-only
+# metrics such as ``mAP@[.50:.95]`` instead of ``rule_pass_rate``.
+#
+# MUST stay in sync with ``comparison.py::PipelineComparison.METRIC_CANDIDATES``
+# — enforced by ``tests/.../test_comparison_consistency.py``. The canonical
+# parse metric is ``rule_pass_rate`` (pass/fail rule semantics from
+# ``ParseEvaluator``). ``grits_trm_composite`` is the primary table-only parse
+# metric. ``normalized_text_score`` is a secondary text-similarity signal and
+# is intentionally NOT in the candidate list — when both are emitted for the
+# same run, we pick the definitive rule-based score.
+COMPARISON_METRIC_CANDIDATES: dict[str, tuple[str, ...]] = {
+    "extract": ("accuracy",),
+    "parse": ("rule_pass_rate", "grits_trm_composite", "mAP@[.50:.95]"),
+    "layout_detection": ("mAP@[.50:.95]",),
 }
+_DEFAULT_COMPARISON_METRIC = "accuracy"
 
 
 def load_evaluation_report(pipeline_path: Path) -> dict | None:
@@ -71,8 +84,10 @@ def get_directory_suffix(pipeline_dir: Path) -> str:
     """
     parent_name = pipeline_dir.parent.name
 
-    # Try to extract a run ID pattern (e.g., run-21391181794)
-    run_id_match = re.search(r"run-(\d+)", parent_name)
+    # Try to extract a run ID pattern (e.g., run-21391181794). Matrix-leg
+    # dirs append a dataset suffix (run-<id>-<dataset-slug>) — keep it, or
+    # two legs of the same parent run would get identical labels.
+    run_id_match = re.search(r"run-(\d+(?:-[A-Za-z0-9._-]+)?)", parent_name)
     if run_id_match:
         return f"run-{run_id_match.group(1)}"
 
@@ -94,23 +109,39 @@ def get_directory_suffix(pipeline_dir: Path) -> str:
 
 
 def get_predictions_from_inference(inference: dict | None) -> list[dict] | None:
-    """Extract predictions as list of dicts from inference result."""
+    """Extract layout predictions from an inference result as list of dicts.
+
+    Reads ``output.layout_pages[*].items``: each item's ``bbox`` is xywh pixel,
+    ``label`` (or falling back to ``item.type``) is the class name, and
+    ``score`` is detector confidence. Returns bboxes in ``[x1, y1, x2, y2]``
+    (xyxy) to match ``comparison.py::_get_predictions`` and the dashboard
+    overlay renderer, both of which consume xyxy. Returns ``None`` when no
+    layout items are present.
+    """
     if not inference:
         return None
     output = inference.get("output")
     if not output:
         return None
-    core_predictions = output.get("core_predictions")
-    if not core_predictions:
-        return None
-    return [
-        {
-            "bbox": p.get("bbox"),
-            "class": p.get("core_class"),
-            "score": p.get("score"),
-        }
-        for p in core_predictions
-    ]
+    layout_pages = output.get("layout_pages") or []
+    predictions: list[dict] = []
+    for page in layout_pages:
+        for item in page.get("items", []):
+            bbox = item.get("bbox")
+            if not bbox:
+                continue
+            x = float(bbox.get("x") or 0)
+            y = float(bbox.get("y") or 0)
+            w = float(bbox.get("w") or 0)
+            h = float(bbox.get("h") or 0)
+            predictions.append(
+                {
+                    "bbox": [x, y, x + w, y + h],
+                    "class": bbox.get("label") or item.get("type"),
+                    "score": item.get("score"),
+                }
+            )
+    return predictions or None
 
 
 def compare_pipelines(
@@ -157,7 +188,30 @@ def compare_pipelines(
         first_result = next(iter(results_a.values()))
         product_type = first_result.get("product_type", "extract").lower()
 
-    comparison_metric = COMPARISON_METRIC_MAP.get(product_type, "accuracy")
+    metric_candidates = COMPARISON_METRIC_CANDIDATES.get(product_type, (_DEFAULT_COMPARISON_METRIC,))
+
+    def _pick_metric(metrics_list: list) -> float | None:
+        """Return the first candidate metric value present in ``metrics_list``."""
+        by_name = {m.get("metric_name"): m.get("value") for m in metrics_list}
+        for name in metric_candidates:
+            if name in by_name:
+                return by_name[name]  # type: ignore[no-any-return]
+        return None
+
+    # Resolve the label for the comparison metric to whichever candidate was
+    # actually emitted across examples. Mirrors
+    # ``comparison.py::_resolve_comparison_metric_name``: scan all emitted
+    # metric names, pick the highest-priority candidate present, fall back
+    # to the first candidate for empty/no-match runs so an empty summary
+    # still gets a sane label. Without this, layout-only parse runs mislabel
+    # their ``mAP@[.50:.95]`` values as ``rule_pass_rate``.
+    emitted_names = {
+        m.get("metric_name") for result in (*results_a.values(), *results_b.values()) for m in result.get("metrics", [])
+    }
+    comparison_metric = next(
+        (name for name in metric_candidates if name in emitted_names),
+        metric_candidates[0],
+    )
 
     # Compare matched results
     matched_results: list[dict[str, Any]] = []
@@ -171,12 +225,14 @@ def compare_pipelines(
         result_b = results_b.get(test_id)
 
         if result_a and result_b:
-            # Both have results - compare
+            # Both have results - compare using the first fallback candidate
+            # that is emitted by this example (layout-only parse runs fall
+            # through to ``mAP@[.50:.95]``).
             metrics_a = result_a.get("metrics", [])
             metrics_b = result_b.get("metrics", [])
 
-            metric_a = get_metric_value(metrics_a, comparison_metric)
-            metric_b = get_metric_value(metrics_b, comparison_metric)
+            metric_a = _pick_metric(metrics_a)
+            metric_b = _pick_metric(metrics_b)
 
             # Load inference results for output data
             inference_a = load_inference_result(path_a, test_id)
@@ -223,6 +279,14 @@ def compare_pipelines(
                 output_b = inference_b.get("output", {}) if inference_b else {}
                 comparison["pipeline_a"]["output"] = output_a.get("markdown")
                 comparison["pipeline_b"]["output"] = output_b.get("markdown")
+                # Surface layout predictions (if any) so the dashboard can
+                # render the overlay view for layout-bearing parse runs.
+                predictions_a = get_predictions_from_inference(inference_a)
+                predictions_b = get_predictions_from_inference(inference_b)
+                if predictions_a or predictions_b:
+                    comparison["pipeline_a"]["predictions"] = predictions_a
+                    comparison["pipeline_b"]["predictions"] = predictions_b
+                    comparison["gt_annotations"] = None
 
             # Determine comparison category
             if metric_a is not None and metric_b is not None:

--- a/src/parse_bench/analysis/detailed_report.py
+++ b/src/parse_bench/analysis/detailed_report.py
@@ -1750,12 +1750,25 @@ function buildDetailPanel(ex) {
     var ruleMetrics = Object.keys(ex.ruleResults);
     if (ruleMetrics.length) {
         var totalRules = 0;
-        for (var r = 0; r < ruleMetrics.length; r++) { totalRules += ex.ruleResults[ruleMetrics[r]].length; }
+        var failedRules = 0;
+        for (var r = 0; r < ruleMetrics.length; r++) {
+            var metricRules = ex.ruleResults[ruleMetrics[r]];
+            totalRules += metricRules.length;
+            for (var fri = 0; fri < metricRules.length; fri++) {
+                if (metricRules[fri].status === 'fail' || metricRules[fri].passed === false) failedRules++;
+            }
+        }
         if (totalRules > 0) {
+            // Auto-expand when anything failed: the failures are what the
+            // reader opened the example to see.
+            var ruleOpenClass = failedRules > 0 ? ' open' : '';
+            var ruleSummary = failedRules > 0
+                ? '<span class="rule-fail">' + failedRules + ' failed</span> / ' + totalRules + ' rules'
+                : totalRules + ' rules';
             html += '<div class="detail-collapsible">' +
-                '<button class="detail-collapsible-toggle" onclick="event.stopPropagation();toggleCollapsible(this)">' +
-                '<span class="chevron">&#9654;</span> Rule Results (' + totalRules + ' rules)</button>' +
-                '<div class="detail-collapsible-body">';
+                '<button class="detail-collapsible-toggle' + ruleOpenClass + '" onclick="event.stopPropagation();toggleCollapsible(this)">' +
+                '<span class="chevron">&#9654;</span> Rule Results (' + ruleSummary + ')</button>' +
+                '<div class="detail-collapsible-body' + ruleOpenClass + '">';
             for (var r = 0; r < ruleMetrics.length; r++) {
                 var rmName = ruleMetrics[r];
                 var rules = ex.ruleResults[rmName];
@@ -1887,10 +1900,10 @@ window.savePdfBaseUrl = function() {
     }
 };
 
-window.loadPdf = function(testId, productType) {
-    var baseUrl = document.getElementById('pdf-base-url').value.replace(/\/+$/, '');
-    if (!baseUrl) return;
-    savePdfBaseUrl();
+function buildPdfDocumentUrl(baseUrl, testId) {
+    baseUrl = String(baseUrl || '').replace(/\/+$/, '');
+    testId = String(testId || '');
+    if (!baseUrl || !testId) return '';
     // Strip overlapping path segments between baseUrl and testId to avoid duplication
     // e.g. baseUrl="http://host/data/tables/v1" + testId="tables/v1/file" -> ".../data/tables/v1/file.pdf"
     var relPath = testId;
@@ -1904,12 +1917,20 @@ window.loadPdf = function(testId, productType) {
             break;
         }
     }
-    var url;
-    if (/^https?:\/\//i.test(baseUrl)) {
-        url = baseUrl + '/' + relPath.split('/').map(function(p) { return encodeURIComponent(p); }).join('/') + '.pdf';
-    } else {
-        url = baseUrl + '/' + relPath + '.pdf';
+    // Root-relative bases (e.g. "/files/data") are URLs too: a test id with
+    // spaces or unicode in it must be percent-encoded per segment just like
+    // it is for an absolute http(s) base.
+    if (/^https?:\/\//i.test(baseUrl) || baseUrl.charAt(0) === '/') {
+        return baseUrl + '/' + relPath.split('/').map(function(p) { return encodeURIComponent(p); }).join('/') + '.pdf';
     }
+    return baseUrl + '/' + relPath + '.pdf';
+}
+
+window.loadPdf = function(testId, productType) {
+    var baseUrl = document.getElementById('pdf-base-url').value;
+    var url = buildPdfDocumentUrl(baseUrl, testId);
+    if (!url) return;
+    savePdfBaseUrl();
     var wrap = document.getElementById('pdf-canvas-wrap');
     wrap.innerHTML = '<div class="pdf-placeholder">Loading PDF...</div>';
     document.getElementById('pdf-nav').style.display = 'none';

--- a/src/parse_bench/evaluation/cli.py
+++ b/src/parse_bench/evaluation/cli.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import fire
 
+from parse_bench import __version__
 from parse_bench.analysis.detailed_report import generate_detailed_html_report
 from parse_bench.evaluation.reports import (
     export_csv as export_csv_report,
@@ -113,7 +114,15 @@ class EvaluationCLI:
             # The metadata may have pipeline's default product_type, but the results
             # may have been produced with auto-detected product_type
             if product_type is None:
-                for result_file in output_dir_path.rglob("*.result.json"):
+                # Smallest file first: this sniff needs a single key, and a
+                # citation-heavy extract result can be ~1 GB of JSON.
+                def _result_file_size(path: Path) -> int:
+                    try:
+                        return path.stat().st_size
+                    except OSError:
+                        return 1 << 62
+
+                for result_file in sorted(output_dir_path.rglob("*.result.json"), key=_result_file_size):
                     try:
                         with open(result_file) as f:
                             result_data = json.load(f)
@@ -168,6 +177,7 @@ class EvaluationCLI:
                 max_workers=max_workers,
             )
             summary.completed_at = datetime.now()
+            summary.parse_bench_version = __version__
 
             # Save JSON report
             report_json_path = report_dir_path / "_evaluation_report.json"
@@ -202,15 +212,21 @@ class EvaluationCLI:
                 html_path = export_html_report(summary, report_dir_path)
                 print(f"🌐 HTML report exported to: {html_path.resolve()}")
 
-                detailed_html_path = generate_detailed_html_report(
-                    summary,
-                    report_dir_path,
-                    output_dir=output_dir_path,
-                    test_cases_dir=test_cases_dir_path,
-                    pipeline_name=pipeline_name,
-                    group=group,
-                )
-                print(f"🌐 Detailed HTML report exported to: {detailed_html_path.resolve()}")
+                # Detailed HTML reports are cosmetic explorers; never let a
+                # rendering failure (e.g. markdown2 recursion on pathological
+                # model output) fail the whole evaluation.
+                try:
+                    detailed_html_path = generate_detailed_html_report(
+                        summary,
+                        report_dir_path,
+                        output_dir=output_dir_path,
+                        test_cases_dir=test_cases_dir_path,
+                        pipeline_name=pipeline_name,
+                        group=group,
+                    )
+                    print(f"🌐 Detailed HTML report exported to: {detailed_html_path.resolve()}")
+                except Exception as e:
+                    print(f"⚠️  Skipped detailed HTML report (non-fatal): {e}", file=sys.stderr)
 
             return 0
 
@@ -332,14 +348,17 @@ class EvaluationCLI:
                 html_path = export_html_report(summary, report_dir_path)
                 print(f"  HTML: {html_path.resolve()}")
 
-                detailed_html_path = generate_detailed_html_report(
-                    summary,
-                    report_dir_path,
-                    output_dir=output_dir_path,
-                    test_cases_dir=test_cases_dir_path,
-                    pdf_base_url=pdf_base_url,
-                )
-                print(f"  Detailed HTML: {detailed_html_path.resolve()}")
+                try:
+                    detailed_html_path = generate_detailed_html_report(
+                        summary,
+                        report_dir_path,
+                        output_dir=output_dir_path,
+                        test_cases_dir=test_cases_dir_path,
+                        pdf_base_url=pdf_base_url,
+                    )
+                    print(f"  Detailed HTML: {detailed_html_path.resolve()}")
+                except Exception as e:
+                    print(f"⚠️  Skipped detailed HTML report (non-fatal): {e}", file=sys.stderr)
 
             print("\nDone!")
             return 0

--- a/src/parse_bench/evaluation/metric_aggregation.py
+++ b/src/parse_bench/evaluation/metric_aggregation.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Collection, Mapping, Sequence
 
 CountTriple = tuple[int, int, int]
 
@@ -10,33 +10,47 @@ CountTriple = tuple[int, int, int]
 def add_precision_recall_f1_aggregates(
     aggregate: dict[str, float],
     metric_counts: Mapping[str, Sequence[CountTriple]],
+    *,
+    counted_metric_names: Collection[str] = (),
 ) -> None:
-    """Add total TP/FP/FN and pooled micro precision/recall/F1 aggregates."""
-    summed_counts: dict[str, CountTriple] = {}
+    """Add total TP/FP/FN and pooled ``micro_*`` aggregates from tp/fp/fn metadata.
+
+    ``avg_*`` stays the document-weighted macro average; the pooled counters are
+    exposed through explicit ``micro_*`` keys. Each metric is pooled from its
+    own tp/fp/fn, so a standalone ``*_f1`` / ``*accuracy`` / ``*pass_rate``
+    metric gets a micro value even when the precision/recall/f1 trio is not
+    emitted together:
+
+    - ``*_precision`` -> tp / (tp + fp)
+    - ``*_recall``    -> tp / (tp + fn)
+    - ``*_f1``        -> harmonic mean of the two
+    - ``*accuracy`` and ``*pass_rate`` -> tp / (tp + fp + fn)
+
+    ``counted_metric_names`` lists metrics that already have a pooled
+    ``micro_*`` from ``passed``/``total`` metadata; their pass-rate micro is
+    left alone so the rule-count denominator wins over the tp/fp/fn one.
+    """
     for metric_name, counts in metric_counts.items():
         tp = sum(item[0] for item in counts)
         fp = sum(item[1] for item in counts)
         fn = sum(item[2] for item in counts)
-        summed_counts[metric_name] = (tp, fp, fn)
-        aggregate[f"total_{metric_name}_tp"] = float(tp)
-        aggregate[f"total_{metric_name}_fp"] = float(fp)
-        aggregate[f"total_{metric_name}_fn"] = float(fn)
-
-    for precision_metric, counts in summed_counts.items():
-        if not precision_metric.endswith("_precision"):
-            continue
-
-        metric_prefix = precision_metric[: -len("_precision")]
-        recall_metric = f"{metric_prefix}_recall"
-        f1_metric = f"{metric_prefix}_f1"
-        if recall_metric not in summed_counts or f1_metric not in summed_counts:
-            continue
-
-        tp, fp, fn = counts
         precision = tp / (tp + fp) if (tp + fp) > 0 else 0.0
         recall = tp / (tp + fn) if (tp + fn) > 0 else 0.0
         f1 = 2.0 * precision * recall / (precision + recall) if (precision + recall) > 0 else 0.0
-
-        aggregate[f"micro_{precision_metric}"] = precision
-        aggregate[f"micro_{recall_metric}"] = recall
-        aggregate[f"micro_{f1_metric}"] = f1
+        if metric_name == "precision" or metric_name.endswith("_precision"):
+            aggregate[f"micro_{metric_name}"] = precision
+        elif metric_name == "recall" or metric_name.endswith("_recall"):
+            aggregate[f"micro_{metric_name}"] = recall
+        elif metric_name == "f1" or metric_name.endswith("_f1"):
+            aggregate[f"micro_{metric_name}"] = f1
+        elif metric_name.endswith("accuracy"):
+            total = tp + fp + fn
+            if total > 0:
+                aggregate[f"micro_{metric_name}"] = tp / total
+        elif metric_name.endswith("pass_rate") and metric_name not in counted_metric_names:
+            total = tp + fp + fn
+            if total > 0:
+                aggregate[f"micro_{metric_name}"] = tp / total
+        aggregate[f"total_{metric_name}_tp"] = float(tp)
+        aggregate[f"total_{metric_name}_fp"] = float(fp)
+        aggregate[f"total_{metric_name}_fn"] = float(fn)

--- a/src/parse_bench/evaluation/runner.py
+++ b/src/parse_bench/evaluation/runner.py
@@ -7,13 +7,14 @@ import json
 import os
 import sys
 import unicodedata
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from concurrent.futures import (
+    FIRST_COMPLETED,
+    Future,
     ProcessPoolExecutor,
-    as_completed,
 )
 from concurrent.futures import (
-    TimeoutError as FuturesTimeoutError,
+    wait as futures_wait,
 )
 from datetime import datetime
 from pathlib import Path
@@ -314,6 +315,108 @@ def _scale_layout_output_coordinates(
     )
 
 
+# --- Eval pool stall handling -------------------------------------------------
+# Longest an eval batch may go with NOTHING completing before the collector gives
+# up on the workers still in flight. A hung worker cannot be cancelled once it is
+# running, so this is the only cap that exists: without it a single pathological
+# document (measured 2026-08-19: one document out of 411 stuck in a network wait
+# inside the LLM-judge calls, workers at ~0% CPU) holds the whole run open
+# indefinitely. Generous enough that a legitimately slow document is never cut
+# off while its peers keep finishing -- the window restarts on every completion,
+# so it only elapses when the pool has genuinely stopped making progress.
+_EVAL_WORKER_STALL_TIMEOUT_SECONDS = 8 * 60
+# Grace period for a SIGTERMed eval worker to die before we stop waiting on it.
+_EVAL_WORKER_KILL_JOIN_SECONDS = 5
+# ProcessPoolExecutor keeps its call queue pre-fed, so the tasks sitting in the
+# pipe behind a hung worker are already flagged RUNNING and are indistinguishable
+# from it in the parent -- a stall would zero-score up to a poolful of documents
+# that never actually ran. Give a timed-out task one more shot on the fresh pool
+# when there was queued work to blame; the genuinely hung one dies on the second
+# strike, so this is bounded and the batch always shrinks.
+_EVAL_WORKER_MAX_ATTEMPTS = 2
+
+
+def _drain_eval_futures(
+    futures: Iterable[Future],
+    timeout: float,
+    on_done: Callable[[Future], None],
+) -> tuple[set[Future], set[Future]]:
+    """Hand every finished future to ``on_done``, bailing out on a stalled pool.
+
+    Returns ``(timed_out, unstarted)``: the futures that were still *running*
+    when ``timeout`` seconds passed with nothing completing, and the ones that
+    had not started yet and were therefore cancelled cleanly. Both sets are
+    empty on the normal path, where every future is drained.
+
+    This is deliberately NOT ``for f in as_completed(futures): f.result(timeout=...)``
+    -- that idiom looks like a per-worker cap but is a no-op, because
+    ``as_completed`` only ever yields futures that are already done, so the
+    ``result()`` timeout can never elapse. ``wait(..., FIRST_COMPLETED)`` puts
+    the deadline where the blocking actually happens.
+
+    The window is measured from the last completion rather than from each task's
+    start, because a ProcessPool gives the parent no way to see when a queued
+    task begins running. Measuring it against progress is the conservative
+    reading: a slow document is only ever cut off once it is the thing holding
+    the batch up, and a task that is merely queued behind a hung one is never
+    mistaken for a hung task itself.
+    """
+    pending = set(futures)
+    while pending:
+        done, pending = futures_wait(pending, timeout=timeout, return_when=FIRST_COMPLETED)
+        for future in done:
+            on_done(future)
+        if not done:
+            # Nothing finished inside the window: the pool has stalled. Split
+            # what is left into "running (unreclaimable, give up on it)" and
+            # "never started (cancel and re-run on a fresh pool)". A future can
+            # still finish in the gap between the wait timing out and this
+            # sweep, so check for that first rather than failing a completed
+            # evaluation.
+            timed_out: set[Future] = set()
+            unstarted: set[Future] = set()
+            for future in pending:
+                if future.done():
+                    on_done(future)
+                elif future.cancel():
+                    unstarted.add(future)
+                else:
+                    timed_out.add(future)
+            return timed_out, unstarted
+    return set(), set()
+
+
+def _shutdown_eval_pool(executor: ProcessPoolExecutor, *, force: bool) -> None:
+    """Tear the eval pool down, killing stuck workers when ``force`` is set.
+
+    On the normal path this is just a blocking ``shutdown``. On the stall path a
+    blocking shutdown would re-create the very hang the timeout exists to escape
+    (``shutdown(wait=True)`` waits on the hung worker), and there is no public
+    API for evicting a running task -- so SIGTERM the worker processes and only
+    then wait. That breaks the executor, which is fine: the caller has already
+    cancelled everything still queued and re-submits it to a fresh pool.
+    """
+    if not force:
+        executor.shutdown(wait=True)
+        return
+    # Snapshot before shutdown; the executor drops its process map on teardown.
+    # Private attribute by necessity -- ProcessPoolExecutor exposes no way to
+    # reach its workers -- so tolerate it being absent or reshaped.
+    processes = list((getattr(executor, "_processes", None) or {}).values())
+    executor.shutdown(wait=False, cancel_futures=True)
+    for proc in processes:
+        try:
+            if proc.is_alive():
+                proc.terminate()
+        except (OSError, ValueError):  # already reaped
+            pass
+    for proc in processes:
+        try:
+            proc.join(timeout=_EVAL_WORKER_KILL_JOIN_SECONDS)
+        except (OSError, ValueError, AssertionError):
+            pass
+
+
 class EvaluationRunner:
     """
     Runs evaluation on saved inference results.
@@ -403,6 +506,12 @@ class EvaluationRunner:
         result_files = []
         # Look for .result.json files (normalized results)
         for result_file in output_dir.rglob("*.result.json"):
+            relative_parts = result_file.relative_to(output_dir).parts[:-1]
+            # Inline-image crop parsing writes its own normalized artifacts to
+            # ``<document>.images/``. They are dependencies of the parent Parse
+            # result, not benchmark examples, and must never enter evaluation.
+            if any(part.endswith(".images") for part in relative_parts):
+                continue
             result_files.append(result_file)
         return sorted(result_files)
 
@@ -1015,43 +1124,102 @@ class EvaluationRunner:
                         )
                     )
 
-                # Use ProcessPoolExecutor for true parallelism (bypasses GIL)
-                with ProcessPoolExecutor(max_workers=num_workers) as executor:
-                    # Submit all tasks
-                    futures = [executor.submit(_evaluate_single_worker, *task) for task in worker_tasks]
+                worker_timeout = _EVAL_WORKER_STALL_TIMEOUT_SECONDS
 
-                    # Per-worker timeout: 8 minutes per evaluation
-                    worker_timeout = 8 * 60
+                # Collect results as they complete
+                completed = 0
 
-                    # Collect results as they complete
-                    completed = 0
-                    for future in as_completed(futures):
-                        try:
-                            result_dict = future.result(timeout=worker_timeout)
-                            eval_result = EvaluationResult.model_validate(result_dict)
-                            evaluation_results.append(eval_result)
+                def _note_completed() -> None:
+                    """Advance the shared progress bar by one finished document."""
+                    nonlocal completed
+                    completed += 1
+                    if progress and total_task_id is not None:
+                        progress.update(total_task_id, completed=completed)  # type: ignore[arg-type]
 
-                            if eval_result.success:
-                                successful += 1
-                                log_progress(eval_result.test_id, "OK")
-                            elif _is_skipped_result(eval_result):
-                                skipped += 1
-                                log_progress(eval_result.test_id, "skipped (no layout data)")
-                            else:
-                                failed += 1
-                                log_progress(eval_result.test_id, "FAILED")
-                        except FuturesTimeoutError:
+                # (task, progress label, attempts so far). Consumed a batch at a
+                # time: a stalled pool is torn down and whatever it did not
+                # finish is re-submitted to a fresh one, so a hung document
+                # costs its own evaluation and nothing else's.
+                TaskEntry = tuple[tuple[Any, ...], str, int]
+                pending_tasks: list[TaskEntry] = [
+                    (task, str(task[1].get("test_id") or "unknown"), 0) for task in worker_tasks
+                ]
+                # Refilled per batch (cleared + updated, never reassigned, so the
+                # handler below closes over a stable mapping).
+                future_tasks: dict[Future, TaskEntry] = {}
+
+                def _handle_future(future: Future) -> None:
+                    nonlocal successful, failed, skipped
+                    try:
+                        result_dict = future.result()
+                        eval_result = EvaluationResult.model_validate(result_dict)
+                        evaluation_results.append(eval_result)
+
+                        if eval_result.success:
+                            successful += 1
+                            log_progress(eval_result.test_id, "OK")
+                        elif _is_skipped_result(eval_result):
+                            skipped += 1
+                            log_progress(eval_result.test_id, "skipped (no layout data)")
+                        else:
                             failed += 1
-                            log_progress("unknown", f"FAILED (worker timed out after {worker_timeout}s)")
-                        except Exception:
-                            # Worker process error
-                            failed += 1
-                            log_progress("unknown", "FAILED (worker error)")
+                            log_progress(eval_result.test_id, "FAILED")
+                    except Exception:
+                        # Worker process error
+                        failed += 1
+                        log_progress("unknown", "FAILED (worker error)")
 
-                        # Update progress (can't do this in worker due to separate processes)
-                        completed += 1
-                        if progress and total_task_id is not None:
-                            progress.update(total_task_id, completed=completed)  # type: ignore[arg-type]
+                    # Update progress (can't do this in worker due to separate processes)
+                    _note_completed()
+
+                def _fail_timed_out(entry: TaskEntry) -> None:
+                    nonlocal failed
+                    failed += 1
+                    log_progress(entry[1], f"FAILED (worker timed out after {worker_timeout}s)")
+                    _note_completed()
+
+                while pending_tasks:
+                    # Use ProcessPoolExecutor for true parallelism (bypasses GIL)
+                    executor = ProcessPoolExecutor(max_workers=num_workers)
+                    stalled = False
+                    try:
+                        # Submit all tasks
+                        futures = [
+                            executor.submit(_evaluate_single_worker, *task) for task, _label, _n in pending_tasks
+                        ]
+                        future_tasks.clear()
+                        future_tasks.update(zip(futures, pending_tasks, strict=True))
+
+                        timed_out, unstarted = _drain_eval_futures(futures, worker_timeout, _handle_future)
+                        stalled = bool(timed_out or unstarted)
+
+                        # Keep submission order so a retried batch behaves like
+                        # the original one.
+                        retry: list[TaskEntry] = []
+                        for future, entry in future_tasks.items():
+                            if future in unstarted:
+                                retry.append(entry)
+                            elif future in timed_out:
+                                entry_task, label, attempts = entry
+                                # Only worth a re-run if something was queued behind
+                                # this batch: that is the case where the pool's
+                                # pre-fed call queue makes a never-started task look
+                                # like a running one. With nothing queued, a RUNNING
+                                # future really was running, so blame it directly.
+                                if unstarted and attempts + 1 < _EVAL_WORKER_MAX_ATTEMPTS:
+                                    retry.append((entry_task, label, attempts + 1))
+                                else:
+                                    _fail_timed_out(entry)
+                        if not timed_out and len(retry) == len(future_tasks):
+                            # The batch stalled without a single task completing or
+                            # even starting -- a pool that never came up. Retrying
+                            # the identical batch would spin forever, so fail it.
+                            for entry in retry:
+                                _fail_timed_out(entry)
+                            retry = []
+                        pending_tasks = retry
+                    finally:
+                        _shutdown_eval_pool(executor, force=stalled)
 
             # Process QA evaluations concurrently
             if qa_evaluation_tasks:
@@ -1135,7 +1303,8 @@ class EvaluationRunner:
         # Collect all metric values by metric name
         metric_values: dict[str, list[float]] = {}
         # Also collect counts from metadata (for rules, etc.)
-        metric_counts: dict[str, list[tuple[int, int]]] = {}  # (passed, total) pairs
+        metric_counts: dict[str, list[tuple[float, float]]] = {}  # (score sum, denominator) pairs
+        metric_numerator_labels: dict[str, str] = {}
         metric_prf_counts: dict[str, list[tuple[int, int, int]]] = {}  # (tp, fp, fn) triples
         metric_score_sums: dict[str, list[tuple[float, float]]] = {}  # (score_sum, score_count)
         weighted_metric_values: dict[str, list[tuple[float, float]]] = {}  # (weighted_value, weight)
@@ -1184,8 +1353,16 @@ class EvaluationRunner:
                         metric_counts[metric.metric_name] = []
                     passed = metric.metadata.get("passed", 0)
                     total = metric.metadata.get("total", 0)
-                    if isinstance(passed, int) and isinstance(total, int):
-                        metric_counts[metric.metric_name].append((passed, total))
+                    if (
+                        isinstance(passed, int | float)
+                        and not isinstance(passed, bool)
+                        and isinstance(total, int | float)
+                        and not isinstance(total, bool)
+                    ):
+                        metric_counts[metric.metric_name].append((float(passed), float(total)))
+                        numerator_label = metric.metadata.get("numerator_label")
+                        if numerator_label in {"passed", "score"}:
+                            metric_numerator_labels[metric.metric_name] = numerator_label
 
                 if metric.metadata and "count" in metric.metadata:
                     count = metric.metadata.get("count")
@@ -1260,11 +1437,12 @@ class EvaluationRunner:
             total_passed = sum(passed for passed, _ in count_pairs)
             total_rules = sum(total for _, total in count_pairs)
             if total_rules > 0:
-                aggregate[f"total_{metric_name}_passed"] = float(total_passed)
+                numerator_label = metric_numerator_labels.get(metric_name, "passed")
+                aggregate[f"total_{metric_name}_{numerator_label}"] = float(total_passed)
                 aggregate[f"total_{metric_name}_evaluated"] = float(total_rules)
                 aggregate[f"micro_{metric_name}"] = total_passed / total_rules
 
-        add_precision_recall_f1_aggregates(aggregate, metric_prf_counts)
+        add_precision_recall_f1_aggregates(aggregate, metric_prf_counts, counted_metric_names=metric_counts)
 
         for metric_name, score_pairs in metric_score_sums.items():
             score_sum = sum(item[0] for item in score_pairs)

--- a/src/parse_bench/evaluation/stats.py
+++ b/src/parse_bench/evaluation/stats.py
@@ -1,11 +1,21 @@
 """Shared helper to build operational RunStat entries from an InferenceResult."""
 
+from __future__ import annotations
+
+import math
+from typing import Any
+
 from parse_bench.schemas.evaluation import RunStat
 from parse_bench.schemas.pipeline_io import InferenceResult
 
 # Stat keys to look for in raw_output, with their units
 _RAW_OUTPUT_STATS: list[tuple[str, str]] = [
     ("credits_used", "credits"),
+    ("credits_per_page", "credits/page"),
+    ("parse_credits", "credits"),
+    ("extract_credits", "credits"),
+    ("total_credits", "credits"),
+    ("num_pages_billed", "pages"),
     ("cost_usd", "$"),
     ("cost_per_page_usd", "$/page"),
     ("input_cost_usd", "$"),
@@ -13,19 +23,50 @@ _RAW_OUTPUT_STATS: list[tuple[str, str]] = [
     ("cached_input_cost_usd", "$"),
     ("output_and_thinking_cost_usd", "$"),
     ("cache_storage_cost_usd", "$"),
+    # Non-token charges from server-side tool use, and the cache-write term some
+    # model families bill separately. Without these the per-term cost breakdown
+    # under-sums against cost_usd — by roughly a third on a GPT-5.6 tool run,
+    # where the container fee plus cache writes carry that much of the bill.
+    ("cache_write_cost_usd", "$"),
+    ("container_cost_usd", "$"),
+    ("container_time_cost_usd", "$"),
+    ("tool_surcharge_usd", "$"),
+    ("token_cost_usd", "$"),
+    ("acu_content_extraction_cost_usd", "$"),
+    ("acu_contextualization_cost_usd", "$"),
     # Token metrics (when available from provider)
     ("input_tokens", "tokens"),
     ("tool_use_prompt_tokens", "tokens"),
     ("cached_content_tokens", "tokens"),
+    ("cache_write_tokens", "tokens"),
     ("output_tokens", "tokens"),
     ("total_tokens", "tokens"),
     ("thinking_tokens", "tokens"),
     ("num_api_calls", "calls"),
+    # A tool pipeline where the model never called the tool is otherwise
+    # indistinguishable in a report from one where it did.
+    ("num_tool_calls", "calls"),
+    ("num_containers", "containers"),
+    ("num_regions", "regions"),
     ("input_tokens_per_page", "tokens/page"),
     ("tool_use_prompt_tokens_per_page", "tokens/page"),
     ("cached_content_tokens_per_page", "tokens/page"),
     ("output_tokens_per_page", "tokens/page"),
 ]
+
+
+def is_valid_timing_stat(name: str, value: Any) -> bool:
+    """Whether a numeric timing stat is safe to aggregate.
+
+    Zero is a valid measured value (for example, an explicit no-op), whereas
+    ``None`` is used for unavailable timing.  Callers that derive a rate must
+    still guard against zero denominators separately.
+    """
+
+    del name  # The numeric validity rule applies to every timing stat name.
+    return (
+        isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(float(value)) and value >= 0
+    )
 
 
 def build_operational_stats(inference_result: InferenceResult) -> list[RunStat]:
@@ -38,19 +79,21 @@ def build_operational_stats(inference_result: InferenceResult) -> list[RunStat]:
     raw = inference_result.raw_output
 
     # Latency (from dedicated field)
-    if inference_result.latency_in_ms is not None:
-        stats.append(RunStat(name="latency_ms", value=float(inference_result.latency_in_ms), unit="ms"))
+    latency_ms = inference_result.latency_in_ms
+    if latency_ms is not None and is_valid_timing_stat("latency_ms", latency_ms):
+        stats.append(RunStat(name="latency_ms", value=float(latency_ms), unit="ms"))
 
-    # Per-page latency (computed from latency and num_pages)
-    num_pages = raw.get("num_pages")
-    if inference_result.latency_in_ms is not None and isinstance(num_pages, (int, float)) and num_pages > 0:
-        stats.append(
-            RunStat(
-                name="latency_ms_per_page",
-                value=float(inference_result.latency_in_ms) / float(num_pages),
-                unit="ms/page",
+        # Per-page latency (computed from latency and num_pages). A
+        # zero-duration job has a valid latency point but no meaningful rate.
+        num_pages = raw.get("num_pages")
+        if latency_ms > 0 and isinstance(num_pages, (int, float)) and not isinstance(num_pages, bool) and num_pages > 0:
+            stats.append(
+                RunStat(
+                    name="latency_ms_per_page",
+                    value=float(latency_ms) / float(num_pages),
+                    unit="ms/page",
+                )
             )
-        )
 
     # Cost and token stats (from raw_output, pre-computed by provider)
     for key, unit in _RAW_OUTPUT_STATS:

--- a/src/parse_bench/schemas/evaluation.py
+++ b/src/parse_bench/schemas/evaluation.py
@@ -72,6 +72,10 @@ class EvaluationSummary(BaseModel):
         default=None,
         description=("Confusion matrix for layout detection evaluations (computed during evaluation)"),
     )
+    parse_bench_version: str | None = Field(
+        default=None,
+        description="Version of parse-bench that produced this summary (for reproducibility)",
+    )
     started_at: datetime = Field(default_factory=datetime.now, description="When evaluation started")
     completed_at: datetime | None = Field(default=None, description="When evaluation completed")
     tag_metrics: dict[str, dict[str, float]] = Field(

--- a/tests/parse_bench/analysis/test_comparison_consistency.py
+++ b/tests/parse_bench/analysis/test_comparison_consistency.py
@@ -1,0 +1,73 @@
+"""The two comparison entry points must agree on the primary-metric chain.
+
+``comparison.py`` (Pydantic-backed, used by the CLI) and ``comparison_core.py``
+(dependency-free, used by the dashboard) each carry a per-product-type
+candidate list; a drift between them would make the CLI and the dashboard
+crown different winners for the same pair of runs.
+"""
+
+from __future__ import annotations
+
+from parse_bench.analysis.comparison import PipelineComparison
+from parse_bench.analysis.comparison_core import COMPARISON_METRIC_CANDIDATES
+from parse_bench.schemas.evaluation import EvaluationResult, EvaluationSummary, MetricValue
+
+
+def test_candidate_chains_are_identical() -> None:
+    assert PipelineComparison.METRIC_CANDIDATES == COMPARISON_METRIC_CANDIDATES
+
+
+def test_parse_chain_starts_with_rule_pass_rate_and_excludes_text_score() -> None:
+    parse_chain = COMPARISON_METRIC_CANDIDATES["parse"]
+    assert parse_chain[0] == "rule_pass_rate"
+    assert "grits_trm_composite" in parse_chain
+    assert "mAP@[.50:.95]" in parse_chain
+    assert "normalized_text_score" not in parse_chain
+    assert "form_composite" not in parse_chain
+
+
+def _result(test_id: str, metrics: dict[str, float]) -> EvaluationResult:
+    return EvaluationResult(
+        test_id=test_id,
+        example_id=test_id,
+        pipeline_name="p",
+        product_type="parse",
+        success=True,
+        metrics=[MetricValue(metric_name=k, value=v) for k, v in metrics.items()],
+    )
+
+
+def _summary(results: list[EvaluationResult]) -> EvaluationSummary:
+    return EvaluationSummary(
+        total_examples=len(results),
+        successful=len(results),
+        failed=0,
+        skipped=0,
+        aggregate_metrics={},
+        per_example_results=results,
+    )
+
+
+def test_pipeline_comparison_falls_through_the_chain_per_example() -> None:
+    comparison = PipelineComparison.__new__(PipelineComparison)
+    layout_only = _result("a", {"mAP@[.50:.95]": 0.4, "normalized_text_score": 0.9})
+    rules = _result("b", {"rule_pass_rate": 0.7, "mAP@[.50:.95]": 0.1})
+
+    assert comparison._get_comparison_metric(layout_only, "parse") == 0.4
+    assert comparison._get_comparison_metric(rules, "parse") == 0.7
+    assert comparison._get_comparison_metric(_result("c", {"normalized_text_score": 0.5}), "parse") is None
+
+
+def test_pipeline_comparison_label_matches_the_metric_actually_emitted() -> None:
+    comparison = PipelineComparison.__new__(PipelineComparison)
+
+    layout_only = _summary([_result("a", {"mAP@[.50:.95]": 0.4})])
+    assert comparison._resolve_comparison_metric_name(layout_only, "parse") == "mAP@[.50:.95]"
+
+    mixed = _summary([_result("a", {"mAP@[.50:.95]": 0.4}), _result("b", {"rule_pass_rate": 0.7})])
+    assert comparison._resolve_comparison_metric_name(mixed, "parse") == "rule_pass_rate"
+
+    # Empty summaries still get a sane label.
+    assert comparison._resolve_comparison_metric_name(_summary([]), "parse") == "rule_pass_rate"
+    assert comparison._resolve_comparison_metric_name(_summary([]), "layout_detection") == "mAP@[.50:.95]"
+    assert comparison._resolve_comparison_metric_name(_summary([]), "unknown") == "accuracy"

--- a/tests/parse_bench/analysis/test_comparison_core.py
+++ b/tests/parse_bench/analysis/test_comparison_core.py
@@ -1,0 +1,256 @@
+"""Tests for analysis.comparison_core helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from parse_bench.analysis.comparison_core import (
+    compare_pipelines,
+    get_predictions_from_inference,
+)
+
+
+def test_get_predictions_from_inference_returns_xyxy_bbox() -> None:
+    """Bboxes in ``output.layout_pages`` are xywh pixel; the helper must return
+    xyxy so the dashboard overlay (which consumes ``bbox[2]-bbox[0]``) and
+    ``comparison.py::_get_predictions`` agree."""
+    inference = {
+        "output": {
+            "layout_pages": [
+                {
+                    "page_number": 1,
+                    "items": [
+                        {
+                            "type": "Title",
+                            "score": 0.9,
+                            "bbox": {
+                                "x": 10.0,
+                                "y": 20.0,
+                                "w": 30.0,
+                                "h": 40.0,
+                                "label": "Title",
+                            },
+                        }
+                    ],
+                }
+            ]
+        }
+    }
+
+    predictions = get_predictions_from_inference(inference)
+    assert predictions is not None
+    assert len(predictions) == 1
+    pred = predictions[0]
+    # xyxy: [x, y, x + w, y + h] = [10, 20, 40, 60]
+    assert pred["bbox"] == [10.0, 20.0, 40.0, 60.0]
+    assert pred["class"] == "Title"
+    assert pred["score"] == 0.9
+
+
+def test_get_predictions_from_inference_handles_missing_bbox() -> None:
+    """Items without a ``bbox`` are skipped."""
+    inference = {
+        "output": {
+            "layout_pages": [
+                {
+                    "page_number": 1,
+                    "items": [
+                        {"type": "Text", "bbox": None},
+                        {"type": "Text"},
+                    ],
+                }
+            ]
+        }
+    }
+    assert get_predictions_from_inference(inference) is None
+
+
+def test_get_predictions_from_inference_returns_none_when_empty() -> None:
+    """No layout_pages -> None (not an empty list)."""
+    assert get_predictions_from_inference(None) is None
+    assert get_predictions_from_inference({}) is None
+    assert get_predictions_from_inference({"output": {}}) is None
+    assert get_predictions_from_inference({"output": {"layout_pages": []}}) is None
+
+
+def test_get_predictions_from_inference_falls_back_to_item_type() -> None:
+    """When bbox has no ``label``, ``class`` falls back to ``item.type``."""
+    inference = {
+        "output": {
+            "layout_pages": [
+                {
+                    "page_number": 1,
+                    "items": [
+                        {
+                            "type": "Picture",
+                            "bbox": {"x": 0.0, "y": 0.0, "w": 5.0, "h": 5.0},
+                        }
+                    ],
+                }
+            ]
+        }
+    }
+    predictions = get_predictions_from_inference(inference)
+    assert predictions is not None
+    assert predictions[0]["class"] == "Picture"
+    assert predictions[0]["bbox"] == [0.0, 0.0, 5.0, 5.0]
+
+
+def _write_eval_report(
+    pipeline_dir: Path,
+    pipeline_name: str,
+    per_example: list[dict],
+) -> None:
+    """Write a minimal ``_evaluation_report.json`` to ``pipeline_dir``."""
+    pipeline_dir.mkdir(parents=True, exist_ok=True)
+    report = {
+        "total_examples": len(per_example),
+        "successful": len(per_example),
+        "failed": 0,
+        "skipped": 0,
+        "aggregate_metrics": {},
+        "per_example_results": [
+            {
+                "test_id": ex["test_id"],
+                "example_id": ex["test_id"],
+                "pipeline_name": pipeline_name,
+                "product_type": "parse",
+                "success": True,
+                "metrics": ex["metrics"],
+                "error": None,
+                "stats": [],
+                "tags": [],
+            }
+            for ex in per_example
+        ],
+    }
+    (pipeline_dir / "_evaluation_report.json").write_text(json.dumps(report))
+
+
+def test_comparison_metric_label_reflects_picked_metric_not_first_candidate(
+    tmp_path: Path,
+) -> None:
+    """For a layout-only parse run, only ``mAP@[.50:.95]`` is emitted; the
+    dashboard label must reflect that instead of the first candidate."""
+    path_a = tmp_path / "pipeline_a"
+    path_b = tmp_path / "pipeline_b"
+    _write_eval_report(
+        path_a,
+        "pipeline_a",
+        [{"test_id": "grp/doc1", "metrics": [{"metric_name": "mAP@[.50:.95]", "value": 0.42}]}],
+    )
+    _write_eval_report(
+        path_b,
+        "pipeline_b",
+        [{"test_id": "grp/doc1", "metrics": [{"metric_name": "mAP@[.50:.95]", "value": 0.55}]}],
+    )
+
+    result = compare_pipelines(path_a, path_b)
+
+    assert result["comparison_metric"] == "mAP@[.50:.95]"
+    assert result["stats"]["comparison_metric"] == "mAP@[.50:.95]"
+    # And the actual values must come from the picked metric, so category
+    # reflects the mAP comparison.
+    assert result["matched_results"][0]["category"] == "b_better"
+
+
+def test_comparison_metric_uses_table_metric_for_table_only_parse_runs(
+    tmp_path: Path,
+) -> None:
+    """Table-only parse reports emit ``grits_trm_composite`` but no
+    ``rule_pass_rate``; the dashboard should not classify every row as N/A."""
+    path_a = tmp_path / "pipeline_a"
+    path_b = tmp_path / "pipeline_b"
+    _write_eval_report(
+        path_a,
+        "pipeline_a",
+        [{"test_id": "grp/table1", "metrics": [{"metric_name": "grits_trm_composite", "value": 0.99}]}],
+    )
+    _write_eval_report(
+        path_b,
+        "pipeline_b",
+        [{"test_id": "grp/table1", "metrics": [{"metric_name": "grits_trm_composite", "value": 0.25}]}],
+    )
+
+    result = compare_pipelines(path_a, path_b)
+
+    assert result["comparison_metric"] == "grits_trm_composite"
+    assert result["stats"]["comparison_metric"] == "grits_trm_composite"
+    assert result["matched_results"][0]["category"] == "a_better"
+
+
+def test_comparison_metric_prefers_rule_pass_rate_over_normalized_text_score(
+    tmp_path: Path,
+) -> None:
+    """``normalized_text_score`` is a secondary signal; when both are emitted
+    the rule-based score decides the comparison."""
+    path_a = tmp_path / "pipeline_a"
+    path_b = tmp_path / "pipeline_b"
+    _write_eval_report(
+        path_a,
+        "pipeline_a",
+        [
+            {
+                "test_id": "grp/doc1",
+                "metrics": [
+                    {"metric_name": "normalized_text_score", "value": 0.9},
+                    {"metric_name": "rule_pass_rate", "value": 0.2},
+                ],
+            }
+        ],
+    )
+    _write_eval_report(
+        path_b,
+        "pipeline_b",
+        [
+            {
+                "test_id": "grp/doc1",
+                "metrics": [
+                    {"metric_name": "normalized_text_score", "value": 0.1},
+                    {"metric_name": "rule_pass_rate", "value": 0.8},
+                ],
+            }
+        ],
+    )
+
+    result = compare_pipelines(path_a, path_b)
+
+    assert result["comparison_metric"] == "rule_pass_rate"
+    assert result["matched_results"][0]["category"] == "b_better"
+
+
+def test_comparison_metric_label_prefers_higher_priority_when_mixed(
+    tmp_path: Path,
+) -> None:
+    """When examples emit different candidates (one has ``rule_pass_rate``,
+    another only ``mAP@[.50:.95]``), the label picks the highest-priority
+    candidate actually seen — matching ``comparison.py::_resolve_comparison_metric_name``."""
+    path_a = tmp_path / "pipeline_a"
+    path_b = tmp_path / "pipeline_b"
+    _write_eval_report(
+        path_a,
+        "pipeline_a",
+        [
+            {"test_id": "grp/doc_rules", "metrics": [{"metric_name": "rule_pass_rate", "value": 0.8}]},
+            {"test_id": "grp/doc_layout", "metrics": [{"metric_name": "mAP@[.50:.95]", "value": 0.3}]},
+        ],
+    )
+    _write_eval_report(
+        path_b,
+        "pipeline_b",
+        [
+            {"test_id": "grp/doc_rules", "metrics": [{"metric_name": "rule_pass_rate", "value": 0.6}]},
+            {"test_id": "grp/doc_layout", "metrics": [{"metric_name": "mAP@[.50:.95]", "value": 0.4}]},
+        ],
+    )
+
+    result = compare_pipelines(path_a, path_b)
+
+    # rule_pass_rate ranks ahead of mAP@[.50:.95] in the parse candidate
+    # chain, so it wins even though some examples only emit mAP.
+    assert result["comparison_metric"] == "rule_pass_rate"
+    assert result["stats"]["comparison_metric"] == "rule_pass_rate"
+    # Every example is still compared on whatever it emitted -- no "no data" bucket.
+    categories = {r["test_id"]: r["category"] for r in result["matched_results"]}
+    assert categories == {"grp/doc_rules": "a_better", "grp/doc_layout": "b_better"}

--- a/tests/parse_bench/analysis/test_comparison_directory_suffix.py
+++ b/tests/parse_bench/analysis/test_comparison_directory_suffix.py
@@ -1,0 +1,52 @@
+"""Tests for comparison-report distinguishing labels on suffixed run dirs.
+
+CI composes matrix-leg results dirs as ``run-<gh_run_id>-<dataset-slug>``.
+The directory-suffix label must keep the dataset discriminator — two legs of
+the same parent run would otherwise get identical "distinguishing" labels.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from parse_bench.analysis.comparison import PipelineComparison
+from parse_bench.analysis.comparison_core import get_directory_suffix
+
+CASES = [
+    # Plain run dir — unchanged
+    ("output/run-21391181794/llamaparse_agentic", "run-21391181794"),
+    # Embedded run id with surrounding text — unchanged
+    ("output/financial_tables_run-21391181794/llamaparse_agentic", "run-21391181794"),
+    # Matrix-leg run dir — must keep the dataset discriminator
+    (
+        "results/2026-06-13/run-27055588807-tables_extended-v0.8/llamaparse_agentic",
+        "run-27055588807-tables_extended-v0.8",
+    ),
+    (
+        "results/2026-06-13/run-27055588807-charts_extended-v1.0/llamaparse_agentic",
+        "run-27055588807-charts_extended-v1.0",
+    ),
+    # Date fallback — unchanged
+    ("output/2025-01-27/llamaparse_agentic", "2025-01-27"),
+    # Parent-name fallback — unchanged
+    ("output/experiment_v2/llamaparse_agentic", "experiment_v2"),
+]
+
+
+@pytest.mark.parametrize(("pipeline_dir", "expected"), CASES)
+def test_core_get_directory_suffix(pipeline_dir: str, expected: str) -> None:
+    assert get_directory_suffix(Path(pipeline_dir)) == expected
+
+
+@pytest.mark.parametrize(("pipeline_dir", "expected"), CASES)
+def test_report_get_directory_suffix(pipeline_dir: str, expected: str) -> None:
+    comparison = PipelineComparison.__new__(PipelineComparison)  # suffix helper needs no init state
+    assert comparison._get_directory_suffix(Path(pipeline_dir)) == expected
+
+
+def test_sibling_matrix_legs_get_distinct_labels() -> None:
+    a = Path("results/2026-06-13/run-27055588807-tables_extended-v0.8/llamaparse_agentic")
+    b = Path("results/2026-06-13/run-27055588807-charts_extended-v1.0/llamaparse_agentic")
+    assert get_directory_suffix(a) != get_directory_suffix(b)

--- a/tests/parse_bench/analysis/test_detailed_report.py
+++ b/tests/parse_bench/analysis/test_detailed_report.py
@@ -1,0 +1,81 @@
+"""Detailed HTML report: the embedded viewer script."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from parse_bench.analysis.detailed_report import generate_detailed_html_report
+from parse_bench.schemas.evaluation import EvaluationResult, EvaluationSummary, MetricValue
+
+
+def _summary() -> EvaluationSummary:
+    return EvaluationSummary(
+        total_examples=1,
+        successful=1,
+        failed=0,
+        skipped=0,
+        aggregate_metrics={"avg_rule_pass_rate": 0.5, "min_rule_pass_rate": 0.5, "max_rule_pass_rate": 0.5},
+        per_example_results=[
+            EvaluationResult(
+                test_id="group/doc with spaces",
+                example_id="group/doc with spaces",
+                pipeline_name="p",
+                product_type="parse",
+                success=True,
+                metrics=[
+                    MetricValue(
+                        metric_name="rule_pass_rate",
+                        value=0.5,
+                        metadata={
+                            "passed": 1,
+                            "total": 2,
+                            "rule_results": [
+                                {"type": "text_presence", "id": "r1", "passed": True, "message": "ok"},
+                                {"type": "text_presence", "id": "r2", "passed": False, "message": "missing"},
+                            ],
+                        },
+                    )
+                ],
+            )
+        ],
+    )
+
+
+def _render(tmp_path: Path, **kwargs: object) -> str:
+    report_dir = tmp_path / "report"
+    report_dir.mkdir(exist_ok=True)
+    path = generate_detailed_html_report(_summary(), report_dir, test_cases_dir=tmp_path / "cases", **kwargs)  # type: ignore[arg-type]
+    return path.read_text(encoding="utf-8")
+
+
+def test_pdf_url_builder_encodes_root_relative_bases(tmp_path: Path) -> None:
+    """Only ``http(s)://`` bases used to be percent-encoded; a root-relative
+    ``/files/...`` base with spaces or unicode in the test id produced a broken
+    PDF URL. Both forms now go through ``buildPdfDocumentUrl``."""
+    html = _render(tmp_path, pdf_base_url="/files/data")
+
+    assert "function buildPdfDocumentUrl(baseUrl, testId)" in html
+    builder = html[html.index("function buildPdfDocumentUrl") :]
+    builder = builder[: builder.index("window.loadPdf")]
+    assert re.search(r"/\^https\?:\\/\\//i\.test\(baseUrl\) \|\| baseUrl\.charAt\(0\) === '/'", builder)
+    assert "encodeURIComponent" in builder
+    # loadPdf delegates instead of carrying its own copy of the logic.
+    load_pdf = html[html.index("window.loadPdf = function") :]
+    load_pdf = load_pdf[: load_pdf.index("function doLoadPdf")]
+    assert "buildPdfDocumentUrl(baseUrl, testId)" in load_pdf
+    assert "encodeURIComponent" not in load_pdf
+
+
+def test_rule_results_panel_reports_failed_count_and_auto_expands(tmp_path: Path) -> None:
+    """The panel used to render collapsed with a bare rule count; readers open
+    an example to see the failures, so it now says ``N failed / M rules`` and
+    starts expanded whenever anything failed."""
+    html = _render(tmp_path)
+
+    assert "failedRules" in html
+    assert "' failed</span> / ' + totalRules + ' rules'" in html
+    assert "var ruleOpenClass = failedRules > 0 ? ' open' : '';" in html
+    assert "'<div class=\"detail-collapsible-body' + ruleOpenClass + '\">'" in html
+    # Both the boolean and the tri-state shapes count as a failure.
+    assert "metricRules[fri].status === 'fail' || metricRules[fri].passed === false" in html

--- a/tests/parse_bench/evaluation/test_cli_detailed_report_nonfatal.py
+++ b/tests/parse_bench/evaluation/test_cli_detailed_report_nonfatal.py
@@ -1,0 +1,57 @@
+"""A detailed-HTML rendering failure must never fail the whole evaluation command."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from parse_bench.evaluation import cli as cli_mod
+from parse_bench.schemas.evaluation import EvaluationResult, EvaluationSummary, MetricValue
+
+
+def _write_summary(evaluation_dir: Path) -> None:
+    summary = EvaluationSummary(
+        total_examples=1,
+        successful=1,
+        failed=0,
+        skipped=0,
+        aggregate_metrics={"avg_rule_pass_rate": 0.5},
+        per_example_results=[
+            EvaluationResult(
+                test_id="g/doc",
+                example_id="g/doc",
+                pipeline_name="p",
+                product_type="parse",
+                success=True,
+                metrics=[MetricValue(metric_name="rule_pass_rate", value=0.5)],
+            )
+        ],
+    )
+    evaluation_dir.mkdir(parents=True, exist_ok=True)
+    (evaluation_dir / "_evaluation_report.json").write_text(summary.model_dump_json(indent=2))
+
+
+def test_regenerate_report_survives_detailed_html_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _write_summary(tmp_path)
+
+    def _boom(*_args: object, **_kwargs: object) -> Path:
+        raise RecursionError("markdown2 blew up on pathological output")
+
+    monkeypatch.setattr(cli_mod, "generate_detailed_html_report", _boom)
+
+    exit_code = cli_mod.EvaluationCLI().regenerate_report(
+        evaluation_dir=tmp_path,
+        export_csv=False,
+        export_rule_csv=False,
+        export_markdown=False,
+        export_html=True,
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "Skipped detailed HTML report (non-fatal)" in captured.err
+    # The summary HTML report was still written.
+    assert any(p.suffix == ".html" for p in tmp_path.iterdir())

--- a/tests/parse_bench/evaluation/test_runner_aggregation.py
+++ b/tests/parse_bench/evaluation/test_runner_aggregation.py
@@ -394,3 +394,154 @@ def test_layout_case_without_annotations_is_not_scored_as_zero(tmp_path: Path, m
     # Unscorable GT (no annotations) is a data issue, not a provider failure
     assert summary.failed == 0
     assert summary.per_example_results == []
+
+
+# ---------------------------------------------------------------------------
+# metric_counts: float partial credit and numerator labels
+# ---------------------------------------------------------------------------
+
+
+def test_float_passed_totals_are_pooled_into_micro_and_total_aggregates() -> None:
+    """A metric emitting fractional ``passed`` (partial credit) must still pool
+    into ``total_*`` / ``micro_*`` — the old int-only guard silently dropped it."""
+    runner = EvaluationRunner(output_dir=Path("/tmp/unused"))
+    results = [
+        _success("a", [MetricValue(metric_name="qa_anls_star", value=0.5, metadata={"passed": 1.5, "total": 3})]),
+        _success("b", [MetricValue(metric_name="qa_anls_star", value=1.0, metadata={"passed": 2.0, "total": 2})]),
+    ]
+
+    aggregate = runner._aggregate_metrics(results)
+
+    assert aggregate["micro_qa_anls_star"] == pytest.approx(3.5 / 5)
+    assert aggregate["total_qa_anls_star_passed"] == 3.5
+    assert aggregate["total_qa_anls_star_evaluated"] == 5.0
+
+
+def test_numerator_label_renames_the_total_key_for_score_sums() -> None:
+    runner = EvaluationRunner(output_dir=Path("/tmp/unused"))
+    results = [
+        _success(
+            "a",
+            [
+                MetricValue(
+                    metric_name="qa_anls_star",
+                    value=0.75,
+                    metadata={"passed": 1.5, "total": 2, "numerator_label": "score"},
+                )
+            ],
+        ),
+    ]
+
+    aggregate = runner._aggregate_metrics(results)
+
+    assert aggregate["total_qa_anls_star_score"] == 1.5
+    assert "total_qa_anls_star_passed" not in aggregate
+    assert aggregate["micro_qa_anls_star"] == pytest.approx(0.75)
+
+
+def test_bool_passed_totals_are_ignored() -> None:
+    runner = EvaluationRunner(output_dir=Path("/tmp/unused"))
+    results = [
+        _success("a", [MetricValue(metric_name="rule_pass_rate", value=1.0, metadata={"passed": True, "total": True})]),
+    ]
+
+    aggregate = runner._aggregate_metrics(results)
+
+    assert "micro_rule_pass_rate" not in aggregate
+    assert aggregate["avg_rule_pass_rate"] == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Pooled micro aggregates for standalone tp/fp/fn metrics
+# ---------------------------------------------------------------------------
+
+
+def test_record_metrics_report_macro_and_micro_aggregates() -> None:
+    """Each metric pools from its own tp/fp/fn; ``*accuracy`` gets tp/(tp+fp+fn)."""
+    runner = EvaluationRunner(output_dir=Path("/tmp/unused"))
+    results = [
+        _success(
+            "a",
+            [
+                MetricValue(metric_name="record_precision", value=1.0, metadata={"tp": 1, "fp": 0, "fn": 9}),
+                MetricValue(metric_name="record_recall", value=0.1, metadata={"tp": 1, "fp": 0, "fn": 9}),
+                MetricValue(metric_name="record_f1", value=0.1818, metadata={"tp": 1, "fp": 0, "fn": 9}),
+                MetricValue(metric_name="record_accuracy", value=0.1, metadata={"tp": 1, "fp": 0, "fn": 9}),
+            ],
+            product_type="extract",
+        ),
+        _success(
+            "b",
+            [
+                MetricValue(metric_name="record_precision", value=0.5, metadata={"tp": 1, "fp": 1, "fn": 0}),
+                MetricValue(metric_name="record_recall", value=1.0, metadata={"tp": 1, "fp": 1, "fn": 0}),
+                MetricValue(metric_name="record_f1", value=0.6667, metadata={"tp": 1, "fp": 1, "fn": 0}),
+                MetricValue(metric_name="record_accuracy", value=0.5, metadata={"tp": 1, "fp": 1, "fn": 0}),
+            ],
+            product_type="extract",
+        ),
+    ]
+
+    summary = runner._aggregate_metrics(results)
+
+    assert summary["avg_record_precision"] == pytest.approx(0.75)
+    assert summary["avg_record_recall"] == pytest.approx(0.55)
+    assert summary["avg_record_f1"] == pytest.approx((0.1818 + 0.6667) / 2)
+    assert summary["avg_record_accuracy"] == pytest.approx(0.3)
+    assert summary["micro_record_precision"] == pytest.approx(2 / 3)
+    assert summary["micro_record_recall"] == pytest.approx(2 / 11)
+    assert summary["micro_record_f1"] == pytest.approx(2 * (2 / 3) * (2 / 11) / ((2 / 3) + (2 / 11)))
+    assert summary["micro_record_accuracy"] == pytest.approx(2 / 12)
+
+
+def test_standalone_f1_and_pass_rate_get_micro_without_the_trio() -> None:
+    """A lone ``*_f1`` or ``*pass_rate`` with tp/fp/fn (no precision/recall
+    siblings, no passed/total) still gets a pooled micro value."""
+    runner = EvaluationRunner(output_dir=Path("/tmp/unused"))
+    results = [
+        _success(
+            "a",
+            [
+                MetricValue(metric_name="picture_f1", value=1.0, metadata={"tp": 2, "fp": 0, "fn": 0}),
+                MetricValue(metric_name="extract_field_pass_rate", value=1.0, metadata={"tp": 2, "fp": 0, "fn": 0}),
+            ],
+        ),
+        _success(
+            "b",
+            [
+                MetricValue(metric_name="picture_f1", value=0.0, metadata={"tp": 0, "fp": 1, "fn": 1}),
+                MetricValue(metric_name="extract_field_pass_rate", value=0.0, metadata={"tp": 0, "fp": 1, "fn": 1}),
+            ],
+        ),
+    ]
+
+    summary = runner._aggregate_metrics(results)
+
+    # tp=2 fp=1 fn=1 -> precision 2/3, recall 2/3, f1 2/3
+    assert summary["micro_picture_f1"] == pytest.approx(2 / 3)
+    assert summary["total_picture_f1_tp"] == 2.0
+    # pass_rate pooled as tp / (tp + fp + fn)
+    assert summary["micro_extract_field_pass_rate"] == pytest.approx(2 / 4)
+
+
+def test_pass_rate_with_passed_total_keeps_the_rule_count_micro() -> None:
+    """When a pass-rate metric carries both passed/total and tp/fp/fn, the
+    rule-count denominator wins so the micro value is not silently redefined."""
+    runner = EvaluationRunner(output_dir=Path("/tmp/unused"))
+    results = [
+        _success(
+            "a",
+            [
+                MetricValue(
+                    metric_name="extract_element_pass_rate",
+                    value=0.5,
+                    metadata={"passed": 1, "total": 2, "tp": 1, "fp": 5, "fn": 5},
+                )
+            ],
+        ),
+    ]
+
+    summary = runner._aggregate_metrics(results)
+
+    assert summary["micro_extract_element_pass_rate"] == pytest.approx(0.5)
+    assert summary["total_extract_element_pass_rate_tp"] == 1.0

--- a/tests/parse_bench/evaluation/test_runner_result_files.py
+++ b/tests/parse_bench/evaluation/test_runner_result_files.py
@@ -1,0 +1,33 @@
+"""Which ``*.result.json`` files the runner treats as benchmark examples."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from parse_bench.evaluation.runner import EvaluationRunner
+
+
+def test_excludes_inline_image_crop_parse_artifacts(tmp_path: Path) -> None:
+    """Inline-image crop parsing writes its own normalized artifacts to
+    ``<document>.images/``; they are dependencies of the parent Parse result,
+    not examples, and must never be scored."""
+    runner = EvaluationRunner(output_dir=tmp_path)
+    expected = tmp_path / "group" / "document.result.json"
+    crop = tmp_path / "document.pdf.images" / "page_1_image_1_v2.result.json"
+    nested_crop = tmp_path / "group" / "other.pdf.images" / "nested" / "page_2_image_1.result.json"
+    for path in (expected, crop, nested_crop):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{}")
+
+    assert runner._find_result_files(tmp_path) == [expected]
+
+
+def test_images_suffix_only_matches_directory_components(tmp_path: Path) -> None:
+    """A file whose *own* name mentions images is still a result; only a
+    ``*.images`` directory on the path excludes it."""
+    runner = EvaluationRunner(output_dir=tmp_path)
+    keep = tmp_path / "group" / "images.result.json"
+    keep.parent.mkdir(parents=True)
+    keep.write_text("{}")
+
+    assert runner._find_result_files(tmp_path) == [keep]

--- a/tests/parse_bench/evaluation/test_runner_worker_timeout.py
+++ b/tests/parse_bench/evaluation/test_runner_worker_timeout.py
@@ -1,0 +1,264 @@
+"""The eval pool's per-worker timeout, and the stalled-batch recovery it drives.
+
+The cap used to be written as ``for f in as_completed(futures): f.result(timeout=N)``,
+which never fires: ``as_completed`` blocks (it was called without a timeout) until
+each future is *already done*, so the ``result()`` timeout has nothing left to wait
+for and the "worker timed out" branch was dead code. One pathological document --
+stuck in a network wait inside the LLM-judge calls, worker at ~0% CPU -- held a
+411-document parse evaluation open for over 90 minutes.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from concurrent.futures import Future, ThreadPoolExecutor
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from parse_bench.evaluation import runner as runner_mod
+from parse_bench.evaluation.runner import EvaluationRunner, _drain_eval_futures
+from parse_bench.schemas.pipeline_io import InferenceRequest, InferenceResult
+from parse_bench.schemas.product import ProductType
+
+# --- _drain_eval_futures ------------------------------------------------------
+
+
+def test_drain_hands_every_completed_future_to_the_callback() -> None:
+    """The happy path drains everything and reports no casualties."""
+    seen: list[int] = []
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        futures = [pool.submit(lambda n=i: n) for i in range(6)]  # type: ignore[misc]
+        timed_out, unstarted = _drain_eval_futures(futures, 30, lambda f: seen.append(f.result()))
+    assert sorted(seen) == list(range(6))
+    assert (timed_out, unstarted) == (set(), set())
+
+
+def test_drain_cuts_off_a_worker_that_exceeds_the_cap() -> None:
+    """A worker still running when the window elapses is abandoned, and the work
+    queued behind it is cancelled for a fresh pool rather than lost."""
+    release = threading.Event()
+    seen: list[str] = []
+
+    def _hang() -> str:
+        assert release.wait(timeout=30), "test never released the blocked worker"
+        return "hung"
+
+    try:
+        # One worker: the hanging task occupies it and the rest never start.
+        pool = ThreadPoolExecutor(max_workers=1)
+        hung = pool.submit(_hang)
+        queued = [pool.submit(lambda n=i: f"queued-{n}") for i in range(3)]  # type: ignore[misc]
+
+        timed_out, unstarted = _drain_eval_futures([hung, *queued], 0.2, lambda f: seen.append(f.result()))
+
+        assert timed_out == {hung}, "the running-but-stuck worker must be reported as timed out"
+        assert unstarted == set(queued), "queued work must be cancelled, not blamed for the stall"
+        assert seen == [], "nothing completed, so nothing should have been handed to the callback"
+        assert all(f.cancelled() for f in queued)
+    finally:
+        release.set()
+        pool.shutdown(wait=True)
+
+
+def test_drain_keeps_collecting_while_the_pool_makes_progress() -> None:
+    """The window restarts on every completion: fast documents are all collected
+    even though a slow one is hogging a worker the whole time."""
+    release = threading.Event()
+    seen: list[str] = []
+
+    def _hang() -> str:
+        assert release.wait(timeout=30), "test never released the blocked worker"
+        return "hung"
+
+    try:
+        pool = ThreadPoolExecutor(max_workers=4)
+        hung = pool.submit(_hang)
+        fast = [pool.submit(lambda n=i: f"fast-{n}") for i in range(3)]  # type: ignore[misc]
+
+        timed_out, unstarted = _drain_eval_futures([hung, *fast], 0.5, lambda f: seen.append(f.result()))
+
+        assert sorted(seen) == ["fast-0", "fast-1", "fast-2"]
+        assert timed_out == {hung}
+        assert unstarted == set()
+    finally:
+        release.set()
+        pool.shutdown(wait=True)
+
+
+def test_drain_reports_a_future_that_finishes_during_the_timeout_sweep() -> None:
+    """A future that lands in the gap between the wait expiring and the sweep is
+    a completed evaluation, not a timeout -- never fail one we actually have."""
+    late: Future = Future()
+    late.set_running_or_notify_cancel()
+    seen: list[str] = []
+
+    def _on_done(future: Future) -> None:
+        seen.append(future.result())
+
+    # Resolve it "just after" the wait gave up, before the sweep inspects it.
+    late.set_result("landed")
+    timed_out, unstarted = _drain_eval_futures([late], 0.05, _on_done)
+    assert seen == ["landed"]
+    assert (timed_out, unstarted) == (set(), set())
+
+
+# --- end-to-end through run_evaluation ---------------------------------------
+
+
+def _write_case(gt_dir: Path, out_dir: Path, name: str) -> str:
+    """Create a matching (test case, result) pair; return the loader's test_id."""
+    test_id = f"g/{name}"
+    doc_dir = gt_dir / "g"
+    doc_dir.mkdir(parents=True, exist_ok=True)
+    (doc_dir / f"{name}.pdf").write_bytes(b"%PDF-1.4 dummy")
+    (doc_dir / f"{name}.test.json").write_text(
+        json.dumps(
+            {
+                "data_schema": {"type": "object", "properties": {"name": {"type": "string"}}},
+                "expected_output": {"name": "Alice"},
+            }
+        )
+    )
+    now = datetime(2026, 1, 1, 0, 0, 0)
+    result = InferenceResult(
+        request=InferenceRequest(
+            example_id=test_id,
+            source_file_path="/tmp/doc.pdf",
+            product_type=ProductType.EXTRACT,
+        ),
+        pipeline_name="test-pipe",
+        product_type=ProductType.EXTRACT,
+        raw_output={},
+        output={
+            "task_type": "extract",
+            "example_id": test_id,
+            "pipeline_name": "test-pipe",
+            "extracted_data": {"name": "Alice"},
+        },
+        started_at=now,
+        completed_at=now,
+        latency_in_ms=0,
+    )
+    res_dir = out_dir / "test-pipe" / "g"
+    res_dir.mkdir(parents=True, exist_ok=True)
+    (res_dir / f"{name}.result.json").write_text(result.model_dump_json())
+    return test_id
+
+
+def test_hung_worker_is_reported_and_never_blocks_the_rest_of_the_run(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A document whose worker exceeds the cap is failed with the timeout line, and
+    the documents queued behind it are still evaluated (on a fresh pool)."""
+    gt_dir = tmp_path / "gt"
+    out_dir = tmp_path / "out"
+    hung_id = _write_case(gt_dir, out_dir, "aaa_hangs")
+    ok_ids = [_write_case(gt_dir, out_dir, name) for name in ("bbb_ok", "ccc_ok")]
+
+    release = threading.Event()
+    real_worker = runner_mod._evaluate_single_worker
+
+    def _worker(*task: Any) -> dict[str, Any]:
+        if task[1].get("test_id") == hung_id:
+            assert release.wait(timeout=30), "test never released the blocked worker"
+        return real_worker(*task)  # type: ignore[no-any-return]
+
+    class _SerialThreadPool(ThreadPoolExecutor):
+        """Stand-in for the process pool: one worker, so ``aaa_hangs`` occupies it
+        and the other two documents sit queued behind it."""
+
+        def __init__(self, **kwargs: Any) -> None:
+            super().__init__(max_workers=1)
+
+    monkeypatch.setattr(runner_mod, "_evaluate_single_worker", _worker)
+    monkeypatch.setattr(runner_mod, "ProcessPoolExecutor", _SerialThreadPool)
+    monkeypatch.setattr(runner_mod, "_EVAL_WORKER_STALL_TIMEOUT_SECONDS", 0.5)
+
+    try:
+        summary = EvaluationRunner(output_dir=out_dir, test_cases_dir=gt_dir).run_evaluation(
+            product_type="extract", use_rich=False, max_workers=1
+        )
+    finally:
+        release.set()
+
+    out = capsys.readouterr().out
+    assert f"{hung_id}: FAILED (worker timed out after 0.5s)" in out
+
+    by_id = {r.test_id: r for r in summary.per_example_results}
+    assert summary.successful == 2, "documents queued behind the hung one must still be evaluated"
+    assert summary.failed == 1, "the timed-out document is counted as a failure, not silently dropped"
+    for ok_id in ok_ids:
+        assert by_id[ok_id].success
+
+
+def test_documents_queued_behind_a_stall_are_retried_before_being_blamed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A real ProcessPool keeps its call queue pre-fed, so a document that never
+    ran can still show up as RUNNING and be swept up in the stall. Those get a
+    second attempt on the fresh pool; only the document that stalls again is
+    failed, and it is failed exactly once."""
+    gt_dir = tmp_path / "gt"
+    out_dir = tmp_path / "out"
+    hung_id = _write_case(gt_dir, out_dir, "aaa_hangs")
+    swept_id = _write_case(gt_dir, out_dir, "bbb_swept_up")
+    queued_id = _write_case(gt_dir, out_dir, "ccc_queued")
+
+    release = threading.Event()
+    real_worker = runner_mod._evaluate_single_worker
+    attempts: dict[str, int] = {}
+    lock = threading.Lock()
+
+    def _worker(*task: Any) -> dict[str, Any]:
+        test_id = str(task[1].get("test_id"))
+        with lock:
+            attempts[test_id] = attempts.get(test_id, 0) + 1
+            nth = attempts[test_id]
+        if test_id == hung_id:
+            # Never finishes on its own -- the real pathological document.
+            assert release.wait(timeout=30), "test never released the blocked worker"
+        elif test_id == swept_id and nth == 1:
+            # Stands in for a pre-fed queue entry: occupies a worker slot past the
+            # stall window on the first batch, then evaluates normally on the retry.
+            time.sleep(3)
+        return real_worker(*task)  # type: ignore[no-any-return]
+
+    class _TwoWorkerThreadPool(ThreadPoolExecutor):
+        """Two slots, so aaa + bbb are RUNNING when the batch stalls and ccc is
+        left genuinely unstarted -- the shape that makes a retry worthwhile."""
+
+        def __init__(self, **kwargs: Any) -> None:
+            super().__init__(max_workers=2)
+
+    monkeypatch.setattr(runner_mod, "_evaluate_single_worker", _worker)
+    monkeypatch.setattr(runner_mod, "ProcessPoolExecutor", _TwoWorkerThreadPool)
+    monkeypatch.setattr(runner_mod, "_EVAL_WORKER_STALL_TIMEOUT_SECONDS", 0.5)
+
+    try:
+        summary = EvaluationRunner(output_dir=out_dir, test_cases_dir=gt_dir).run_evaluation(
+            product_type="extract", use_rich=False, max_workers=2
+        )
+    finally:
+        release.set()
+
+    out = capsys.readouterr().out
+    by_id = {r.test_id: r for r in summary.per_example_results}
+
+    assert attempts[swept_id] == 2, "the swept-up document must actually be re-submitted"
+    assert by_id[swept_id].success, "a healthy document caught in the stall must be recovered, not blamed"
+    assert by_id[queued_id].success
+    assert summary.successful == 2
+
+    # The genuinely hung document stalls again on the retry and is failed then --
+    # once, not once per attempt.
+    assert out.count("FAILED (worker timed out after 0.5s)") == 1
+    assert f"{hung_id}: FAILED (worker timed out after 0.5s)" in out

--- a/tests/parse_bench/evaluation/test_stats.py
+++ b/tests/parse_bench/evaluation/test_stats.py
@@ -1,0 +1,86 @@
+"""Operational stat extraction: timing validity guards and cost/credit keys."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from parse_bench.evaluation.stats import (
+    _RAW_OUTPUT_STATS,
+    build_operational_stats,
+    is_valid_timing_stat,
+)
+
+
+def _names_and_values(result: object) -> list[tuple[str, float]]:
+    return [(stat.name, stat.value) for stat in build_operational_stats(result)]  # type: ignore[arg-type]
+
+
+def test_positive_latency_emits_latency_and_per_page_rate() -> None:
+    result = SimpleNamespace(latency_in_ms=125, raw_output={"num_pages": 5})
+    assert _names_and_values(result) == [("latency_ms", 125.0), ("latency_ms_per_page", 25.0)]
+
+
+def test_zero_latency_emits_latency_without_per_page_rate() -> None:
+    """Zero is a real measurement (an explicit no-op) but has no meaningful rate."""
+    result = SimpleNamespace(latency_in_ms=0, raw_output={"num_pages": 5})
+    assert _names_and_values(result) == [("latency_ms", 0.0)]
+
+
+def test_invalid_latency_values_are_dropped() -> None:
+    for bad in (None, -1, float("nan"), float("inf"), True):
+        result = SimpleNamespace(latency_in_ms=bad, raw_output={"num_pages": 5})
+        assert _names_and_values(result) == [], repr(bad)
+
+
+def test_per_page_rate_requires_a_positive_numeric_page_count() -> None:
+    for pages in (0, -2, None, True, "3"):
+        result = SimpleNamespace(latency_in_ms=100, raw_output={"num_pages": pages})
+        assert _names_and_values(result) == [("latency_ms", 100.0)], repr(pages)
+
+
+def test_is_valid_timing_stat_rejects_bools_negatives_and_non_finite() -> None:
+    assert is_valid_timing_stat("latency_ms", 0)
+    assert is_valid_timing_stat("latency_ms", 12.5)
+    assert not is_valid_timing_stat("latency_ms", True)
+    assert not is_valid_timing_stat("latency_ms", -0.1)
+    assert not is_valid_timing_stat("latency_ms", float("nan"))
+    assert not is_valid_timing_stat("latency_ms", "12")
+
+
+def test_cost_credit_and_tool_keys_are_picked_up_from_raw_output() -> None:
+    raw = {
+        "num_pages": 2,
+        "cost_usd": 1.5,
+        "cache_write_cost_usd": 0.25,
+        "container_cost_usd": 0.1,
+        "container_time_cost_usd": 0.05,
+        "tool_surcharge_usd": 0.2,
+        "token_cost_usd": 0.9,
+        "parse_credits": 6,
+        "extract_credits": 4,
+        "total_credits": 10,
+        "credits_per_page": 5,
+        "num_pages_billed": 2,
+        "cache_write_tokens": 300,
+        "num_tool_calls": 3,
+        "num_containers": 1,
+        "num_regions": 4,
+    }
+    result = SimpleNamespace(latency_in_ms=10, raw_output=raw)
+    stats = {stat.name: (stat.value, stat.unit) for stat in build_operational_stats(result)}  # type: ignore[arg-type]
+
+    for key, value in raw.items():
+        if key == "num_pages":
+            continue
+        assert stats[key][0] == float(value), key
+    assert stats["parse_credits"][1] == "credits"
+    assert stats["credits_per_page"][1] == "credits/page"
+    assert stats["num_pages_billed"][1] == "pages"
+    assert stats["num_tool_calls"][1] == "calls"
+    assert stats["cache_write_tokens"][1] == "tokens"
+    assert stats["tool_surcharge_usd"][1] == "$"
+
+
+def test_raw_output_stat_keys_are_unique() -> None:
+    keys = [key for key, _unit in _RAW_OUTPUT_STATS]
+    assert len(keys) == len(set(keys))


### PR DESCRIPTION
- worker pool: replace the dead result(timeout) idiom with a draining loop, forced shutdown of stuck workers and one bounded retry
- skip *.images/ artifact directories when discovering results
- metric_counts accepts fractional passed counts and numerator labels; micro aggregates for standalone f1/accuracy/pass-rate metrics
- stats: credit/cost/tool keys and validity guards
- detailed report generation is non-fatal; PDF URL encoding for root-relative bases; failed-rule counts in the rule panel
- comparison: ordered primary-metric chain, layout_pages prediction reader, dataset-suffix-preserving run labels
- parse_bench_version recorded in _evaluation_report.json