### PR TITLE
4. Port visual-grounding and extract scoring fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,14 @@ with this version.
 - Formatting rules: emphasis is resolved with a delimiter-run pairer instead of regex,
   typographic and ASCII quotes are folded, and `<strong>/<em>/<mark>/<sup>/<sub>` with
   attributes are recognised.
+- Visual grounding: the LlamaParse V2 `code` item type is mapped (code blocks were
+  silently dropped); LlamaParse attribution is restricted to layout-aware segments
+  rather than falling back to coarse item bboxes; Docling attribution blocks no longer
+  fall back to the item bbox.
+- Extract accuracy: a missing object or array is weighted by its leaf count instead of 1;
+  date normalization handles `MM/DD/YY`, missing spaces after commas and out-of-range
+  years; keyless lists are aligned order-invariantly; nullable numeric fields treat `0`
+  and `null` as equal when the schema allows null.
 - `ParseTestCase` accepts layout and extract-field rules on `test_rules` and carries `metadata`.
 - Rule schemas and classes for `table_marker_cells`, `text_color`, `absent_unless_strikeout`,
   `present_as_strikeout`, `is_not_latex` and the extended `form_field` rule (`label` list,

--- a/src/parse_bench/evaluation/evaluators/extract.py
+++ b/src/parse_bench/evaluation/evaluators/extract.py
@@ -147,11 +147,15 @@ class ExtractEvaluator(BaseEvaluator):
         # doesn't emit (e.g. ``client_id``) still appear in expected_output.
         # That drop is a correct signal, not noise — if scalar coverage
         # matters, run a per_doc pipeline instead. See list_unwrap.py.
-        if test_case.expected_output:
+        if test_case.expected_output is not None:
             expected_output = test_case.expected_output
 
             # Calculate overall accuracy using the metric
-            accuracy_metric = self._accuracy_metric.compute(expected=expected_output, actual=extracted_data)
+            accuracy_metric = self._accuracy_metric.compute(
+                expected=expected_output,
+                actual=extracted_data,
+                data_schema=test_case.data_schema,
+            )
             metrics.append(accuracy_metric)
 
             # Calculate field-level accuracy if both are dicts

--- a/src/parse_bench/evaluation/layout_adapters/adapters.py
+++ b/src/parse_bench/evaluation/layout_adapters/adapters.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, cast
 
@@ -32,7 +33,7 @@ from parse_bench.schemas.layout_detection_output import (
     LayoutTableContent,
     LayoutTextContent,
 )
-from parse_bench.schemas.parse_output import ParseOutput
+from parse_bench.schemas.parse_output import ParseLayoutPageIR, ParseOutput
 from parse_bench.schemas.pipeline_io import InferenceResult
 from parse_bench.test_cases.schema import TestCase
 
@@ -93,6 +94,7 @@ class LlamaParseLayoutAdapter(LayoutAdapter):
 
     def __init__(self) -> None:
         self._pages_payload: list[dict[str, Any]] | None = None
+        self._attribution_pages_payload: list[dict[str, Any]] | None = None
 
     @classmethod
     def matches(cls, inference_result: InferenceResult) -> bool:
@@ -125,6 +127,10 @@ class LlamaParseLayoutAdapter(LayoutAdapter):
         page_filter: int | None = None,
     ) -> LayoutOutput:
         pages = _resolve_llamaparse_pages(inference_result)
+        self._attribution_pages_payload = _resolve_llamaparse_pages(
+            inference_result,
+            include_bbox_segment_fallback=False,
+        )
         raw_output = inference_result.raw_output if isinstance(inference_result.raw_output, dict) else {}
 
         if pages:
@@ -176,7 +182,8 @@ class LlamaParseLayoutAdapter(LayoutAdapter):
                 test_case=None,
             )
 
-        raw_page = _find_page_payload(self._pages_payload, page_number)
+        attribution_pages = self._attribution_pages_payload or self._pages_payload
+        raw_page = _find_page_payload(attribution_pages, page_number)
         if raw_page is None:
             return super().to_attribution_blocks(
                 layout_output,
@@ -195,7 +202,21 @@ class LlamaParseLayoutAdapter(LayoutAdapter):
         page_md = raw_page.get("md", "") or raw_page.get("text", "") or ""
         page_width = float(raw_page.get("width") or layout_output.image_width or 1)
         page_height = float(raw_page.get("height") or layout_output.image_height or 1)
-        return parse_pred_blocks(items, page_md, page_width, page_height)
+        # Attribution-scope policy: only layout-aware segments become
+        # attribution claims. Items that carry a coarse item-level ``bBox``
+        # but no ``layoutAwareBbox`` segments are dropped instead of
+        # contributing a whole-block claim (the attribution payload above is
+        # built with ``include_bbox_segment_fallback=False`` for the same
+        # reason). This matches the internal benchmark runs that produce the
+        # public leaderboard rows, so LlamaParse Visual Grounding LAP/AF1
+        # stay comparable between ParseBench and internal.
+        return parse_pred_blocks(
+            items,
+            page_md,
+            page_width,
+            page_height,
+            require_layout_aware_segments=True,
+        )
 
     def to_granular_pages(self, inference_result: InferenceResult) -> list[_GranularPage]:
         raw_output = inference_result.raw_output if isinstance(inference_result.raw_output, dict) else {}
@@ -886,14 +907,14 @@ class DoclingParseLayoutAdapter(LayoutAdapter):
 
         blocks: list[PredBlock] = []
         for item_index, item in enumerate(page.items):
-            segments = item.layout_segments or ([item.bbox] if item.bbox is not None else [])
+            segments = item.layout_segments
             if not segments:
                 continue
 
             for seg in segments:
                 label = seg.label or item.type or "unknown"
                 block_type = item.type or "text"
-                if item.type == "table":
+                if (item.type or "").strip().lower() == "table":
                     raw_text = extract_text_from_html(item.value)
                 else:
                     raw_text = item.value or ""
@@ -2464,7 +2485,11 @@ def _infer_page_number_from_example_id(example_id: str) -> int | None:
     return page_token if page_token > 0 else 1
 
 
-def _resolve_llamaparse_pages(inference_result: InferenceResult) -> list[dict[str, Any]]:
+def _resolve_llamaparse_pages(
+    inference_result: InferenceResult,
+    *,
+    include_bbox_segment_fallback: bool = True,
+) -> list[dict[str, Any]]:
     from parse_bench.inference.providers.parse.llamaparse_v2_normalization import (
         build_pages_from_cli2_raw_payload,
         build_pages_from_sdk_response_payload,
@@ -2503,9 +2528,46 @@ def _resolve_llamaparse_pages(inference_result: InferenceResult) -> list[dict[st
 
     if isinstance(inference_result.output, ParseOutput):
         if len(inference_result.output.layout_pages) > 0:
-            return layout_pages_to_legacy_pages_payload(inference_result.output.layout_pages)
+            layout_pages = inference_result.output.layout_pages
+            legacy_pages = layout_pages_to_legacy_pages_payload(layout_pages)
+            if include_bbox_segment_fallback:
+                return legacy_pages
+            # The normalizer always synthesizes a single layoutAwareBbox from
+            # the item bBox when no layout segments exist. Strip those
+            # synthesized segments when the caller opted out of the fallback.
+            return _strip_bbox_fallback_segments(legacy_pages, layout_pages)
 
     return []
+
+
+def _strip_bbox_fallback_segments(
+    legacy_pages: list[dict[str, Any]],
+    layout_pages: Sequence[ParseLayoutPageIR],
+) -> list[dict[str, Any]]:
+    """Drop ``layoutAwareBbox`` entries synthesized from a bare item ``bbox``.
+
+    ``layout_pages_to_legacy_pages_payload`` emits items 1:1 and in order
+    per page (pages sorted by ``page_number``), so a positional walk over the
+    typed ``layout_pages`` tells us which legacy items had no real
+    ``layout_segments`` and only received a bbox-derived segment.
+    """
+    typed_pages = sorted(layout_pages, key=lambda page: page.page_number)
+    stripped: list[dict[str, Any]] = []
+    for legacy_page, typed_page in zip(legacy_pages, typed_pages, strict=False):
+        page_copy = dict(legacy_page)
+        legacy_items = legacy_page.get("items")
+        if not isinstance(legacy_items, list):
+            stripped.append(page_copy)
+            continue
+        new_items: list[dict[str, Any]] = []
+        for legacy_item, typed_item in zip(legacy_items, typed_page.items, strict=False):
+            item_copy = dict(legacy_item)
+            if not typed_item.layout_segments:
+                item_copy.pop("layoutAwareBbox", None)
+            new_items.append(item_copy)
+        page_copy["items"] = new_items
+        stripped.append(page_copy)
+    return stripped
 
 
 def _find_page_payload(

--- a/src/parse_bench/evaluation/layout_adapters/base.py
+++ b/src/parse_bench/evaluation/layout_adapters/base.py
@@ -45,7 +45,12 @@ class LayoutAdapter(ABC):
         page_number: int,
         test_case: TestCase | None = None,
     ) -> list[PredBlock]:
-        """Build attribution blocks from normalized prediction content."""
+        """Build attribution blocks from normalized prediction content.
+
+        This generic path assumes ``layout_output.predictions`` are already
+        leaf-like attribution claims. Providers with container trees or richer
+        segment payloads must override this method.
+        """
         del test_case
         if layout_output.image_width <= 0 or layout_output.image_height <= 0:
             return []

--- a/src/parse_bench/evaluation/layout_label_mappers/projection.py
+++ b/src/parse_bench/evaluation/layout_label_mappers/projection.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Any, Literal
 
 from parse_bench.evaluation.layout_adapters.base import normalize_bbox_xyxy
 from parse_bench.evaluation.layout_label_mappers.registry import (
@@ -21,7 +21,7 @@ def project_layout_predictions(
     evaluation_view: Literal["core", "canonical"] = "core",
     target_ontology: str = "basic",
     page_filter: int | None = None,
-) -> list[dict[str, float | str | list[float] | int | None]]:
+) -> list[dict[str, Any]]:
     """Project unified layout predictions to evaluator-ready class labels."""
     if layout_output.image_width <= 0 or layout_output.image_height <= 0:
         return []
@@ -29,7 +29,7 @@ def project_layout_predictions(
     context = build_mapping_context(inference_result, layout_output)
     mapper = resolve_layout_label_mapper(context)
 
-    projected: list[dict[str, float | str | list[float] | int | None]] = []
+    projected: list[dict[str, Any]] = []
     for prediction in layout_output.predictions:
         if page_filter is not None and prediction.page != page_filter:
             continue
@@ -47,6 +47,15 @@ def project_layout_predictions(
         class_name = mapper.to_target_ontology(label_for_view, target_ontology)
         raw_order_index = prediction.provider_metadata.get("order_index")
         order_index = raw_order_index if isinstance(raw_order_index, int) else None
+        # Copy attributes so downstream consumers can mutate freely without
+        # leaking into the original prediction.
+        attributes = dict(prediction.attributes) if prediction.attributes else {}
+        # Downstream metric code (classification_utils, layoutdet evaluator)
+        # assumes ``score`` is always a float — it calls ``float(p["score"])``
+        # and stuffs the list into ``np.array(..., dtype=float)``. Coerce a
+        # missing score to 0.0 here rather than letting ``None`` leak
+        # downstream and silently become ``nan`` in score-sorted matching.
+        score = prediction.score if prediction.score is not None else 0.0
         projected.append(
             {
                 "bbox": normalize_bbox_xyxy(
@@ -55,9 +64,10 @@ def project_layout_predictions(
                     height=layout_output.image_height,
                 ),
                 "class_name": class_name,
-                "score": prediction.score,
+                "score": score,
                 "page": prediction.page,
                 "order_index": order_index,
+                "attributes": attributes,
             }
         )
 

--- a/src/parse_bench/evaluation/metrics/attribution/core.py
+++ b/src/parse_bench/evaluation/metrics/attribution/core.py
@@ -21,6 +21,7 @@ from dataclasses import dataclass, field
 
 import numpy as np
 
+from parse_bench.evaluation.metrics.attribution.constants import ATTRIBUTION_TOKEN_F1_THRESHOLD
 from parse_bench.evaluation.metrics.attribution.geometry import (
     coco_to_xyxy,
     compute_overlap_matrix,
@@ -73,6 +74,30 @@ class PredBlock:
     order_index: int  # position in output list
 
 
+@dataclass(frozen=True)
+class GTTokenInstance:
+    """A single ordered GT token instance."""
+
+    gt_index: int
+    token: str
+    token_index: int
+
+
+@dataclass
+class PredBlockSupport:
+    """Prediction-side support diagnostics for duplicate-claim analysis."""
+
+    pred_index: int
+    overlap_gt_indices: list[int]
+    support_precision: float = 0.0
+    matched_token_instance_ids: list[tuple[int, int]] = field(default_factory=list)
+    owned_token_instance_ids: list[tuple[int, int]] = field(default_factory=list)
+    duplicate_token_instance_ids: list[tuple[int, int]] = field(default_factory=list)
+    overlap_scores_by_gt: dict[int, float] = field(default_factory=dict)
+    longest_matched_span_by_gt: dict[int, int] = field(default_factory=dict)
+    fp_bucket: str = "spatial_fp"
+
+
 @dataclass
 class AttributionResult:
     """Results from attribution evaluation for a single page."""
@@ -98,6 +123,24 @@ class AttributionResult:
     per_class_grounding: dict[str, float] = field(default_factory=dict)  # accuracy per class
     per_class_grounded_count: dict[str, int] = field(default_factory=dict)  # pass count per class
     per_class_total_count: dict[str, int] = field(default_factory=dict)  # total count per class
+
+    # Prediction-side duplicate claim / overclaim metrics
+    overclaim_metric_available: bool = False
+    grounding_overclaim_rate: float = 0.0
+    grounding_duplicate_supported_token_rate: float = 0.0
+    grounding_supported_block_precision: float = 0.0
+    grounding_spatial_fp_rate: float = 0.0
+    grounding_unsupported_block_rate: float = 0.0
+    grounding_redundant_block_rate: float = 0.0
+    supported_claim_count: int = 0
+    duplicate_claim_count: int = 0
+    claimed_supported_token_instances: int = 0
+    duplicate_supported_token_instances: int = 0
+    num_scored_pred_blocks: int = 0
+    supported_tp_blocks: int = 0
+    spatial_fp_blocks: int = 0
+    unsupported_fp_blocks: int = 0
+    redundant_fp_blocks: int = 0
 
     # Diagnostics
     num_gt_elements: int = 0
@@ -215,22 +258,207 @@ def _filter_pred_blocks_for_lap(
     if not gt_elements or not pred_blocks:
         return pred_blocks
 
+    kept_indices = _filter_pred_block_indices_for_lap(gt_elements, pred_blocks, ioa_threshold)
+    return [pred_blocks[pred_idx] for pred_idx in kept_indices]
+
+
+def _filter_pred_block_indices_for_lap(
+    gt_elements: list[GTElement],
+    pred_blocks: list[PredBlock],
+    ioa_threshold: float,
+) -> list[int]:
+    """Return indices of predictions that remain in precision-side scoring scope."""
+    if not gt_elements or not pred_blocks:
+        return list(range(len(pred_blocks)))
+
     gt_boxes = np.array([g.bbox_xyxy for g in gt_elements])
     pred_boxes = np.array([p.bbox_xyxy for p in pred_blocks])
     ioa_matrix = compute_overlap_matrix(gt_boxes, pred_boxes)
     explicit_mask = [gt_element_is_explicit(gt) for gt in gt_elements]
 
-    filtered: list[PredBlock] = []
-    for pred_idx, pred in enumerate(pred_blocks):
+    filtered: list[int] = []
+    for pred_idx, _pred in enumerate(pred_blocks):
         overlapping_gt_indices = np.where(ioa_matrix[:, pred_idx] >= ioa_threshold)[0]
         if len(overlapping_gt_indices) == 0:
-            filtered.append(pred)
+            filtered.append(pred_idx)
             continue
         if all(explicit_mask[int(gt_idx)] for gt_idx in overlapping_gt_indices):
             continue
-        filtered.append(pred)
+        filtered.append(pred_idx)
 
     return filtered
+
+
+def _build_gt_token_instances(
+    gt_elements: list[GTElement],
+    gt_indices: list[int],
+) -> list[GTTokenInstance]:
+    """Expand overlapping GT elements into ordered token instances."""
+    token_instances: list[GTTokenInstance] = []
+    ordered_gt_indices = sorted(gt_indices, key=lambda idx: (gt_elements[idx].ro_index, idx))
+    for gt_idx in ordered_gt_indices:
+        token_instances.extend(
+            GTTokenInstance(gt_index=gt_idx, token=token, token_index=token_idx)
+            for token_idx, token in enumerate(gt_elements[gt_idx].tokens)
+        )
+    return token_instances
+
+
+def _align_pred_tokens_to_gt_instances(
+    pred_tokens: list[str],
+    candidate_instances: list[GTTokenInstance],
+) -> list[GTTokenInstance]:
+    """Align prediction tokens to ordered GT token instances with deterministic LCS."""
+    if not pred_tokens or not candidate_instances:
+        return []
+
+    gt_tokens = [instance.token for instance in candidate_instances]
+    rows = len(pred_tokens)
+    cols = len(gt_tokens)
+    dp = [[0] * (cols + 1) for _ in range(rows + 1)]
+
+    for pred_idx in range(rows):
+        pred_token = pred_tokens[pred_idx]
+        for gt_idx in range(cols):
+            if pred_token == gt_tokens[gt_idx]:
+                dp[pred_idx + 1][gt_idx + 1] = dp[pred_idx][gt_idx] + 1
+            else:
+                dp[pred_idx + 1][gt_idx + 1] = max(dp[pred_idx][gt_idx + 1], dp[pred_idx + 1][gt_idx])
+
+    matches: list[GTTokenInstance] = []
+    pred_idx = rows
+    gt_idx = cols
+    while pred_idx > 0 and gt_idx > 0:
+        if pred_tokens[pred_idx - 1] == gt_tokens[gt_idx - 1]:
+            matches.append(candidate_instances[gt_idx - 1])
+            pred_idx -= 1
+            gt_idx -= 1
+            continue
+        if dp[pred_idx - 1][gt_idx] > dp[pred_idx][gt_idx - 1]:
+            pred_idx -= 1
+        else:
+            # On ties, prefer skipping the later GT candidate so repeated tokens
+            # resolve to the earliest valid token instances consistently.
+            gt_idx -= 1
+
+    matches.reverse()
+    return matches
+
+
+def _longest_consecutive_run(token_indices: list[int]) -> int:
+    """Return the longest contiguous token-index run."""
+    if not token_indices:
+        return 0
+    longest = 1
+    current = 1
+    ordered = sorted(token_indices)
+    for idx in range(1, len(ordered)):
+        if ordered[idx] == ordered[idx - 1] + 1:
+            current += 1
+            longest = max(longest, current)
+        else:
+            current = 1
+    return longest
+
+
+def _compute_pred_block_supports(
+    gt_elements: list[GTElement],
+    pred_blocks: list[PredBlock],
+    ioa_threshold: float,
+    support_threshold: float,
+) -> tuple[bool, list[PredBlockSupport]]:
+    """Compute order-invariant prediction-side support and ownership diagnostics.
+
+    The canonical claim unit is the adapted ``PredBlock`` list produced by the
+    evaluator's provider adapter. Provider-native containers or segment trees
+    must be resolved before this function runs.
+    """
+    scored_pred_indices = _filter_pred_block_indices_for_lap(gt_elements, pred_blocks, ioa_threshold)
+    has_textual_gt = any(gt.tokens for gt in gt_elements)
+    has_text_bearing_scored_pred = any(pred_blocks[pred_idx].tokens for pred_idx in scored_pred_indices)
+
+    if not scored_pred_indices:
+        return False, []
+
+    if gt_elements:
+        gt_boxes = np.array([gt.bbox_xyxy for gt in gt_elements])
+        pred_boxes = np.array([pred.bbox_xyxy for pred in pred_blocks])
+        overlap_matrix = compute_overlap_matrix(gt_boxes, pred_boxes)
+    else:
+        overlap_matrix = np.zeros((0, len(pred_blocks)))
+
+    supports: list[PredBlockSupport] = []
+    for pred_idx in scored_pred_indices:
+        overlapping_gt_indices = (
+            np.where(overlap_matrix[:, pred_idx] >= ioa_threshold)[0].tolist() if gt_elements else []
+        )
+        support = PredBlockSupport(
+            pred_index=pred_idx,
+            overlap_gt_indices=[int(gt_idx) for gt_idx in overlapping_gt_indices],
+            overlap_scores_by_gt={
+                int(gt_idx): float(overlap_matrix[int(gt_idx), pred_idx]) for gt_idx in overlapping_gt_indices
+            },
+        )
+        pred = pred_blocks[pred_idx]
+
+        if not overlapping_gt_indices:
+            support.fp_bucket = "spatial_fp"
+            supports.append(support)
+            continue
+
+        if not pred.tokens:
+            support.fp_bucket = "unsupported_fp"
+            supports.append(support)
+            continue
+
+        candidate_instances = _build_gt_token_instances(gt_elements, [int(gt_idx) for gt_idx in overlapping_gt_indices])
+        matched_instances = _align_pred_tokens_to_gt_instances(pred.tokens, candidate_instances)
+        matched_token_ids = [(instance.gt_index, instance.token_index) for instance in matched_instances]
+        support.matched_token_instance_ids = matched_token_ids
+        support.support_precision = len(matched_token_ids) / len(pred.tokens)
+
+        matched_token_indices_by_gt: dict[int, list[int]] = {}
+        for instance in matched_instances:
+            matched_token_indices_by_gt.setdefault(instance.gt_index, []).append(instance.token_index)
+        support.longest_matched_span_by_gt = {
+            gt_idx: _longest_consecutive_run(token_indices)
+            for gt_idx, token_indices in matched_token_indices_by_gt.items()
+        }
+
+        support.fp_bucket = "supported_tp" if support.support_precision >= support_threshold else "unsupported_fp"
+        supports.append(support)
+
+    supported_claimants = [support for support in supports if support.support_precision >= support_threshold]
+    claimants_by_token: dict[tuple[int, int], list[PredBlockSupport]] = {}
+    for support in supported_claimants:
+        for token_id in support.matched_token_instance_ids:
+            claimants_by_token.setdefault(token_id, []).append(support)
+
+    for token_id, claimants in claimants_by_token.items():
+        gt_idx, _token_index = token_id
+        owner = max(
+            claimants,
+            key=lambda claimant: (
+                claimant.support_precision,
+                claimant.overlap_scores_by_gt.get(gt_idx, 0.0),
+                claimant.longest_matched_span_by_gt.get(gt_idx, 0),
+                -claimant.pred_index,
+            ),
+        )
+        for claimant in claimants:
+            if claimant.pred_index == owner.pred_index:
+                claimant.owned_token_instance_ids.append(token_id)
+            else:
+                claimant.duplicate_token_instance_ids.append(token_id)
+
+    for support in supported_claimants:
+        if support.owned_token_instance_ids:
+            support.fp_bucket = "supported_tp"
+        else:
+            support.fp_bucket = "redundant_fp"
+
+    metric_available = has_textual_gt and has_text_bearing_scored_pred
+    return metric_available, supports
 
 
 def parse_gt_elements(test_rules: list[dict]) -> list[GTElement]:
@@ -293,6 +521,8 @@ def parse_pred_blocks(
     page_md: str,
     page_width: float,
     page_height: float,
+    *,
+    require_layout_aware_segments: bool = False,
 ) -> list[PredBlock]:
     """Parse predicted output items into PredBlock objects.
 
@@ -361,6 +591,9 @@ def parse_pred_blocks(
                         order_index=idx,
                     )
                 )
+            continue
+
+        if require_layout_aware_segments:
             continue
 
         bbox_norm = normalize_bbox_to_unit(bbox_dict, page_width, page_height)
@@ -773,6 +1006,12 @@ def compute_attribution_metrics(
     ga, ga_pass, ga_total, per_class_ga, per_class_ga_pass, per_class_ga_total = compute_grounding_accuracy(
         attribution_gt, pred_blocks, ioa_threshold
     )
+    overclaim_metric_available, pred_block_supports = _compute_pred_block_supports(
+        attribution_gt,
+        pred_blocks,
+        ioa_threshold,
+        support_threshold=ATTRIBUTION_TOKEN_F1_THRESHOLD,
+    )
 
     # Compute per-class LAP (by GT class) and AF1
     per_class_lap = compute_per_class_lap_by_gt(lap_gt, lap_pred_blocks, ioa_threshold)
@@ -801,6 +1040,24 @@ def compute_attribution_metrics(
         unmatched_gt = len(attribution_gt)
         unmatched_pred = len(pred_blocks)
 
+    claim_counts_by_token: dict[tuple[int, int], int] = {}
+    for support in pred_block_supports:
+        if support.support_precision < ATTRIBUTION_TOKEN_F1_THRESHOLD:
+            continue
+        for token_id in support.matched_token_instance_ids:
+            claim_counts_by_token[token_id] = claim_counts_by_token.get(token_id, 0) + 1
+
+    supported_claim_count = sum(claim_counts_by_token.values())
+    duplicate_claim_count = sum(max(0, count - 1) for count in claim_counts_by_token.values())
+    claimed_supported_token_instances = len(claim_counts_by_token)
+    duplicate_supported_token_instances = sum(1 for count in claim_counts_by_token.values() if count > 1)
+
+    num_scored_pred_blocks = len(pred_block_supports)
+    supported_tp_blocks = sum(1 for support in pred_block_supports if support.fp_bucket == "supported_tp")
+    spatial_fp_blocks = sum(1 for support in pred_block_supports if support.fp_bucket == "spatial_fp")
+    unsupported_fp_blocks = sum(1 for support in pred_block_supports if support.fp_bucket == "unsupported_fp")
+    redundant_fp_blocks = sum(1 for support in pred_block_supports if support.fp_bucket == "redundant_fp")
+
     return AttributionResult(
         lap=lap,
         lar=lar,
@@ -816,6 +1073,32 @@ def compute_attribution_metrics(
         per_class_grounding=per_class_ga,
         per_class_grounded_count=per_class_ga_pass,
         per_class_total_count=per_class_ga_total,
+        overclaim_metric_available=overclaim_metric_available,
+        grounding_overclaim_rate=(duplicate_claim_count / supported_claim_count if supported_claim_count > 0 else 0.0),
+        grounding_duplicate_supported_token_rate=(
+            duplicate_supported_token_instances / claimed_supported_token_instances
+            if claimed_supported_token_instances > 0
+            else 0.0
+        ),
+        grounding_supported_block_precision=(
+            supported_tp_blocks / num_scored_pred_blocks if num_scored_pred_blocks > 0 else 0.0
+        ),
+        grounding_spatial_fp_rate=spatial_fp_blocks / num_scored_pred_blocks if num_scored_pred_blocks > 0 else 0.0,
+        grounding_unsupported_block_rate=(
+            unsupported_fp_blocks / num_scored_pred_blocks if num_scored_pred_blocks > 0 else 0.0
+        ),
+        grounding_redundant_block_rate=(
+            redundant_fp_blocks / num_scored_pred_blocks if num_scored_pred_blocks > 0 else 0.0
+        ),
+        supported_claim_count=supported_claim_count,
+        duplicate_claim_count=duplicate_claim_count,
+        claimed_supported_token_instances=claimed_supported_token_instances,
+        duplicate_supported_token_instances=duplicate_supported_token_instances,
+        num_scored_pred_blocks=num_scored_pred_blocks,
+        supported_tp_blocks=supported_tp_blocks,
+        spatial_fp_blocks=spatial_fp_blocks,
+        unsupported_fp_blocks=unsupported_fp_blocks,
+        redundant_fp_blocks=redundant_fp_blocks,
         num_gt_elements=len(attribution_gt),
         num_pred_blocks=len(pred_blocks),
         num_gt_tokens=num_gt_tokens,

--- a/src/parse_bench/evaluation/metrics/extract/json_subset_match.py
+++ b/src/parse_bench/evaluation/metrics/extract/json_subset_match.py
@@ -6,58 +6,199 @@ Ports json_subset_match_score from extract-tests with date normalization support
 import re
 from typing import Any
 
+import numpy as np
 from autoevals.number import NumericDiff  # type: ignore[import-untyped]
 from autoevals.string import EmbeddingSimilarity, Levenshtein  # type: ignore[import-untyped]
 from dateutil import parser as date_parser  # type: ignore[import-untyped]
+from scipy.optimize import linear_sum_assignment
+
+_COMMA_WS_RE = re.compile(r"\s*,\s*")
 
 
-def normalize_date_string(date_str: str) -> str:
-    """
-    Normalize various date formats to a standard ISO format (YYYY-MM-DD).
-    Returns the original string if it's not a recognizable date.
+def normalize_date_string(date_str: Any) -> Any:
+    """Normalise a date string to ISO format (YYYY-MM-DD).
 
-    :param date_str: Input date string
-    :return: Normalized date string or original if not a date
+    Returns the input unchanged if it does not look like a date.
     """
     if not isinstance(date_str, str):
         return date_str
 
-    # Skip if it's clearly not a date (too short/long or contains non-date characters)
     if len(date_str) < 4 or len(date_str) > 50:
         return date_str
 
-    # Skip strings that are just numbers (likely IDs, not dates)
     if date_str.isdigit():
         return date_str
 
-    # Skip if it contains patterns that are unlikely to be dates
-    # like very long numbers, special characters, etc.
-    if re.search(r"\d{10,}", date_str):  # 10+ consecutive digits
+    # Long digit runs (10+) are almost certainly IDs, not dates.
+    if re.search(r"\d{10,}", date_str):
         return date_str
 
-    # Check for common date patterns first
+    # Spacing around the comma carries no meaning: "March 28,1956" and
+    # "March 27 ,1956" name the same date as "March 27, 1956". Normalize the
+    # comma to ", " on a probe copy so these variants clear the pattern gate
+    # and parse; the original is still what we return unchanged when it is not
+    # a date. Comma-gated and comma-only on purpose: this function runs on
+    # every string leaf of every dataset, and a wider rewrite (e.g. collapsing
+    # doubled spaces) would silently widen what counts as a date everywhere.
+    probe = _COMMA_WS_RE.sub(", ", date_str) if "," in date_str else date_str
+
     date_patterns = [
         r"\d{4}-\d{1,2}-\d{1,2}",  # YYYY-MM-DD
         r"\d{1,2}/\d{1,2}/\d{4}",  # MM/DD/YYYY
+        r"\d{1,2}/\d{1,2}/\d{2}\b",  # MM/DD/YY (v5 GT canonical format)
         r"\d{1,2}-\d{1,2}-\d{4}",  # MM-DD-YYYY
-        r"[A-Za-z]+ \d{1,2},? \d{4}",  # Month DD, YYYY or Month DD YYYY
+        r"\d{1,2}-\d{1,2}-\d{2}\b",  # MM-DD-YY
+        r"[A-Za-z]+ \d{1,2},? \d{4}",  # Month DD, YYYY
         r"[A-Za-z]+\.? [A-Za-z]+\.? \d{1,2},? \d{4}",  # Weekday Month DD YYYY
         r"\d{1,2} [A-Za-z]+ \d{4}",  # DD Month YYYY
     ]
-
-    # Only try to parse if it matches common date patterns
-    has_date_pattern = any(re.search(pattern, date_str) for pattern in date_patterns)
-    if not has_date_pattern:
+    if not any(re.search(p, probe) for p in date_patterns):
         return date_str
 
     try:
-        # Try to parse the date
-        parsed_date = date_parser.parse(date_str, fuzzy=False)
-        # Return in ISO format (YYYY-MM-DD)
-        return parsed_date.strftime("%Y-%m-%d")  # type: ignore[no-any-return]
-    except (ValueError, TypeError):
-        # If parsing fails, return original string
+        parsed = date_parser.parse(probe, fuzzy=False)
+        if parsed.year < 1900 or parsed.year > 2100:
+            return date_str
+        return parsed.strftime("%Y-%m-%d")
+    except (ValueError, TypeError, date_parser.ParserError, OverflowError):
         return date_str
+
+
+def _is_nullable_numeric_field(schema_node: Any) -> bool:
+    """True when a field's JSON Schema shape is a nullable number.
+
+    Recognizes both idiomatic Pydantic/JSON Schema encodings used across
+    extract test cases:
+
+    * ``{"anyOf": [{"type": "number"}, {"type": "null"}], "default": null}``
+    * ``{"anyOf": [{"type": "null"}, {"type": "number"}], ...}`` (order-agnostic)
+    * ``{"type": ["number", "null"]}`` / ``{"type": ["null", "number"]}``
+
+    Only the shape gate — the ``default`` clause is not required. Callers use
+    this to treat ``0`` / ``0.0`` and ``None`` as equivalent on such fields,
+    because "not present on this row" and "amount = zero" are not distinguished
+    semantically in financial extraction ground truth.
+    """
+    if not isinstance(schema_node, dict):
+        return False
+    any_of = schema_node.get("anyOf")
+    if isinstance(any_of, list) and len(any_of) == 2:
+        types = {branch.get("type") for branch in any_of if isinstance(branch, dict)}
+        if types == {"number", "null"}:
+            return True
+    type_field = schema_node.get("type")
+    if isinstance(type_field, list) and set(type_field) == {"number", "null"}:
+        return True
+    return False
+
+
+def _normalize_nullable_numeric(value: Any) -> Any:
+    """Collapse ``0`` / ``0.0`` to ``None`` on nullable numeric fields.
+
+    Everything else (non-zero numbers, non-numeric types) is returned as-is.
+    Booleans are explicitly excluded from the zero collapse so that ``False``
+    is never conflated with an absent value.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)) and value == 0:
+        return None
+    return value
+
+
+# Budget for the order-invariant assignment's n×m cost matrix. Beyond it
+# (e.g. a 3,000-row shuffled array is 9M pairs and ~3s of Python-level cost
+# building, recursing into nested lists) index pairing applies instead of
+# stalling the evaluator.
+_ASSIGNMENT_MAX_PAIRS = 250_000
+
+
+def _count_leaves(value: Any) -> int:
+    """Count leaf nodes in a JSON-like value.
+
+    A leaf is any primitive (str, number, bool, None) or an empty dict / list.
+    Used to weight a missing field by the structural cost of what it contains
+    in `expected`, so that dropping a 15-claim array isn't scored the same
+    as dropping a single scalar.
+
+    Conservative behavior:
+    - Empty dict or empty list contribute weight 1 (matches the existing
+      "empty == empty" success path which also uses weight 1).
+    - Any non-dict / non-list value contributes weight 1.
+    """
+    if isinstance(value, dict):
+        if not value:
+            return 1
+        return sum(_count_leaves(v) for v in value.values())
+    if isinstance(value, list):
+        if not value:
+            return 1
+        return sum(_count_leaves(item) for item in value)
+    return 1
+
+
+def _flatten_normalized_leaves(
+    value: Any,
+    *,
+    case_sensitive: bool,
+    normalize_dates: bool,
+    _path: tuple[Any, ...] = (),
+) -> dict[tuple[Any, ...], Any]:
+    """Flatten a JSON-like value into {path: normalized_leaf}.
+
+    Used to build the assignment cost matrix for order-invariant list
+    pairing. Strings are normalized the same way the scalar scoring path
+    normalizes them (lowercase unless case_sensitive, then date
+    normalization) so the approximate cost agrees with the real scorer on
+    exact matches. Empty dicts / lists are kept as leaves, matching
+    `_count_leaves` semantics.
+    """
+    if isinstance(value, dict) and value:
+        flat: dict[tuple[Any, ...], Any] = {}
+        for k, v in value.items():
+            flat.update(
+                _flatten_normalized_leaves(
+                    v, case_sensitive=case_sensitive, normalize_dates=normalize_dates, _path=(*_path, k)
+                )
+            )
+        return flat
+    if isinstance(value, list) and value:
+        flat = {}
+        for i, v in enumerate(value):
+            flat.update(
+                _flatten_normalized_leaves(
+                    v, case_sensitive=case_sensitive, normalize_dates=normalize_dates, _path=(*_path, i)
+                )
+            )
+        return flat
+    if isinstance(value, str):
+        normalized = value if case_sensitive else value.lower()
+        if normalize_dates:
+            normalized = normalize_date_string(normalized)
+        return {_path: normalized}
+    return {_path: value}
+
+
+def _descend_schema_for_key(schema_node: Any, key: str) -> Any:
+    """Return the child schema for ``key`` under ``schema_node`` if declared."""
+    if not isinstance(schema_node, dict):
+        return None
+    props = schema_node.get("properties")
+    if isinstance(props, dict) and key in props:
+        return props[key]
+    return None
+
+
+def _descend_schema_for_items(schema_node: Any) -> Any:
+    """Return the ``items`` schema for an array node."""
+    if not isinstance(schema_node, dict):
+        return None
+    items = schema_node.get("items")
+    if isinstance(items, dict):
+        return items
+    return None
 
 
 def _compute_score_with_weight(
@@ -69,6 +210,7 @@ def _compute_score_with_weight(
     normalize_dates: bool,
     string_scorer: Any,
     number_scorer: Any,
+    schema_node: Any = None,
 ) -> tuple[float, int]:
     """
     Recursively compute match score and weight.
@@ -81,9 +223,21 @@ def _compute_score_with_weight(
     :param normalize_dates: Normalize date strings before comparison
     :param string_scorer: Scorer for string comparison
     :param number_scorer: Scorer for number comparison
+    :param schema_node: JSON Schema node describing ``expected`` (when known);
+        used to gate the nullable-numeric ``0 == None`` collapse
     :return: (score, weight) where weight is the number of leaf nodes in expected
+
+    When `expected` has structure (dict/list) but `actual` is missing or of
+    a non-matching type (most commonly: the key was absent from a parent dict
+    so `dict.get(k)` returned None), the score is 0 with weight equal to the
+    full leaf count of `expected`. This ensures a dropped 15-claim array is
+    penalized by 15 × per-claim leaves rather than weight=1.
     """
-    if isinstance(expected, dict) and isinstance(actual, dict):
+    if isinstance(expected, dict):
+        if not isinstance(actual, dict):
+            # actual is missing the key entirely (or wrong type). Score 0
+            # with weight equal to expected's full leaf count.
+            return (0.0, _count_leaves(expected))
         if len(expected) == 0 and len(actual) == 0:
             return (1.0, 1)
         if len(expected) == 0:
@@ -101,6 +255,7 @@ def _compute_score_with_weight(
                 normalize_dates=normalize_dates,
                 string_scorer=string_scorer,
                 number_scorer=number_scorer,
+                schema_node=_descend_schema_for_key(schema_node, k),
             )
             results.append((score, weight))
 
@@ -118,59 +273,89 @@ def _compute_score_with_weight(
 
         return (agg_score, max(total_weight, 1))
 
-    elif isinstance(expected, list) and isinstance(actual, list):
+    elif isinstance(expected, list):
+        if not isinstance(actual, list):
+            # actual is missing the key entirely (or wrong type). Score 0
+            # with weight equal to expected's full leaf count, recursively.
+            return (0.0, _count_leaves(expected))
         if len(expected) == 0 and len(actual) == 0:
             return (1.0, 1)
         if len(expected) == 0:
             return (1.0, 1)
         if len(actual) == 0:
-            # All expected items missing - compute total weight of expected
-            total_weight = sum(
-                _compute_score_with_weight(
-                    e,
-                    None,
-                    weighted,
-                    case_sensitive,
-                    cosine_similarity,
-                    normalize_dates,
-                    string_scorer,
-                    number_scorer,
-                )[1]
-                for e in expected
-            )
-            return (0.0, max(total_weight, 1))
+            # All expected items missing - weight by expected's full leaf
+            # count so a dropped 15-claim array is penalized by 15 × per-claim
+            # leaves, not just len(expected).
+            return (0.0, max(_count_leaves(expected), 1))
 
-        # Pair up elements by index
-        min_len = min(len(expected), len(actual))
+        item_schema = _descend_schema_for_items(schema_node)
+
+        # Order-invariant pairing: optimal one-to-one assignment between
+        # expected and actual elements (Hungarian algorithm). The assignment
+        # cost is an approximate mismatch count over pre-normalized leaves
+        # (cheap exact equality, computed once per element so the n×m matrix
+        # stays cheap); the score for each assigned pair is then the full
+        # recursive partial-credit score. Unmatched expected elements score 0
+        # with their full leaf weight; extra actual elements are ignored in
+        # weighted mode (subset semantics) and penalized through the
+        # max-length denominator in unweighted mode.
+        if len(expected) * len(actual) > _ASSIGNMENT_MAX_PAIRS:
+            # Pathologically long arrays: building the cost matrix is
+            # O(n·m·leaves) in Python, so beyond the pair budget pair by
+            # index instead of stalling the evaluator.
+            assigned = {i: i for i in range(min(len(expected), len(actual)))}
+        else:
+            expected_flat = [
+                _flatten_normalized_leaves(item, case_sensitive=case_sensitive, normalize_dates=normalize_dates)
+                for item in expected
+            ]
+            actual_flat = [
+                _flatten_normalized_leaves(item, case_sensitive=case_sensitive, normalize_dates=normalize_dates)
+                for item in actual
+            ]
+            # Tie-break toward index order: scipy does not document which
+            # optimal assignment it returns when several are tied (e.g.
+            # every row is a near-miss and the cost matrix is uniform), so
+            # without this a scipy upgrade could legally swap aligned
+            # near-miss rows for crossed ones and silently drop their
+            # Levenshtein partial credit. The index distance term is scaled
+            # so its total over any assignment stays below 1 (sum of |i-j|
+            # is bounded by n*m), which means it can never override a real
+            # integer mismatch-count difference.
+            tiebreak_eps = 1.0 / (len(expected) * len(actual) + 1)
+            cost = np.empty((len(expected), len(actual)))
+            for i, exp_leaves in enumerate(expected_flat):
+                for j, act_leaves in enumerate(actual_flat):
+                    mismatches = sum(
+                        1
+                        for leaf_path, leaf in exp_leaves.items()
+                        if leaf_path not in act_leaves or act_leaves[leaf_path] != leaf
+                    )
+                    cost[i, j] = mismatches + tiebreak_eps * abs(i - j)
+            exp_indices, act_indices = linear_sum_assignment(cost)
+            assigned = dict(zip(exp_indices.tolist(), act_indices.tolist(), strict=True))
+
         list_results: list[tuple[float, int]] = []
-
-        # Matched elements
-        for i in range(min_len):
+        for i, exp_item in enumerate(expected):
+            paired_index = assigned.get(i)
+            if paired_index is None:
+                # More expected than actual: this element went unmatched.
+                # Weight by full leaf count so dropping rows of a long
+                # array isn't under-penalized.
+                list_results.append((0.0, _count_leaves(exp_item)))
+                continue
             score, weight = _compute_score_with_weight(
-                expected[i],
-                actual[i],
+                exp_item,
+                actual[paired_index],
                 weighted=weighted,
                 case_sensitive=case_sensitive,
                 cosine_similarity=cosine_similarity,
                 normalize_dates=normalize_dates,
                 string_scorer=string_scorer,
                 number_scorer=number_scorer,
+                schema_node=item_schema,
             )
             list_results.append((score, weight))
-
-        # Missing expected elements (score = 0)
-        for i in range(min_len, len(expected)):
-            _, weight = _compute_score_with_weight(
-                expected[i],
-                None,
-                weighted=weighted,
-                case_sensitive=case_sensitive,
-                cosine_similarity=cosine_similarity,
-                normalize_dates=normalize_dates,
-                string_scorer=string_scorer,
-                number_scorer=number_scorer,
-            )
-            list_results.append((0.0, weight))
 
         if not list_results:
             return (0.0, 1)
@@ -207,6 +392,18 @@ def _compute_score_with_weight(
         return (score, 1)
 
     elif isinstance(expected, (int, float)):
+        # Nullable numeric fields treat 0 / 0.0 and None as equivalent — the
+        # semantic on financial extraction ground truth is that null means
+        # "not present on this row" and there is no meaningful distinction
+        # between "not present" and "amount = zero". Gated strictly on the
+        # JSON Schema shape so plain numeric fields keep strict semantics.
+        # Booleans are excluded from the collapse (they are a subclass of int
+        # but ``False`` is never conflated with an absent value).
+        if not isinstance(expected, bool) and _is_nullable_numeric_field(schema_node):
+            norm_expected = _normalize_nullable_numeric(expected)
+            norm_actual = _normalize_nullable_numeric(actual)
+            if norm_expected is None and norm_actual is None:
+                return (1.0, 1)
         if not isinstance(actual, (int, float)):
             return (0.0, 1)
         result = number_scorer.eval(expected, actual)
@@ -215,6 +412,15 @@ def _compute_score_with_weight(
 
     elif expected is None:
         if actual is None:
+            return (1.0, 1)
+        # Same nullable-numeric gate for the None-expected direction: 0/0.0
+        # predicted against a null-expected cell scores as a match.
+        if (
+            _is_nullable_numeric_field(schema_node)
+            and isinstance(actual, (int, float))
+            and not isinstance(actual, bool)
+            and _normalize_nullable_numeric(actual) is None
+        ):
             return (1.0, 1)
         return (0.0, 1)
 
@@ -230,6 +436,7 @@ def json_subset_match_score(
     cosine_similarity: bool = False,
     normalize_dates: bool = True,
     weighted: bool = True,
+    data_schema: dict[str, Any] | None = None,
 ) -> float:
     """
     Calculate similarity score between expected and actual JSON structures.
@@ -244,6 +451,9 @@ def json_subset_match_score(
     :param normalize_dates: Normalize date strings before comparison
     :param weighted: If True (default), weight fields by their number of leaf nodes.
                      If False, use simple averaging (each field/element counts equally).
+    :param data_schema: Optional JSON Schema for ``expected``; when provided,
+        nullable numeric fields (``anyOf: [number, null]`` / ``type: [number, null]``)
+        treat ``0`` / ``0.0`` and ``None`` as equivalent
     :return: Similarity score between 0.0 and 1.0
     """
     string_scorer = Levenshtein() if not cosine_similarity else EmbeddingSimilarity()
@@ -258,5 +468,6 @@ def json_subset_match_score(
         normalize_dates=normalize_dates,
         string_scorer=string_scorer,
         number_scorer=number_scorer,
+        schema_node=data_schema,
     )
     return score

--- a/src/parse_bench/evaluation/metrics/extract/json_subset_match_metric.py
+++ b/src/parse_bench/evaluation/metrics/extract/json_subset_match_metric.py
@@ -57,6 +57,7 @@ class JsonSubsetMatchMetric(Metric):
         cosine_similarity = kwargs.get("cosine_similarity", self._cosine_similarity)
         normalize_dates = kwargs.get("normalize_dates", self._normalize_dates)
         weighted = kwargs.get("weighted", self._weighted)
+        data_schema = kwargs.get("data_schema")
 
         score = json_subset_match_score(
             expected=expected,
@@ -65,6 +66,7 @@ class JsonSubsetMatchMetric(Metric):
             cosine_similarity=cosine_similarity,
             normalize_dates=normalize_dates,
             weighted=weighted,
+            data_schema=data_schema,
         )
 
         return MetricValue(

--- a/src/parse_bench/evaluation/metrics/field_grounding/extract_adapter.py
+++ b/src/parse_bench/evaluation/metrics/field_grounding/extract_adapter.py
@@ -181,7 +181,20 @@ def _compute_null_hallucination_metrics(
     "missed-null" outcome). The runner's standard tp/fp/fn pooling
     produces ``total_null_hallucination_rate_*`` for the global view.
     """
-    null_rules = [rule for rule in field_rules if rule.expected_value is None and rule.verified]
+
+    # A rule is null-expected when it carries no expected value and, if the
+    # rule declares per-evidence values (v0.2 evidence entries), no evidence
+    # entry carries a value either. Legacy rules (no evidence) collapse to
+    # the original ``expected_value is None`` check.
+    def _is_null_expected(rule: ExtractFieldTestRule) -> bool:
+        if rule.expected_value is not None:
+            return False
+        evidence = getattr(rule, "evidence", None)
+        if evidence:
+            return all(getattr(entry, "value", None) is None for entry in evidence)
+        return True
+
+    null_rules = [rule for rule in field_rules if _is_null_expected(rule) and rule.verified]
     if not null_rules:
         return []
 

--- a/src/parse_bench/evaluation/metrics/layoutdet/classification_utils.py
+++ b/src/parse_bench/evaluation/metrics/layoutdet/classification_utils.py
@@ -5,11 +5,14 @@ and computing per-class precision/recall/F1 metrics.
 """
 
 from collections import defaultdict
+from collections.abc import Callable
 
 import numpy as np
 from sklearn.metrics import average_precision_score
 
 from parse_bench.evaluation.metrics.layoutdet.iou import compute_iou_matrix
+
+OverlapFn = Callable[[dict, dict], float]
 
 
 def match_predictions_to_gt(
@@ -80,6 +83,9 @@ def compute_per_class_metrics(
     ground_truth: list[dict],  # [{bbox, class_name}, ...]
     class_names: list[str],
     iou_threshold: float = 0.5,
+    *,
+    overlap_fn: OverlapFn | None = None,
+    page_key: str = "example_id",
 ) -> dict[str, dict[str, float]]:
     """
     Compute per-class precision, recall, F1 at given IoU threshold.
@@ -90,85 +96,10 @@ def compute_per_class_metrics(
     :param iou_threshold: IoU threshold for matching (default 0.5)
     :return: Dict mapping class_name to metrics dict {precision, recall, f1, ap, support}
     """
-    class_to_idx = {name: i for i, name in enumerate(class_names)}
     class_set = set(class_names)
     results: dict[str, dict[str, float]] = {}
 
-    has_pages = False
-    for entry in predictions:
-        if "example_id" in entry:
-            has_pages = True
-            break
-    if not has_pages:
-        for entry in ground_truth:
-            if "example_id" in entry:
-                has_pages = True
-                break
-
-    if not has_pages:
-        for class_name in class_names:
-            class_idx = class_to_idx[class_name]
-
-            # Filter by class
-            class_preds = [p for p in predictions if p["class_name"] == class_name]
-            class_gt = [g for g in ground_truth if g["class_name"] == class_name]
-
-            if len(class_gt) == 0:
-                results[class_name] = {
-                    "precision": 0.0,
-                    "recall": 0.0,
-                    "f1": 0.0,
-                    "ap": 0.0,
-                    "support": 0,
-                }
-                continue
-
-            if len(class_preds) == 0:
-                results[class_name] = {
-                    "precision": 0.0,
-                    "recall": 0.0,
-                    "f1": 0.0,
-                    "ap": 0.0,
-                    "support": len(class_gt),
-                }
-                continue
-
-            # Convert to numpy arrays
-            pred_boxes = np.array([p["bbox"] for p in class_preds])
-            pred_scores = np.array([p["score"] for p in class_preds])
-            pred_classes = np.full(len(class_preds), class_idx)
-
-            gt_boxes = np.array([g["bbox"] for g in class_gt])
-            gt_classes = np.full(len(class_gt), class_idx)
-
-            # Match predictions to GT
-            y_true, y_scores = match_predictions_to_gt(
-                pred_boxes, pred_scores, pred_classes, gt_boxes, gt_classes, iou_threshold
-            )
-
-            # Compute metrics
-            tp = int(np.sum(y_true))
-            fp = len(y_true) - tp
-            fn = len(class_gt) - tp
-
-            precision = tp / (tp + fp) if (tp + fp) > 0 else 0.0
-            recall = tp / (tp + fn) if (tp + fn) > 0 else 0.0
-            f1 = 2 * precision * recall / (precision + recall) if (precision + recall) > 0 else 0.0
-
-            # Compute AP using sklearn
-            if len(np.unique(y_true)) > 1:
-                ap = float(average_precision_score(y_true, y_scores))
-            else:
-                ap = precision if np.all(y_true == 1) else 0.0
-
-            results[class_name] = {
-                "precision": precision,
-                "recall": recall,
-                "f1": f1,
-                "ap": ap,
-                "support": len(class_gt),
-            }
-        return results
+    has_pages = any(page_key in entry for entry in predictions) or any(page_key in entry for entry in ground_truth)
 
     # Per-page matching to keep IoU matrices bounded by per-page box counts.
     predictions_by_page = defaultdict(lambda: defaultdict(list))  # type: ignore[var-annotated]
@@ -177,19 +108,18 @@ def compute_per_class_metrics(
     for pred in predictions:
         if pred.get("class_name") not in class_set:
             continue
-        page_id = str(pred.get("example_id", "__missing__"))
+        page_id = str(pred.get(page_key, "__missing__")) if has_pages else "__all__"
         predictions_by_page[page_id][pred["class_name"]].append(pred)
 
     for gt in ground_truth:
         if gt.get("class_name") not in class_set:
             continue
-        page_id = str(gt.get("example_id", "__missing__"))
+        page_id = str(gt.get(page_key, "__missing__")) if has_pages else "__all__"
         ground_truth_by_page[page_id][gt["class_name"]].append(gt)
 
     page_ids = set(predictions_by_page.keys()) | set(ground_truth_by_page.keys())
 
     for class_name in class_names:
-        class_idx = class_to_idx[class_name]
         total_true = 0
         total_false = 0
         total_support = 0
@@ -209,14 +139,11 @@ def compute_per_class_metrics(
             if not class_preds:
                 continue
 
-            pred_boxes = np.array([p["bbox"] for p in class_preds])
-            pred_scores = np.array([p["score"] for p in class_preds])
-            pred_classes = np.full(len(class_preds), class_idx)
-            gt_boxes = np.array([g["bbox"] for g in class_gt])
-            gt_classes = np.full(len(class_gt), class_idx)
-
-            y_true, y_scores = match_predictions_to_gt(
-                pred_boxes, pred_scores, pred_classes, gt_boxes, gt_classes, iou_threshold
+            y_true, y_scores = match_prediction_dicts_to_gt(
+                class_preds,
+                class_gt,
+                iou_threshold=iou_threshold,
+                overlap_fn=overlap_fn,
             )
             y_true_list = [int(v) for v in y_true.tolist()]
             y_score_list = [float(v) for v in y_scores.tolist()]
@@ -258,11 +185,73 @@ def compute_per_class_metrics(
     return results
 
 
+def match_prediction_dicts_to_gt(
+    predictions: list[dict],
+    ground_truth: list[dict],
+    *,
+    iou_threshold: float,
+    overlap_fn: OverlapFn | None = None,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Match same-class prediction/GT dictionaries using axis-aligned or custom overlap."""
+    if len(predictions) == 0:
+        return np.array([]), np.array([])
+
+    pred_scores = np.array([float(pred.get("score", 0.0)) for pred in predictions])
+    if len(ground_truth) == 0:
+        return np.zeros(len(predictions)), pred_scores.copy()
+
+    if overlap_fn is None:
+        pred_boxes = np.array([pred["bbox"] for pred in predictions])
+        pred_classes = np.zeros(len(predictions), dtype=int)
+        gt_boxes = np.array([gt["bbox"] for gt in ground_truth])
+        gt_classes = np.zeros(len(ground_truth), dtype=int)
+        return match_predictions_to_gt(
+            pred_boxes,
+            pred_scores,
+            pred_classes,
+            gt_boxes,
+            gt_classes,
+            iou_threshold,
+        )
+
+    overlap_matrix: np.ndarray | None = None
+    matrix_fn = getattr(overlap_fn, "matrix", None)
+    if callable(matrix_fn):
+        overlap_matrix = matrix_fn(predictions, ground_truth)
+
+    sorted_indices = np.argsort(-pred_scores)
+    y_true = np.zeros(len(predictions))
+    matched_gt: set[int] = set()
+
+    for pred_idx in sorted_indices:
+        pred = predictions[int(pred_idx)]
+        best_iou = 0.0
+        best_gt_idx = -1
+
+        for gt_idx, gt in enumerate(ground_truth):
+            if gt_idx in matched_gt:
+                continue
+
+            iou = float(overlap_matrix[int(pred_idx), gt_idx]) if overlap_matrix is not None else overlap_fn(pred, gt)
+            if iou >= iou_threshold and iou > best_iou:
+                best_iou = iou
+                best_gt_idx = gt_idx
+
+        if best_gt_idx >= 0:
+            y_true[int(pred_idx)] = 1
+            matched_gt.add(best_gt_idx)
+
+    return y_true, pred_scores.copy()
+
+
 def compute_map_at_thresholds(
     predictions: list[dict],  # [{bbox, class_name, score}, ...]
     ground_truth: list[dict],  # [{bbox, class_name}, ...]
     class_names: list[str],
     iou_thresholds: list[float] | None = None,
+    *,
+    overlap_fn: OverlapFn | None = None,
+    page_key: str = "example_id",
 ) -> dict[str, float]:
     """
     Compute mAP at multiple IoU thresholds (COCO-style).
@@ -282,7 +271,14 @@ def compute_map_at_thresholds(
     ap75 = 0.0
 
     for threshold in iou_thresholds:
-        per_class = compute_per_class_metrics(predictions, ground_truth, class_names, iou_threshold=threshold)
+        per_class = compute_per_class_metrics(
+            predictions,
+            ground_truth,
+            class_names,
+            iou_threshold=threshold,
+            overlap_fn=overlap_fn,
+            page_key=page_key,
+        )
 
         # Mean AP across classes (only classes with support > 0)
         aps = [m["ap"] for m in per_class.values() if m["support"] > 0]

--- a/src/parse_bench/evaluation/metrics/qa/answer_comparison.py
+++ b/src/parse_bench/evaluation/metrics/qa/answer_comparison.py
@@ -1,6 +1,7 @@
 """Answer comparison metric for QA evaluation."""
 
 import re
+from collections.abc import Mapping
 from typing import Any
 
 from parse_bench.schemas.evaluation import MetricValue
@@ -25,6 +26,26 @@ class AnswerComparisonMetric:
         :param metadata: Optional metadata (tolerance, options, etc.)
         :return: MetricValue with pass/fail and metadata
         """
+        # ``exact_choice`` is deliberately an opt-in grading contract.  Do
+        # not route legacy single-choice items through it: older datasets rely
+        # on the permissive letter extraction below (and, in particular, may
+        # use answer strings rather than a serialized model response).
+        if isinstance(metadata, dict) and "grading_mode" in metadata:
+            grading_mode = metadata.get("grading_mode")
+            if grading_mode == "exact_choice":
+                return self._compare_exact_choice(predicted, expected, metadata)
+            return MetricValue(
+                metric_name="qa_answer_match",
+                value=0.0,
+                metadata={
+                    "passed": False,
+                    "predicted": predicted,
+                    "expected": expected,
+                    "question_type": question_type,
+                    "error": f"Unsupported grading mode: {grading_mode!r}",
+                },
+            )
+
         if question_type == "single_choice":
             return self._compare_single_choice(predicted, expected, metadata)
         elif question_type == "multiple_choice":
@@ -44,6 +65,99 @@ class AnswerComparisonMetric:
                     "error": f"Unknown question type: {question_type}",
                 },
             )
+
+    def _compare_exact_choice(
+        self,
+        predicted: str,
+        expected: str,
+        metadata: dict[str, Any],
+    ) -> MetricValue:
+        """Grade one strict ``Answer: <letter>`` response.
+
+        The parser intentionally has no fallback to bare-letter or prose
+        extraction. It is used only when the annotation explicitly sets
+        ``metadata.grading_mode`` to ``exact_choice``; all unconfigured QA
+        items retain the historical comparison behavior. A configured answer
+        may be any single letter A-Z. When an option grid is supplied, its
+        labelled choices narrow the accepted set.
+        """
+
+        valid_choices = self._exact_choice_set(expected, metadata)
+        predicted_choice = self._parse_exact_choice_response(predicted)
+        expected_choice = expected.strip().upper()
+        valid_expected = bool(re.fullmatch(r"[A-Z]", expected_choice)) and expected_choice in valid_choices
+        choice_valid = predicted_choice is not None and predicted_choice in valid_choices
+        passed = valid_expected and choice_valid and predicted_choice == expected_choice
+
+        return MetricValue(
+            metric_name="qa_answer_match",
+            value=1.0 if passed else 0.0,
+            metadata={
+                "passed": passed,
+                "predicted": predicted,
+                "expected": expected,
+                "question_type": "single_choice",
+                "grading_mode": "exact_choice",
+                "predicted_choice": predicted_choice,
+                "format_valid": choice_valid,
+                "expected_valid": valid_expected,
+                "valid_choices": sorted(valid_choices),
+                "options": metadata.get("options"),
+            },
+        )
+
+    @staticmethod
+    def _exact_choice_set(expected: str, metadata: dict[str, Any]) -> set[str]:
+        """Return the configured exact-choice labels.
+
+        A single-letter expected answer is sufficient configuration and keeps
+        this mode useful for datasets without an option grid. If ``options``
+        contains explicit labels, those labels are authoritative instead.
+        Invalid/unlabelled option text falls back to A-Z so it cannot make a
+        valid annotation impossible to grade merely because display text was
+        omitted from a sidecar.
+        """
+
+        options = metadata.get("options")
+        labels: set[str] = set()
+        if isinstance(options, str):
+            labels.update(
+                label.upper() for label in re.findall(r"(?<![A-Za-z0-9])([A-Z])\s*[).:]", options, re.IGNORECASE)
+            )
+        elif isinstance(options, Mapping):
+            labels.update(str(key).strip().upper() for key in options if re.fullmatch(r"[A-Za-z]", str(key).strip()))
+        elif isinstance(options, (list, tuple, set)):
+            for option in options:
+                if isinstance(option, Mapping):
+                    label = option.get("label", option.get("id", ""))
+                else:
+                    label = option
+                if isinstance(label, str):
+                    match = re.match(r"^\s*([A-Za-z])\s*[).:]", label)
+                    if match:
+                        labels.add(match.group(1).upper())
+
+        if labels:
+            return labels
+
+        expected_choice = expected.strip().upper()
+        if re.fullmatch(r"[A-Z]", expected_choice):
+            return set("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+        return set()
+
+    @staticmethod
+    def _parse_exact_choice_response(response: str) -> str | None:
+        """Parse exactly one ``Answer: <letter>`` response."""
+
+        if not isinstance(response, str):
+            return None
+        candidate = response.strip()
+        # ``\s`` would accept a newline at either end.  Reject all line breaks
+        # explicitly so prose or a second answer can never be accepted.
+        if "\n" in candidate or "\r" in candidate:
+            return None
+        match = re.fullmatch(r"Answer:[ \t]+([A-Z])[ \t]*", candidate, flags=re.IGNORECASE)
+        return match.group(1).upper() if match else None
 
     def _compare_single_choice(self, predicted: str, expected: str, metadata: dict[str, Any] | None) -> MetricValue:
         """Compare single choice answers."""

--- a/src/parse_bench/layout_label_mapping.py
+++ b/src/parse_bench/layout_label_mapping.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+
 from parse_bench.schemas.layout_ontology import (
     CANONICAL_TO_BASIC,
     DEFAULT_LAYOUT_EVALUATION_ONTOLOGY,
@@ -91,6 +93,10 @@ LLAMAPARSE_V2_RAW_TO_CANONICAL: dict[str, tuple[CanonicalLabel, dict[str, str]]]
     "table": (CanonicalLabel.TABLE, {}),
     "formula": (CanonicalLabel.FORMULA, {}),
     "algorithm": (CanonicalLabel.CODE, {}),
+    # LlamaParse V2 SDK ``CodeItem`` emits ``type="code"`` even when
+    # ``layoutAwareBbox`` labels look V2-only, so without this alias the V2-path
+    # canonicalizer silently dropped code blocks.
+    "code": (CanonicalLabel.CODE, {}),
 }
 
 
@@ -292,3 +298,127 @@ def map_label_to_target_ontology(
         return basic_label.value
 
     return label
+
+
+# ---------------------------------------------------------------------------
+# Picture-type vocabulary
+# ---------------------------------------------------------------------------
+
+# Figure-classifier labels LlamaParse emits as `![label: description](path)`
+# alt-text prefixes (docling DocumentFigureClassifier vocabulary). Kept for
+# documentation/tests only: picture-type handling is an OPEN list, so labels
+# outside this set are normalized and scored rather than rejected.
+LLAMAPARSE_PICTURE_TYPE_LABELS = frozenset(
+    {
+        "logo",
+        "photograph",
+        "icon",
+        "engineering_drawing",
+        "line_chart",
+        "bar_chart",
+        "other",
+        "table",
+        "flow_chart",
+        "screenshot_from_computer",
+        "signature",
+        "screenshot_from_manual",
+        "geographical_map",
+        "pie_chart",
+        "page_thumbnail",
+        "stamp",
+        "music",
+        "calendar",
+        "qr_code",
+        "bar_code",
+        "full_page_image",
+        "scatter_plot",
+        "chemistry_structure",
+        "topographical_map",
+        "crossword_puzzle",
+        "box_plot",
+    }
+)
+
+# Predicted-vocabulary -> ground-truth-vocabulary aliases. The layout GT
+# annotations use a coarser vocabulary (e.g. "image", "screenshot", "map")
+# than the classifier's specific labels; both sides are normalized through
+# this map before comparison so cosmetic vocabulary drift never scores as a
+# misclassification.
+PICTURE_TYPE_ALIASES: dict[str, str] = {
+    "photo": "image",
+    "photograph": "image",
+    "full_page_image": "image",
+    "screenshot_from_computer": "screenshot",
+    "screenshot_from_manual": "screenshot",
+    "geographical_map": "map",
+    "topographical_map": "map",
+    "scatter_plot": "scatter_chart",
+    "seal": "stamp",
+}
+
+# Attribute values that are annotation noise, not picture classes.
+_PICTURE_TYPE_DENYLIST = frozenset({"true", "false", "caption", "none", "null", "unknown", "n_a", "na"})
+
+_PICTURE_TYPE_SEPARATOR_RE = re.compile(r"[\s\-/]+")
+_PICTURE_TYPE_INVALID_CHARS_RE = re.compile(r"[^a-z0-9_]")
+# A class token, not a leaked description: bounded length and word count.
+_PICTURE_TYPE_MAX_LENGTH = 40
+_PICTURE_TYPE_MAX_WORDS = 4
+
+_GENERIC_CHART_TYPE = "chart"
+_DATA_CHART_SUFFIXES = ("_chart", "_plot", "_graph")
+# Diagram-like classes whose *_chart names are not data charts: the GT
+# vocabulary keeps these distinct from the generic "chart" annotation.
+_NON_DATA_CHART_TYPES = frozenset({"flow_chart", "org_chart"})
+
+
+def normalize_picture_type(value: object) -> str | None:
+    """Normalize a picture-type label to a comparable snake_case token.
+
+    Open-list by design (labels outside ``LLAMAPARSE_PICTURE_TYPE_LABELS``
+    survive): lowercases, converts separators to underscores, applies
+    ``PICTURE_TYPE_ALIASES``, and returns None for annotation noise or
+    values that read as a leaked description rather than a class token.
+    """
+    if not isinstance(value, str):
+        return None
+    token = _PICTURE_TYPE_SEPARATOR_RE.sub("_", value.strip().lower())
+    token = _PICTURE_TYPE_INVALID_CHARS_RE.sub("", token).strip("_")
+    if not token or token in _PICTURE_TYPE_DENYLIST:
+        return None
+    if len(token) > _PICTURE_TYPE_MAX_LENGTH or token.count("_") >= _PICTURE_TYPE_MAX_WORDS:
+        return None
+    return PICTURE_TYPE_ALIASES.get(token, token)
+
+
+def _is_specific_data_chart(picture_type: str) -> bool:
+    return picture_type.endswith(_DATA_CHART_SUFFIXES) and picture_type not in _NON_DATA_CHART_TYPES
+
+
+def is_chart_family_picture_type(picture_type: str) -> bool:
+    """Whether a *normalized* picture type belongs to the data-chart family.
+
+    The family is the generic ``chart`` plus every specific data-chart class
+    (``bar_chart``, ``pie_chart``, ``line_chart``, ``scatter_chart``, ...) —
+    the same equivalence class :func:`picture_types_match` already tolerates.
+    Diagram-like ``*_chart`` classes (``flow_chart``, ``org_chart``) are not
+    data charts and stay outside the family.
+    """
+    return picture_type == _GENERIC_CHART_TYPE or _is_specific_data_chart(picture_type)
+
+
+def picture_types_match(gt_picture_type: str, pred_picture_type: str) -> bool:
+    """Whether two *normalized* picture types count as the same class.
+
+    Exact match, plus generic<->specific data-chart tolerance: GT annotators
+    often write the generic "chart" where the classifier answers "bar_chart",
+    and the reverse happens when the raw bbox label is the generic "chart".
+    Diagram-like ``*_chart`` classes (flow_chart) stay distinct.
+    """
+    if gt_picture_type == pred_picture_type:
+        return True
+    if gt_picture_type == _GENERIC_CHART_TYPE and _is_specific_data_chart(pred_picture_type):
+        return True
+    if pred_picture_type == _GENERIC_CHART_TYPE and _is_specific_data_chart(gt_picture_type):
+        return True
+    return False

--- a/src/parse_bench/schemas/layout_detection_output.py
+++ b/src/parse_bench/schemas/layout_detection_output.py
@@ -6,6 +6,7 @@ from typing import Annotated, Any, Literal
 from pydantic import BaseModel, Discriminator, Field, Tag, field_validator
 
 from parse_bench.schemas.layout_ontology import CanonicalLabel
+from parse_bench.schemas.parse_output import ParseLayoutPageIR
 
 
 class YoloLabel(IntEnum):
@@ -526,6 +527,13 @@ class LayoutOutput(BaseModel):
     image_width: int = Field(ge=1, description="Width of the input image in pixels")
     image_height: int = Field(ge=1, description="Height of the input image in pixels")
     predictions: list[LayoutPrediction] = Field(default_factory=list)
+    layout_pages: list[ParseLayoutPageIR] = Field(
+        default_factory=list,
+        description=(
+            "Per-page layout payload. Target shape for layout detectors "
+            "(migration in progress — see predictions field)."
+        ),
+    )
     markdown: str = Field(
         default="",
         description=("Optional document markdown for providers that can supply it (e.g., LlamaParse layout runs)."),

--- a/src/parse_bench/schemas/parse_output.py
+++ b/src/parse_bench/schemas/parse_output.py
@@ -55,6 +55,17 @@ class LayoutItemIR(BaseModel):
         default_factory=list,
         validation_alias=AliasChoices("layout_segments", "layoutAwareBbox"),
     )
+    # Populated by layout-detection providers; left default for parse providers.
+    score: float | None = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description="Detector confidence in [0,1]. None for parse-pipeline items.",
+    )
+    attributes: dict[str, str] = Field(
+        default_factory=dict,
+        description="Semantic attributes (e.g. scope=mark, picture_type=chart).",
+    )
 
     @field_validator("type", mode="before")
     @classmethod

--- a/tests/parse_bench/evaluation/evaluators/test_extract_empty_expected_output.py
+++ b/tests/parse_bench/evaluation/evaluators/test_extract_empty_expected_output.py
@@ -1,0 +1,59 @@
+"""An empty-dict ``expected_output`` must still be scored, not skipped."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+from parse_bench.evaluation.evaluators.extract import ExtractEvaluator
+from parse_bench.schemas.extract_output import ExtractOutput
+from parse_bench.schemas.pipeline_io import InferenceRequest, InferenceResult
+from parse_bench.schemas.product import ProductType
+from parse_bench.test_cases.schema import ExtractTestCase
+
+
+def _result(extracted: dict) -> InferenceResult:
+    now = datetime.now()
+    return InferenceResult(
+        request=InferenceRequest(
+            example_id="group/doc",
+            source_file_path="doc.pdf",
+            product_type=ProductType.EXTRACT,
+        ),
+        pipeline_name="extract",
+        product_type=ProductType.EXTRACT,
+        raw_output={},
+        output=ExtractOutput(example_id="group/doc", pipeline_name="extract", extracted_data=extracted),
+        started_at=now,
+        completed_at=now,
+        latency_in_ms=1,
+    )
+
+
+def _case(expected_output: dict | None) -> ExtractTestCase:
+    return ExtractTestCase(
+        test_id="group/doc",
+        group="group",
+        file_path=Path("doc.pdf"),
+        schema={"type": "object", "properties": {}},
+        expected_output=expected_output,
+    )
+
+
+def test_empty_dict_expected_output_emits_accuracy_metric() -> None:
+    evaluator = ExtractEvaluator(enable_rule_based=False)
+    test_case = _case({})
+    assert evaluator.can_evaluate(_result({}), test_case)
+
+    evaluation = evaluator.evaluate(_result({}), test_case)
+    names = [metric.metric_name for metric in evaluation.metrics]
+    assert "accuracy" in names
+    accuracy = next(metric for metric in evaluation.metrics if metric.metric_name == "accuracy")
+    assert accuracy.value == 1.0
+
+
+def test_non_empty_expected_output_still_scored() -> None:
+    evaluator = ExtractEvaluator(enable_rule_based=False)
+    evaluation = evaluator.evaluate(_result({"name": "Ada"}), _case({"name": "Ada"}))
+    accuracy = next(metric for metric in evaluation.metrics if metric.metric_name == "accuracy")
+    assert accuracy.value == 1.0

--- a/tests/parse_bench/evaluation/layout_adapters/test_docling_parse_layout_adapter.py
+++ b/tests/parse_bench/evaluation/layout_adapters/test_docling_parse_layout_adapter.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from parse_bench.evaluation.layout_adapters import create_layout_adapter_for_result
+from parse_bench.evaluation.layout_label_mappers.projection import project_layout_predictions
+from parse_bench.schemas.parse_output import (
+    LayoutItemIR,
+    LayoutSegmentIR,
+    PageIR,
+    ParseLayoutPageIR,
+    ParseOutput,
+)
+from parse_bench.schemas.pipeline_io import InferenceRequest, InferenceResult
+from parse_bench.schemas.product import ProductType
+
+
+def _make_docling_parse_inference_result(*, layout_pages: list[ParseLayoutPageIR], markdown: str) -> InferenceResult:
+    now = datetime.now()
+    output = ParseOutput(
+        task_type="parse",
+        example_id="doc-1",
+        pipeline_name="docling_parse",
+        pages=[PageIR(page_index=0, markdown=markdown)],
+        layout_pages=layout_pages,
+        markdown=markdown,
+    )
+    return InferenceResult(
+        request=InferenceRequest(
+            example_id="doc-1",
+            source_file_path="/tmp/doc-1.pdf",
+            product_type=ProductType.PARSE,
+        ),
+        pipeline_name="docling_parse",
+        product_type=ProductType.PARSE,
+        raw_output={"docling_document": {"schema_name": "DoclingDocument"}},
+        output=output,
+        started_at=now,
+        completed_at=now,
+        latency_in_ms=1,
+    )
+
+
+def test_docling_parse_projection_maps_reference_and_document_index_distinctly() -> None:
+    inference_result = _make_docling_parse_inference_result(
+        markdown="References\n\n<table><tr><td>Contents</td></tr></table>",
+        layout_pages=[
+            ParseLayoutPageIR(
+                page_number=1,
+                width=1000.0,
+                height=1000.0,
+                md="References\n\n<table><tr><td>Contents</td></tr></table>",
+                items=[
+                    LayoutItemIR(
+                        type="text",
+                        value="References entry",
+                        bbox=LayoutSegmentIR(x=0.1, y=0.1, w=0.3, h=0.05, label="reference"),
+                        layout_segments=[
+                            LayoutSegmentIR(
+                                x=0.1,
+                                y=0.1,
+                                w=0.3,
+                                h=0.05,
+                                label="reference",
+                                start_index=0,
+                                end_index=9,
+                            )
+                        ],
+                    ),
+                    LayoutItemIR(
+                        type="table",
+                        value="<table><tr><td>Contents</td></tr></table>",
+                        bbox=LayoutSegmentIR(x=0.1, y=0.2, w=0.4, h=0.2, label="document_index"),
+                        layout_segments=[
+                            LayoutSegmentIR(
+                                x=0.1,
+                                y=0.2,
+                                w=0.4,
+                                h=0.2,
+                                label="document_index",
+                            )
+                        ],
+                    ),
+                ],
+            )
+        ],
+    )
+
+    adapter = create_layout_adapter_for_result(inference_result)
+    layout_output = adapter.to_layout_output(inference_result)
+    projected = project_layout_predictions(
+        inference_result,
+        layout_output,
+        evaluation_view="canonical",
+        target_ontology="canonical",
+    )
+
+    assert layout_output.model.value == "docling_parse_layout"
+    assert [prediction["class_name"] for prediction in projected] == ["Text", "Document Index"]
+
+
+def test_docling_parse_adapter_preserves_spans_and_table_text_for_attribution() -> None:
+    inference_result = _make_docling_parse_inference_result(
+        markdown="AlphaBeta\n\n<table><tr><td>A</td></tr></table>",
+        layout_pages=[
+            ParseLayoutPageIR(
+                page_number=1,
+                width=1000.0,
+                height=1000.0,
+                md="AlphaBeta\n\n<table><tr><td>A</td></tr></table>",
+                items=[
+                    LayoutItemIR(
+                        type="text",
+                        value="AlphaBeta",
+                        bbox=LayoutSegmentIR(x=0.1, y=0.1, w=0.2, h=0.05, label="text"),
+                        layout_segments=[
+                            LayoutSegmentIR(
+                                x=0.1,
+                                y=0.1,
+                                w=0.2,
+                                h=0.05,
+                                label="text",
+                                start_index=0,
+                                end_index=4,
+                            )
+                        ],
+                    ),
+                    LayoutItemIR(
+                        type="table",
+                        value="<table><tr><td>A</td></tr></table>",
+                        bbox=LayoutSegmentIR(x=0.1, y=0.2, w=0.3, h=0.2, label="table"),
+                        layout_segments=[
+                            LayoutSegmentIR(
+                                x=0.1,
+                                y=0.2,
+                                w=0.3,
+                                h=0.2,
+                                label="table",
+                            )
+                        ],
+                    ),
+                ],
+            )
+        ],
+    )
+
+    adapter = create_layout_adapter_for_result(inference_result)
+    layout_output = adapter.to_layout_output(inference_result)
+    blocks = adapter.to_attribution_blocks(layout_output, page_number=1)
+
+    assert len(layout_output.predictions) == 2
+    assert layout_output.predictions[1].content is not None
+    assert layout_output.predictions[1].content.type == "table"
+    assert [block.text for block in blocks] == ["Alpha", "A"]
+    assert [block.label for block in blocks] == ["text", "table"]
+
+
+def test_docling_parse_adapter_table_type_check_is_case_insensitive() -> None:
+    inference_result = _make_docling_parse_inference_result(
+        markdown="<table><tr><td>Cell</td></tr></table>",
+        layout_pages=[
+            ParseLayoutPageIR(
+                page_number=1,
+                width=1000.0,
+                height=1000.0,
+                md="<table><tr><td>Cell</td></tr></table>",
+                items=[
+                    LayoutItemIR(
+                        type="Table ",
+                        value="<table><tr><td>Cell</td></tr></table>",
+                        bbox=LayoutSegmentIR(x=0.1, y=0.2, w=0.3, h=0.2, label="table"),
+                        layout_segments=[LayoutSegmentIR(x=0.1, y=0.2, w=0.3, h=0.2, label="table")],
+                    ),
+                ],
+            )
+        ],
+    )
+
+    adapter = create_layout_adapter_for_result(inference_result)
+    layout_output = adapter.to_layout_output(inference_result)
+    blocks = adapter.to_attribution_blocks(layout_output, page_number=1)
+
+    assert [block.text for block in blocks] == ["Cell"]
+
+
+def test_docling_parse_adapter_skips_bbox_only_items_for_attribution() -> None:
+    inference_result = _make_docling_parse_inference_result(
+        markdown="Container fallback",
+        layout_pages=[
+            ParseLayoutPageIR(
+                page_number=1,
+                width=1000.0,
+                height=1000.0,
+                md="Container fallback",
+                items=[
+                    LayoutItemIR(
+                        type="text",
+                        value="Container fallback",
+                        bbox=LayoutSegmentIR(x=0.1, y=0.1, w=0.2, h=0.05, label="text"),
+                        layout_segments=[],
+                    )
+                ],
+            )
+        ],
+    )
+
+    adapter = create_layout_adapter_for_result(inference_result)
+    layout_output = adapter.to_layout_output(inference_result)
+    blocks = adapter.to_attribution_blocks(layout_output, page_number=1)
+
+    assert len(layout_output.predictions) == 1
+    assert blocks == []

--- a/tests/parse_bench/evaluation/layout_adapters/test_llamaparse_attribution_scope.py
+++ b/tests/parse_bench/evaluation/layout_adapters/test_llamaparse_attribution_scope.py
@@ -1,0 +1,108 @@
+"""LlamaParse attribution claims are restricted to layout-aware segments."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from parse_bench.evaluation.layout_adapters.adapters import (
+    LlamaParseLayoutAdapter,
+    _resolve_llamaparse_pages,
+)
+from parse_bench.schemas.parse_output import (
+    LayoutItemIR,
+    LayoutSegmentIR,
+    PageIR,
+    ParseLayoutPageIR,
+    ParseOutput,
+)
+from parse_bench.schemas.pipeline_io import InferenceRequest, InferenceResult
+from parse_bench.schemas.product import ProductType
+
+
+def _make_llamaparse_result(layout_pages: list[ParseLayoutPageIR]) -> InferenceResult:
+    now = datetime.now()
+    output = ParseOutput(
+        task_type="parse",
+        example_id="doc-1",
+        pipeline_name="llamaparse",
+        pages=[PageIR(page_index=0, markdown="Alpha\n\nBeta")],
+        layout_pages=layout_pages,
+        markdown="Alpha\n\nBeta",
+    )
+    return InferenceResult(
+        request=InferenceRequest(
+            example_id="doc-1",
+            source_file_path="/tmp/doc-1.pdf",
+            product_type=ProductType.PARSE,
+        ),
+        pipeline_name="llamaparse",
+        product_type=ProductType.PARSE,
+        raw_output={},
+        output=output,
+        started_at=now,
+        completed_at=now,
+        latency_in_ms=1,
+    )
+
+
+def _pages() -> list[ParseLayoutPageIR]:
+    return [
+        ParseLayoutPageIR(
+            page_number=1,
+            width=1000.0,
+            height=1000.0,
+            md="Alpha\n\nBeta",
+            items=[
+                LayoutItemIR(
+                    type="text",
+                    value="Alpha",
+                    bbox=LayoutSegmentIR(x=100.0, y=100.0, w=200.0, h=50.0, label="text", confidence=1.0),
+                    layout_segments=[
+                        LayoutSegmentIR(
+                            x=100.0,
+                            y=100.0,
+                            w=200.0,
+                            h=50.0,
+                            label="text",
+                            confidence=1.0,
+                            start_index=0,
+                            end_index=4,
+                        )
+                    ],
+                ),
+                # Coarse item bbox only: no layout-aware segments.
+                LayoutItemIR(
+                    type="text",
+                    value="Beta",
+                    bbox=LayoutSegmentIR(x=100.0, y=300.0, w=200.0, h=50.0, label="text", confidence=1.0),
+                    layout_segments=[],
+                ),
+            ],
+        )
+    ]
+
+
+def test_resolve_pages_without_bbox_fallback_drops_synthesized_segments() -> None:
+    result = _make_llamaparse_result(_pages())
+
+    with_fallback = _resolve_llamaparse_pages(result)
+    assert [len(item.get("layoutAwareBbox") or []) for item in with_fallback[0]["items"]] == [1, 1]
+
+    without_fallback = _resolve_llamaparse_pages(result, include_bbox_segment_fallback=False)
+    items = without_fallback[0]["items"]
+    assert "layoutAwareBbox" in items[0]
+    assert "layoutAwareBbox" not in items[1]
+    # The coarse bbox itself is untouched so layout detection still sees it.
+    assert items[1]["bBox"]["x"] == 100.0
+
+
+def test_llamaparse_attribution_blocks_only_from_layout_aware_segments() -> None:
+    result = _make_llamaparse_result(_pages())
+    adapter = LlamaParseLayoutAdapter()
+    layout_output = adapter.to_layout_output(result)
+
+    # Layout detection keeps both items (bbox fallback still applies there).
+    assert len(layout_output.predictions) == 2
+
+    blocks = adapter.to_attribution_blocks(layout_output, page_number=1)
+    assert [block.text for block in blocks] == ["Alpha"]

--- a/tests/parse_bench/evaluation/layout_label_mappers/test_projection_attributes.py
+++ b/tests/parse_bench/evaluation/layout_label_mappers/test_projection_attributes.py
@@ -1,0 +1,84 @@
+"""Regression tests for ``project_layout_predictions`` output shape."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from parse_bench.evaluation.layout_label_mappers.projection import project_layout_predictions
+from parse_bench.schemas.layout_detection_output import (
+    LayoutDetectionModel,
+    LayoutOutput,
+    LayoutPrediction,
+)
+from parse_bench.schemas.pipeline_io import InferenceRequest, InferenceResult
+from parse_bench.schemas.product import ProductType
+
+
+def _make_inference_result(layout_output: LayoutOutput) -> InferenceResult:
+    request = InferenceRequest(
+        example_id=layout_output.example_id,
+        source_file_path="/tmp/fake.png",
+        product_type=ProductType.PARSE,
+    )
+    now = datetime.now(UTC)
+    return InferenceResult(
+        request=request,
+        pipeline_name=layout_output.pipeline_name,
+        product_type=ProductType.PARSE,
+        raw_output={},
+        output=layout_output,
+        started_at=now,
+        completed_at=now,
+        latency_in_ms=0,
+    )
+
+
+def test_legacy_predictions_branch_projects_unchanged() -> None:
+    """Flat ``predictions`` project through the llamaparse mapper chain and
+    carry a copied ``attributes`` dict."""
+    prediction = LayoutPrediction(
+        bbox=[100.0, 200.0, 300.0, 400.0],
+        score=0.9,
+        label="text",  # LlamaParse V2 string label -> Canonical "Text"
+        page=None,
+        attributes={"scope": "region"},
+        provider_metadata={"order_index": 3},
+    )
+    layout_output = LayoutOutput(
+        example_id="doc1/page-1",
+        pipeline_name="llamaparse",
+        model=LayoutDetectionModel.LLAMAPARSE,
+        image_width=1000,
+        image_height=1000,
+        predictions=[prediction],
+    )
+    result = _make_inference_result(layout_output)
+    projected = project_layout_predictions(result, layout_output, evaluation_view="core")
+
+    assert len(projected) == 1
+    entry = projected[0]
+    assert entry["bbox"] == pytest.approx([0.1, 0.2, 0.3, 0.4])
+    assert entry["score"] == pytest.approx(0.9)
+    assert isinstance(entry["score"], float)
+    assert entry["class_name"] == "Text"
+    assert entry["order_index"] == 3
+    assert entry["attributes"] == {"scope": "region"}
+    # Copied, not aliased: mutating the projection must not leak upstream.
+    entry["attributes"]["scope"] = "mark"
+    assert prediction.attributes == {"scope": "region"}
+
+
+def test_projection_emits_empty_attributes_dict_when_absent() -> None:
+    layout_output = LayoutOutput(
+        example_id="doc1/page-1",
+        pipeline_name="llamaparse",
+        model=LayoutDetectionModel.LLAMAPARSE,
+        image_width=1000,
+        image_height=1000,
+        predictions=[LayoutPrediction(bbox=[0.0, 0.0, 10.0, 10.0], score=0.5, label="text")],
+    )
+    result = _make_inference_result(layout_output)
+    projected = project_layout_predictions(result, layout_output, evaluation_view="core")
+    assert projected[0]["attributes"] == {}

--- a/tests/parse_bench/evaluation/metrics/attribution/test_attribution_overclaim.py
+++ b/tests/parse_bench/evaluation/metrics/attribution/test_attribution_overclaim.py
@@ -1,0 +1,195 @@
+"""Prediction-side duplicate-claim / overclaim diagnostics for attribution."""
+
+from parse_bench.evaluation.metrics.attribution.core import (
+    GTElement,
+    PredBlock,
+    compute_attribution_metrics,
+    parse_pred_blocks,
+)
+from parse_bench.evaluation.metrics.attribution.text_utils import (
+    normalize_attribution_text,
+    tokenize,
+)
+
+
+def _make_gt(bbox_xyxy, text, cls="Text", ro_index=0, attrs=None):
+    norm = normalize_attribution_text(text)
+    return GTElement(
+        bbox_coco=[
+            bbox_xyxy[0],
+            bbox_xyxy[1],
+            bbox_xyxy[2] - bbox_xyxy[0],
+            bbox_xyxy[3] - bbox_xyxy[1],
+        ],
+        bbox_xyxy=bbox_xyxy,
+        canonical_class=cls,
+        text=text,
+        normalized_text=norm,
+        tokens=tokenize(norm),
+        ro_index=ro_index,
+        content_type="text",
+        attributes=attrs or {},
+    )
+
+
+def _make_pred(bbox_xyxy, text, label="text", order=0, block_type="text"):
+    norm = normalize_attribution_text(text)
+    return PredBlock(
+        bbox_xyxy=bbox_xyxy,
+        block_type=block_type,
+        label=label,
+        text=text,
+        normalized_text=norm,
+        tokens=tokenize(norm),
+        order_index=order,
+    )
+
+
+class TestGroundingOverclaim:
+    def test_exact_duplicate_local_segment_is_redundant_overclaim(self):
+        gt = [_make_gt([0.1, 0.1, 0.6, 0.2], "notes")]
+        pred = [
+            _make_pred([0.1, 0.1, 0.6, 0.2], "notes", order=0),
+            _make_pred([0.1, 0.1, 0.6, 0.2], "notes", order=1),
+        ]
+
+        result = compute_attribution_metrics(gt, pred)
+
+        assert result.overclaim_metric_available is True
+        assert result.supported_claim_count == 2
+        assert result.duplicate_claim_count == 1
+        assert result.claimed_supported_token_instances == 1
+        assert result.duplicate_supported_token_instances == 1
+        assert abs(result.grounding_overclaim_rate - 0.5) < 1e-9
+        assert result.grounding_duplicate_supported_token_rate == 1.0
+        assert result.num_scored_pred_blocks == 2
+        assert result.supported_tp_blocks == 1
+        assert result.redundant_fp_blocks == 1
+        assert abs(result.grounding_supported_block_precision - 0.5) < 1e-9
+        assert abs(result.grounding_redundant_block_rate - 0.5) < 1e-9
+
+    def test_repeated_tokens_use_distinct_gt_token_instances(self):
+        gt = [_make_gt([0.1, 0.1, 0.6, 0.2], "notes notes")]
+        pred = [
+            _make_pred([0.1, 0.1, 0.6, 0.2], "notes notes", order=0),
+            _make_pred([0.1, 0.1, 0.6, 0.2], "notes", order=1),
+        ]
+
+        result = compute_attribution_metrics(gt, pred)
+
+        assert result.claimed_supported_token_instances == 2
+        assert result.duplicate_supported_token_instances == 1
+        assert result.supported_claim_count == 3
+        assert result.duplicate_claim_count == 1
+        assert abs(result.grounding_overclaim_rate - (1.0 / 3.0)) < 1e-9
+        assert result.supported_tp_blocks == 1
+        assert result.redundant_fp_blocks == 1
+
+    def test_remote_substring_claim_is_unsupported_fp(self):
+        gt = [
+            _make_gt([0.0, 0.0, 0.4, 0.2], "alpha beta", ro_index=0),
+            _make_gt([0.6, 0.0, 1.0, 0.2], "notes", ro_index=1),
+        ]
+        pred = [
+            _make_pred([0.0, 0.0, 0.4, 0.2], "alpha beta", order=0),
+            _make_pred([0.0, 0.0, 0.4, 0.2], "notes", order=1),
+        ]
+
+        result = compute_attribution_metrics(gt, pred)
+
+        assert result.overclaim_metric_available is True
+        assert result.num_scored_pred_blocks == 2
+        assert result.supported_tp_blocks == 1
+        assert result.unsupported_fp_blocks == 1
+        assert result.redundant_fp_blocks == 0
+        assert result.duplicate_claim_count == 0
+        assert abs(result.grounding_supported_block_precision - 0.5) < 1e-9
+        assert abs(result.grounding_unsupported_block_rate - 0.5) < 1e-9
+
+    def test_overlapping_empty_image_like_block_is_unsupported_fp(self):
+        gt = [_make_gt([0.1, 0.1, 0.6, 0.2], "alpha beta")]
+        pred = [
+            _make_pred([0.1, 0.1, 0.6, 0.2], "alpha beta", order=0),
+            _make_pred([0.1, 0.1, 0.6, 0.2], "", label="image", order=1, block_type="image"),
+        ]
+
+        result = compute_attribution_metrics(gt, pred)
+
+        assert result.overclaim_metric_available is True
+        assert result.num_scored_pred_blocks == 2
+        assert result.supported_tp_blocks == 1
+        assert result.unsupported_fp_blocks == 1
+        assert result.spatial_fp_blocks == 0
+        assert abs(result.grounding_unsupported_block_rate - 0.5) < 1e-9
+
+    def test_existing_metrics_unchanged_by_diagnostics(self):
+        """LAP/LAR/AF1/grounding accuracy are untouched by the new fields."""
+        gt = [_make_gt([0.1, 0.1, 0.6, 0.2], "alpha beta")]
+        pred = [_make_pred([0.1, 0.1, 0.6, 0.2], "alpha beta")]
+        result = compute_attribution_metrics(gt, pred)
+        assert result.lap == 1.0
+        assert result.lar == 1.0
+        assert result.af1 == 1.0
+        assert result.grounding_accuracy == 1.0
+        assert result.grounding_overclaim_rate == 0.0
+
+
+class TestRequireLayoutAwareSegments:
+    def test_default_keeps_bbox_only_items(self):
+        items = [
+            {
+                "type": "text",
+                "value": "container fallback",
+                "bBox": {"x": 100, "y": 100, "w": 200, "h": 50, "label": "text"},
+            }
+        ]
+        blocks = parse_pred_blocks(items, page_md="", page_width=1000.0, page_height=1000.0)
+        assert len(blocks) == 1
+        assert blocks[0].text == "container fallback"
+
+    def test_require_layout_aware_segments_skips_bbox_only_items(self):
+        items = [
+            {
+                "type": "text",
+                "value": "container fallback",
+                "bBox": {"x": 100, "y": 100, "w": 200, "h": 50, "label": "text"},
+            }
+        ]
+
+        blocks = parse_pred_blocks(
+            items,
+            page_md="",
+            page_width=1000.0,
+            page_height=1000.0,
+            require_layout_aware_segments=True,
+        )
+        assert blocks == []
+
+    def test_require_layout_aware_segments_keeps_segmented_items(self):
+        items = [
+            {
+                "type": "text",
+                "value": "abcdef",
+                "bBox": {"x": 100, "y": 100, "w": 200, "h": 50, "label": "text"},
+                "layoutAwareBbox": [
+                    {
+                        "x": 100,
+                        "y": 100,
+                        "w": 100,
+                        "h": 50,
+                        "label": "text",
+                        "startIndex": 1,
+                        "endIndex": 3,
+                    }
+                ],
+            }
+        ]
+        blocks = parse_pred_blocks(
+            items,
+            page_md="",
+            page_width=1000.0,
+            page_height=1000.0,
+            require_layout_aware_segments=True,
+        )
+        assert len(blocks) == 1
+        assert blocks[0].text == "bcd"

--- a/tests/parse_bench/evaluation/metrics/extract/test_json_subset_match.py
+++ b/tests/parse_bench/evaluation/metrics/extract/test_json_subset_match.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+
+from typing import Any
+
+from parse_bench.evaluation.metrics.extract.json_subset_match import (
+    json_subset_match_score,
+    normalize_date_string,
+)
+from parse_bench.evaluation.metrics.extract.json_subset_match_metric import JsonSubsetMatchMetric
+
+
+def test_normalize_date_string_handles_weekday_prefix_with_periods() -> None:
+    assert normalize_date_string("Mon. Jan. 02 2023") == "2023-01-02"
+    assert normalize_date_string("Fri. Dec. 29 2023") == "2023-12-29"
+
+
+def test_normalize_date_string_tolerates_comma_spacing() -> None:
+    assert normalize_date_string("March 27 ,1956") == "1956-03-27"
+    assert normalize_date_string("March 28,1956") == "1956-03-28"
+
+
+def test_normalize_date_string_two_digit_year_patterns() -> None:
+    assert normalize_date_string("01/02/23") == "2023-01-02"
+    assert normalize_date_string("01-02-23") == "2023-01-02"
+
+
+def test_normalize_date_string_rejects_implausible_years() -> None:
+    assert normalize_date_string("0001-01-01") == "0001-01-01"
+    assert normalize_date_string("3000-01-01") == "3000-01-01"
+
+
+def test_normalize_date_string_non_string_passthrough() -> None:
+    assert normalize_date_string(None) is None
+    assert normalize_date_string(42) == 42
+    assert normalize_date_string("12345678") == "12345678"
+
+
+def test_normalize_date_string_probe_is_comma_scoped() -> None:
+    """The comma-respacing probe must not widen what counts as a date: strings
+    without a comma are left exactly as before (doubled spaces included)."""
+    assert normalize_date_string("March  27 1956") == "March  27 1956"
+    assert normalize_date_string("March 27 1956") == "1956-03-27"
+
+
+def test_json_subset_match_scores_weekday_date_equivalence() -> None:
+    score = json_subset_match_score(
+        {"attendance_records": [{"date": "2023-01-02"}]},
+        {"attendance_records": [{"date": "Mon. Jan. 02 2023"}]},
+    )
+
+    assert score == 1.0
+
+
+# Regression tests: missing arrays/dicts must be weighted by the full leaf
+# count of `expected`, not weight=1. Otherwise a pipeline that drops a whole
+# claims array can score the same as one that extracts it.
+
+
+def test_missing_top_level_array_weighted_by_full_leaf_count() -> None:
+    """A 15-claim array dropped entirely must outweigh a 1-leaf scalar field."""
+    expected = {
+        "scalar_field": "x",
+        "claims": [{"a": 1, "b": 2, "c": 3} for _ in range(15)],
+    }
+    actual = {"scalar_field": "x"}
+
+    score = json_subset_match_score(expected, actual, weighted=True)
+    # 1 leaf right out of 46 total => ~0.022. Pre-fix this was ~0.5 because
+    # the missing claims array was treated as a single weight=1 leaf.
+    assert score < 0.05, f"expected score <0.05, got {score}"
+
+
+def test_missing_array_same_as_empty_array() -> None:
+    """An absent key and `[]` should score identically when expected is non-empty."""
+    expected = {"claims": [{"a": 1, "b": 2}]}
+    score_missing = json_subset_match_score(expected, {}, weighted=True)
+    score_empty = json_subset_match_score(expected, {"claims": []}, weighted=True)
+    assert score_missing == score_empty == 0.0
+
+
+def test_missing_nested_dict_weighted_by_subtree() -> None:
+    """A dropped nested dict must be weighted by its leaf count."""
+    expected = {
+        "id": "x",
+        "patient": {
+            "first_name": "A",
+            "last_name": "B",
+            "address": {"city": "X", "zip": "1"},
+        },
+    }
+    actual = {"id": "x"}
+    score = json_subset_match_score(expected, actual, weighted=True)
+    # 1/5 = 0.20
+    assert 0.18 < score < 0.22, f"expected ~0.20, got {score}"
+
+
+def test_partial_array_drop_weights_each_missing_item_recursively() -> None:
+    """Dropping the tail of an array must penalize by per-item leaves."""
+    expected = {
+        "claims": [
+            {"a": 1, "b": 2, "c": 3, "d": 4, "e": 5},
+            {"a": 1, "b": 2, "c": 3, "d": 4, "e": 5},
+            {"a": 1, "b": 2, "c": 3, "d": 4, "e": 5},
+        ]
+    }
+    actual = {"claims": [{"a": 1, "b": 2, "c": 3, "d": 4, "e": 5}]}
+
+    score = json_subset_match_score(expected, actual, weighted=True)
+    # 5/15 = ~0.33. Pre-fix this would be ~0.78 because each missing tail
+    # item only contributed weight=1.
+    assert 0.30 < score < 0.40, f"expected ~0.33, got {score}"
+
+
+def test_dropped_large_array_scores_low() -> None:
+    """When a pipeline returns one section correctly but doesn't emit a
+    15-record array with ~10 fields each, the score should reflect that
+    ~150 leaves are missing, not weight=1."""
+    expected = {
+        "header": [
+            {
+                "check": {"check_number": "X", "check_amount": 100, "check_date": "2026-01-01"},
+                "payer": {"payer_name": "P", "payer_phone": "555"},
+                "payee": {"payee_name": "Q"},
+            }
+        ],
+        "records": [
+            {
+                "record_number": f"C{i}",
+                "name": f"P{i}",
+                "total_paid": i * 10.0,
+                "total_submitted": i * 12.0,
+                "from_date": "2026-01-01",
+                "to_date": "2026-01-31",
+                "account_number": f"A{i}",
+                "plan_type": "PPO",
+                "status": "PAID",
+                "responsibility": 0.0,
+            }
+            for i in range(15)
+        ],
+    }
+    actual = {"header": expected["header"]}
+    score = json_subset_match_score(expected, actual, weighted=True)
+    # header has 7 leaves, records has 15 × 10 = 150 leaves. 7/157 = ~0.045.
+    # Pre-fix this scored ~0.875 (header perfect / records weight=1).
+    assert score < 0.10, f"dropped 15-record array should score <0.10, got {score}"
+
+
+# Order-invariant pairing: lists must be paired by optimal assignment
+# (Hungarian), not by index. Shuffled-but-correct extractions should not be
+# penalized for row order.
+
+
+def test_anonymous_record_list_is_order_invariant() -> None:
+    expected = {
+        "rows": [
+            {"col_a": 1, "col_b": "x"},
+            {"col_a": 2, "col_b": "y"},
+            {"col_a": 3, "col_b": "z"},
+        ]
+    }
+    actual = {"rows": list(reversed(expected["rows"]))}
+
+    assert json_subset_match_score(expected, actual, weighted=True) == 1.0
+
+
+def test_scalar_list_is_order_invariant() -> None:
+    assert json_subset_match_score({"chunks": ["a", "b", "c"]}, {"chunks": ["c", "a", "b"]}) == 1.0
+
+
+def test_exact_lists_score_perfectly() -> None:
+    expected = {"chunks": ["a", "b", "c"]}
+    actual = {"chunks": ["a", "b", "c"]}
+    assert json_subset_match_score(expected, actual, weighted=True) == 1.0
+
+    expected2 = {"rows": [{"col_a": 1, "col_b": 2}, {"col_a": 3, "col_b": 4}]}
+    actual2 = {"rows": [{"col_a": 1, "col_b": 2}, {"col_a": 3, "col_b": 4}]}
+    assert json_subset_match_score(expected2, actual2, weighted=True) == 1.0
+
+
+def test_order_invariant_pairing_recovers_dropped_middle_row() -> None:
+    """A dropped middle row must cost only that row, not cascade an
+    off-by-one penalty onto every subsequent index-paired row."""
+    expected = {"rows": [{"a": i, "b": f"r{i}"} for i in range(4)]}
+    actual = {"rows": [expected["rows"][0], expected["rows"][2], expected["rows"][3]]}
+
+    score = json_subset_match_score(expected, actual, weighted=True)
+    # 3 of 4 rows match perfectly, each row has 2 leaves: 6/8 = 0.75.
+    assert score == 0.75, f"expected 0.75, got {score}"
+
+
+def test_tied_assignment_prefers_index_order() -> None:
+    """When every pairing is a near-miss (uniform approximate cost matrix),
+    index order must win the tie deterministically. Pins the eps*|i-j|
+    tie-break: without it, which optimal assignment wins is an undocumented
+    scipy implementation detail, and a scipy upgrade could silently swap
+    aligned near-miss rows for crossed ones, dropping the Levenshtein
+    partial credit with no code change."""
+    expected = {"rows": [{"text": "alpha bravo"}, {"text": "charlie delta"}]}
+    # Aligned rows with one-character typos: no leaf matches exactly, so the
+    # approximate cost is 1 for every pairing — a fully tied matrix.
+    actual = {"rows": [{"text": "alpha brivo"}, {"text": "charlie delte"}]}
+
+    score = json_subset_match_score(expected, actual, weighted=True)
+    # Index-aligned pairing keeps ~0.92 Levenshtein partial credit; the
+    # crossed pairing would score near zero.
+    assert score > 0.8, f"aligned near-miss rows should keep partial credit, got {score}"
+
+
+def test_order_invariant_pairing_does_not_reward_wrong_values() -> None:
+    """Optimal assignment must not inflate scores when values are wrong —
+    a fully mismatched list still scores low."""
+    expected = {"rows": [{"a": 1}, {"a": 2}]}
+    actual = {"rows": [{"a": 7}, {"a": 8}]}
+
+    score = json_subset_match_score(expected, actual, weighted=True)
+    assert score < 0.5, f"expected <0.5, got {score}"
+
+
+def test_unweighted_mode_penalizes_extra_actual_items() -> None:
+    expected = {"rows": ["a", "b"]}
+    actual = {"rows": ["b", "a", "c", "d"]}
+    assert json_subset_match_score(expected, actual, weighted=False) == 0.5
+
+
+def test_assignment_pairing_falls_back_to_index_beyond_pair_cap(monkeypatch: Any) -> None:
+    """Beyond the bounded pair budget the n×m assignment is skipped and
+    index pairing applies, so pathological very-long arrays don't stall the
+    evaluator."""
+    import parse_bench.evaluation.metrics.extract.json_subset_match as jsm
+
+    expected = {"rows": [{"a": i} for i in range(3)]}
+    actual = {"rows": [{"a": i} for i in reversed(range(3))]}
+
+    monkeypatch.setattr(jsm, "_ASSIGNMENT_MAX_PAIRS", 4)
+    capped = json_subset_match_score(expected, actual, weighted=True)
+    assert capped < 1.0, f"beyond the cap, index pairing should penalize reorder, got {capped}"
+
+    monkeypatch.setattr(jsm, "_ASSIGNMENT_MAX_PAIRS", 250_000)
+    assert json_subset_match_score(expected, actual, weighted=True) == 1.0
+
+
+# Nullable-numeric collapse: gated strictly on the JSON Schema shape.
+
+_NULLABLE_NUMBER_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "amount": {"anyOf": [{"type": "number"}, {"type": "null"}], "default": None},
+        "rows": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {"fee": {"type": ["null", "number"]}},
+            },
+        },
+    },
+}
+
+
+def test_nullable_numeric_zero_matches_null_with_schema() -> None:
+    assert json_subset_match_score({"amount": 0}, {"amount": None}, data_schema=_NULLABLE_NUMBER_SCHEMA) == 1.0
+    assert json_subset_match_score({"amount": None}, {"amount": 0.0}, data_schema=_NULLABLE_NUMBER_SCHEMA) == 1.0
+    assert (
+        json_subset_match_score(
+            {"rows": [{"fee": 0.0}]},
+            {"rows": [{"fee": None}]},
+            data_schema=_NULLABLE_NUMBER_SCHEMA,
+        )
+        == 1.0
+    )
+
+
+def test_nullable_numeric_collapse_requires_schema() -> None:
+    assert json_subset_match_score({"amount": 0}, {"amount": None}) == 0.0
+    assert json_subset_match_score({"amount": None}, {"amount": 0}) == 0.0
+
+
+def test_nullable_numeric_collapse_does_not_apply_to_plain_numbers_or_bools() -> None:
+    plain_schema = {"type": "object", "properties": {"amount": {"type": "number"}}}
+    assert json_subset_match_score({"amount": 0}, {"amount": None}, data_schema=plain_schema) == 0.0
+    bool_schema = {"type": "object", "properties": {"flag": {"anyOf": [{"type": "number"}, {"type": "null"}]}}}
+    assert json_subset_match_score({"flag": False}, {"flag": None}, data_schema=bool_schema) == 0.0
+
+
+def test_nullable_numeric_nonzero_still_compares_numerically() -> None:
+    assert json_subset_match_score({"amount": 5}, {"amount": None}, data_schema=_NULLABLE_NUMBER_SCHEMA) == 0.0
+    assert json_subset_match_score({"amount": 5}, {"amount": 5}, data_schema=_NULLABLE_NUMBER_SCHEMA) == 1.0
+
+
+def test_metric_passes_data_schema_through() -> None:
+    metric = JsonSubsetMatchMetric()
+    without = metric.compute(expected={"amount": 0}, actual={"amount": None})
+    with_schema = metric.compute(expected={"amount": 0}, actual={"amount": None}, data_schema=_NULLABLE_NUMBER_SCHEMA)
+    assert without.value == 0.0
+    assert with_schema.value == 1.0

--- a/tests/parse_bench/evaluation/metrics/layoutdet/test_classification_utils_paging.py
+++ b/tests/parse_bench/evaluation/metrics/layoutdet/test_classification_utils_paging.py
@@ -1,0 +1,98 @@
+"""Behaviour-preservation tests for the paged/non-paged classification path."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from parse_bench.evaluation.metrics.layoutdet.classification_utils import (
+    compute_map_at_thresholds,
+    compute_per_class_metrics,
+    match_prediction_dicts_to_gt,
+)
+
+_GT = [
+    {"bbox": [0.0, 0.0, 0.5, 0.5], "class_name": "Text"},
+    {"bbox": [0.5, 0.5, 1.0, 1.0], "class_name": "Table"},
+]
+_PRED = [
+    {"bbox": [0.0, 0.0, 0.5, 0.5], "class_name": "Text", "score": 0.9},
+    {"bbox": [0.5, 0.5, 1.0, 1.0], "class_name": "Table", "score": 0.8},
+    {"bbox": [0.0, 0.5, 0.2, 0.7], "class_name": "Text", "score": 0.3},  # FP
+]
+
+
+def _with_page(entries: list[dict], page: str) -> list[dict]:
+    return [{**entry, "example_id": page} for entry in entries]
+
+
+def test_non_paged_and_single_page_inputs_give_identical_metrics() -> None:
+    non_paged = compute_per_class_metrics(_PRED, _GT, ["Text", "Table"])
+    paged = compute_per_class_metrics(_with_page(_PRED, "p1"), _with_page(_GT, "p1"), ["Text", "Table"])
+    assert non_paged == paged
+    assert non_paged["Text"]["precision"] == pytest.approx(0.5)
+    assert non_paged["Text"]["recall"] == pytest.approx(1.0)
+    assert non_paged["Text"]["support"] == 1
+    assert non_paged["Table"]["f1"] == pytest.approx(1.0)
+
+
+def test_class_without_gt_or_predictions_is_zero_filled() -> None:
+    metrics = compute_per_class_metrics(_PRED, _GT, ["Text", "Table", "Picture"])
+    assert metrics["Picture"] == {"precision": 0.0, "recall": 0.0, "f1": 0.0, "ap": 0.0, "support": 0}
+
+
+def test_custom_page_key_separates_pages() -> None:
+    preds = [{**_PRED[0], "page_id": "a"}]
+    gts = [{**_GT[0], "page_id": "b"}]  # same box, different page: no match
+    metrics = compute_per_class_metrics(preds, gts, ["Text"], page_key="page_id")
+    assert metrics["Text"]["recall"] == 0.0
+    metrics_same = compute_per_class_metrics(preds, [{**_GT[0], "page_id": "a"}], ["Text"], page_key="page_id")
+    assert metrics_same["Text"]["recall"] == 1.0
+
+
+def test_match_prediction_dicts_to_gt_defaults_to_axis_aligned_iou() -> None:
+    y_true, y_scores = match_prediction_dicts_to_gt(
+        [p for p in _PRED if p["class_name"] == "Text"],
+        [g for g in _GT if g["class_name"] == "Text"],
+        iou_threshold=0.5,
+    )
+    assert y_true.tolist() == [1.0, 0.0]
+    assert y_scores.tolist() == [0.9, 0.3]
+
+
+def test_match_prediction_dicts_to_gt_handles_empty_inputs() -> None:
+    y_true, y_scores = match_prediction_dicts_to_gt([], _GT, iou_threshold=0.5)
+    assert y_true.size == 0 and y_scores.size == 0
+    y_true, y_scores = match_prediction_dicts_to_gt(_PRED[:1], [], iou_threshold=0.5)
+    assert y_true.tolist() == [0.0]
+    assert y_scores.tolist() == [0.9]
+
+
+def test_match_prediction_dicts_to_gt_custom_overlap_fn() -> None:
+    def always_overlap(pred: dict, gt: dict) -> float:
+        return 1.0
+
+    y_true, _ = match_prediction_dicts_to_gt(
+        [{"bbox": [0.0, 0.0, 0.1, 0.1], "class_name": "Text", "score": 0.5}],
+        [{"bbox": [0.9, 0.9, 1.0, 1.0], "class_name": "Text"}],
+        iou_threshold=0.5,
+        overlap_fn=always_overlap,
+    )
+    assert y_true.tolist() == [1.0]
+
+
+def test_missing_score_defaults_to_zero() -> None:
+    y_true, y_scores = match_prediction_dicts_to_gt(
+        [{"bbox": [0.0, 0.0, 0.5, 0.5], "class_name": "Text"}],
+        [_GT[0]],
+        iou_threshold=0.5,
+    )
+    assert y_true.tolist() == [1.0]
+    assert np.array_equal(y_scores, np.array([0.0]))
+
+
+def test_compute_map_at_thresholds_accepts_page_key_and_overlap_fn() -> None:
+    default = compute_map_at_thresholds(_PRED, _GT, ["Text", "Table"])
+    explicit = compute_map_at_thresholds(_PRED, _GT, ["Text", "Table"], overlap_fn=None, page_key="example_id")
+    assert default == explicit
+    assert default["AP50"] == pytest.approx(1.0)

--- a/tests/parse_bench/evaluation/metrics/qa/test_answer_comparison_exact_choice.py
+++ b/tests/parse_bench/evaluation/metrics/qa/test_answer_comparison_exact_choice.py
@@ -1,0 +1,66 @@
+"""Opt-in ``exact_choice`` grading for single-choice QA items."""
+
+from parse_bench.evaluation.metrics.qa.answer_comparison import AnswerComparisonMetric
+
+
+class TestExactChoiceOptIn:
+    """Strict response parsing is opt-in and fail-closed."""
+
+    def setup_method(self) -> None:
+        self.metric = AnswerComparisonMetric()
+
+    def test_exact_answer_line_matches(self) -> None:
+        result = self.metric.compare(
+            "Answer: A",
+            "A",
+            "single_choice",
+            {"grading_mode": "exact_choice"},
+        )
+        assert result.value == 1.0
+        assert result.metadata["format_valid"] is True
+
+    def test_exact_mode_rejects_bare_choice_prose_and_multiletter(self) -> None:
+        for prediction in ("A", "Answer: A because…", "Answer: CD", "Answer: A\nextra"):
+            result = self.metric.compare(
+                prediction,
+                "A",
+                "single_choice",
+                {"grading_mode": "exact_choice"},
+            )
+            assert result.value == 0.0, prediction
+            assert result.metadata["format_valid"] is False
+
+    def test_exact_mode_accepts_any_single_letter_choice(self) -> None:
+        for choice in ("C", "D"):
+            result = self.metric.compare(
+                f"Answer: {choice}",
+                choice,
+                "single_choice",
+                {"grading_mode": "exact_choice"},
+            )
+            assert result.value == 1.0, choice
+            assert result.metadata["format_valid"] is True
+
+    def test_explicit_option_labels_narrow_exact_choice_set(self) -> None:
+        metadata = {
+            "grading_mode": "exact_choice",
+            "options": "A) Alpha  C) Charlie  D) Delta",
+        }
+        assert self.metric.compare("Answer: C", "C", "single_choice", metadata).value == 1.0
+        invalid = self.metric.compare("Answer: B", "C", "single_choice", metadata)
+        assert invalid.value == 0.0
+        assert invalid.metadata["format_valid"] is False
+
+    def test_legacy_single_choice_remains_permissive(self) -> None:
+        result = self.metric.compare("A", "A", "single_choice")
+        assert result.value == 1.0
+
+    def test_unknown_explicit_mode_fails_closed(self) -> None:
+        result = self.metric.compare(
+            "A",
+            "A",
+            "single_choice",
+            {"grading_mode": "future_mode"},
+        )
+        assert result.value == 0.0
+        assert result.metadata["passed"] is False

--- a/tests/parse_bench/test_layout_label_mapping_code_alias.py
+++ b/tests/parse_bench/test_layout_label_mapping_code_alias.py
@@ -1,0 +1,63 @@
+"""Regression tests for LlamaParse V2 label aliases and picture-type helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from parse_bench.layout_label_mapping import (
+    LLAMAPARSE_V2_RAW_TO_CANONICAL,
+    PICTURE_TYPE_ALIASES,
+    is_chart_family_picture_type,
+    normalize_picture_type,
+    picture_types_match,
+)
+from parse_bench.schemas.layout_ontology import CanonicalLabel
+
+
+def test_llamaparse_v2_code_alias_maps_to_canonical_code() -> None:
+    """The V2 SDK ``CodeItem`` emits ``type="code"``; without this alias code
+    blocks were silently dropped from the canonicalized layout."""
+    assert LLAMAPARSE_V2_RAW_TO_CANONICAL["code"] == (CanonicalLabel.CODE, {})
+    assert LLAMAPARSE_V2_RAW_TO_CANONICAL["algorithm"] == (CanonicalLabel.CODE, {})
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("Bar Chart", "bar_chart"),
+        ("photograph", "image"),
+        ("screenshot-from-computer", "screenshot"),
+        ("geographical_map", "map"),
+        ("scatter_plot", "scatter_chart"),
+        ("logo", "logo"),
+        ("true", None),
+        ("caption", None),
+        ("", None),
+        (None, None),
+        ("this is a very long leaked description of the picture", None),
+    ],
+)
+def test_normalize_picture_type(raw: object, expected: str | None) -> None:
+    assert normalize_picture_type(raw) == expected
+
+
+def test_picture_type_aliases_are_normalized_targets() -> None:
+    for alias_target in PICTURE_TYPE_ALIASES.values():
+        assert normalize_picture_type(alias_target) == alias_target
+
+
+def test_chart_family_membership() -> None:
+    assert is_chart_family_picture_type("chart")
+    assert is_chart_family_picture_type("bar_chart")
+    assert is_chart_family_picture_type("scatter_chart")
+    assert not is_chart_family_picture_type("flow_chart")
+    assert not is_chart_family_picture_type("org_chart")
+    assert not is_chart_family_picture_type("logo")
+
+
+def test_picture_types_match_generic_specific_tolerance() -> None:
+    assert picture_types_match("chart", "bar_chart")
+    assert picture_types_match("pie_chart", "chart")
+    assert picture_types_match("logo", "logo")
+    assert not picture_types_match("chart", "flow_chart")
+    assert not picture_types_match("bar_chart", "pie_chart")


### PR DESCRIPTION
- LlamaParse V2 'code' items mapped (were silently dropped from layout scoring)
- LlamaParse attribution restricted to layout-aware segments; Docling attribution blocks no longer fall back to the item bbox
- projection copies prediction attributes and coerces None scores
- attribution overclaim/duplicate-claim diagnostics (additive)
- extract: leaf-count weighting for missing structures, hardened date parsing, order-invariant keyless list alignment, nullable-numeric collapse
- Extend provider: reserved 'id' property aliasing, schema keyword stripping, credit-based cost model
- LayoutOutput.layout_pages and LayoutItemIR.score/attributes fields