### PR TITLE
5. Various parse scoring core fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,41 @@ compared with care.
 
 ## [0.3.0] - 2026-09-02
 
+This release brings the public evaluator back to parity with the internal
+LlamaIndex benchmark harness, which had accumulated five months of fixes since
+ParseBench was extracted from it. Existing leaderboard rows were produced by the
+internal harness and are therefore already consistent with this code; runs made
+with `parse-bench` 0.2.0 or earlier are **not** directly comparable to runs made
+with this version.
+
+### Scoring (changes evaluation numbers)
+- Text similarity: removed an erroneous `/100` that made `text_similarity` ~100x too small.
+- Text normalization: combining marks are preserved for Thai, Indic and related scripts;
+  abutting inline tags (`</u><s>`) no longer weld adjacent words; trailing dot-leader
+  stripping is linear instead of quadratic; shared dot-leader, boolean-marker (checkmark),
+  quote and dash normalizers are applied consistently across table metrics.
+- Tables: table cell text now *replaces* the table in the rule-augmented text instead of
+  being appended, which previously counted every table word two to three times in
+  occurrence-counting rules; `<thead>/<tbody>/<tfoot>`, `scope=`, `<colgroup>` and
+  `<caption>` are honoured; a `<th>` section-label row inside `<tbody>` is no longer folded
+  into the column headers; row provenance uses identity instead of structural equality.
+- Table pairing: GriTS and TEDS pair GT and predicted tables per page (`expected_pages`
+  metadata) instead of document-wide, and a `<caption>` on one side versus a title band
+  on the other is neutralised symmetrically.
+- Table record match and header accuracy compare cells leader-insensitively, so `no.`
+  and `no` no longer unmatch a whole column.
+- Rules: `order` anchors strip residual HTML; bag-of-words rules use a Unicode word class
+  and ignore markdown image alt text; degenerate marker-only rules are excluded from the
+  denominator instead of scoring 0; a per-document rule budget and a timeout around
+  normalization stop a single pathological page from stalling a run.
+- Formatting rules: emphasis is resolved with a delimiter-run pairer instead of regex,
+  typographic and ASCII quotes are folded, and `<strong>/<em>/<mark>/<sup>/<sub>` with
+  attributes are recognised.
+- `ParseTestCase` accepts layout and extract-field rules on `test_rules` and carries `metadata`.
+- Rule schemas and classes for `table_marker_cells`, `text_color`, `absent_unless_strikeout`,
+  `present_as_strikeout`, `is_not_latex` and the extended `form_field` rule (`label` list,
+  `label_max_diffs`, `value_max_diffs`); `is_latex` requires `formula`. Not used by the public dataset.
+
 ### Added
 - `parse-bench` is now published to PyPI. Install with `pip install "parse-bench[runners]"`.
 - Per-provider extras (`llamaparse`, `openai`, `anthropic`, `google`, `azure`, `aws`,

--- a/src/parse_bench/evaluation/evaluators/parse.py
+++ b/src/parse_bench/evaluation/evaluators/parse.py
@@ -59,7 +59,34 @@ from parse_bench.schemas.evaluation import EvaluationResult, MetricValue
 from parse_bench.schemas.parse_output import ParseOutput
 from parse_bench.schemas.pipeline_io import InferenceResult
 from parse_bench.schemas.product import ProductType
-from parse_bench.test_cases.schema import ExtractTestCase, ParseTestCase, TestCase
+from parse_bench.test_cases.schema import (
+    ExtractFieldTestRule,
+    ExtractTestCase,
+    LayoutTestRule,
+    ParseTestCase,
+    TestCase,
+)
+
+# Filter tuple for ``ParseTestCase.test_rules`` — layout and extract_field rule
+# models coexist with parse rules on the same list and are invisible to the
+# parse rule factory; they'd otherwise count as spurious failures in
+# ``RuleBasedMetric``.
+_NON_PARSE_RULE_TYPES: tuple[type, ...] = (LayoutTestRule, ExtractFieldTestRule)
+_STYLING_F_BETA = 0.5
+
+
+def _styling_f_beta_score(pos_score: float, neg_score: float) -> float:
+    """Combine styling scores while weighting negative-rule failures more.
+
+    For beta below 1, F-beta weights its precision-like input more heavily.
+    ``neg_score`` occupies that slot because false styling should cost more
+    than missed styling.
+    """
+    if pos_score + neg_score == 0:
+        return 0.0
+
+    beta_squared = _STYLING_F_BETA**2
+    return (1 + beta_squared) * neg_score * pos_score / (beta_squared * neg_score + pos_score)
 
 
 def _has_html_tables(content: str) -> bool:
@@ -80,17 +107,78 @@ def _has_extract_field_bboxes(test_case: ExtractTestCase) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _compute_teds_standalone(expected: str, actual: str, variants: set[str] | None = None) -> list[MetricValue]:
+def _predicted_markdown_and_pages(output: ParseOutput) -> tuple[str, list[int]] | None:
+    """Predicted table markdown sourced from ``output.pages``, plus a page label
+    per top-level table.
+
+    Concatenates the per-page markdown in page order and records each table's
+    page **intrinsically** (it came from that page's markdown) — so no positional
+    re-join against the flat ``output.markdown`` is needed, and a document whose
+    ``output.markdown`` is ordered differently from its pages cannot mislabel.
+    Returns ``None`` when ``output.pages`` is empty — the caller then matches
+    document-globally.
+    """
+    pages = getattr(output, "pages", None) or []
+    if not pages:
+        return None
+    parts: list[str] = []
+    labels: list[int] = []
+    for page in pages:
+        md = page.markdown or ""
+        parts.append(md)
+        labels.extend([int(page.page_index) + 1] * len(extract_html_tables(md)))
+    return "\n\n".join(parts), labels
+
+
+def _gt_markdown_and_pages(expected_pages: list[dict[str, Any]]) -> tuple[str, list[int]]:
+    """GT table markdown plus a page label per top-level GT table, both sourced
+    from the native per-page GT field
+    ``metadata["expected_pages"] = [{"page": int, "markdown": str}, ...]``.
+
+    Mirror of :func:`_predicted_markdown_and_pages`: the markdown and the labels
+    are built together (one entry per page, tables grouped under their page), so
+    they align by construction regardless of the order the pages are listed in —
+    no assumption that ``expected_pages`` is sorted by, or contiguous in, page
+    number, and no dependence on the flat ``expected_markdown`` ordering.
+    """
+    parts: list[str] = []
+    labels: list[int] = []
+    for entry in expected_pages:
+        md = entry.get("markdown", "") or ""
+        parts.append(md)
+        labels.extend([int(entry["page"])] * len(extract_html_tables(md)))
+    return "\n\n".join(parts), labels
+
+
+def _compute_teds_standalone(
+    expected: str,
+    actual: str,
+    variants: set[str] | None = None,
+    expected_pages: list[int] | None = None,
+    actual_pages: list[int] | None = None,
+) -> list[MetricValue]:
     """Compute TEDS metrics in a worker process."""
-    return TEDSMetric(variants=variants).compute(expected=expected, actual=actual)
+    return TEDSMetric(variants=variants).compute(
+        expected=expected,
+        actual=actual,
+        expected_pages=expected_pages,
+        actual_pages=actual_pages,
+    )
 
 
 def _compute_grits_standalone(
     expected_tables: list[ExtractedTable],
     actual_tables: list[ExtractedTable],
+    expected_pages: list[int] | None = None,
+    actual_pages: list[int] | None = None,
 ) -> list[MetricValue]:
     """Compute GriTS metrics in a worker process."""
-    return GriTSMetric().compute(expected_tables, actual_tables)
+    return GriTSMetric().compute(
+        expected_tables,
+        actual_tables,
+        expected_pages=expected_pages,
+        actual_pages=actual_pages,
+    )
 
 
 def _compute_table_metrics_parallel(
@@ -99,15 +187,22 @@ def _compute_table_metrics_parallel(
     expected_tables: list[ExtractedTable],
     actual_tables: list[ExtractedTable],
     teds_variants: set[str] | None = None,
+    expected_pages: list[int] | None = None,
+    actual_pages: list[int] | None = None,
 ) -> tuple[list[MetricValue], list[MetricValue]]:
     """Run TEDS and GriTS in parallel via separate processes.
 
     TEDS still operates on raw markdown (unchanged). GriTS receives the
-    pre-extracted ExtractedTable lists from the shared stage.
+    pre-extracted ExtractedTable lists from the shared stage. When per-table
+    page labels are supplied, both run page-constrained matching.
     """
     with ProcessPoolExecutor(max_workers=2) as pool:
-        teds_future = pool.submit(_compute_teds_standalone, expected, actual, teds_variants)
-        grits_future = pool.submit(_compute_grits_standalone, expected_tables, actual_tables)
+        teds_future = pool.submit(
+            _compute_teds_standalone, expected, actual, teds_variants, expected_pages, actual_pages
+        )
+        grits_future = pool.submit(
+            _compute_grits_standalone, expected_tables, actual_tables, expected_pages, actual_pages
+        )
         return teds_future.result(), grits_future.result()
 
 
@@ -178,8 +273,15 @@ class ParseEvaluator(BaseEvaluator):
         Requires:
         - ProductType.PARSE
         - inference_result.output is a ParseOutput instance
-        - test_case is a ParseTestCase with either test_rules or expected_markdown,
-          or an ExtractTestCase with extract_field bbox rules.
+        - test_case is one of:
+            - ParseTestCase with test_rules or expected_markdown (classic path)
+            - ParseTestCase carrying metric-specific GT in metadata
+              (cross-page table consistency or table merging). These datasets
+              have no rules or markdown; their metadata metric is the whole
+              evaluation.
+            - ExtractTestCase whose extract_field rules carry non-empty
+              bboxes (grounding-only scoring for parse pipelines against
+              extract-field GT)
         """
         if inference_result.product_type != ProductType.PARSE:
             return False
@@ -197,11 +299,15 @@ class ParseEvaluator(BaseEvaluator):
         if test_case.qa_config is not None:
             return False
 
-        # Need either test rules or expected markdown
+        # Need test rules, expected markdown, or supported metadata-only GT.
         has_test_rules = test_case.test_rules is not None and len(test_case.test_rules) > 0
         has_expected_markdown = test_case.expected_markdown is not None
-
-        return has_test_rules or has_expected_markdown
+        metadata_metric_keys = {"cross_page_table_consistency", "table_merging"}
+        test_case_metadata = getattr(test_case, "metadata", None)
+        has_metadata_gt = isinstance(test_case_metadata, dict) and bool(
+            metadata_metric_keys.intersection(test_case_metadata)
+        )
+        return has_test_rules or has_expected_markdown or has_metadata_gt
 
     def evaluate(self, inference_result: InferenceResult, test_case: TestCase) -> EvaluationResult:
         """
@@ -213,7 +319,10 @@ class ParseEvaluator(BaseEvaluator):
         :raises ValueError: If test case is invalid or missing required data
         """
         if not self.can_evaluate(inference_result, test_case):
-            raise ValueError("Cannot evaluate: missing test_rules or expected_markdown, or invalid product type")
+            raise ValueError(
+                "Cannot evaluate: missing test_rules, expected_markdown, or supported metadata GT; "
+                "or invalid product type"
+            )
 
         if not isinstance(inference_result.output, ParseOutput):
             raise ValueError("Inference result output is not ParseOutput")
@@ -228,9 +337,13 @@ class ParseEvaluator(BaseEvaluator):
 
         # Rule-based evaluation
         if self._enable_rule_based:
-            if not test_case.test_rules:
+            parse_rules_only = [r for r in (test_case.test_rules or []) if not isinstance(r, _NON_PARSE_RULE_TYPES)]
+            if not parse_rules_only:
+                skip_reason = (
+                    "no parse rules (only layout rules present)" if test_case.test_rules else "test_rules not provided"
+                )
                 logger.debug(
-                    f"Skipping rule-based metric: test_rules not provided "
+                    f"Skipping rule-based metric: {skip_reason} "
                     f"(test_id: {test_case.test_id}, "
                     f"example_id: {inference_result.request.example_id})"
                 )
@@ -244,7 +357,7 @@ class ParseEvaluator(BaseEvaluator):
 
                 # Execute rules
                 rule_result = self._rule_metric.compute(
-                    expected=test_case.test_rules,  # type: ignore[arg-type]
+                    expected=parse_rules_only,  # type: ignore[arg-type]
                     actual=markdown_content,
                     page=None,  # Document-level for now
                     raw_output=inference_result.raw_output,
@@ -353,6 +466,7 @@ class ParseEvaluator(BaseEvaluator):
                     _TEXT_STYLING_PAIRS = [
                         ("is_bold", "is_not_bold"),
                         ("is_strikeout", "is_not_strikeout"),
+                        ("present_as_strikeout", "is_not_strikeout"),
                         ("is_sup", "is_not_sup"),
                         ("is_sub", "is_not_sub"),
                     ]
@@ -375,9 +489,9 @@ class ParseEvaluator(BaseEvaluator):
                         "bag_of_digit_percent",
                     }
                     _ORDER_TYPES = {"order"}
-                    _TITLE_TYPES = {"is_title", "title_hierarchy_percent"}
+                    _TITLE_TYPES = {"is_title", "title_hierarchy_percent", "heading_structure"}
                     _CODE_BLOCK_TYPES = {"is_code_block"}
-                    _LATEX_TYPES = {"is_latex"}
+                    _LATEX_TYPES = {"is_latex", "is_not_latex"}
 
                     _NORMALIZED_CATEGORIES: dict[str, set[str]] = {
                         "normalized_text_styling": _TEXT_STYLING_TYPES,
@@ -411,13 +525,7 @@ class ParseEvaluator(BaseEvaluator):
                                 neg_score = (
                                     sum(_rule_score(r) for r in neg_rules) / len(neg_rules) if neg_rules else 1.0
                                 )
-                                beta = 0.5
-                                if pos_score + neg_score > 0:
-                                    cat_value = (
-                                        (1 + beta**2) * pos_score * neg_score / (beta**2 * pos_score + neg_score)
-                                    )
-                                else:
-                                    cat_value = 0.0
+                                cat_value = _styling_f_beta_score(pos_score, neg_score)
                                 _cat_values[metric_name] = cat_value
                                 metrics.append(
                                     MetricValue(
@@ -559,10 +667,31 @@ class ParseEvaluator(BaseEvaluator):
                 )
                 metrics.append(similarity_result)
 
-            # Table similarity metrics (TEDS and GriTS)
+            # Table similarity metrics (TEDS and GriTS).
+            # Page-aware GT datasets source BOTH sides' tables from their separate
+            # pages — GT from ``metadata["expected_pages"]`` and predictions from
+            # ``output.pages`` — so each table's page is intrinsic and matching is
+            # constrained to within-page. Every other dataset stays document-global
+            # (the whole document is effectively a single page).
+            expected_labels: list[int] | None = None
+            actual_labels: list[int] | None = None
+            table_expected_markdown = test_case.expected_markdown
+            table_actual_markdown = actual_markdown
+            gt_pages_field = (getattr(test_case, "metadata", None) or {}).get("expected_pages")
+            if gt_pages_field:
+                predicted = _predicted_markdown_and_pages(inference_result.output)
+                if predicted is not None:
+                    table_actual_markdown, actual_labels = predicted
+                    table_expected_markdown, expected_labels = _gt_markdown_and_pages(gt_pages_field)
+                else:
+                    logger.warning(
+                        "Page-aware GT but output.pages is empty; matching tables document-globally (test_id: %s).",
+                        test_case.test_id,
+                    )
+
             # Normalize predicted tables: merge preceding titles into tables
-            # when GT has full-width colspan title rows
-            actual_for_tables = merge_preceding_titles_into_tables(test_case.expected_markdown, actual_markdown)
+            # when GT has full-width colspan title rows.
+            actual_for_tables = merge_preceding_titles_into_tables(table_expected_markdown, table_actual_markdown)
 
             # Check for HTML tables once (used by both TEDS and GriTS)
             has_expected_tables = _has_html_tables(test_case.expected_markdown)
@@ -573,11 +702,13 @@ class ParseEvaluator(BaseEvaluator):
                     # Both sides have tables — compute table metrics
                     metrics.extend(
                         self._compute_table_similarity_metrics(
-                            test_case.expected_markdown,
+                            table_expected_markdown,
                             actual_for_tables,
                             allow_splitting_ambiguous_merged_tables=test_case.allow_splitting_ambiguous_merged_tables,
                             trm_unsupported=test_case.trm_unsupported,
                             max_top_title_rows=test_case.max_top_title_rows,
+                            expected_pages=expected_labels,
+                            actual_pages=actual_labels,
                         )
                     )
                 else:
@@ -732,6 +863,27 @@ class ParseEvaluator(BaseEvaluator):
                     f"example_id: {inference_result.request.example_id})"
                 )
 
+        # Cross-page table-consistency metric (gated on GT in test-case metadata;
+        # normal parse datasets carry no such metadata and are unaffected).
+        cpc_meta = getattr(test_case, "metadata", None)
+        if isinstance(cpc_meta, dict) and "cross_page_table_consistency" in cpc_meta:
+            from parse_bench.evaluation.metrics.parse.cross_page_table_consistency import (
+                compute_cross_page_table_metrics,
+            )
+
+            metrics.extend(
+                compute_cross_page_table_metrics(inference_result.output, cpc_meta["cross_page_table_consistency"])
+            )
+
+        # Table-merging (junction merge) metric — same metadata-keyed gating; a
+        # table_merging dataset carries metadata["table_merging"] and no rules.
+        if isinstance(cpc_meta, dict) and "table_merging" in cpc_meta:
+            from parse_bench.evaluation.metrics.parse.table_merging import (
+                compute_table_merging_metrics,
+            )
+
+            metrics.extend(compute_table_merging_metrics(inference_result.output, cpc_meta["table_merging"]))
+
         stats = build_operational_stats(inference_result)
 
         return EvaluationResult(
@@ -884,6 +1036,8 @@ class ParseEvaluator(BaseEvaluator):
         allow_splitting_ambiguous_merged_tables: bool = False,
         trm_unsupported: bool = False,
         max_top_title_rows: int = 1,
+        expected_pages: list[int] | None = None,
+        actual_pages: list[int] | None = None,
     ) -> list[MetricValue]:
         """Compute enabled table similarity metrics.
 
@@ -891,6 +1045,11 @@ class ParseEvaluator(BaseEvaluator):
         enabled, since they are independent CPU-bound computations.
         Falls back to sequential execution if parallel dispatch fails or
         only one metric is enabled.
+
+        When ``expected_pages`` / ``actual_pages`` are supplied (per-table page
+        labels for a multi-page table dataset), GriTS/TEDS match tables only
+        within the same page; everything falls back to global matching if the
+        labels turn out inconsistent with the table counts.
         """
         grits_results: list[MetricValue] = []
 
@@ -908,6 +1067,25 @@ class ParseEvaluator(BaseEvaluator):
         # that asymmetry is intentional.
         if allow_splitting_ambiguous_merged_tables:
             actual_tables, _ = split_ambiguous_merged_pred(expected_tables, actual_tables)
+
+        # Validate page labels align with the table lists GriTS/TEDS consume.
+        # The splitter can change the predicted count; when it does (or the
+        # labels are missing/mismatched) disable page-blocking for this doc.
+        if expected_pages is not None and (
+            actual_pages is None
+            or len(expected_pages) != len(expected_tables)
+            or len(actual_pages) != len(actual_tables)
+        ):
+            logger.warning(
+                "Page-constrained table matching disabled: page labels inconsistent "
+                "with table counts (expected_pages=%s vs %d GT tables, actual_pages=%s vs %d pred tables).",
+                len(expected_pages),
+                len(expected_tables),
+                None if actual_pages is None else len(actual_pages),
+                len(actual_tables),
+            )
+            expected_pages = None
+            actual_pages = None
 
         # Title-row stripping: detect leading <td> title rows and top <th>
         # spanning titles, physically remove them from each table's grid,
@@ -948,6 +1126,8 @@ class ParseEvaluator(BaseEvaluator):
                     expected_tables,
                     actual_tables,
                     teds_variants=self._teds_metric.variants,
+                    expected_pages=expected_pages,
+                    actual_pages=actual_pages,
                 )
                 results: list[MetricValue] = list(teds_results)
                 for r in grits_results:
@@ -986,9 +1166,21 @@ class ParseEvaluator(BaseEvaluator):
         # Sequential fallback (or only one metric enabled, or ref_grits active)
         results: list[MetricValue] = []  # type: ignore[no-redef]
         if self._enable_teds:
-            results.extend(self._teds_metric.compute(expected=expected, actual=actual))
+            results.extend(
+                self._teds_metric.compute(
+                    expected=expected,
+                    actual=actual,
+                    expected_pages=expected_pages,
+                    actual_pages=actual_pages,
+                )
+            )
         if self._enable_grits:
-            grits_results = self._grits_metric.compute(expected_tables, actual_tables)
+            grits_results = self._grits_metric.compute(
+                expected_tables,
+                actual_tables,
+                expected_pages=expected_pages,
+                actual_pages=actual_pages,
+            )
             for r in grits_results:
                 if r.metadata is None:
                     r.metadata = {}

--- a/src/parse_bench/evaluation/metrics/parse/emphasis_spans.py
+++ b/src/parse_bench/evaluation/metrics/parse/emphasis_spans.py
@@ -1,0 +1,242 @@
+"""Delimiter-run pairing for the markdown emphasis detectors.
+
+The ``**`` / ``*`` / ``_`` / ``~~`` arms of ``FormattingRule`` used to be
+regexes guarded by CommonMark flanking rules. Flanking is a *local* test, and
+two requirements proved locally indistinguishable: whitespace-padded emphasis
+(``Grand ** Total ** shown below.``) must count as emphasis, while the same
+characters seen between two padded spans (``** Alpha ** plain ** Beta **``)
+must not let ``plain`` score. Around a single delimiter run those contexts are
+identical - only *which run pairs with which* separates them - so this module
+resolves emphasis the way a parser does: tokenize delimiter runs, pair openers
+with closers, and let the caller search query text inside the paired spans.
+
+Pairing happens in two passes over each kind's runs:
+
+1. **Strict pass** - runs are classified with CommonMark's flanking rules
+   (including the punctuation nuances and the no-intraword restriction for
+   ``_``) and paired on a stack, nearest-opener-first. This resolves every
+   tightly-delimited span exactly like a markdown parser would, and keeps a
+   literal run such as the ``**`` in ``2**3`` from stealing an opener.
+2. **Padded pass** - the runs left unpaired keep any strict capability they
+   had and additionally may open or close across *inner* padding, provided the
+   padded side's immediate neighbor really is whitespace. This is the
+   evaluator's one deliberate departure from CommonMark: parser output often
+   pads just inside the markers (``** Total **``, ``**Total **:``) while still
+   meaning emphasis, so padded shapes score exactly like tight ones. A padded
+   pairing whose content range would swallow a strict-pass span is discarded:
+   two padded runs bracketing a real span (``** foo **bold** bar **``) are
+   that span's neighbors, not its padding, and letting them pair would score
+   the plain text around it.
+
+Both passes drop stack openers once a blank line intervenes: markdown emphasis
+cannot cross a paragraph break, whatever the line endings.
+
+Padding may wrap a single line break for ``**`` and ``~~`` (a closer on its own
+line, ``**Total\\n**``, still closes) but stays horizontal for ``*`` and ``_``:
+a line-leading ``*`` is usually a bullet, and letting it reach across the line
+break would pair one list item's marker with the next and italicize the item.
+"""
+
+from __future__ import annotations
+
+import re
+import string
+from dataclasses import dataclass
+
+# A paragraph break with LF or CRLF endings, possibly with trailing whitespace
+# on the blank line.
+_BLANK_LINE_RE = re.compile(r"\r?\n[ \t]*\r?\n")
+
+# ASCII punctuation, per CommonMark's flanking definitions. Parser output is
+# overwhelmingly ASCII; Unicode punctuation is treated as an ordinary letter.
+_PUNCT = frozenset(string.punctuation)
+
+
+@dataclass(frozen=True)
+class _KindSpec:
+    char: str
+    exact_length: int | None  # run must be exactly this long (None: 2 or more)
+    underscore_rule: bool  # apply CommonMark's no-intraword restriction
+    padding_may_break_line: bool
+
+
+_KIND_SPECS = {
+    "bold": _KindSpec("*", None, False, True),
+    "italic_star": _KindSpec("*", 1, False, False),
+    "italic_under": _KindSpec("_", 1, True, False),
+    "strikeout": _KindSpec("~", None, False, True),
+}
+
+
+@dataclass(frozen=True)
+class _Run:
+    start: int
+    end: int
+
+
+def _find_runs(md: str, spec: _KindSpec) -> list[_Run]:
+    runs = []
+    for match in re.finditer(re.escape(spec.char) + "+", md):
+        length = match.end() - match.start()
+        if spec.exact_length is not None:
+            if length != spec.exact_length:
+                continue
+        elif length < 2:
+            continue
+        runs.append(_Run(match.start(), match.end()))
+    return runs
+
+
+def _is_ws(char: str | None) -> bool:
+    # String edges count as whitespace, as in CommonMark.
+    return char is None or char.isspace()
+
+
+def _is_punct(char: str | None) -> bool:
+    return char is not None and char in _PUNCT
+
+
+def _strict_caps(md: str, run: _Run, spec: _KindSpec) -> tuple[bool, bool]:
+    """(can_open, can_close) under CommonMark flanking rules."""
+    prev = md[run.start - 1] if run.start > 0 else None
+    nxt = md[run.end] if run.end < len(md) else None
+
+    left_flanking = not _is_ws(nxt) and (not _is_punct(nxt) or _is_ws(prev) or _is_punct(prev))
+    right_flanking = not _is_ws(prev) and (not _is_punct(prev) or _is_ws(nxt) or _is_punct(nxt))
+
+    if not spec.underscore_rule:
+        return left_flanking, right_flanking
+    # Underscores do not open or close intraword emphasis (snake_case).
+    can_open = left_flanking and (not right_flanking or _is_punct(prev))
+    can_close = right_flanking and (not left_flanking or _is_punct(nxt))
+    return can_open, can_close
+
+
+def _padded_after(md: str, pos: int, may_break_line: bool) -> bool:
+    """Non-whitespace follows *pos* after inner padding (never a blank line)."""
+    i = pos
+    while i < len(md) and md[i] in " \t":
+        i += 1
+    if may_break_line and i < len(md) and md[i] in "\r\n":
+        if md[i] == "\r":
+            i += 1
+        if i < len(md) and md[i] == "\n":
+            i += 1
+        while i < len(md) and md[i] in " \t":
+            i += 1
+    return i < len(md) and not md[i].isspace()
+
+
+def _padded_before(md: str, pos: int, may_break_line: bool) -> bool:
+    """Non-whitespace precedes *pos* before inner padding (never a blank line)."""
+    i = pos - 1
+    while i >= 0 and md[i] in " \t":
+        i -= 1
+    if may_break_line and i >= 0 and md[i] == "\n":
+        i -= 1
+        if i >= 0 and md[i] == "\r":
+            i -= 1
+        while i >= 0 and md[i] in " \t":
+            i -= 1
+    return i >= 0 and not md[i].isspace()
+
+
+def _padded_caps(md: str, run: _Run, spec: _KindSpec, strict: tuple[bool, bool]) -> tuple[bool, bool]:
+    """Strict capabilities carried forward, plus genuinely padded sides.
+
+    A padded capability requires actual padding - the immediate neighbor must
+    be whitespace. Without that gate this pass would re-grant capabilities the
+    strict rules deliberately withheld (an intraword ``_``, for example).
+    """
+    strict_open, strict_close = strict
+    prev = md[run.start - 1] if run.start > 0 else None
+    nxt = md[run.end] if run.end < len(md) else None
+    can_open = strict_open or (
+        nxt is not None and nxt.isspace() and _padded_after(md, run.end, spec.padding_may_break_line)
+    )
+    can_close = strict_close or (
+        prev is not None and prev.isspace() and _padded_before(md, run.start, spec.padding_may_break_line)
+    )
+    return can_open, can_close
+
+
+def _pair(
+    md: str,
+    runs: list[_Run],
+    caps: dict[int, tuple[bool, bool]],
+    blank_line_starts: list[int],
+) -> tuple[list[tuple[int, int]], list[_Run]]:
+    """Stack-pair *runs*, closing against the nearest open run first.
+
+    A run that can both open and close acts as a closer whenever an opener is
+    on the stack, as in CommonMark. Returns the paired spans as (start, end)
+    content ranges plus the runs left unpaired.
+    """
+    spans: list[tuple[int, int]] = []
+    stack: list[_Run] = []
+    paired: set[int] = set()
+    for run in runs:
+        # Emphasis cannot cross a paragraph break: openers left of one are dead.
+        # Openers sit in stack order, so one blank line strands all of them.
+        if stack and _has_blank_between(blank_line_starts, stack[-1].end, run.start):
+            stack.clear()
+        can_open, can_close = caps[run.start]
+        if can_close and stack:
+            opener = stack.pop()
+            spans.append((opener.end, run.start))
+            paired.add(opener.start)
+            paired.add(run.start)
+        elif can_open:
+            stack.append(run)
+    unpaired = [run for run in runs if run.start not in paired]
+    return spans, unpaired
+
+
+def _has_blank_between(blank_line_starts: list[int], lo: int, hi: int) -> bool:
+    import bisect
+
+    idx = bisect.bisect_left(blank_line_starts, lo)
+    return idx < len(blank_line_starts) and blank_line_starts[idx] < hi
+
+
+def emphasis_spans(md: str, kind: str) -> list[tuple[int, int]]:
+    """Content ranges of every *kind* emphasis span in *md*, in order."""
+    spec = _KIND_SPECS[kind]
+    runs = _find_runs(md, spec)
+    if len(runs) < 2:
+        return []
+    blank_line_starts = [match.start() for match in _BLANK_LINE_RE.finditer(md)]
+
+    strict = {run.start: _strict_caps(md, run, spec) for run in runs}
+    spans, leftover = _pair(md, runs, strict, blank_line_starts)
+    padded = {run.start: _padded_caps(md, run, spec, strict[run.start]) for run in leftover}
+    more, _ = _pair(md, leftover, padded, blank_line_starts)
+    # Two padded runs bracketing a strict span pair into a wrapper that would
+    # score the plain text around that span. Bracketing is not padding: drop
+    # any padded span that contains a strict one.
+    more = [padded_span for padded_span in more if not _contains_any(padded_span, spans)]
+    return sorted(spans + more)
+
+
+def _contains_any(outer: tuple[int, int], spans: list[tuple[int, int]]) -> bool:
+    return any(outer[0] <= start and end <= outer[1] for start, end in spans)
+
+
+class EmphasisSpanMatcher:
+    """Searches for a query pattern inside paired emphasis spans.
+
+    Duck-types the one method ``FormattingRule.run`` uses on its compiled
+    patterns, so a matcher can sit in the same detector list as the tag-pair
+    and heading regexes.
+    """
+
+    def __init__(self, kinds: tuple[str, ...], query: str):
+        self._kinds = kinds
+        self._query = re.compile(query, re.IGNORECASE)
+
+    def search(self, content: str) -> bool:
+        return any(
+            self._query.search(content[start:end])
+            for kind in self._kinds
+            for start, end in emphasis_spans(content, kind)
+        )

--- a/src/parse_bench/evaluation/metrics/parse/grits_metric.py
+++ b/src/parse_bench/evaluation/metrics/parse/grits_metric.py
@@ -14,16 +14,18 @@ Reference paper:
 """
 
 import itertools
+import os
 from collections import defaultdict
+from dataclasses import replace
 from difflib import SequenceMatcher
 from functools import lru_cache
-from typing import Any
+from typing import Any, Literal, overload
 
 import numpy as np
 from lxml import html
-from scipy.optimize import linear_sum_assignment
 
 from parse_bench.evaluation.metrics.base import Metric
+from parse_bench.evaluation.metrics.parse.table_pairing import assign_tables, page_blocking_active
 from parse_bench.evaluation.metrics.parse.table_parsing import (
     _ASCII_TO_SUBSCRIPT,
     _ASCII_TO_SUPERSCRIPT,
@@ -275,6 +277,231 @@ def _align_2d_outer(
     return true_indices, pred_indices, score
 
 
+def _kernel_mode() -> str:
+    """Select the ``factored_2dmss`` implementation: ``array`` | ``memo`` | ``slow``.
+
+    ``array`` (default) builds the reward as a vectorized numpy tensor over a
+    unique-cell-value similarity matrix and runs the alignment DP on Python lists
+    — no per-pair LCS redundancy, no R1·C1·R2·C2 dict build, no numpy scalar
+    indexing. ``memo`` is the previous fast path (memoized dict build). ``slow`` is
+    the original dict path. All three return bit-identical scores; the non-array
+    modes exist only for before/after benchmarking.
+
+    ``BENCH_GRITS_KERNEL`` selects explicitly; the legacy boolean
+    ``BENCH_GRITS_FAST_KERNEL=0`` forces ``slow``.
+    """
+    mode = os.environ.get("BENCH_GRITS_KERNEL", "").strip().lower()
+    if mode in ("array", "memo", "slow"):
+        return mode
+    return "slow" if os.environ.get("BENCH_GRITS_FAST_KERNEL", "1") == "0" else "array"
+
+
+def _precompute_rewards(
+    true_grid: np.ndarray,
+    pred_grid: np.ndarray,
+    reward_function: Any,
+    memoize: bool,
+) -> tuple[dict[tuple[int, int, int, int], float], dict[tuple[int, int, int, int], float]]:
+    """Original dict reward lookups over every cell pair (``slow`` / ``memo`` modes).
+
+    The reward depends only on the two cell VALUES, but the grids carry the same
+    string in many cells, so the naive ``range(R1·C1·R2·C2)`` loop calls
+    ``reward_function`` (an LCS over strings) up to 1.7M times per pair with massive
+    redundancy. ``memoize`` caches by ``(cell_value, cell_value)`` (a pure-function
+    cache → identical rewards). The ``array`` kernel avoids this loop entirely.
+    """
+    pre_computed: dict[tuple[int, int, int, int], float] = {}
+    transpose_rewards: dict[tuple[int, int, int, int], float] = {}
+    product = itertools.product(
+        range(true_grid.shape[0]),
+        range(true_grid.shape[1]),
+        range(pred_grid.shape[0]),
+        range(pred_grid.shape[1]),
+    )
+    if memoize:
+        cache: dict[tuple[Any, Any], float] = {}
+        for trow, tcol, prow, pcol in product:
+            value_key = (true_grid[trow, tcol], pred_grid[prow, pcol])
+            reward = cache.get(value_key)
+            if reward is None:
+                reward = reward_function(*value_key)
+                cache[value_key] = reward
+            pre_computed[(trow, tcol, prow, pcol)] = reward
+            transpose_rewards[(tcol, trow, pcol, prow)] = reward
+    else:
+        for trow, tcol, prow, pcol in product:
+            reward = reward_function(true_grid[trow, tcol], pred_grid[prow, pcol])
+            pre_computed[(trow, tcol, prow, pcol)] = reward
+            transpose_rewards[(tcol, trow, pcol, prow)] = reward
+    return pre_computed, transpose_rewards
+
+
+def _reward_tensor(
+    true_grid: np.ndarray,
+    pred_grid: np.ndarray,
+    reward_function: Any,
+) -> np.ndarray:
+    """Reward tensor ``R[trow, tcol, prow, pcol] = reward(true[trow,tcol], pred[prow,pcol])``.
+
+    ``reward_function`` is evaluated once per *distinct* (true_value, pred_value)
+    pair over a unique-string similarity matrix, then broadcast-gathered into the
+    full R1·C1·R2·C2 tensor — no per-cell Python loop, no LCS redundancy. Values
+    are the same doubles the dict path would store, so downstream scores are
+    bit-identical.
+    """
+    true_uids: dict[Any, int] = {}
+    pred_uids: dict[Any, int] = {}
+    uid_true = np.empty(true_grid.shape, dtype=np.intp)
+    uid_pred = np.empty(pred_grid.shape, dtype=np.intp)
+    unique_true: list[Any] = []
+    unique_pred: list[Any] = []
+    for r in range(true_grid.shape[0]):
+        for c in range(true_grid.shape[1]):
+            value = true_grid[r, c]
+            uid = true_uids.get(value)
+            if uid is None:
+                uid = len(unique_true)
+                true_uids[value] = uid
+                unique_true.append(value)
+            uid_true[r, c] = uid
+    for r in range(pred_grid.shape[0]):
+        for c in range(pred_grid.shape[1]):
+            value = pred_grid[r, c]
+            uid = pred_uids.get(value)
+            if uid is None:
+                uid = len(unique_pred)
+                pred_uids[value] = uid
+                unique_pred.append(value)
+            uid_pred[r, c] = uid
+
+    sim = np.empty((len(unique_true), len(unique_pred)), dtype=np.float64)
+    for a, value_a in enumerate(unique_true):
+        for b, value_b in enumerate(unique_pred):
+            sim[a, b] = reward_function(value_a, value_b)
+
+    # Broadcast-gather: (R1,C1,1,1) x (1,1,R2,C2) -> (R1,C1,R2,C2)
+    return sim[uid_true[:, :, None, None], uid_pred[None, None, :, :]]
+
+
+def _traceback_list(pointers: list[list[int]]) -> tuple[list[int], list[int]]:
+    """List-based traceback (mirror of :func:`_traceback`). -1=up, 1=left, 0=match."""
+    i = len(pointers) - 1
+    j = len(pointers[0]) - 1
+    seq1_indices: list[int] = []
+    seq2_indices: list[int] = []
+    while not (i == 0 and j == 0):
+        ptr = pointers[i][j]
+        if ptr == -1:
+            i -= 1
+        elif ptr == 1:
+            j -= 1
+        else:
+            i -= 1
+            j -= 1
+            seq1_indices.append(i)
+            seq2_indices.append(j)
+    return seq1_indices[::-1], seq2_indices[::-1]
+
+
+@overload
+def _align_matrix(reward_matrix: list[list[float]], return_alignment: Literal[False] = False) -> float: ...
+
+
+@overload
+def _align_matrix(
+    reward_matrix: list[list[float]], return_alignment: Literal[True]
+) -> tuple[list[int], list[int], float]: ...
+
+
+def _align_matrix(
+    reward_matrix: list[list[float]],
+    return_alignment: bool = False,
+) -> float | tuple[list[int], list[int], float]:
+    """Max-reward monotonic alignment over a dense ``M×N`` reward matrix.
+
+    Identical DP and tie-breaking to :func:`_align_1d` / :func:`_align_2d_outer`
+    (``best = max(diag, up, left)``; tie prefers diag, then up, then left), but on
+    plain Python lists — no numpy scalar indexing, no 4-tuple dict keys.
+    """
+    m = len(reward_matrix)
+    n = len(reward_matrix[0]) if m else 0
+    scores = [[0.0] * (n + 1) for _ in range(m + 1)]
+    pointers = [[0] * (n + 1) for _ in range(m + 1)]
+    for i in range(1, m + 1):
+        pointers[i][0] = -1  # up
+    for j in range(1, n + 1):
+        pointers[0][j] = 1  # left
+
+    for i in range(1, m + 1):
+        reward_row = reward_matrix[i - 1]
+        scores_prev = scores[i - 1]
+        scores_cur = scores[i]
+        pointers_cur = pointers[i]
+        for j in range(1, n + 1):
+            diag = scores_prev[j - 1] + reward_row[j - 1]
+            skip_up = scores_prev[j]
+            skip_left = scores_cur[j - 1]
+            best = max(diag, skip_up, skip_left)
+            scores_cur[j] = best
+            if diag == best:
+                pointers_cur[j] = 0
+            elif skip_up == best:
+                pointers_cur[j] = -1
+            else:
+                pointers_cur[j] = 1
+
+    score = scores[m][n]
+    if not return_alignment:
+        return score
+    seq1_indices, seq2_indices = _traceback_list(pointers)
+    return seq1_indices, seq2_indices, score
+
+
+def _factored_2dmss_array(
+    true_grid: np.ndarray,
+    pred_grid: np.ndarray,
+    reward_function: Any,
+) -> tuple[float, float, float, float, dict[int, int], dict[int, int]]:
+    """Array-kernel ``factored_2dmss`` — bit-identical to the dict path.
+
+    Builds the reward tensor once (vectorized), then does the same factored
+    row/column alignments. The per-row-pair column score and per-col-pair row
+    score matrices (``RR`` / ``CC``) are exactly the inner ``_align_1d`` scores the
+    dict path recomputes inside ``_align_2d_outer``. ``positive_match`` is summed in
+    the original nested order so floating-point rounding matches to the last bit.
+    """
+    reward = _reward_tensor(true_grid, pred_grid, reward_function)
+    n_true_rows, n_true_cols, n_pred_rows, n_pred_cols = reward.shape
+
+    # Row alignment: reward between true row i and pred row j is their column
+    # alignment score over reward[i, :, j, :] (C1×C2).
+    rr = [[_align_matrix(reward[i, :, j, :].tolist()) for j in range(n_pred_rows)] for i in range(n_true_rows)]
+    true_row_nums, pred_row_nums, row_score = _align_matrix(rr, return_alignment=True)
+
+    # Column alignment: reward between true col i and pred col j is their row
+    # alignment score over reward[:, i, :, j] (R1×R2).
+    cc = [[_align_matrix(reward[:, i, :, j].tolist()) for j in range(n_pred_cols)] for i in range(n_true_cols)]
+    true_col_nums, pred_col_nums, col_score = _align_matrix(cc, return_alignment=True)
+
+    num_true = n_true_rows * n_true_cols
+    num_pos = n_pred_rows * n_pred_cols
+
+    upper_bound = min(row_score, col_score)
+    ub_fscore, _, _ = _compute_fscore(upper_bound, num_true, num_pos)
+
+    # Sum matched-cell rewards in the same (row-pair outer, col-pair inner) order
+    # as the dict path so the float reduction is bit-identical.
+    positive_match = 0.0
+    for true_row, pred_row in zip(true_row_nums, pred_row_nums, strict=True):
+        for true_col, pred_col in zip(true_col_nums, pred_col_nums, strict=True):
+            positive_match += float(reward[true_row, true_col, pred_row, pred_col])
+
+    fscore, precision, recall = _compute_fscore(positive_match, num_true, num_pos)
+    row_map = dict(zip(true_row_nums, pred_row_nums, strict=True))
+    col_map = dict(zip(true_col_nums, pred_col_nums, strict=True))
+    return fscore, precision, recall, ub_fscore, row_map, col_map
+
+
 def factored_2dmss(
     true_grid: np.ndarray,
     pred_grid: np.ndarray,
@@ -287,18 +514,14 @@ def factored_2dmss(
 
     Returns (fscore, precision, recall, upper_bound_score).
     """
-    pre_computed: dict[tuple[int, int, int, int], float] = {}
-    transpose_rewards: dict[tuple[int, int, int, int], float] = {}
+    mode = _kernel_mode()
+    if mode == "array":
+        fscore, precision, recall, ub_fscore, _, _ = _factored_2dmss_array(true_grid, pred_grid, reward_function)
+        return fscore, precision, recall, ub_fscore
 
-    for trow, tcol, prow, pcol in itertools.product(
-        range(true_grid.shape[0]),
-        range(true_grid.shape[1]),
-        range(pred_grid.shape[0]),
-        range(pred_grid.shape[1]),
-    ):
-        reward = reward_function(true_grid[trow, tcol], pred_grid[prow, pcol])
-        pre_computed[(trow, tcol, prow, pcol)] = reward
-        transpose_rewards[(tcol, trow, pcol, prow)] = reward
+    pre_computed, transpose_rewards = _precompute_rewards(
+        true_grid, pred_grid, reward_function, memoize=(mode == "memo")
+    )
 
     num_pos = pred_grid.shape[0] * pred_grid.shape[1]
     num_true = true_grid.shape[0] * true_grid.shape[1]
@@ -333,18 +556,13 @@ def factored_2dmss_with_alignment(
     Returns (fscore, precision, recall, upper_bound, row_map, col_map)
     where row_map = {true_row: pred_row} and col_map = {true_col: pred_col}.
     """
-    pre_computed: dict[tuple[int, int, int, int], float] = {}
-    transpose_rewards: dict[tuple[int, int, int, int], float] = {}
+    mode = _kernel_mode()
+    if mode == "array":
+        return _factored_2dmss_array(true_grid, pred_grid, reward_function)
 
-    for trow, tcol, prow, pcol in itertools.product(
-        range(true_grid.shape[0]),
-        range(true_grid.shape[1]),
-        range(pred_grid.shape[0]),
-        range(pred_grid.shape[1]),
-    ):
-        reward = reward_function(true_grid[trow, tcol], pred_grid[prow, pcol])
-        pre_computed[(trow, tcol, prow, pcol)] = reward
-        transpose_rewards[(tcol, trow, pcol, prow)] = reward
+    pre_computed, transpose_rewards = _precompute_rewards(
+        true_grid, pred_grid, reward_function, memoize=(mode == "memo")
+    )
 
     num_pos = pred_grid.shape[0] * pred_grid.shape[1]
     num_true = true_grid.shape[0] * true_grid.shape[1]
@@ -567,6 +785,49 @@ def grits_from_html(
     return metrics
 
 
+def _leading_title_band_text(td: TableData) -> str | None:
+    """Normalized text of a leading full-width title band, if the table has one.
+
+    A title band is row 0 rendered as one colspan cell: after span expansion
+    every column of row 0 carries the same non-empty text. Tables with only
+    one row, or only one column, are excluded — the first has no body left to
+    score once the band is dropped, the second cannot distinguish a band from
+    an ordinary cell.
+    """
+    n_rows, n_cols = td.data.shape
+    if n_rows < 2 or n_cols < 2:
+        return None
+    texts = {normalize_cell_text(str(td.data[0, c])) for c in range(n_cols)}
+    if len(texts) != 1:
+        return None
+    text = texts.pop()
+    return text or None
+
+
+def _drop_caption_matched_title_band(td: TableData, other_caption: str) -> TableData:
+    """Drop ``td``'s leading title band when ``other_caption`` says the same thing.
+
+    ``<caption>`` is the semantically correct place for a table's title, and a
+    prediction that uses it must not be scored as having lost the title row
+    that a ground truth spells as a full-width header band (or vice versa).
+    The caption never enters either grid — it is not a ``<td>``/``<th>`` — so
+    the band on the other side is the only asymmetry, and removing it makes
+    the two structures comparable.
+
+    Guarded by text equality under the ordinary cell normalization, so a band
+    that says something the caption does not is left in place and still
+    scores. Applied in both directions by the caller, so the treatment is
+    symmetric between ground truth and prediction.
+    """
+    caption = normalize_cell_text(other_caption)
+    if not caption:
+        return td
+    band = _leading_title_band_text(td)
+    if band is None or band != caption:
+        return td
+    return replace(td, data=td.data[1:, :])
+
+
 def grits_con_from_table_data(
     gt_td: TableData,
     pred_td: TableData,
@@ -580,6 +841,17 @@ def grits_con_from_table_data(
     and applies the upgraded ``normalize_cell_text``. P5 entry point — replaces
     the older ``grits_from_html`` path on the GriTS hot path.
     """
+    if gt_td.data.size == 0 or pred_td.data.size == 0:
+        return None
+
+    # A <caption> on one side and a full-width title band saying the same
+    # thing on the other are the same title rendered two ways; neutralize the
+    # band so the difference costs nothing. Both directions, so the treatment
+    # is symmetric.
+    if pred_td.caption:
+        gt_td = _drop_caption_matched_title_band(gt_td, pred_td.caption)
+    if gt_td.caption:
+        pred_td = _drop_caption_matched_title_band(pred_td, gt_td.caption)
     if gt_td.data.size == 0 or pred_td.data.size == 0:
         return None
 
@@ -672,6 +944,9 @@ class GriTSMetric(Metric):
         self,
         expected_tables: list[Any],
         actual_tables: list[Any],
+        *,
+        expected_pages: list[int] | None = None,
+        actual_pages: list[int] | None = None,
         **kwargs: Any,
     ) -> list[MetricValue]:
         """Compute GriTS_Con scores between expected and actual table sets.
@@ -685,6 +960,13 @@ class GriTSMetric(Metric):
         Args:
             expected_tables: Pre-extracted GT tables (``list[ExtractedTable]``).
             actual_tables: Pre-extracted predicted tables (``list[ExtractedTable]``).
+            expected_pages: Optional page number (1-indexed) per GT table, aligned
+                with ``expected_tables``. When supplied together with
+                ``actual_pages`` (and length-consistent), the GT->pred assignment
+                is solved per page so a GT table only pairs with a prediction on
+                the same page. Omit for the document-global assignment.
+            actual_pages: Optional page number per predicted table, aligned with
+                ``actual_tables``.
             kwargs: Additional parameters (not used)
 
         Returns:
@@ -719,30 +1001,42 @@ class GriTSMetric(Metric):
 
         n_expected = len(expected_td)
         n_actual = len(actual_td)
-        total_pairs = n_expected * n_actual
+
+        # When per-table page labels are supplied, only same-page pairs are
+        # eligible to match — so only those need a GriTS comparison. This both
+        # constrains the assignment to within-page pairs and avoids the O(n_gt *
+        # n_pred) blow-up on multi-page documents.
+        blocked = page_blocking_active(expected_pages, actual_pages, n_expected, n_actual)
+        allowed_pairs = [
+            (i, j)
+            for i in range(n_expected)
+            for j in range(n_actual)
+            if not blocked or expected_pages[i] == actual_pages[j]  # type: ignore[index]
+        ]
+        total_pairs = len(allowed_pairs)
 
         print(
-            f"  GriTS: comparing {n_expected} expected x {n_actual} actual = {total_pairs} table pair(s)",
+            f"  GriTS: comparing {n_expected} expected x {n_actual} actual = {total_pairs} table pair(s)"
+            f"{' (same-page only)' if blocked else ''}",
             flush=True,
         )
 
-        # Compute all pairwise GriTS scores sequentially
+        # Compute pairwise GriTS scores for the eligible pairs only. Disallowed
+        # (cross-page) cells keep cost 0.0 and are never read — the per-page
+        # assignment only ever selects same-page pairs.
         results_cache: dict[tuple[int, int], dict[str, Any]] = {}
         cost_matrix = np.zeros((n_expected, n_actual))
 
-        pair_idx = 0
-        for i, gt_table in enumerate(expected_td):
-            for j, pred_table in enumerate(actual_td):
-                pair_idx += 1
-                if total_pairs > 1:
-                    print(f"  GriTS: table pair {pair_idx}/{total_pairs}", flush=True)
-                maybe_result = grits_con_from_table_data(gt_table, pred_table)
-                result = maybe_result if maybe_result is not None else dict(_ZERO_RESULT)
-                results_cache[(i, j)] = result
-                cost_matrix[i, j] = -result["grits_con"]
+        for pair_idx, (i, j) in enumerate(allowed_pairs, start=1):
+            if total_pairs > 1:
+                print(f"  GriTS: table pair {pair_idx}/{total_pairs}", flush=True)
+            maybe_result = grits_con_from_table_data(expected_td[i], actual_td[j])
+            result = maybe_result if maybe_result is not None else dict(_ZERO_RESULT)
+            results_cache[(i, j)] = result
+            cost_matrix[i, j] = -result["grits_con"]
 
-        # Solve assignment via Hungarian algorithm
-        row_ind, col_ind = linear_sum_assignment(cost_matrix)
+        # Solve assignment (per page when page labels are supplied, else global).
+        row_ind, col_ind = assign_tables(cost_matrix, expected_pages, actual_pages)
 
         per_table_details: list[dict[str, Any]] = []
         con_scores: list[float] = []
@@ -752,31 +1046,34 @@ class GriTSMetric(Metric):
             gi, pi = int(gt_idx), int(pred_idx)
             result = results_cache[(gi, pi)]
             con_scores.append(result["grits_con"])
-            per_table_details.append(
-                {
-                    "gt_table_index": gi,
-                    "pred_table_index": pi,
-                    "grits_con": result["grits_con"],
-                    "grits_precision_con": result["grits_precision_con"],
-                    "grits_recall_con": result["grits_recall_con"],
-                    "_con_row_alignment": result.get("_con_row_alignment", {}),
-                    "_con_col_alignment": result.get("_con_col_alignment", {}),
-                }
-            )
+            detail: dict[str, Any] = {
+                "gt_table_index": gi,
+                "pred_table_index": pi,
+                "grits_con": result["grits_con"],
+                "grits_precision_con": result["grits_precision_con"],
+                "grits_recall_con": result["grits_recall_con"],
+                "_con_row_alignment": result.get("_con_row_alignment", {}),
+                "_con_col_alignment": result.get("_con_col_alignment", {}),
+            }
+            if blocked:
+                detail["gt_page"] = expected_pages[gi]  # type: ignore[index]
+                detail["pred_page"] = actual_pages[pi]  # type: ignore[index]
+            per_table_details.append(detail)
             matched_gt.add(gi)
 
         # Unmatched expected tables score 0
         for i in range(n_expected):
             if i not in matched_gt:
                 con_scores.append(0.0)
-                per_table_details.append(
-                    {
-                        "gt_table_index": i,
-                        "pred_table_index": None,
-                        "grits_con": 0.0,
-                        "note": "No matching table in actual",
-                    }
-                )
+                unmatched_detail: dict[str, Any] = {
+                    "gt_table_index": i,
+                    "pred_table_index": None,
+                    "grits_con": 0.0,
+                    "note": "No matching table in actual",
+                }
+                if blocked:
+                    unmatched_detail["gt_page"] = expected_pages[i]  # type: ignore[index]
+                per_table_details.append(unmatched_detail)
 
         avg_con = sum(con_scores) / len(con_scores) if con_scores else 0.0
         print(f"  GriTS: done, con = {avg_con:.4f}", flush=True)

--- a/src/parse_bench/evaluation/metrics/parse/header_accuracy_metric.py
+++ b/src/parse_bench/evaluation/metrics/parse/header_accuracy_metric.py
@@ -64,7 +64,11 @@ from parse_bench.evaluation.metrics.parse.grits_metric import (
 )
 from parse_bench.evaluation.metrics.parse.table_extraction import extract_html_tables
 from parse_bench.evaluation.metrics.parse.table_parsing import _sup_sub_to_unicode
-from parse_bench.evaluation.metrics.parse.utils import normalize_cell_text, normalize_text
+from parse_bench.evaluation.metrics.parse.utils import (
+    cells_match_leader_insensitive,
+    normalize_cell_text,
+    normalize_text,
+)
 from parse_bench.schemas.evaluation import MetricValue
 
 
@@ -586,6 +590,9 @@ def _header_data_alignment_score(
 
     Returns fraction of GT header cells whose text matches at the
     aligned position. Returns 1.0 when GT has no headers.
+
+    The text check is leader-insensitive — a trailing dot/period run is
+    decoration, not content. See ``utils.cells_match_leader_insensitive``.
     """
     if not gt_cells:
         return 1.0
@@ -598,7 +605,7 @@ def _header_data_alignment_score(
         mapped_c = col_map.get(gc.col)
         if mapped_r is not None and mapped_c is not None:
             pred_text = pred_text_lookup.get((mapped_r, mapped_c), "")
-            if gc.text == pred_text:
+            if cells_match_leader_insensitive(gc.text, pred_text):
                 hits += 1
 
     return hits / len(gt_cells)
@@ -707,6 +714,10 @@ def _header_content_bag_score(
     For each GT header cell text, check if any pred header cell text
     matches exactly (after formatting normalization).
     Score = matched / total GT.
+
+    "Exactly" is leader-insensitive: a header that differs only in a trailing
+    dot/period run ("no." vs "no") is the same header. See
+    ``utils.cells_match_leader_insensitive``.
     """
     if not gt_cells and not pred_cells:
         return 1.0
@@ -721,7 +732,7 @@ def _header_content_bag_score(
         for j, pt in enumerate(pred_texts):
             if used[j]:
                 continue
-            if gt_cell.text == pt:
+            if cells_match_leader_insensitive(gt_cell.text, pt):
                 used[j] = True
                 matched += 1
                 break
@@ -737,6 +748,12 @@ def _header_perfect_score(
 
     Returns 1.0 iff the header cells have the same count and each
     (text, row, col, rowspan, colspan) matches exactly (in sorted order).
+
+    Geometry must match exactly; the text is compared leader-insensitively,
+    the same way ``header_content_bag`` and ``header_data_alignment`` compare
+    it, so the three submetrics cannot disagree about whether a trailing dot
+    run makes two headers different. Sorting still uses the raw text, which
+    is inert here: (row, col, rowspan, colspan) is already unique per cell.
     """
     if not gt_cells and not pred_cells:
         return 1.0
@@ -750,7 +767,7 @@ def _header_perfect_score(
     pred_sorted = sorted(pred_cells, key=_key)
 
     for g, p in zip(gt_sorted, pred_sorted, strict=True):
-        if _key(g) != _key(p):
+        if _key(g)[:4] != _key(p)[:4] or not cells_match_leader_insensitive(g.text, p.text):
             return 0.0
     return 1.0
 

--- a/src/parse_bench/evaluation/metrics/parse/rule_based_judge_metric.py
+++ b/src/parse_bench/evaluation/metrics/parse/rule_based_judge_metric.py
@@ -20,7 +20,7 @@ from parse_bench.evaluation.metrics.parse.llm_normalization.postprocess import (
 from parse_bench.evaluation.metrics.parse.rule_based_metric import RuleBasedMetric
 from parse_bench.schemas.evaluation import MetricValue
 
-_CHART_TYPES = {"chart_data_point", "chart_data_array_labels"}
+_CHART_TYPES = {"chart_data_point", "chart_data_array_labels", "chart_data_array_data"}
 
 
 class RuleBasedJudgeMetric(RuleBasedMetric):

--- a/src/parse_bench/evaluation/metrics/parse/rule_based_metric.py
+++ b/src/parse_bench/evaluation/metrics/parse/rule_based_metric.py
@@ -1,11 +1,13 @@
 """Rule-based metric for executing parse test rules."""
 
+import os
 import signal
 import time
 from collections import Counter
-from typing import Any
+from typing import Any, cast
 
 from parse_bench.evaluation.metrics.base import Metric
+from parse_bench.evaluation.metrics.parse.rules_base import RuleNotApplicable
 from parse_bench.evaluation.metrics.parse.test_rules import (
     MissingSpecificWordRule,
     RotateCheckRule,
@@ -28,6 +30,34 @@ from parse_bench.test_cases.parse_rule_schemas import (
 
 # Per-rule timeout in seconds. Rules that exceed this are marked as failed.
 RULE_TIMEOUT_SECONDS = 120
+
+# Fallback for ``_doc_rule_budget_seconds`` when BENCH_DOC_RULE_BUDGET_SECONDS is
+# unset, blank or unparseable.
+DOC_RULE_BUDGET_DEFAULT_SECONDS = 600.0
+
+
+def _doc_rule_budget_seconds() -> float:
+    """Cumulative wall-clock budget for ALL rules of a single document.
+
+    The per-rule ``RULE_TIMEOUT_SECONDS`` alarm bounds one rule, but a document
+    with hundreds of rules that each time out can still consume ``n_rules * 120s``
+    (hours) and block the whole evaluation pool until the CI job hits its 6h cap.
+    This aggregate budget is the backstop: once a document has spent this long on
+    rules, the remaining rules are skipped (scored 0, same as a blank output) so
+    the eval moves on. One or two pathological documents lose their rule scores
+    instead of stalling the entire run.
+
+    Override with ``BENCH_DOC_RULE_BUDGET_SECONDS`` (0 or negative disables the
+    cap). The ``DOC_RULE_BUDGET_DEFAULT_SECONDS`` default bounds a single document
+    to roughly ``budget + RULE_TIMEOUT_SECONDS`` in the worst case.
+    """
+    raw = os.environ.get("BENCH_DOC_RULE_BUDGET_SECONDS")
+    if raw is None or raw.strip() == "":
+        return DOC_RULE_BUDGET_DEFAULT_SECONDS
+    try:
+        return float(raw)
+    except ValueError:
+        return DOC_RULE_BUDGET_DEFAULT_SECONDS
 
 
 class _RuleTimeoutError(Exception):
@@ -119,12 +149,6 @@ class RuleBasedMetric(Metric):
                 },
             )
 
-        # Pre-normalize content ONCE for all rules (major performance optimization)
-        t_normalize_start = time.monotonic()
-        normalized_actual = normalize_text(actual)
-        t_normalize_elapsed = time.monotonic() - t_normalize_start
-        print(f"  Pre-normalized content: {len(actual)} -> {len(normalized_actual)} chars ({t_normalize_elapsed:.1f}s)")
-
         # Execute each rule
         passed = 0
         ambiguous_anchor_failures = 0
@@ -133,20 +157,105 @@ class RuleBasedMetric(Metric):
         missing_specific_word_cache: tuple[Counter[str], str] | None = None
 
         # Timing accumulators
-        t_rules_start = time.monotonic()
         slow_rules: list[tuple[int, str, float]] = []  # (index, type, seconds)
         timed_out_rules: list[tuple[int, str]] = []  # (index, type)
 
+        # Aggregate per-document budget: bounds the whole rule loop so a single
+        # pathological document cannot consume the entire evaluation.
+        doc_budget = _doc_rule_budget_seconds()
+        skipped_over_budget = 0
+        # Rules that turned out to be undefined for this document: (type, why).
+        # These are dropped from rule_results entirely, so they neither pass nor
+        # fail and never reach the aggregation.
+        skipped_inapplicable: list[tuple[str, str]] = []
+
+        def _skipped_rule_entry(rule_data: Any, explanation: str) -> dict[str, Any]:
+            """Score a rule 0 without running it (skipped, not evaluated)."""
+            return {
+                "type": get_rule_type(rule_data),
+                "id": rule_data.id if isinstance(rule_data, ParseRuleBase) else get_rule_id(rule_data),
+                "page": get_rule_page(rule_data),
+                "tags": rule_data.tags if isinstance(rule_data, ParseRuleBase) else [],
+                "layout_id": get_rule_layout_id(rule_data),
+                "layout_ids": get_rule_layout_ids(rule_data),
+                "layout_bindings": get_rule_layout_bindings(rule_data),
+                "passed": False,
+                "score": 0.0,
+                "explanation": explanation,
+            }
+
         # Use signal.alarm for per-rule timeout (Unix only, main thread of worker process)
         use_alarm = hasattr(signal, "SIGALRM")
+
+        # Pre-normalize content ONCE for all rules (major performance optimization).
+        # Guard it with the per-rule timeout too: a pathological document (e.g. an
+        # O(n^2) regex triggered by degenerate OCR content) must not stall a worker
+        # before the rule-loop budget can even take effect. If normalization blows
+        # its budget, skip the whole document's rules (scored 0) and move on.
+        t_normalize_start = time.monotonic()
+        normalize_timed_out = False
+        norm_prev_handler = None
+        if use_alarm:
+            norm_prev_handler = signal.signal(signal.SIGALRM, _alarm_handler)
+            signal.alarm(RULE_TIMEOUT_SECONDS)
+        try:
+            normalized_actual = normalize_text(actual)
+        except _RuleTimeoutError:
+            normalize_timed_out = True
+            normalized_actual = ""
+        finally:
+            if use_alarm:
+                signal.alarm(0)
+                signal.signal(signal.SIGALRM, norm_prev_handler)
+        t_normalize_elapsed = time.monotonic() - t_normalize_start
+
+        if normalize_timed_out:
+            print(
+                f"  NORMALIZE TIMEOUT after {t_normalize_elapsed:.1f}s: skipping all {total} rules for this document",
+                flush=True,
+            )
+            explanation = f"Skipped: normalization exceeded {RULE_TIMEOUT_SECONDS}s"
+            return MetricValue(
+                metric_name=self.name,
+                value=0.0,
+                metadata={
+                    "passed": 0,
+                    "total": total,
+                    "ambiguous_anchor_failures": 0,
+                    "skipped_over_budget": total,
+                    "note": explanation,
+                    "rule_results": [_skipped_rule_entry(r, explanation) for r in rules_to_run],
+                },
+            )
+        print(f"  Pre-normalized content: {len(actual)} -> {len(normalized_actual)} chars ({t_normalize_elapsed:.1f}s)")
+
+        # Re-install the per-rule alarm handler for the loop below.
         prev_handler = None
         if use_alarm:
             prev_handler = signal.signal(signal.SIGALRM, _alarm_handler)
+
+        # Timing baseline for the rule loop (drives the aggregate budget below).
+        t_rules_start = time.monotonic()
 
         # Log every ~100 rules, but at least first and last
         log_interval = max(total // 10, 100) if total > 10 else total
         try:
             for i, rule_data in enumerate(rules_to_run):
+                # Aggregate budget check BEFORE arming the alarm: if this document
+                # has already spent its budget, skip every remaining rule (score 0)
+                # so one bad document can't stall the whole eval pool.
+                if doc_budget > 0 and (time.monotonic() - t_rules_start) > doc_budget:
+                    remaining = rules_to_run[i:]
+                    budget_explanation = f"Skipped: document rule budget ({doc_budget:.0f}s) exceeded"
+                    for remaining_rule in remaining:
+                        rule_results.append(_skipped_rule_entry(remaining_rule, budget_explanation))
+                    skipped_over_budget = len(remaining)
+                    print(
+                        f"    BUDGET EXCEEDED after {time.monotonic() - t_rules_start:.1f}s"
+                        f" ({doc_budget:.0f}s cap): skipping {skipped_over_budget} of {total} remaining rules",
+                        flush=True,
+                    )
+                    break
                 if i == 0 or (i + 1) % log_interval == 0:
                     elapsed = time.monotonic() - t_rules_start
                     print(f"  Processing rule {i + 1}/{total} ({elapsed:.1f}s elapsed)", flush=True)
@@ -207,6 +316,8 @@ class RuleBasedMetric(Metric):
                         "score": score,
                         "explanation": explanation,
                     }
+                    if rule.result_details:
+                        rule_result_entry["details"] = rule.result_details
                     if isinstance(rule, RotateCheckRule):
                         rule_result_entry["expected_angle"] = rule.expected_angle
                     rule_results.append(rule_result_entry)
@@ -214,6 +325,17 @@ class RuleBasedMetric(Metric):
                         passed += 1
                     elif explanation.startswith("[AMBIGUOUS ANCHORS]"):
                         ambiguous_anchor_failures += 1
+                except RuleNotApplicable as e:
+                    # The rule carries no evaluable constraint (degenerate rule
+                    # definition), so the parser had nothing to get right or
+                    # wrong. Emit NO rule result: that is what keeps it out of
+                    # the per-type pass rates, the normalized category scores
+                    # and semantic_formatting. Counting it 0.0 would zero a
+                    # category on a document that parsed correctly.
+                    if use_alarm:
+                        signal.alarm(0)
+                    skipped_inapplicable.append((rule_type_name, str(e)))
+                    continue
                 except _RuleTimeoutError:
                     t_rule_elapsed = time.monotonic() - t_rule_start
                     timed_out_rules.append((i, rule_type_name))
@@ -262,15 +384,34 @@ class RuleBasedMetric(Metric):
                 if prev_handler is not None:
                     signal.signal(signal.SIGALRM, prev_handler)
 
+        # Inapplicable rules leave the denominator as well as the numerator:
+        # they were never evaluated, so they must not dilute the pass rate.
+        total -= len(skipped_inapplicable)
+
         total_score = 0.0
         for r in rule_results:
-            total_score += float(r["score"])
-        pass_rate = total_score / total if total > 0 else 0.0
+            total_score += float(cast(float, r["score"]))
+        if total > 0:
+            pass_rate = total_score / total
+        elif skipped_inapplicable:
+            # Every rule for this document was undefined. Same convention as a
+            # document with no rules at all: nothing to fail.
+            pass_rate = 1.0
+        else:
+            pass_rate = 0.0
         t_rules_total = time.monotonic() - t_rules_start
         print(
             f"  Rules: done, {passed}/{total} passed ({pass_rate:.1%}) in {t_rules_total:.1f}s",
             flush=True,
         )
+        if skipped_over_budget:
+            print(
+                f"    SKIPPED {skipped_over_budget} rule(s): document budget ({doc_budget:.0f}s) exceeded",
+                flush=True,
+            )
+        if skipped_inapplicable:
+            for rtype, why in skipped_inapplicable:
+                print(f"    NOT APPLICABLE, excluded from scoring: type={rtype} ({why})", flush=True)
         if timed_out_rules:
             for idx, rtype in timed_out_rules:
                 print(f"    TIMED OUT rule #{idx}: type={rtype}", flush=True)
@@ -285,6 +426,9 @@ class RuleBasedMetric(Metric):
                 "passed": passed,
                 "total": total,
                 "ambiguous_anchor_failures": ambiguous_anchor_failures,
+                "skipped_over_budget": skipped_over_budget,
+                "skipped_inapplicable": len(skipped_inapplicable),
+                "skipped_inapplicable_detail": skipped_inapplicable,
                 "rule_results": rule_results,
             },
         )

--- a/src/parse_bench/evaluation/metrics/parse/rules_bag.py
+++ b/src/parse_bench/evaluation/metrics/parse/rules_bag.py
@@ -17,7 +17,11 @@ from parse_bench.evaluation.metrics.parse.rules_base import (
     _unescape_html_entities,
 )
 from parse_bench.evaluation.metrics.parse.test_types import TestType
-from parse_bench.evaluation.metrics.parse.utils import normalize_text
+from parse_bench.evaluation.metrics.parse.utils import (
+    NON_WORD_CHAR_CLASS,
+    WORD_CHAR_CLASS,
+    normalize_text,
+)
 from parse_bench.test_cases.parse_rule_schemas import (
     ParseBagOfDigitPercentRule,
     ParseExtraContentRule,
@@ -58,12 +62,13 @@ def _is_cjk_char(ch: str) -> bool:
     return any(lo <= ch <= hi for lo, hi in _CJK_RANGES)
 
 
-# Unicode-aware word tokenization: matches sequences of Unicode letters
-# and/or digits (using Unicode categories L and N), properly handling
-# accented characters, CJK, etc.
-# Aligned with JS annotation tool which uses /[\p{L}\p{N}]+/gu — consecutive
-# CJK characters stay grouped as a single token.
-_UNICODE_WORD_PATTERN = re.compile(r"[\w]+", re.UNICODE)
+# Unicode-aware word tokenization: matches sequences of Unicode letters,
+# digits and combining marks, properly handling accented characters, CJK, etc.
+# Combining marks are word characters: Python's ``\w`` excludes them, which cut
+# Thai/Indic words at every vowel sign, tone mark and virama.
+# Aligned with the JS annotation tool, which uses /[\p{L}\p{M}\p{N}]+/gu —
+# consecutive CJK characters stay grouped as a single token.
+_UNICODE_WORD_PATTERN = re.compile(rf"{WORD_CHAR_CLASS}+", re.UNICODE)
 
 
 def _tokenize_unicode_words(text: str, min_length: int = 2) -> list[str]:
@@ -108,11 +113,15 @@ def _word_boundary_count(word: str, text: str) -> int:
 
     Uses Unicode-aware boundaries: for CJK words (single or multi-char),
     count raw substring occurrences.  For Latin words, uses ``\\b``.
+
+    Combining marks count as word characters, so a marked word is not matched
+    by a prefix of itself that stops just before one of its marks.
     """
     if any(_is_cjk_char(ch) for ch in word):
         # CJK: count raw substring occurrences (no word boundary concept)
         return text.count(word)
-    return len(re.findall(r"(?<!\w)" + re.escape(word) + r"(?!\w)", text, re.UNICODE))
+    pattern = rf"(?<!{WORD_CHAR_CLASS}){re.escape(word)}(?!{WORD_CHAR_CLASS})"
+    return len(re.findall(pattern, text, re.UNICODE))
 
 
 class SentenceBagRule(ParseTestRule):
@@ -136,7 +145,9 @@ class SentenceBagRule(ParseTestRule):
     _SENTENCE_SPLIT_PATTERN = re.compile(
         r"\n+|(?<!\d)\.(?!\d)|[!?]+|[\u3002\u3001\uFF0C\uFF01\uFF1F\uFF1B\u2026\u2025\u22EF]+"
     )
-    _BOUNDARY_PUNCT_PATTERN = re.compile(r"^[^\w]+|[^\w]+$")
+    # Combining marks are word characters here too: without them a trailing Thai
+    # tone mark reads as punctuation and gets trimmed off the last word.
+    _BOUNDARY_PUNCT_PATTERN = re.compile(rf"^{NON_WORD_CHAR_CLASS}+|{NON_WORD_CHAR_CLASS}+$")
     # Matches markdown image tags: ![alt text](url) — stripped entirely so alt text
     # does not produce spurious sentence/word matches.
     _MARKDOWN_IMAGE_PATTERN = re.compile(r"!\[[^\]]*\]\([^)]*\)")
@@ -242,7 +253,8 @@ class SentenceBagRule(ParseTestRule):
         plain ``str.count`` is used for performance.
         """
         if len(sentence) < 20:
-            return len(re.findall(r"(?<!\w)" + re.escape(sentence) + r"(?!\w)", full_text))
+            pattern = rf"(?<!{WORD_CHAR_CLASS}){re.escape(sentence)}(?!{WORD_CHAR_CLASS})"
+            return len(re.findall(pattern, full_text))
         return full_text.count(sentence)
 
     def _extract_normalized_sentences(self, md_content: str, include_table_cells: bool = False) -> Counter[str]:
@@ -686,6 +698,7 @@ class WordBagRule(ParseTestRule):
         """
         md_content = _strip_fenced_code_blocks(md_content)
         md_content = _strip_and_replace_latex(md_content)
+        md_content = SentenceBagRule._MARKDOWN_IMAGE_PATTERN.sub(" ", md_content)
         md_content = _augment_with_table_cell_text(md_content)
         normalized_content = normalize_text(md_content)
         unescaped_content = _unescape_html_entities(normalized_content)
@@ -720,6 +733,7 @@ class WordBagRule(ParseTestRule):
         """
         md_content = _strip_fenced_code_blocks(md_content)
         md_content = _strip_and_replace_latex(md_content)
+        md_content = SentenceBagRule._MARKDOWN_IMAGE_PATTERN.sub(" ", md_content)
         if include_table_cells:
             md_content = _augment_with_table_cell_text(md_content)
         else:

--- a/src/parse_bench/evaluation/metrics/parse/rules_base.py
+++ b/src/parse_bench/evaluation/metrics/parse/rules_base.py
@@ -7,10 +7,12 @@ from pathlib import Path
 from typing import Any
 
 from parse_bench.evaluation.metrics.parse.table_parsing import (
+    TableData,
     parse_html_tables,
     parse_markdown_tables,
 )
 from parse_bench.evaluation.metrics.parse.test_types import TestType
+from parse_bench.evaluation.metrics.parse.utils import normalize_text
 from parse_bench.schemas.parse_output import ParseOutput
 from parse_bench.test_cases.parse_rule_schemas import (
     ParseExtraContentRule,
@@ -70,6 +72,53 @@ CELL_FUZZY_MATCH_THRESHOLD = 0.8
 
 
 logger = logging.getLogger(__name__)
+
+
+class RuleNotApplicable(Exception):
+    """Raised when a rule carries no evaluable constraint for this document.
+
+    This is *not* a failure and *not* an error: the rule definition itself is
+    degenerate, so the parser had nothing to get right or wrong. Scoring such a
+    rule 0.0 would penalise a correct parse for a defect in the ground truth.
+
+    ``RuleBasedMetric`` catches this and emits **no rule result at all**, which
+    is what excludes the rule from every downstream rollup - the per-type pass
+    rate, the normalized category scores, and ``semantic_formatting`` - by the
+    same "emit nothing when the measurement is undefined" convention the extract
+    grounding metrics use.
+
+    Reserve this for rules that are undefined *by construction*. A rule whose
+    constraint is well defined but unmet by the output is a real failure and
+    must keep scoring low.
+    """
+
+
+# The marker characters the annotation tool itself treats as markup noise: it
+# harvests rule text with ``text.replace(/[*_~]+/g, " ")``, and ``normalize_text``
+# mirrors that (see the note on the underscore branch in ``utils.normalize_text``).
+# Deliberately NOT the wider punctuation class: characters such as ``+`` and ``®``
+# are real superscript payloads in this corpus, and rules querying them are
+# satisfiable.
+_MARKDOWN_MARKER_CHARS = frozenset("*_~")
+
+
+def is_degenerate_marker_text(text: str) -> bool:
+    """True when a rule's query text cannot identify any content.
+
+    Annotation harvests rule text from ASCII banners and decorative rules, which
+    yields queries that are pure markdown markers - ``"*"``, ``"**"``, ``"~~"``.
+    ``normalize_text`` reduces those to markers or to nothing, so no output can
+    ever satisfy them: the rule is unsatisfiable by construction and permanently
+    scores 0.0.
+
+    Text that merely *contains* markers around real words (``"*Important*"``)
+    normalizes to that word and is a perfectly good query, so it is not
+    degenerate.
+    """
+    normalized = normalize_text(text).strip()
+    if not normalized:
+        return True
+    return all(char in _MARKDOWN_MARKER_CHARS or char.isspace() for char in normalized)
 
 
 _DATETIME_RE = re.compile(r"^(\d{4})-(\d{2})-(\d{2})\s+\d{2}:\d{2}:\d{2}$")
@@ -254,6 +303,12 @@ _HTML_TABLE_BLOCK_PATTERN = re.compile(
     flags=re.IGNORECASE | re.DOTALL,
 )
 _HTML_TABLE_START_PATTERN = re.compile(r"<table\b[^>]*>", flags=re.IGNORECASE)
+# A markdown pipe table is a run of two or more consecutive lines that each
+# contain a ``|`` — the same shape ``parse_markdown_tables`` recognises.
+_MARKDOWN_TABLE_BLOCK_PATTERN = re.compile(
+    r"(?:^[^\n]*\|[^\n]*\n)+^[^\n]*\|[^\n]*$",
+    flags=re.MULTILINE,
+)
 
 
 def _strip_html_tables_and_content(md_content: str) -> str:
@@ -287,53 +342,60 @@ def _strip_html_tables_and_content(md_content: str) -> str:
     return stripped
 
 
+def _strip_tables_and_content(md_content: str) -> str:
+    """Remove HTML *and* markdown pipe tables, payload included."""
+    stripped = _strip_html_tables_and_content(md_content)
+    return _MARKDOWN_TABLE_BLOCK_PATTERN.sub(" ", stripped)
+
+
 def _extract_table_cell_texts(md_content: str) -> list[str]:
-    """Extract non-empty cell texts from markdown and HTML tables.
+    """Extract each authored non-empty table cell's text exactly once.
 
-    This is used by missing-content bag rules so table content remains searchable
-    while still allowing per-cell sentence/word extraction behavior.
+    Cells are returned in document order (markdown tables first, then HTML
+    tables), so consecutive cells of a row stay adjacent for substring
+    matching once whitespace is collapsed.
 
-    In addition to individual cell texts, concatenated row texts are emitted so
-    that sentences spanning multiple cells in the same row can be matched as
-    contiguous substrings after normalization.
+    Grid positions that exist only because a cell was expanded across a
+    ``rowspan``/``colspan`` are skipped: emitting them would count the
+    spanning cell's words once per covered position.
+
+    ``<caption>`` text is emitted too — it lives inside the table but outside
+    any cell, so it would otherwise be lost with the rest of the markup.
     """
     cell_texts: list[str] = []
 
-    for table in parse_markdown_tables(md_content):
-        for row in table.data:
-            row_parts: list[str] = []
-            for cell in row:
+    for table in (*parse_markdown_tables(md_content), *parse_html_tables(md_content)):
+        if table.caption:
+            cell_texts.append(table.caption)
+        for row_idx, row in enumerate(table.data):
+            for col_idx, cell in enumerate(row):
+                if (row_idx, col_idx) in table.spanned_cells:
+                    continue
                 text = str(cell).strip()
                 if text:
                     cell_texts.append(text)
-                    row_parts.append(text)
-            if len(row_parts) > 1:
-                cell_texts.append(" ".join(row_parts))
-
-    for table in parse_html_tables(md_content):
-        for row in table.data:
-            row_parts = []
-            for cell in row:
-                text = str(cell).strip()
-                if text:
-                    cell_texts.append(text)
-                    row_parts.append(text)
-            if len(row_parts) > 1:
-                cell_texts.append(" ".join(row_parts))
 
     return cell_texts
 
 
 def _augment_with_table_cell_text(md_content: str) -> str:
-    """Append table cell text to content without removing original markdown.
+    """Replace tables with their cell text, one cell per line.
 
     Why: missing_* rules should search substrings everywhere (including tables)
-    and treat each table cell as an independent text unit for splitting.
+    and treat each table cell as an independent text unit for splitting — but
+    the occurrence-counting rules (too_many_*, unexpected_*, bag_of_digit) read
+    the same text, so a cell must appear exactly once. Appending cell text to
+    content that still held the table counted every table word two to three
+    times (table markup + cell + row join) and inflated those scores.
+
+    Cells are emitted one per line, so the sentence splitter still sees each
+    cell as its own unit, while whitespace collapse in the full-text paths
+    keeps a row's cells contiguous for cross-cell substring matches.
     """
     cell_texts = _extract_table_cell_texts(md_content)
     if not cell_texts:
         return md_content
-    return f"{md_content}\n" + "\n".join(cell_texts)
+    return f"{_strip_tables_and_content(md_content)}\n" + "\n".join(cell_texts)
 
 
 def _unescape_html_entities(text: str) -> str:
@@ -375,6 +437,13 @@ class ParseTestRule:
         # Structured parse payload is injected by RuleBasedMetric when available.
         # Keep this optional so direct unit tests can still run rules against raw markdown only.
         self.parse_output: ParseOutput | None = None
+        # Structured rule-specific diagnostics copied into rule_results by the
+        # metric runner. Graduated rules use this for auditable component distances.
+        self.result_details: dict[str, Any] = {}
+        # The metric runner may inject one document/page-local table parse into
+        # chart rules. ``None`` preserves the direct-call parsing fallback;
+        # ``[]`` is a valid cached result for table-free content.
+        self.parsed_tables: list[TableData] | None = None
 
     def run(self, md_content: str, normalized_content: str | None = None) -> tuple[bool, str] | tuple[bool, str, float]:
         """
@@ -459,11 +528,15 @@ def create_test_rule(rule_data: ParseRuleInput) -> "ParseTestRule":
     )
     from parse_bench.evaluation.metrics.parse.rules_formatting import (
         _FORMATTING_TEST_TYPES,
+        AbsentUnlessStrikeoutRule,
         CodeBlockRule,
         FormattingRule,
         LatexRule,
         MarkColorRule,
+        NotLatexRule,
         PageSectionRule,
+        PresentAsStrikeoutRule,
+        TextColorRule,
         TitleHierarchyPercentRule,
         TitleLevelRule,
     )
@@ -475,6 +548,7 @@ def create_test_rule(rule_data: ParseRuleInput) -> "ParseTestRule":
         TableColspanRule,
         TableHeaderChainRule,
         TableLeftHeaderRule,
+        TableMarkerCellsRule,
         TableNoAboveRule,
         TableNoBelowRule,
         TableNoLeftRule,
@@ -543,6 +617,8 @@ def create_test_rule(rule_data: ParseRuleInput) -> "ParseTestRule":
         return TablesNumRowsRule(typed_rule)
     elif rule_type == TestType.TABLES_NUM_COLS.value:
         return TablesNumColsRule(typed_rule)
+    elif rule_type == TestType.TABLE_MARKER_CELLS.value:
+        return TableMarkerCellsRule(typed_rule)
     # Table hierarchy rules
     elif rule_type == TestType.TABLE_COLSPAN.value:
         return TableColspanRule(typed_rule)
@@ -590,9 +666,17 @@ def create_test_rule(rule_data: ParseRuleInput) -> "ParseTestRule":
     elif rule_type in _FORMATTING_TEST_TYPES:
         if rule_type == TestType.MARK_COLOR.value:
             return MarkColorRule(typed_rule)
+        if rule_type == TestType.TEXT_COLOR.value:
+            return TextColorRule(typed_rule)
         return FormattingRule(typed_rule)
+    elif rule_type == TestType.ABSENT_UNLESS_STRIKEOUT.value:
+        return AbsentUnlessStrikeoutRule(typed_rule)
+    elif rule_type == TestType.PRESENT_AS_STRIKEOUT.value:
+        return PresentAsStrikeoutRule(typed_rule)
     elif rule_type == TestType.IS_LATEX.value:
         return LatexRule(typed_rule)
+    elif rule_type == TestType.IS_NOT_LATEX.value:
+        return NotLatexRule(typed_rule)
     elif rule_type == TestType.IS_CODE_BLOCK.value:
         return CodeBlockRule(typed_rule)
     # Title / heading level rule

--- a/src/parse_bench/evaluation/metrics/parse/rules_chart.py
+++ b/src/parse_bench/evaluation/metrics/parse/rules_chart.py
@@ -28,6 +28,12 @@ from parse_bench.test_cases.parse_rule_schemas import (
     ParseRotateCheckRule,
 )
 
+
+def parse_chart_tables(content: str) -> list[TableData]:
+    """Parse the Markdown and HTML tables consumed by chart rules."""
+    return [*parse_markdown_tables(content), *parse_html_tables(content)]
+
+
 # =============================================================================
 # Number Normalization Utilities for Chart Tests
 # =============================================================================
@@ -309,63 +315,252 @@ class ChartDataPointRule(ParseTestRule):
 
         return matches
 
-    def _check_label_association(  # type: ignore[no-untyped-def]
+    def _label_matches(self, label: str, cell_text: str, *, allow_partial: bool = True) -> bool:
+        """Match labels consistently across table cells and chart context."""
+        normalized_label = normalize_text(label)
+        normalized_cell = normalize_text(cell_text)
+
+        if normalized_label == normalized_cell:
+            return True
+
+        stripped_label = self._strip_for_label_compare(normalized_label)
+        stripped_cell = self._strip_for_label_compare(normalized_cell)
+        if stripped_label and stripped_label == stripped_cell:
+            return True
+
+        if not allow_partial:
+            return False
+
+        # Short labels such as ``Q1`` and ``US`` can validly appear as a
+        # distinct token inside a longer, candidate-local cell.  Permit that
+        # narrow form while continuing to reject fuzzy/substring matches for
+        # short fragments: ``EU27`` must not bind to a value cell ``7``.
+        if min(len(stripped_label), len(stripped_cell)) < 3:
+            # Keep periods within abbreviations such as ``U.S.`` but split
+            # slash- and hyphen-delimited chart labels such as ``Q1/2024``.
+            # A compacted value like ``us7`` remains a different token and
+            # cannot donate the ``US`` label.
+            cell_tokens = re.findall(r"[a-z0-9]+(?:\.[a-z0-9]+)*", normalized_cell)
+            label_tokens = re.findall(r"[a-z0-9]+(?:\.[a-z0-9]+)*", normalized_label)
+            delimited_label_match = bool(
+                len(label_tokens) > 1
+                and any(
+                    [self._strip_for_label_compare(token) for token in cell_tokens[start : start + len(label_tokens)]]
+                    == [self._strip_for_label_compare(token) for token in label_tokens]
+                    for start in range(len(cell_tokens) - len(label_tokens) + 1)
+                )
+            )
+            return (
+                bool(
+                    re.search(r"[a-z]", stripped_label)
+                    and any(self._strip_for_label_compare(token) == stripped_label for token in cell_tokens)
+                )
+                or delimited_label_match
+            )
+
+        threshold = max(0.5, 1.0 - (self.max_diffs / max(len(normalized_label), 1)))
+        return (
+            fuzz.partial_ratio(normalized_label, normalized_cell) / 100.0 >= threshold
+            or stripped_label in stripped_cell
+        )
+
+    @staticmethod
+    def _two_digit_year_matches_candidate_evidence(label: str, evidence: str) -> bool:
+        """Match chart shorthand such as ``09`` to a local ``2009`` token.
+
+        This equivalence is deliberately narrower than the general label
+        matcher. It is used only after a value candidate has selected its own
+        row and authored header chain, so a year in a caption or another body
+        row cannot repair an otherwise unrelated value. Tokenization also
+        prevents compact values such as ``20090`` or ``2009.0`` from donating
+        a year.
+        """
+        normalized_label = normalize_text(label)
+        if not re.fullmatch(r"\d{2}", normalized_label):
+            return False
+
+        tokens = re.findall(r"[a-z0-9]+(?:\.[a-z0-9]+)*", normalize_text(evidence))
+        return any(
+            re.fullmatch(r"(?:19|20)\d{2}", token) is not None and token[-2:] == normalized_label for token in tokens
+        )
+
+    def _candidate_label_matches(self, label: str, evidence: str) -> bool:
+        """Match a label against evidence already bound to one value candidate."""
+        return self._label_matches(label, evidence) or self._two_digit_year_matches_candidate_evidence(label, evidence)
+
+    def _candidate_data_scope(  # type: ignore[no-untyped-def]
         self,
         table_array,
         value_row: int,
         value_col: int,
-        label: str,
         table_data: TableData | None = None,
-    ) -> bool:
-        """
-        Check if a label is associated with a value cell.
+    ) -> list[str]:
+        """Return only parser-authored evidence local to one value candidate."""
+        _, cols = table_array.shape
+        scope: list[str] = []
+        seen: set[str] = set()
 
-        A label is associated if it appears in the same row OR same column,
-        including colspan/rowspan headers tracked by col_headers/row_headers.
-        """
-        rows, cols = table_array.shape
-        threshold = max(0.5, 1.0 - (self.max_diffs / max(len(label), 1)))
-        stripped_label = self._strip_for_label_compare(label)
+        def add(text: object) -> None:
+            normalized = normalize_text(str(text))
+            if normalized and normalized not in seen:
+                seen.add(normalized)
+                scope.append(normalized)
 
-        def _label_matches(cell_text: str) -> bool:
-            if fuzz.partial_ratio(label, cell_text) / 100.0 >= threshold:
-                return True
-            stripped_cell = self._strip_for_label_compare(cell_text)
-            if stripped_label and stripped_cell and stripped_label in stripped_cell:
-                return True
-            return False
-
-        # Check same row
+        # A data label may come from the candidate row, but never from an
+        # arbitrary body row merely because it shares the value column.
         for col_idx in range(cols):
-            if col_idx == value_col:
-                continue
-            cell_text = normalize_text(str(table_array[value_row, col_idx]))
-            if _label_matches(cell_text):
-                return True
+            if col_idx != value_col and (not table_data or (value_row, col_idx) not in table_data.header_cells):
+                add(table_array[value_row, col_idx])
 
-        # Check same column
+        if not table_data:
+            return scope
+
+        # ``parse_html_tables`` records every row containing a ``<th>`` in
+        # ``header_rows``, including row headers in ``<tbody>``. Cross-row
+        # labels may come from an explicit ``<thead>``, or from an initial
+        # top-level block whose cells are all ``<th>``. Body-row headers stay
+        # local to their own candidate metadata. Markdown tables have no HTML
+        # header cells and explicitly designate row zero as their header, so
+        # preserve that parser-authored convention too.
+        if table_data.thead_rows:
+            preceding_thead_rows = {row_idx for row_idx in table_data.thead_rows if row_idx < value_row}
+            authored_header_rows = set()
+            if preceding_thead_rows:
+                last_thead_row = max(preceding_thead_rows)
+                for row_idx in range(last_thead_row, -1, -1):
+                    if row_idx not in preceding_thead_rows:
+                        break
+                    authored_header_rows.add(row_idx)
+            authored_header_rows |= {
+                row_idx
+                for row_idx in table_data.column_scope_rows
+                if row_idx < value_row and row_idx not in table_data.tfoot_rows
+            }
+        elif not table_data.header_cells:
+            authored_header_rows = {row_idx for row_idx in table_data.header_rows if row_idx < value_row}
+        else:
+            authored_header_rows = {
+                row_idx
+                for row_idx in table_data.column_scope_rows
+                if row_idx < value_row and row_idx not in table_data.tfoot_rows
+            }
+            for row_idx in range(value_row):
+                # A top-level implicit header may use an empty ``<td>`` as
+                # the corner filler (the common row-label/year layout).  It
+                # is still authored as a header row only when every other
+                # cell is a real ``<th>``; non-empty ``<td>`` cells are body
+                # leakage and must terminate the inferred block.  Explicit
+                # ``<tbody>`` rows are never eligible, even when all cells
+                # happen to be ``<th>``.
+                row_header_cells = [col_idx for col_idx in range(cols) if (row_idx, col_idx) in table_data.header_cells]
+                row_values = [str(table_array[row_idx, col_idx]).strip() for col_idx in range(cols)]
+                unique_nonempty = {value for value in row_values if value}
+                if row_idx in table_data.tbody_rows or row_idx in table_data.tfoot_rows:
+                    break
+                if row_idx in table_data.row_scope_rows:
+                    break
+                if not row_header_cells:
+                    # Match the title stripper's limited leading-row
+                    # behavior: empty spacers and a uniform full-width
+                    # ``<td colspan>`` title precede, rather than replace,
+                    # an implicit ``<th>`` header block.
+                    if not unique_nonempty or (cols > 1 and len(unique_nonempty) == 1 and all(row_values)):
+                        continue
+                    break
+                if any(
+                    (row_idx, col_idx) not in table_data.header_cells and str(table_array[row_idx, col_idx]).strip()
+                    for col_idx in range(cols)
+                ):
+                    break
+                authored_header_rows.add(row_idx)
+
+        # Parser-expanded rowspan/colspan metadata provides the candidate's
+        # local row and column header chains.
+        for header_entry in table_data.row_headers.get(value_row, []):
+            add(header_entry[1])
+        column_headers = [
+            header_entry
+            for header_entry in table_data.col_headers.get(value_col, [])
+            if header_entry[0] in authored_header_rows
+        ]
+        for header_entry in column_headers:
+            add(header_entry[1])
+
+        # ``col_headers`` contains only ``<th>`` cells.  An explicit
+        # ``<thead>`` is authored header provenance even when a level uses a
+        # ``<td>``, so fill only header rows not already represented by that
+        # metadata from the physical candidate column.  This is also the
+        # malformed-HTML fallback; it never consults another body row. A
+        # row-scoped ``<th>`` excludes only its own physical cell: an adjacent
+        # ``<td>`` in the same explicit header row may still be the column
+        # label for this candidate.
+        represented_header_rows = {header_entry[0] for header_entry in column_headers}
+        for header_row in sorted(authored_header_rows - represented_header_rows):
+            if (header_row, value_col) not in table_data.header_cells:
+                add(table_array[header_row, value_col])
+
+        return scope
+
+    def _labels_match_candidate_scope(  # type: ignore[no-untyped-def]
+        self,
+        table_array,
+        value_row: int,
+        value_col: int,
+        labels: list[str],
+        table_data: TableData | None = None,
+    ) -> tuple[list[str], list[str]]:
+        """Return labels matched and missing from one value candidate's scope."""
+        scope = self._candidate_data_scope(table_array, value_row, value_col, table_data)
+        matched = [label for label in labels if any(self._candidate_label_matches(label, item) for item in scope)]
+        missing = [label for label in labels if label not in matched]
+        return matched, missing
+
+    def _all_td_candidate_scope(  # type: ignore[no-untyped-def]
+        self,
+        table_array,
+        value_row: int,
+        value_col: int,
+        table_data: TableData,
+    ) -> list[str]:
+        """Return the legacy row/column scope for an un-authored HTML grid.
+
+        Model output sometimes uses only ``<td>`` elements, even for a visually
+        obvious first-row or first-column header. Such a table has no authored
+        header provenance to follow. The caller may use this broader scope only
+        when it identifies exactly one value candidate; otherwise cross-row
+        borrowing would make duplicate values ambiguous.
+        """
+        rows, _ = table_array.shape
+        scope = self._candidate_data_scope(table_array, value_row, value_col, table_data)
+        seen = set(scope)
+
         for row_idx in range(rows):
             if row_idx == value_row:
                 continue
-            cell_text = normalize_text(str(table_array[row_idx, value_col]))
-            if _label_matches(cell_text):
-                return True
+            normalized = normalize_text(str(table_array[row_idx, value_col]))
+            if normalized and normalized not in seen:
+                seen.add(normalized)
+                scope.append(normalized)
 
-        # Check col_headers for the value's column (handles colspan headers)
-        if table_data and table_data.col_headers:
-            for header_entry in table_data.col_headers.get(value_col, []):
-                header_text = normalize_text(str(header_entry[1]))
-                if _label_matches(header_text):
-                    return True
+        return scope
 
-        # Check row_headers for the value's row (handles rowspan headers)
-        if table_data and table_data.row_headers:
-            for header_entry in table_data.row_headers.get(value_row, []):
-                header_text = normalize_text(str(header_entry[1]))
-                if _label_matches(header_text):
-                    return True
+    def _unique_all_td_fallback_candidate(  # type: ignore[no-untyped-def]
+        self,
+        table_array,
+        value_matches: list[tuple[int, int]],
+        table_data: TableData,
+    ) -> tuple[int, int] | None:
+        """Resolve one unambiguous value candidate in an all-``td`` HTML table."""
+        if table_data.header_cells or table_data.header_rows:
+            return None
 
-        return False
+        winners = []
+        for value_row, value_col in value_matches:
+            scope = self._all_td_candidate_scope(table_array, value_row, value_col, table_data)
+            if all(any(self._label_matches(label, item) for item in scope) for label in self.labels):
+                winners.append((value_row, value_col))
+
+        return winners[0] if len(winners) == 1 else None
 
     def _extract_formatted_labels(self, context: str) -> set[str]:
         """Extract bold text and headings from markdown/HTML context."""
@@ -401,22 +596,12 @@ class ChartDataPointRule(ParseTestRule):
         This prevents labels like "Retail Ecommerce Sales" from being treated
         as title labels when they are actually column headers in the table.
         """
-        threshold = max(0.5, 1.0 - (self.max_diffs / max(len(label), 1)))
-        stripped_label = self._strip_for_label_compare(label)
         rows, cols = table_array.shape
-
-        def _label_matches(cell_text: str) -> bool:
-            if fuzz.partial_ratio(label, cell_text) / 100.0 >= threshold:
-                return True
-            stripped_cell = self._strip_for_label_compare(cell_text)
-            if stripped_label and stripped_cell and stripped_label in stripped_cell:
-                return True
-            return False
 
         for r in range(rows):
             for c in range(cols):
                 cell_text = normalize_text(str(table_array[r, c]))
-                if _label_matches(cell_text):
+                if self._label_matches(label, cell_text):
                     return True
 
         # Also check col_headers and row_headers
@@ -426,7 +611,7 @@ class ChartDataPointRule(ParseTestRule):
                     for entries in headers.values():
                         for entry in entries:
                             header_text = normalize_text(str(entry[1]))
-                            if _label_matches(header_text):
+                            if self._label_matches(label, header_text):
                                 return True
 
         return False
@@ -448,12 +633,17 @@ class ChartDataPointRule(ParseTestRule):
         threshold = 0.60
 
         for formatted_label in formatted_labels:
+            if self._label_matches(normalized_label, formatted_label, allow_partial=False):
+                return True
             similarity = fuzz.ratio(normalized_label, formatted_label) / 100.0
-            if similarity >= threshold:
+            if (
+                min(len(stripped_label), len(self._strip_for_label_compare(formatted_label))) >= 3
+                and similarity >= threshold
+            ):
                 return True
             # Fallback: compare with whitespace/special chars stripped
             stripped_formatted = self._strip_for_label_compare(formatted_label)
-            if stripped_label and stripped_formatted:
+            if min(len(stripped_label), len(stripped_formatted)) >= 3:
                 similarity = fuzz.ratio(stripped_label, stripped_formatted) / 100.0
                 if similarity >= threshold:
                     return True
@@ -467,43 +657,32 @@ class ChartDataPointRule(ParseTestRule):
         or "<caption>Solar PV (modules) ...</caption>").  Uses partial_ratio since
         headings/captions are typically longer than the label.
         """
-        normalized_label = normalize_text(label)
-        stripped_label = self._strip_for_label_compare(normalized_label)
-        threshold = max(0.5, 1.0 - (self.max_diffs / max(len(normalized_label), 1)))
-
-        def _matches(text: str) -> bool:
-            text = normalize_text(text)
-            if fuzz.partial_ratio(normalized_label, text) / 100.0 >= threshold:
-                return True
-            stripped = self._strip_for_label_compare(text)
-            if stripped_label and stripped and stripped_label in stripped:
-                return True
-            return False
-
         # Check <caption> elements
         for match in re.finditer(r"<caption[^>]*>(.+?)</caption>", context, re.IGNORECASE):
-            if _matches(match.group(1)):
+            if self._label_matches(label, match.group(1)):
                 return True
 
         # Check markdown headings (# Title, ## Title, etc.)
         for match in re.finditer(r"^#{1,6}\s+(.+?)$", context, re.MULTILINE):
-            if _matches(match.group(1)):
+            if self._label_matches(label, match.group(1)):
+                return True
+
+        # Check HTML headings. Unlike generic bold text, an authored heading
+        # is a strong chart-identity signal even when the same token also
+        # appears in a table body cell.
+        for match in re.finditer(r"<h[1-6][^>]*>(.+?)</h[1-6]>", context, re.IGNORECASE | re.DOTALL):
+            if self._label_matches(label, match.group(1)):
                 return True
 
         return False
 
     def run(self, content: str, normalized_content: str | None = None) -> tuple[bool, str, float]:
         """Check if value is associated with all labels in any table."""
-        # Parse all tables
-        tables_to_check = []
-
-        # Parse markdown tables
-        md_tables = parse_markdown_tables(content)
-        tables_to_check.extend(md_tables)
-
-        # Parse HTML tables
-        html_tables = parse_html_tables(content)
-        tables_to_check.extend(html_tables)
+        # ``[]`` is a real cache hit for table-free content. Only ``None``
+        # means this rule was invoked directly and must parse for itself.
+        tables_to_check = self.parsed_tables
+        if tables_to_check is None:
+            tables_to_check = parse_chart_tables(content)
 
         if not tables_to_check:
             return False, "No tables found in content", 0.0
@@ -522,19 +701,40 @@ class ChartDataPointRule(ParseTestRule):
             if not value_matches:
                 continue  # Try next table
 
+            # Some model-generated HTML uses no ``<th>`` elements at all.
+            # Preserve its visually vertical row/column association only when
+            # that broader evidence selects exactly one matching value cell.
+            all_td_fallback_candidate = self._unique_all_td_fallback_candidate(
+                table_array,
+                value_matches,
+                table_data,
+            )
+
             # For each matching cell, try validation phases
             for value_row, value_col in value_matches:
-                # PHASE 1: Try strict matching - all labels in table cells
-                missing_labels_strict = []
-                for label in self.labels:
-                    if not self._check_label_association(table_array, value_row, value_col, label, table_data):
-                        missing_labels_strict.append(label)
+                # PHASE 1: every data label must bind to this one value
+                # candidate's row and parser-authored header chains.
+                data_labels, missing_labels_strict = self._labels_match_candidate_scope(
+                    table_array, value_row, value_col, self.labels, table_data
+                )
 
                 if not missing_labels_strict:
-                    # Success - all labels found in table
                     return (
                         True,
-                        f"Value '{self.value}' found with all labels at ({value_row}, {value_col})",
+                        (
+                            f"Value '{self.value}' found with all labels in candidate-local scope "
+                            f"at ({value_row}, {value_col})"
+                        ),
+                        1.0,
+                    )
+
+                if all_td_fallback_candidate == (value_row, value_col):
+                    return (
+                        True,
+                        (
+                            f"Value '{self.value}' found with all labels in unique all-td row/column scope "
+                            f"at ({value_row}, {value_col})"
+                        ),
                         1.0,
                     )
 
@@ -546,25 +746,24 @@ class ChartDataPointRule(ParseTestRule):
                     # This ensures labels that appear in BOTH table and context
                     # are correctly classified as data labels (found in table)
 
-                    data_labels = []  # Labels found in table cells
                     title_labels = []  # Labels found in formatted context only
                     missing_labels = []  # Labels not found anywhere
 
-                    for label in self.labels:
-                        # Check if label is associated with value in table
-                        if self._check_label_association(table_array, value_row, value_col, label, table_data):
-                            data_labels.append(label)
-                        # Only allow formatted-context matching for labels that
-                        # do NOT exist anywhere in the current table.
-                        elif not self._label_exists_in_table(
-                            table_array, label, table_data
-                        ) and self._is_label_in_formatted_context(context, label):
-                            title_labels.append(label)
-                        # Headings and captions are strong table-identity signals;
-                        # allow them even when the label partially matches a table
-                        # cell (e.g. "LDC/LLDCs" heading vs "Average OSI for
-                        # LDC/LLDCs" column header).
-                        elif self._is_label_in_heading_or_caption(context, label):
+                    for label in missing_labels_strict:
+                        # A label found elsewhere in the table is data, not
+                        # chart identity context. It must bind locally.
+                        if self._label_exists_in_table(table_array, label, table_data):
+                            # A genuine heading/caption establishes chart
+                            # identity even when the same text also occurs in
+                            # another table cell. Ordinary formatted context
+                            # does not receive this exception.
+                            if self._is_label_in_heading_or_caption(context, label):
+                                title_labels.append(label)
+                            else:
+                                missing_labels.append(label)
+                        elif self._is_label_in_formatted_context(
+                            context, label
+                        ) or self._is_label_in_heading_or_caption(context, label):
                             title_labels.append(label)
                         else:
                             missing_labels.append(label)
@@ -577,7 +776,7 @@ class ChartDataPointRule(ParseTestRule):
                                 True,
                                 (
                                     f"Value '{self.value}' found with data labels {data_labels} "
-                                    f"in table and title labels "
+                                    f"in candidate-local scope and title labels "
                                     f"{title_labels} in context "
                                     f"at ({value_row}, {value_col})"
                                 ),
@@ -587,14 +786,17 @@ class ChartDataPointRule(ParseTestRule):
                             # All labels in table (no title labels needed)
                             return (
                                 True,
-                                f"Value '{self.value}' found with all labels at ({value_row}, {value_col})",
+                                (
+                                    f"Value '{self.value}' found with all labels in candidate-local scope "
+                                    f"at ({value_row}, {value_col})"
+                                ),
                                 1.0,
                             )
 
                     # Track failure reason
                     all_failed_reasons.append(
                         f"Value at ({value_row}, {value_col}) missing labels: {missing_labels} "
-                        f"(data labels {data_labels} in table, "
+                        f"(data labels {data_labels} in candidate-local scope, "
                         f"title labels {title_labels} in context)"
                     )
                 else:
@@ -759,13 +961,9 @@ class ChartDataArrayLabelsRule(ParseTestRule):
 
         Returns a score-based result where partial matches get proportionally lower scores.
         """
-        tables_to_check = []
-
-        md_tables = parse_markdown_tables(content)
-        tables_to_check.extend(md_tables)
-
-        html_tables = parse_html_tables(content)
-        tables_to_check.extend(html_tables)
+        tables_to_check = self.parsed_tables
+        if tables_to_check is None:
+            tables_to_check = parse_chart_tables(content)
 
         if not tables_to_check:
             return False, "No tables found in content", 0.0
@@ -1259,13 +1457,9 @@ class ChartDataArrayDataRule(ParseTestRule):
 
     def run(self, content: str, normalized_content: str | None = None) -> tuple[bool, str, float]:
         """Check if expected data values match any table in content."""
-        tables_to_check = []
-
-        md_tables = parse_markdown_tables(content)
-        tables_to_check.extend(md_tables)
-
-        html_tables = parse_html_tables(content)
-        tables_to_check.extend(html_tables)
+        tables_to_check = self.parsed_tables
+        if tables_to_check is None:
+            tables_to_check = parse_chart_tables(content)
 
         if not tables_to_check:
             return False, "No tables found in content", 0.0

--- a/src/parse_bench/evaluation/metrics/parse/rules_form.py
+++ b/src/parse_bench/evaluation/metrics/parse/rules_form.py
@@ -14,6 +14,12 @@ high-confidence patterns:
   glyph-first (``☐ Single ☑ Married``) and label-first
   (``Single ☐ Married ☑``) orderings.
 - Markdown task-list checkboxes (``- [x] Label`` / ``- [ ] Label``).
+- Multi-label yes/no checkbox groups, e.g.
+  ``["Multistage cement?", "No"]`` matches
+  ``Multistage cement? Yes [ ] No [x]``.
+- Multi-label table cells where one value is identified by a row/column
+  label set, e.g. ``["PLUG #1", "Cementing Date"]``. Label-list order is
+  ignored; all labels must match anchors around the same value cell.
 
 When the rule has a ``page`` and the metric injects a ``parse_output``,
 matching is scoped to that page's markdown only.
@@ -98,7 +104,11 @@ def _strip_label_punct(s: str) -> str:
     return s
 
 
-def _label_match_score(candidate: str, label: str) -> float:
+def _compact_label_text_for_distance(s: str) -> str:
+    return re.sub(r"[^0-9a-z]+", "", normalize_text(s))
+
+
+def _label_match_score(candidate: str, label: str, max_diffs: int | float = 0) -> float:
     """Score how well *candidate* matches *label* on the ``_label_matches`` axes.
 
     Returns ``0.0`` when the candidate fails every path (same as
@@ -162,10 +172,21 @@ def _label_match_score(candidate: str, label: str) -> float:
         if 1.0 > best:
             best = 1.0
 
+    allowed = int(max_diffs) if max_diffs and max_diffs > 0 else 0
+    if allowed > 0:
+        cand_compact = _compact_label_text_for_distance(candidate)
+        lbl_compact = _compact_label_text_for_distance(label)
+        if cand_compact and lbl_compact:
+            dist = _levenshtein_distance_at_most(cand_compact, lbl_compact, allowed)
+            if dist <= allowed:
+                tolerant_score = max(0.01, 1.0 - (dist / max(len(cand_compact), len(lbl_compact), 1)))
+                if tolerant_score > best:
+                    best = tolerant_score
+
     return best
 
 
-def _label_matches(candidate: str, label: str) -> bool:
+def _label_matches(candidate: str, label: str, max_diffs: int | float = 0) -> bool:
     """Boolean predicate over :func:`_label_match_score` for legacy callers.
 
     Used by callers that only need a boolean (adjacent-line fallback,
@@ -174,7 +195,7 @@ def _label_matches(candidate: str, label: str) -> bool:
     can score-and-pick-best across multiple candidate KV pairs.
     """
 
-    return _label_match_score(candidate, label) > 0.0
+    return _label_match_score(candidate, label, max_diffs) > 0.0
 
 
 def _coerce_bool(value: str | bool | list[str]) -> bool | None:
@@ -189,6 +210,10 @@ def _coerce_bool(value: str | bool | list[str]) -> bool | None:
     if isinstance(value, list):
         return None
     text = str(value).strip().lower()
+    if len(text) == 1 and text in _CHECKED_GLYPHS:
+        return True
+    if len(text) == 1 and text in _UNCHECKED_GLYPHS:
+        return False
     if text in _TRUTHY_TEXT:
         return True
     if text in _FALSY_TEXT:
@@ -208,6 +233,57 @@ def _value_alternatives(value: str | bool | list[str]) -> list[str]:
     if isinstance(value, list):
         return [str(v) for v in value]
     return [str(value)]
+
+
+def _label_parts_with_indexes(label: str | list[str]) -> list[tuple[str, int]]:
+    """Normalize form-field labels and keep original indexes for aligned tolerances."""
+    if isinstance(label, list):
+        return [(text, idx) for idx, part in enumerate(label) if (text := str(part).strip())]
+    text = str(label).strip()
+    return [(text, 0)] if text else []
+
+
+def _label_parts(label: str | list[str]) -> list[str]:
+    """Normalize a form-field label into one or more required visible keys."""
+
+    return [part for part, _ in _label_parts_with_indexes(label)]
+
+
+def _format_label_for_message(label: str | list[str]) -> str:
+    parts = _label_parts(label)
+    if len(parts) <= 1:
+        return repr(parts[0] if parts else "")
+    return repr(parts)
+
+
+def _label_max_diffs_parts(
+    value: int | float | list[int | float],
+    count: int,
+    source_indexes: list[int] | None = None,
+) -> list[int]:
+    if isinstance(value, list):
+        indexes = source_indexes or list(range(count))
+        return [
+            int(value[idx]) if idx < len(value) and isinstance(value[idx], (int, float)) and value[idx] > 0 else 0
+            for idx in indexes[:count]
+        ] + [0] * max(count - len(indexes), 0)
+    n = int(value) if isinstance(value, (int, float)) and value > 0 else 0
+    return [n] * count
+
+
+def _dedupe_nonempty_text(parts: list[str]) -> list[str]:
+    out: list[str] = []
+    seen: set[str] = set()
+    for part in parts:
+        clean = str(part).strip()
+        if not clean:
+            continue
+        key = normalize_text(clean)
+        if key in seen:
+            continue
+        out.append(clean)
+        seen.add(key)
+    return out
 
 
 def _multi_col_header_data_pairs(table: TableData) -> list[tuple[str, str]]:
@@ -504,6 +580,21 @@ _BOLD_COLON_RE = re.compile(
     r"\*\*[ \t]*([^*\n]+?)[ \t]*\*\*[ \t]*:?[ \t]*([^\n*]*?)(?=[ \t]*\*\*|$)",
     re.MULTILINE,
 )
+_EXPLICIT_BOLD_COLON_RE = re.compile(
+    r"\*\*[ \t]*([^*\n]+?)[ \t]*(?:[ \t]*:[ \t]*\*\*[ \t]*|\*\*[ \t]*:[ \t]*)([^\n*]*?)(?=[ \t]*\*\*|$)",
+    re.MULTILINE,
+)
+_ANY_BOLD_COLON_ON_LINE_RE = re.compile(r"\*\*[ \t]*[^*\n]+?[ \t]*\*\*[ \t]*:")
+_ANY_BOLD_INTERNAL_COLON_ON_LINE_RE = re.compile(r"\*\*[ \t]*[^*\n]+?:[ \t]*\*\*")
+_BOLD_VALUE_RE = re.compile(r"\*\*[ \t]*([^*\n]+?)[ \t]*\*\*")
+_LIST_LINE_RE = re.compile(r"^\s*\\?[-*+]\s+")
+
+
+def _has_bold_colon_label(content: str) -> bool:
+    """Return true if any line contains an explicit bold label marker."""
+
+    return bool(_ANY_BOLD_COLON_ON_LINE_RE.search(content) or _ANY_BOLD_INTERNAL_COLON_ON_LINE_RE.search(content))
+
 
 # Connector words that the parser sometimes wraps in bold inside a numeric
 # range, e.g. ``**Depth Drilled**: 105 **to**: 15437`` or
@@ -549,7 +640,7 @@ def _extend_value_across_bold_connectors(content: str, value_end_offset: int, ba
     return joined
 
 
-def _iter_bold_colon_pairs(content: str) -> list[tuple[str, str]]:
+def _iter_bold_colon_pairs_from_regex(content: str, pattern: re.Pattern[str]) -> list[tuple[str, str]]:
     """Yield every (label, value) pair surfaced via bold-colon syntax.
 
     Generic post-processing applied to every yielded pair: HTML tags
@@ -560,7 +651,7 @@ def _iter_bold_colon_pairs(content: str) -> list[tuple[str, str]]:
     """
 
     out: list[tuple[str, str]] = []
-    for match in _BOLD_COLON_RE.finditer(content):
+    for match in pattern.finditer(content):
         cand_label = match.group(1).strip(": ").strip()
         # Strip trailing markdown line-continuation backslash before whitespace.
         # Some parsers emit ``**Label**: \`` for empty fields; without this
@@ -581,6 +672,25 @@ def _iter_bold_colon_pairs(content: str) -> list[tuple[str, str]]:
         # Recover any sibling pipe-concatenated pairs riding the same line.
         out.extend(_split_pipe_concatenated_pairs(raw_value))
     return out
+
+
+def _iter_bold_colon_pairs(content: str) -> list[tuple[str, str]]:
+    """Yield every (label, value) pair surfaced via bold-colon syntax.
+
+    Kept intentionally backward-compatible with older generated rules: this
+    accepts both ``**Label:** value`` / ``**Label**: value`` and the historical
+    no-colon form. New rule generation should use
+    :func:`_iter_explicit_bold_colon_pairs` so bold emphasis on values is not
+    mistaken for a label.
+    """
+
+    return _iter_bold_colon_pairs_from_regex(content, _BOLD_COLON_RE)
+
+
+def _iter_explicit_bold_colon_pairs(content: str) -> list[tuple[str, str]]:
+    """Yield only explicit ``**Label:** value`` / ``**Label**: value`` pairs."""
+
+    return _iter_bold_colon_pairs_from_regex(content, _EXPLICIT_BOLD_COLON_RE)
 
 
 # Plain-colon pattern. Inter-token whitespace is restricted to horizontal
@@ -648,6 +758,166 @@ def _iter_plain_colon_pairs(content: str) -> list[tuple[str, str]]:
             out.append((cand_label, cand_value))
         # Recover any sibling pipe-concatenated pairs riding the same line.
         out.extend(_split_pipe_concatenated_pairs(raw_value))
+    return out
+
+
+_LABEL_BEFORE_BOLD_KNOWN_SUFFIXES = (
+    "Name of Field in which well is located",
+    "Date well was plugged",
+    "Name of Company or Operator",
+    "Name of Farm or Lease",
+    "Name of Party Plugging Well",
+    "Name of Lease",
+    "No. of Acres",
+    "Well No.",
+    "Sec. No.",
+    "Blk No.",
+    "Company",
+    "Address",
+    "Survey",
+    "County",
+    "Has this well ever produced oil or gas?",
+    "Located",
+    "Oil",
+    "Gas",
+    "Dry",
+    "Total Depth",
+    "Top of each producing sand",
+    "Name",
+    "Title",
+)
+_LABEL_BEFORE_BOLD_REJECT_PREFIXES = (
+    "i,",
+    "i ",
+    "if you answered",
+    "subscribed ",
+    "being ",
+)
+_LABEL_BEFORE_BOLD_REJECT_SUFFIXES = (
+    " and",
+    " at",
+    " by",
+    " for",
+    " from",
+    " in",
+    " of",
+    " on",
+    " or",
+    " to",
+)
+
+
+def _clean_label_before_bold(raw: str) -> str:
+    """Normalize the label chunk immediately before a bold value span."""
+
+    label = raw
+    # Empty fill lines often sit between two fields:
+    # ``Blk No. ______ Survey **T.E.&L.**``. The label for the bold value is the
+    # suffix after the blank, not the earlier empty field.
+    label = re.split(r"(?:\\?_){3,}", label)[-1]
+    label = re.sub(r"<br\s*/?>", " ", label, flags=re.IGNORECASE)
+    label = re.sub(r"^[\s\\*_#>\-+|]+", "", label)
+    label = _LABEL_TAG_PREFIX_RE.sub("", label)
+    label = _strip_html_tags(label).strip()
+    label = label.strip("*_ \t:-,;")
+    if ":" in label:
+        label = label.rsplit(":", 1)[-1].strip()
+
+    lowered = label.lower()
+    best: str | None = None
+    for suffix in _LABEL_BEFORE_BOLD_KNOWN_SUFFIXES:
+        idx = lowered.rfind(suffix.lower())
+        if idx < 0:
+            continue
+        if lowered[idx:].strip() != suffix.lower():
+            continue
+        if best is None or len(suffix) > len(best):
+            best = suffix
+    if best is not None:
+        label = label[-len(best) :].strip()
+
+    return label.strip("*_ \t:-,;")
+
+
+def _looks_like_label_before_bold(label: str) -> bool:
+    if not label or len(label) > 100:
+        return False
+    lowered = label.lower()
+    if lowered.startswith(_LABEL_BEFORE_BOLD_REJECT_PREFIXES):
+        return False
+    if not any(ch.isalpha() for ch in label):
+        return False
+    if ")" in label and "(" not in label:
+        return False
+    if len(label) <= 2:
+        return False
+    if lowered.endswith(_LABEL_BEFORE_BOLD_REJECT_SUFFIXES):
+        return False
+    if re.fullmatch(r"(?:19|20)?\d{1,2}", label):
+        return False
+    first_alpha = next((ch for ch in label if ch.isalpha()), "")
+    if first_alpha and first_alpha.islower():
+        return False
+    return True
+
+
+def _extend_inline_year_suffix(
+    value: str,
+    between_this_and_next: str,
+    next_match: re.Match[str] | None,
+) -> str:
+    """Join ``**June 17,** 194 **3**`` into ``June 17, 1943``."""
+
+    if next_match is None:
+        return value
+    year_prefix = re.sub(r"\s+", "", between_this_and_next)
+    if not re.fullmatch(r"(?:19|20)?\d{0,2}", year_prefix):
+        return value
+    suffix = next_match.group(1).strip()
+    if not re.fullmatch(r"\d{1,2}", suffix):
+        return value
+    year = f"{year_prefix}{suffix}"
+    if not re.fullmatch(r"(?:19|20)\d{2}", year):
+        return value
+    return re.sub(r"\s+", " ", f"{value} {year}").strip()
+
+
+def _iter_label_before_bold_value_pairs(content: str) -> list[tuple[str, str]]:
+    """Yield ``(label, value)`` for visual rows shaped as ``Label **Value**``.
+
+    Gemini-style parse output often preserves the printed form row as
+    ``Well No. **Z-5** Name of Lease **W. H. Portwood**`` rather than normalizing
+    it to ``**Well No.**: Z-5``. This matcher treats the text immediately before
+    each bold span as the label and the bold span as the value. It is deliberately
+    lower priority than explicit colon/table sources.
+    """
+
+    out: list[tuple[str, str]] = []
+    for line in content.splitlines():
+        if "**" not in line:
+            continue
+        stripped = line.strip()
+        if not stripped or stripped.startswith(("#", ">", "|", "[Figure")):
+            continue
+        if re.search(r"\binstructions?\b", stripped, flags=re.IGNORECASE):
+            continue
+        if _LIST_LINE_RE.match(line):
+            continue
+        if _has_bold_colon_label(line):
+            continue
+        matches = list(_BOLD_VALUE_RE.finditer(line))
+        if not matches:
+            continue
+        prev_end = 0
+        for idx, match in enumerate(matches):
+            label = _clean_label_before_bold(line[prev_end : match.start()])
+            value = _strip_html_tags(match.group(1)).strip()
+            next_match = matches[idx + 1] if idx + 1 < len(matches) else None
+            next_start = next_match.start() if next_match is not None else len(line)
+            value = _extend_inline_year_suffix(value, line[match.end() : next_start], next_match)
+            if _looks_like_label_before_bold(label) and value:
+                out.append((label, value))
+            prev_end = match.end()
     return out
 
 
@@ -723,7 +993,11 @@ def _iter_underscore_blank_pairs(content: str) -> list[tuple[str, str]]:
 _ITALIC_LABEL_LINE_RE = re.compile(r"^\s*([*_])\s*(\S.*?\S)\s*\1[\s)\\]*$")
 
 
-def _find_text_value_adjacent_line(content: str, label: str) -> tuple[bool, str | None]:
+def _find_text_value_adjacent_line(
+    content: str,
+    label: str,
+    label_max_diffs: int | float = 0,
+) -> tuple[bool, str | None]:
     """Fallback for label-on-its-own-line layouts adjacent to an unlabelled value.
 
     Two layouts share this scanner:
@@ -771,7 +1045,9 @@ def _find_text_value_adjacent_line(content: str, label: str) -> tuple[bool, str 
         cand_norm = normalize_text(cleaned)
         if not cand_norm:
             continue
-        if fuzz.ratio(cand_norm, lbl_norm) / 100.0 < CELL_FUZZY_MATCH_THRESHOLD:
+        strict_match = fuzz.ratio(cand_norm, lbl_norm) / 100.0 >= CELL_FUZZY_MATCH_THRESHOLD
+        tolerant_match = label_max_diffs > 0 and _label_match_score(cleaned, label, label_max_diffs) > 0.0
+        if not strict_match and not tolerant_match:
             continue
         if italic_match:
             search_orders = [
@@ -959,6 +1235,8 @@ def _find_text_value_for_label(
     content: str,
     label: str,
     expected_values: list[str] | None = None,
+    max_diffs: int | float = 0,
+    label_max_diffs: int | float = 0,
 ) -> tuple[bool, str | None]:
     """Look up the value for *label*. Returns (label_found, value).
 
@@ -1019,7 +1297,7 @@ def _find_text_value_for_label(
     ) -> None:
         nonlocal label_seen
         for idx, (cand_label, cand_value) in enumerate(pairs):
-            score = _label_match_score(cand_label, label)
+            score = _label_match_score(cand_label, label, label_max_diffs)
             if score <= 0.0:
                 continue
             label_seen = True
@@ -1034,13 +1312,14 @@ def _find_text_value_for_label(
     _collect(_iter_plain_colon_pairs(content), priority=3, source_name="plain_colon")
     _collect(_iter_md_table_kv_rows(content), priority=2, source_name="md_table")
     _collect(_iter_html_table_kv_rows(content), priority=1, source_name="html_table")
+    _collect(_iter_label_before_bold_value_pairs(content), priority=0, source_name="label_before_bold")
 
     # Underscore blank fields (``Label ____``) — label seen, value empty.
     # The yielded value is always ""; we just record label presence so an
     # empty-expected text rule can pass via the ``label_seen`` short-circuit
     # below.
     for cand_label, _ in _iter_underscore_blank_pairs(content):
-        if _label_matches(cand_label, label):
+        if _label_matches(cand_label, label, label_max_diffs):
             label_seen = True
 
     # Last-resort sources — only fire when no higher-confidence source
@@ -1083,14 +1362,14 @@ def _find_text_value_for_label(
                 if neg_score != best_score_key:
                     break
                 for exp in expected_values:
-                    if _values_match_text(value, exp):
+                    if _values_match_text(value, exp, max_diffs):
                         return True, value
         return True, candidates[0][3]
 
     # Adjacent-line fallback (italic caption below value, or numbered label
     # above value). Only fires when no other matcher located the label.
     if not label_seen:
-        adj_seen, adj_value = _find_text_value_adjacent_line(content, label)
+        adj_seen, adj_value = _find_text_value_adjacent_line(content, label, label_max_diffs)
         if adj_seen:
             return True, adj_value
 
@@ -1145,6 +1424,90 @@ def _tokenize_checkbox_line(line: str) -> list[tuple[str, bool]]:
     return pairs
 
 
+_TRAILING_BOOL_OPTION_RE = re.compile(
+    r"^(?P<context>.*?)(?P<option>\b(?:yes|no|y|n)\b)\s*$",
+    re.IGNORECASE,
+)
+
+
+def _tokenize_checkbox_line_with_context(line: str) -> list[tuple[list[str], bool]]:
+    """Pair inline yes/no checkbox markers with their question context.
+
+    Typical form parsers render a yes/no row as one line:
+
+    ``Multistage cement? Yes [ ] No [x]``
+
+    The plain tokenizer sees ``"Multistage cement? Yes" -> False`` and
+    ``"No" -> True``. For a multi-label checkbox rule we want the more precise
+    candidates ``["Multistage cement?", "Yes"] -> False`` and
+    ``["Multistage cement?", "No"] -> True`` so repeated Yes/No options can be
+    disambiguated by the surrounding question without adding a new schema.
+    """
+
+    marker_matches = list(_MARKER_RE.finditer(line))
+    if not marker_matches:
+        return []
+
+    text_before_first = line[: marker_matches[0].start()].strip()
+    if not text_before_first:
+        return []
+
+    pairs: list[tuple[list[str], bool]] = []
+    current_context: str | None = None
+    prev_end = 0
+    for marker in marker_matches:
+        label_text = line[prev_end : marker.start()].strip()
+        prev_end = marker.end()
+        if not label_text:
+            continue
+
+        labels = [label_text]
+        option_match = _TRAILING_BOOL_OPTION_RE.match(label_text)
+        if option_match:
+            context = option_match.group("context").strip(" :;-")
+            option = option_match.group("option").strip()
+            if context:
+                current_context = context
+                labels = [context, option]
+            elif current_context:
+                labels = [current_context, option]
+
+        parts = _dedupe_nonempty_text(labels)
+        if parts:
+            pairs.append((parts, _marker_is_checked(marker.group())))
+
+    return pairs
+
+
+def _checkbox_label_list_match_score(
+    candidate_labels: list[str],
+    required_labels: list[str],
+    label_max_diffs: list[int],
+) -> float:
+    if len(candidate_labels) < len(required_labels):
+        return 0.0
+
+    used: set[int] = set()
+    total = 0.0
+    for req_idx, required in enumerate(required_labels):
+        allowed = label_max_diffs[req_idx] if req_idx < len(label_max_diffs) else 0
+        best_idx = -1
+        best_score = 0.0
+        for cand_idx, candidate in enumerate(candidate_labels):
+            if cand_idx in used:
+                continue
+            score = _label_match_score(candidate, required, allowed)
+            if score > best_score:
+                best_idx = cand_idx
+                best_score = score
+        if best_idx < 0 or best_score <= 0.0:
+            return 0.0
+        used.add(best_idx)
+        total += best_score
+
+    return total / max(len(required_labels), 1)
+
+
 # Markdown task-list. Allows optional ``\`` escapes around the list marker
 # AND the brackets — some parsers emit ``\[x\]`` (or even ``\- \[x\]`` for a
 # nested escaped bullet) so the markdown source survives literal-character
@@ -1162,7 +1525,7 @@ _MD_TASKLIST_RE = re.compile(
 # trailing widget marker. Both the bullet marker and the brackets may be
 # preceded by a literal backslash escape.
 _MD_BULLET_LABEL_FIRST_RE = re.compile(
-    rf"^\s*\\?{_LIST_MARKER_RE_INLINE}\s+(.+?)\s+\\?\[([ xX])\\?\]\s*$",
+    rf"^\s*\\?{_LIST_MARKER_RE_INLINE}\s+([^\[\n]+?)\s+\\?\[([ xX])\\?\]\s*$",
     re.MULTILINE,
 )
 
@@ -1179,7 +1542,11 @@ _MD_BARE_TASKLIST_RE = re.compile(
 )
 
 
-def _find_checkbox_state_for_label(content: str, label: str) -> bool | None:
+def _find_checkbox_state_for_label(
+    content: str,
+    label: str,
+    label_max_diffs: int | float = 0,
+) -> bool | None:
     """Return True/False if *label* has a checkbox-style state nearby, else None.
 
     Like :func:`_find_text_value_for_label`, this collects every candidate
@@ -1193,7 +1560,7 @@ def _find_checkbox_state_for_label(content: str, label: str) -> bool | None:
     candidates: list[tuple[float, int, int, bool]] = []
 
     def _try_add(cand_label: str, state: bool, priority: int, idx: int) -> None:
-        score = _label_match_score(cand_label, label)
+        score = _label_match_score(cand_label, label, label_max_diffs)
         if score > 0.0:
             candidates.append((-score, -priority, idx, state))
 
@@ -1228,6 +1595,30 @@ def _find_checkbox_state_for_label(content: str, label: str) -> bool | None:
     return None
 
 
+def _find_checkbox_state_for_label_list(
+    content: str,
+    labels: list[str],
+    label_max_diffs: list[int],
+) -> bool | None:
+    """Return the checkbox state for a multi-label yes/no option."""
+
+    candidates: list[tuple[float, int, bool]] = []
+    candidate_idx = 0
+    for line in content.splitlines():
+        if not _MARKER_RE.search(line):
+            continue
+        for candidate_labels, state in _tokenize_checkbox_line_with_context(line):
+            score = _checkbox_label_list_match_score(candidate_labels, labels, label_max_diffs)
+            if score > 0.0:
+                candidates.append((-score, candidate_idx, state))
+            candidate_idx += 1
+
+    if candidates:
+        candidates.sort()
+        return candidates[0][2]
+    return None
+
+
 # Strikethrough span — match a ``~~...~~`` block AND its contents so an edit
 # history like ``~~old~~ new`` collapses to just ``new``. ``normalize_text``
 # only strips the ``~~`` markers (leaving the crossed-out text behind), which
@@ -1240,12 +1631,46 @@ def _strip_strikethrough_spans(s: str) -> str:
     return _STRIKETHROUGH_SPAN_RE.sub("", s).strip()
 
 
-def _values_match_text(found: str, expected: str) -> bool:
-    """Compare two form-field text values strictly.
+def _compact_value_text_for_distance(s: str) -> str:
+    """Keep only alphanumeric content after the normal form-value cleanup."""
 
-    Form values are *extracted*, not estimated, so there is no role for
-    similarity ratios or relative tolerance — a wrong digit, a wrong letter,
-    or a swapped name component is a real mismatch. Two paths only:
+    return re.sub(r"[^0-9a-z]+", "", normalize_text(s))
+
+
+def _levenshtein_distance_at_most(left: str, right: str, max_distance: int) -> int:
+    """Compute edit distance, stopping once it is already above the limit."""
+
+    if left == right:
+        return 0
+    if abs(len(left) - len(right)) > max_distance:
+        return max_distance + 1
+    if len(left) < len(right):
+        left, right = right, left
+
+    previous = list(range(len(right) + 1))
+    for i, lch in enumerate(left, start=1):
+        current = [i]
+        row_min = current[0]
+        for j, rch in enumerate(right, start=1):
+            cost = 0 if lch == rch else 1
+            current.append(
+                min(
+                    previous[j] + 1,
+                    current[j - 1] + 1,
+                    previous[j - 1] + cost,
+                )
+            )
+            row_min = min(row_min, current[-1])
+        if row_min > max_distance:
+            return max_distance + 1
+        previous = current
+    return previous[-1]
+
+
+def _values_match_text(found: str, expected: str, max_diffs: int | float = 0) -> bool:
+    """Compare two form-field text values with optional character tolerance.
+
+    Form values default to strict comparison on the meaningful text:
 
     1. Exact match after normalization (``normalize_text`` already case-folds
        and collapses whitespace), which handles ``Madison`` vs ``madison``,
@@ -1253,6 +1678,13 @@ def _values_match_text(found: str, expected: str) -> bool:
     2. Strict numeric equality via ``normalize_number_string``, which lets
        ``1,234`` match ``1234`` and ``$1,234.00`` match ``1234`` (the same
        value written differently) — but rejects ``53703`` vs ``53704``.
+    3. Exact match after dropping separators/punctuation from the normalized
+       value, which handles handwritten/date separators such as ``9-29`` vs
+       ``9 29`` without making any character substitutions.
+
+    When ``max_diffs`` is positive, the compact normalized values may differ
+    by that many Levenshtein edits. This is intended for hard-to-read form
+    values where one digit/letter may be ambiguous; the default remains 0.
 
     Strikethrough spans (``~~old~~ new``) are stripped from the *found*
     value before comparison so the parser's edit-history rendering matches
@@ -1274,15 +1706,26 @@ def _values_match_text(found: str, expected: str) -> bool:
     if f_num is not None and e_num is not None and f_num == e_num:
         return True
 
+    f_compact = _compact_value_text_for_distance(found_stripped)
+    e_compact = _compact_value_text_for_distance(expected)
+    if f_compact and e_compact and f_compact == e_compact:
+        return True
+
+    allowed = int(max_diffs) if max_diffs and max_diffs > 0 else 0
+    if allowed > 0 and f_compact and e_compact:
+        return _levenshtein_distance_at_most(f_compact, e_compact, allowed) <= allowed
+
     return False
 
 
 # Trailing ``(row N)`` annotation used by the form-field test generator to
 # point a label at a specific data row of a multi-column table. The column is
 # named by the prefix; ``N`` is 1-indexed over data rows (header rows are
-# skipped). We deliberately keep this strict and simple — anything else stays
-# under the bold-colon / 2-col / glyph paths.
+# skipped). This also covers simple repeated inline rows shaped as
+# ``FROM value TO value`` because some form parsers flatten ruled tables that
+# way instead of emitting a markdown table.
 _ROW_LABEL_RE = re.compile(r"\s*\(row\s+(\d+)\)\s*$", re.IGNORECASE)
+_INLINE_FROM_TO_RE = re.compile(r"^FROM\s*(?P<from>.*?)\s+TO\s*(?P<to>.*?)\s*$", re.IGNORECASE)
 
 
 def _split_row_label(label: str) -> tuple[str, int] | None:
@@ -1318,7 +1761,71 @@ def _column_header_for_index(table: TableData, col_idx: int) -> str:
     return ""
 
 
-def _find_table_cell_for_row_label(content: str, label: str) -> tuple[bool, str | None]:
+def _clean_inline_from_to_line(line: str) -> str:
+    clean = _strip_html_tags(line)
+    clean = re.sub(r"[*_`]+", "", clean)
+    clean = clean.replace("\\", "")
+    clean = re.sub(r"^\s*(?:[-+]\s+|\d+\.\s+)", "", clean)
+    clean = re.sub(r"\s+", " ", clean).strip()
+    return clean
+
+
+def _clean_inline_from_to_value(value: str) -> str:
+    value = re.sub(r"(?:_|\s){3,}", " ", value)
+    return value.strip(" :;-_")
+
+
+def _find_inline_from_to_row_label(
+    content: str,
+    col_label: str,
+    row_n: int,
+    label_max_diffs: int | float = 0,
+) -> tuple[bool, str | None]:
+    """Look up ``FROM``/``TO`` values in flattened interval rows.
+
+    Example parser output:
+
+    ``FROM none reported TO RRC``
+
+    The rule keeps the same row-label syntax as markdown tables:
+    ``FROM (row 1)`` -> ``none reported`` and ``TO (row 1)`` -> ``RRC``.
+    """
+
+    wants_from = _label_matches("FROM", col_label, label_max_diffs)
+    wants_to = _label_matches("TO", col_label, label_max_diffs)
+    if not wants_from and not wants_to:
+        return False, None
+
+    rows: list[tuple[str, str]] = []
+    for raw_line in content.splitlines():
+        if "|" in raw_line:
+            continue
+        line = _clean_inline_from_to_line(raw_line)
+        if not line:
+            continue
+        match = _INLINE_FROM_TO_RE.match(line)
+        if not match:
+            continue
+        rows.append(
+            (
+                _clean_inline_from_to_value(match.group("from")),
+                _clean_inline_from_to_value(match.group("to")),
+            )
+        )
+
+    if not rows:
+        return False, None
+    if row_n < 1 or row_n > len(rows):
+        return True, ""
+    row_from, row_to = rows[row_n - 1]
+    return True, row_from if wants_from else row_to
+
+
+def _find_table_cell_for_row_label(
+    content: str,
+    label: str,
+    label_max_diffs: int | float = 0,
+) -> tuple[bool, str | None]:
     """Look up ``"<col_label> (row N)"`` in any multi-column table.
 
     Returns ``(label_seen, value_or_None)``. ``label_seen`` is True if a
@@ -1349,7 +1856,7 @@ def _find_table_cell_for_row_label(content: str, label: str) -> tuple[bool, str 
             header_text = _column_header_for_index(table, col_idx)
             if not header_text:
                 continue
-            if not _label_matches(header_text, col_label):
+            if not _label_matches(header_text, col_label, label_max_diffs):
                 continue
             label_seen = True
             if 0 <= data_row_idx < rows:
@@ -1359,8 +1866,177 @@ def _find_table_cell_for_row_label(content: str, label: str) -> tuple[bool, str 
             # Column matched but cell out of range or empty — keep looking
             # in case a sibling table has the same header populated.
 
+    inline_seen, inline_value = _find_inline_from_to_row_label(content, col_label, row_n, label_max_diffs)
+    if inline_seen:
+        return True, inline_value
+
     if label_seen:
         return True, ""
+    return False, None
+
+
+def _table_anchor_labels_for_cell(table: TableData, row_idx: int, col_idx: int) -> list[str]:
+    """Return visible row/column labels that identify a table value cell."""
+
+    labels: list[str] = []
+    header_rows = getattr(table, "header_rows", set()) or set()
+    row_headers = getattr(table, "row_headers", {}) or {}
+
+    labels.append(_column_header_for_index(table, col_idx))
+
+    for _, text in row_headers.get(row_idx, []):
+        labels.append(str(text))
+
+    # Keep markdown and simple HTML tables robust when header metadata is
+    # sparse: add the header cells above the value and the cells to its left.
+    for rr in sorted(header_rows):
+        if rr < row_idx and col_idx < table.data.shape[1]:
+            labels.append(str(table.data[rr, col_idx]))
+    for cc in range(col_idx):
+        labels.append(str(table.data[row_idx, cc]))
+
+    return _dedupe_nonempty_text(labels)
+
+
+def _compact_anchor_label(s: str) -> str:
+    return _compact_label_text_for_distance(s)
+
+
+def _compact_contains_with_diffs(haystack: str, needle: str, allowed: int) -> bool:
+    """Return True when any compact substring matches within edit distance."""
+
+    if allowed <= 0 or not haystack or not needle:
+        return False
+    if len(needle) > len(haystack):
+        return _levenshtein_distance_at_most(haystack, needle, allowed) <= allowed
+
+    min_len = max(1, len(needle) - allowed)
+    max_len = min(len(haystack), len(needle) + allowed)
+    for start in range(0, len(haystack) - min_len + 1):
+        for size in range(min_len, max_len + 1):
+            end = start + size
+            if end > len(haystack):
+                break
+            if _levenshtein_distance_at_most(haystack[start:end], needle, allowed) <= allowed:
+                return True
+    return False
+
+
+def _table_anchor_label_matches(candidate: str, required: str, max_diffs: int | float = 0) -> bool:
+    """Stricter label match for multi-label table anchors.
+
+    The legacy fuzzy label scorer is intentionally broad for single-key form
+    labels, but it is too broad for sibling columns like PLUG #1 / PLUG #2.
+    Multi-key table lookup needs exact or containment-style evidence instead.
+    """
+
+    cand = normalize_text(candidate)
+    req = normalize_text(required)
+    if not cand or not req:
+        return False
+    if _strip_label_punct(cand) == _strip_label_punct(req):
+        return True
+    if req in cand or cand in req:
+        return True
+
+    cand_compact = _compact_anchor_label(candidate)
+    req_compact = _compact_anchor_label(required)
+    if not cand_compact or not req_compact:
+        return False
+    if cand_compact == req_compact:
+        return True
+    min_containment_len = 4
+    if (
+        len(req_compact) >= min_containment_len
+        and req_compact in cand_compact
+        or len(cand_compact) >= min_containment_len
+        and cand_compact in req_compact
+    ):
+        return True
+
+    allowed = int(max_diffs) if max_diffs and max_diffs > 0 else 0
+    return allowed > 0 and (
+        _levenshtein_distance_at_most(cand_compact, req_compact, allowed) <= allowed
+        or _compact_contains_with_diffs(cand_compact, req_compact, allowed)
+    )
+
+
+def _labels_match_all(
+    candidate_labels: list[str],
+    required_labels: list[str],
+    label_max_diffs: list[int],
+) -> bool:
+    """Order-insensitive match: every required label must match one anchor."""
+
+    for idx, required in enumerate(required_labels):
+        allowed = label_max_diffs[idx] if idx < len(label_max_diffs) else 0
+        if not any(_table_anchor_label_matches(candidate, required, allowed) for candidate in candidate_labels):
+            return False
+    return True
+
+
+def _is_table_value_cell(table: TableData, row_idx: int, col_idx: int) -> bool:
+    header_rows = getattr(table, "header_rows", set()) or set()
+    header_cols = getattr(table, "header_cols", set()) or set()
+    header_cells = getattr(table, "header_cells", set()) or set()
+
+    if row_idx in header_rows:
+        return False
+    if header_cells:
+        if (row_idx, col_idx) in header_cells:
+            return False
+    elif col_idx in header_cols:
+        return False
+
+    # In row/column form tables, the first data column is normally the row
+    # label stub ("Cementing Date", "Depth...", etc.), not a value cell.
+    if col_idx == 0 and table.data.shape[1] > 1:
+        return False
+    return True
+
+
+def _find_table_cell_for_label_list(
+    content: str,
+    labels: list[str],
+    expected_values: list[str] | None = None,
+    max_diffs: int | float = 0,
+    label_max_diffs: list[int] | None = None,
+) -> tuple[bool, str | None]:
+    """Look up a value cell by multiple row/column-style form labels.
+
+    This is deliberately narrower than full table evaluation: it only asks
+    whether the same table cell is anchored by all requested visible labels.
+    The rule JSON does not need row/column roles; labels are matched as an
+    unordered set against the nearby table anchors.
+    """
+
+    label_seen = False
+    fallback_value: str | None = None
+    label_diffs = label_max_diffs or [0] * len(labels)
+    for table in parse_html_tables(content) + parse_markdown_tables(content):
+        if table.data.size == 0:
+            continue
+        rows, cols = table.data.shape
+
+        for row_idx in range(rows):
+            for col_idx in range(cols):
+                if not _is_table_value_cell(table, row_idx, col_idx):
+                    continue
+                anchors = _table_anchor_labels_for_cell(table, row_idx, col_idx)
+                if not _labels_match_all(anchors, labels, label_diffs):
+                    continue
+
+                label_seen = True
+                value = str(table.data[row_idx, col_idx]).strip()
+                if expected_values:
+                    for exp in expected_values:
+                        if _values_match_text(value, exp, max_diffs):
+                            return True, value
+                if fallback_value is None or (not fallback_value and value):
+                    fallback_value = value
+
+    if label_seen:
+        return True, fallback_value or ""
     return False, None
 
 
@@ -1443,10 +2119,19 @@ class FormFieldRule(ParseTestRule):
             raise ValueError(f"Invalid type for FormFieldRule: {self.type}")
 
         self.label = rule_data.label
+        label_parts = _label_parts_with_indexes(rule_data.label)
+        self.labels = [part for part, _ in label_parts]
+        label_indexes = [idx for _, idx in label_parts]
+        self.label_max_diffs = _label_max_diffs_parts(
+            rule_data.label_max_diffs,
+            len(self.labels),
+            label_indexes,
+        )
+        self.value_max_diffs = rule_data.value_max_diffs
         self.value = rule_data.value
         self.value_type = rule_data.value_type
 
-        if not self.label:
+        if not self.labels:
             raise ValueError("label field cannot be empty")
 
     def _content_for_match(self, md_content: str) -> str:
@@ -1469,11 +2154,20 @@ class FormFieldRule(ParseTestRule):
     def _run_text(self, content: str) -> tuple[bool, str, float]:
         # `self.value` can be a list of acceptable alternatives — pass if any matches.
         expected_alternatives = _value_alternatives(self.value)
+        label = self.labels[0]
         # Multi-col table cell lookup ("Column Name (row N)") takes precedence
         # over the bold-colon / 2-col / glyph paths because the suffix
         # explicitly names a tabular position.
-        if _split_row_label(self.label) is not None:
-            label_found, value = _find_table_cell_for_row_label(content, self.label)
+        if len(self.labels) > 1:
+            label_found, value = _find_table_cell_for_label_list(
+                content,
+                self.labels,
+                expected_alternatives,
+                self.value_max_diffs,
+                self.label_max_diffs,
+            )
+        elif _split_row_label(label) is not None:
+            label_found, value = _find_table_cell_for_row_label(content, label, self.label_max_diffs[0])
         else:
             # Thread expected_alternatives so the matcher can disambiguate
             # among candidates at the same top label-match score. The rule's
@@ -1484,13 +2178,19 @@ class FormFieldRule(ParseTestRule):
             # oracle is applied **only** to candidates tied at the head
             # label-match score, so it never leaks across adjacent labels
             # like Country vs County which live at different score levels.
-            label_found, value = _find_text_value_for_label(content, self.label, expected_alternatives)
+            label_found, value = _find_text_value_for_label(
+                content,
+                label,
+                expected_alternatives,
+                self.value_max_diffs,
+                self.label_max_diffs[0],
+            )
         if not label_found:
-            return False, f"label not found: {self.label!r}", 0.0
+            return False, f"label not found: {_format_label_for_message(self.label)}", 0.0
         # value may be "" (label found, cell/value empty); _values_match_text
         # handles empty == empty correctly so empty-expected rules can pass.
         for expected in expected_alternatives:
-            if _values_match_text(value or "", expected):
+            if _values_match_text(value or "", expected, self.value_max_diffs):
                 return True, "match", 1.0
         if len(expected_alternatives) == 1:
             return False, f"expected {expected_alternatives[0]!r}, got {(value or '')!r}", 0.0
@@ -1502,15 +2202,33 @@ class FormFieldRule(ParseTestRule):
             return False, f"checkbox value must be coercible to bool, got {self.value!r}", 0.0
 
         # Prefer a real checkbox-shaped match.
-        state = _find_checkbox_state_for_label(content, self.label)
+        state = (
+            _find_checkbox_state_for_label(content, self.labels[0], self.label_max_diffs[0])
+            if len(self.labels) == 1
+            else _find_checkbox_state_for_label_list(content, self.labels, self.label_max_diffs)
+        )
         if state is None:
             # Fall back to a text-shaped value (e.g. **Married:** Yes / No).
-            if _split_row_label(self.label) is not None:
-                label_found, text_value = _find_table_cell_for_row_label(content, self.label)
+            if len(self.labels) > 1:
+                label_found, text_value = _find_table_cell_for_label_list(
+                    content,
+                    self.labels,
+                    label_max_diffs=self.label_max_diffs,
+                )
+            elif _split_row_label(self.labels[0]) is not None:
+                label_found, text_value = _find_table_cell_for_row_label(
+                    content,
+                    self.labels[0],
+                    self.label_max_diffs[0],
+                )
             else:
-                label_found, text_value = _find_text_value_for_label(content, self.label)
+                label_found, text_value = _find_text_value_for_label(
+                    content,
+                    self.labels[0],
+                    label_max_diffs=self.label_max_diffs[0],
+                )
             if not label_found or not text_value:
-                return False, f"label not found: {self.label!r}", 0.0
+                return False, f"label not found: {_format_label_for_message(self.label)}", 0.0
             state = _coerce_bool(text_value)
             if state is None:
                 return False, f"could not interpret {text_value!r} as checkbox state", 0.0
@@ -1536,9 +2254,20 @@ class FormFieldRule(ParseTestRule):
         # Track label presence separately from value presence — an absent label
         # must NOT pass an "expected unsigned" rule. A form tuple benchmark
         # requires the parser to surface the field at all.
-        label_found, text_value = _find_text_value_for_label(content, self.label)
+        if len(self.labels) > 1:
+            label_found, text_value = _find_table_cell_for_label_list(
+                content,
+                self.labels,
+                label_max_diffs=self.label_max_diffs,
+            )
+        else:
+            label_found, text_value = _find_text_value_for_label(
+                content,
+                self.labels[0],
+                label_max_diffs=self.label_max_diffs[0],
+            )
         if not label_found:
-            return False, f"label not found: {self.label!r}", 0.0
+            return False, f"label not found: {_format_label_for_message(self.label)}", 0.0
         signed = bool(text_value and text_value.strip())
         if signed == expected_signed:
             return True, "match", 1.0

--- a/src/parse_bench/evaluation/metrics/parse/rules_formatting.py
+++ b/src/parse_bench/evaluation/metrics/parse/rules_formatting.py
@@ -4,18 +4,25 @@ import re
 import unicodedata
 from typing import Any, cast
 
+from parse_bench.evaluation.metrics.parse.emphasis_spans import EmphasisSpanMatcher
 from parse_bench.evaluation.metrics.parse.rules_base import (
     ParseTestRule,
+    RuleNotApplicable,
     _unescape_html_entities,
+    is_degenerate_marker_text,
 )
 from parse_bench.evaluation.metrics.parse.test_types import TestType
-from parse_bench.evaluation.metrics.parse.utils import normalize_text
+from parse_bench.evaluation.metrics.parse.utils import _normalize_quotes, normalize_text
 from parse_bench.test_cases.parse_rule_schemas import (
+    ParseAbsentUnlessStrikeoutRule,
     ParseCodeBlockRule,
     ParseFormattingRule,
     ParseLatexRule,
     ParseMarkColorRule,
+    ParseNotLatexRule,
     ParsePageSectionRule,
+    ParsePresentAsStrikeoutRule,
+    ParseTextColorRule,
     ParseTitleHierarchyPercentRule,
     ParseTitleRule,
 )
@@ -39,6 +46,58 @@ _INLINE_MARKUP_OPT = r"(?:\*{1,2}|~~|__?|</?\w+(?:\s[^>]*)?>)*"
 _MD_BACKSLASH_ESCAPE_RE = re.compile(r"\\([!\"#$%&'()*+,\-./:;<=>?@\[\\\]^_`{|}~])")
 
 
+# ---------------------------------------------------------------------------
+# Span scoping for the inline-formatting detectors
+# ---------------------------------------------------------------------------
+# The markdown emphasis arms (``**``, ``*``, ``_``, ``~~``) are not regexes:
+# no guard local to one delimiter run can tell a padded span's own markers
+# from two padded spans' markers seen back to back, so those arms resolve
+# spans by delimiter-run pairing (see ``emphasis_spans``) and search the query
+# inside the paired spans. The HTML tag-pair and heading arms below remain
+# regexes; the guards that follow keep their matches confined to one span.
+
+
+def _tempered(closing: str) -> str:
+    """Lazy any-char run that cannot cross *closing* (a regex literal).
+
+    Without this, ``<b>.*?query.*?</b>`` happily matches by starting at one
+    span's opening tag and borrowing a *later* span's tag as its closer.
+    """
+    return r"(?:(?!" + closing + r").)*?"
+
+
+# Whitespace between the query's own words. A bare ``\s+`` here matches
+# newlines regardless of the DOTALL flag, which lets the QUERY straddle
+# boundaries the surrounding pattern is forbidden to cross - e.g. a query
+# starting on a heading line and finishing in the paragraph below. This run
+# may wrap a single line break but never a paragraph break.
+_WORD_WS = r"(?:(?!\r?\n[ \t]*\r?\n)\s)+"
+
+
+def _confined_to_line(query: str) -> str:
+    """Rewrite a flexible query so its word gaps cannot leave the line.
+
+    Heading text lives on a single line, so a query embedded in a heading
+    pattern must not continue onto the next one. ``_WORD_WS`` is a generated
+    token that cannot arise from ``re.escape``'d rule text (escaping doubles
+    every backslash), so the replacement is unambiguous.
+    """
+    return query.replace(_WORD_WS, r"[ \t]+")
+
+
+def _paragraph_spanning(query: str) -> str:
+    """Rewrite a flexible query so its word gaps may cross paragraph breaks.
+
+    A markdown emphasis span ends at a blank line, but an HTML tag pair ends
+    at its closing tag and legitimately wraps multiple paragraphs - so inside
+    a tag-pair arm the containment scope comes from the tags, and the query's
+    word gaps must stay fully permissive (``<u>alpha\\n\\nbeta</u>`` is
+    underlined). The token replacement is unambiguous for the same reason as
+    in ``_confined_to_line``.
+    """
+    return query.replace(_WORD_WS, r"\s+")
+
+
 def _make_markup_tolerant(escaped_text: str) -> str:
     """Make an escaped regex pattern tolerant of inline formatting markup.
 
@@ -49,7 +108,7 @@ def _make_markup_tolerant(escaped_text: str) -> str:
     # Split on escaped spaces (re.escape turns " " into "\\ ")
     # and rejoin with markup-tolerant whitespace
     parts = escaped_text.split(r"\ ")
-    joiner = _INLINE_MARKUP_OPT + r"\s+" + _INLINE_MARKUP_OPT
+    joiner = _INLINE_MARKUP_OPT + _WORD_WS + _INLINE_MARKUP_OPT
     tolerant = joiner.join(parts)
     # Allow leading and trailing markup adjacent to the text
     return _INLINE_MARKUP_OPT + tolerant + _INLINE_MARKUP_OPT
@@ -62,7 +121,7 @@ _STRIP_PATTERNS: dict[str, list[tuple[re.Pattern, str]]] = {
     "bold": [
         (re.compile(r"\*\*\*(.+?)\*\*\*", re.DOTALL), r"\1"),
         (re.compile(r"\*\*(.+?)\*\*", re.DOTALL), r"\1"),
-        (re.compile(r"</?b>", re.IGNORECASE), ""),
+        (re.compile(r"</?(?:b|strong)>", re.IGNORECASE), ""),
     ],
     "italic": [
         (re.compile(r"(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)"), r"\1"),
@@ -101,11 +160,11 @@ def _strip_other_formatting(text: str, keep_kind: str) -> str:
             continue
         for pattern, repl in replacements:
             result = pattern.sub(repl, result)
-    # Collapse whitespace (preserving line structure — the heading arm of
-    # the bold patterns is line-anchored) and fix stray spaces before
-    # punctuation
+    # Collapse *horizontal* whitespace only. Line structure has to survive:
+    # the detectors distinguish a heading line from body text, and the query's
+    # _WORD_WS gaps wrap line breaks anyway. Collapsing newlines here would
+    # join the whole document into one line and defeat that scoping.
     result = re.sub(r"[^\S\n]+", " ", result)
-    result = re.sub(r" ?\n ?", "\n", result)
     result = re.sub(r" ([,;:!?.\)\]\}])", r"\1", result)
     return result
 
@@ -126,7 +185,7 @@ class FormattingRule(ParseTestRule):
     formatting information is still available.
 
     Supported formatting kinds and their detection patterns:
-    - bold:      **text** or <b>text</b>
+    - bold:      **text**, <b>text</b>, or <strong>text</strong>
     - italic:    *text* or _text_ or <i>text</i>
     - underline: <u>text</u> or <ins>text</ins>
     - strikeout: ~~text~~
@@ -170,113 +229,131 @@ class FormattingRule(ParseTestRule):
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _build_bold_patterns(escaped_query: str) -> list[re.Pattern]:
-        """Detect **text**, <b>text</b>, or markdown heading lines (# text).
+    def _build_bold_patterns(escaped_query: str) -> list[re.Pattern | EmphasisSpanMatcher]:
+        """Detect **text**, <b>/<strong> text, or markdown headings (# text).
 
         The query may be a substring of the bold span (e.g. query
         ``Population`` matches ``**Population:**``).
-
-        The ``**`` delimiters follow CommonMark flanking (an opener is not
-        followed by whitespace, a closer is not preceded by it) and the
-        ``<b>`` filler cannot cross a closing tag — otherwise the closer of
-        one span pairs with the opener of the next and the unformatted text
-        between two bold spans (``**Name:** John **Age:**``) tests as bold.
-        The heading arm's fillers stay on the heading's own line for the
-        same reason. (The whitespace joiners inside a multi-word query can
-        still cross these boundaries; only the fillers are constrained.)
         """
-        # Tempered greedy token: match any char that doesn't start a new **
-        _not_bold_close = r"(?:(?!\*\*).)*?"
-        # Same idea for the HTML arm: don't cross a closing </b>
-        _not_b_close_tag = r"(?:(?!</b>).)*?"
         return [
+            # ** spans come from delimiter-run pairing, so the query can only
+            # ever match text that sits between an opener and its own closer.
+            EmphasisSpanMatcher(("bold",), escaped_query),
+            # Tag pairs may wrap multiple paragraphs, so the query's word gaps
+            # go back to \s+ here: containment is scoped by the closing tag.
             re.compile(
-                r"\*\*(?!\s)" + _not_bold_close + escaped_query + _not_bold_close + r"(?<!\s)\*\*",
+                r"<b>" + _tempered(r"</b>") + _paragraph_spanning(escaped_query) + _tempered(r"</b>") + r"</b>",
                 re.IGNORECASE | re.DOTALL,
             ),
             re.compile(
-                r"<b>" + _not_b_close_tag + escaped_query + _not_b_close_tag + r"</b>",
+                r"<strong>"
+                + _tempered(r"</strong>")
+                + _paragraph_spanning(escaped_query)
+                + _tempered(r"</strong>")
+                + r"</strong>",
                 re.IGNORECASE | re.DOTALL,
             ),
+            # Heading text must live on the heading's own line: no DOTALL, the
+            # intra-line separators use [ \t] because \s matches newlines
+            # regardless of the DOTALL flag, and the query itself is confined
+            # so its own word gaps cannot continue past the heading line.
             re.compile(
-                r"^[ \t]*#{1,6}[ \t]+[^\n]*?" + escaped_query + r"[^\n]*?[ \t]*(?:#+[ \t]*)?$",
+                r"^[ \t]*#{1,6}[ \t]+[^\n]*?" + _confined_to_line(escaped_query) + r"[^\n]*?[ \t]*(?:#+[ \t]*)?$",
                 re.IGNORECASE | re.MULTILINE,
             ),
         ]
 
     @staticmethod
-    def _build_italic_patterns(escaped_query: str) -> list[re.Pattern]:
+    def _build_italic_patterns(escaped_query: str) -> list[re.Pattern | EmphasisSpanMatcher]:
         """Detect *text* (not **), _text_ (not __), or <i>text</i>.
 
         The query may be a substring of the italic span (e.g. query
         ``Grazing Line`` matches ``*Grazing Line, Macquarie Marshes, NSW*``).
         """
-        # Tempered greedy token: any char that isn't a lone * (i.e. not * unless followed by *)
-        _not_italic_close_star = r"(?:(?!\*(?!\*)).)*?"
-        # Same idea for _
-        _not_italic_close_under = r"(?:(?!_(?!_)).)*?"
-        # And for the HTML arms: the fillers must not cross a closing tag,
-        # or adjacent spans (<i>A</i> x <i>B</i>) merge into one match.
-        _not_i_close_tag = r"(?:(?!</i>).)*?"
-        _not_em_close_tag = r"(?:(?!</em>).)*?"
         return [
-            # *text* but NOT **text** – use negative lookbehind/lookahead
+            # Lone-* and lone-_ spans from delimiter-run pairing. Run length
+            # is exact, so ** and __ never feed the italic arm.
+            EmphasisSpanMatcher(("italic_star", "italic_under"), escaped_query),
+            # Tag pairs may wrap multiple paragraphs: paragraph-spanning gaps.
             re.compile(
-                r"(?<!\*)\*(?!\*)" + _not_italic_close_star + escaped_query + _not_italic_close_star + r"\*(?!\*)",
+                r"<i>" + _tempered(r"</i>") + _paragraph_spanning(escaped_query) + _tempered(r"</i>") + r"</i>",
                 re.IGNORECASE | re.DOTALL,
             ),
             re.compile(
-                r"(?<!_)_(?!_)" + _not_italic_close_under + escaped_query + _not_italic_close_under + r"_(?!_)",
-                re.IGNORECASE | re.DOTALL,
-            ),
-            re.compile(
-                r"<i>" + _not_i_close_tag + escaped_query + _not_i_close_tag + r"</i>",
-                re.IGNORECASE | re.DOTALL,
-            ),
-            re.compile(
-                r"<em>" + _not_em_close_tag + escaped_query + _not_em_close_tag + r"</em>",
+                r"<em>" + _tempered(r"</em>") + _paragraph_spanning(escaped_query) + _tempered(r"</em>") + r"</em>",
                 re.IGNORECASE | re.DOTALL,
             ),
         ]
 
     @staticmethod
     def _build_underline_patterns(escaped_query: str) -> list[re.Pattern]:
-        """Detect <u>text</u> or <ins>text</ins>."""
+        """Detect <u>text</u> or <ins>text</ins>.
+
+        The rule text may be a substring of the underlined span. This mirrors
+        the other inline formatting rules: a focused assertion such as
+        ``intellectual`` should match when the parser correctly wraps the
+        complete sentence containing it. Tag pairs may wrap multiple
+        paragraphs, so the closing tag scopes containment.
+        """
+        query = _paragraph_spanning(escaped_query)
         return [
-            re.compile(r"<u>" + escaped_query + r"</u>", re.IGNORECASE),
-            re.compile(r"<ins>" + escaped_query + r"</ins>", re.IGNORECASE),
+            re.compile(
+                r"<u>" + _tempered(r"</u>") + query + _tempered(r"</u>") + r"</u>",
+                re.IGNORECASE | re.DOTALL,
+            ),
+            re.compile(
+                r"<ins>" + _tempered(r"</ins>") + query + _tempered(r"</ins>") + r"</ins>",
+                re.IGNORECASE | re.DOTALL,
+            ),
         ]
 
     @staticmethod
-    def _build_strikeout_patterns(escaped_query: str) -> list[re.Pattern]:
-        """Detect ~~text~~ or <s>text</s> / <del>text</del> / <strike>text</strike>."""
+    def _build_strikeout_patterns(escaped_query: str) -> list[re.Pattern | EmphasisSpanMatcher]:
+        """Detect the query inside one continuous strikeout span."""
+        query = _paragraph_spanning(escaped_query)
         return [
-            re.compile(r"~~" + escaped_query + r"~~", re.IGNORECASE),
+            # ~~ is GFM strikethrough - markdown emphasis, so it pairs and
+            # scopes exactly like the ** arm: paragraph-confined spans, inner
+            # padding (``~~ text ~~``) accepted on the same terms.
+            EmphasisSpanMatcher(("strikeout",), escaped_query),
+            # HTML strike tags may carry attributes and wrap multiple
+            # paragraphs. Backreference the opener so malformed mixed pairs
+            # do not count as producer-supported strikeout markup.
             re.compile(
-                r"<(?:s|del|strike)>" + escaped_query + r"</(?:s|del|strike)>",
-                re.IGNORECASE,
+                r"<(s|del|strike)\b[^>]*>" + _tempered(r"</\1>") + query + _tempered(r"</\1>") + r"</\1>",
+                re.IGNORECASE | re.DOTALL,
+            ),
+            # Some producers retain CSS line-through instead of translating
+            # it to Markdown or a semantic strike tag.
+            re.compile(
+                r"<(\w+)\b(?=[^>]*text-decoration\s*:\s*[^>]*line-through)[^>]*>"
+                + _tempered(r"</\1>")
+                + query
+                + _tempered(r"</\1>")
+                + r"</\1>",
+                re.IGNORECASE | re.DOTALL,
             ),
         ]
 
     @staticmethod
     def _build_mark_patterns(escaped_query: str) -> list[re.Pattern]:
-        """Detect <mark>text</mark>."""
+        """Detect ``<mark>`` with or without attributes around the target text."""
         return [
-            re.compile(r"<mark>" + escaped_query + r"</mark>", re.IGNORECASE),
+            re.compile(r"<mark(?:\s+[^>]*)?>" + _paragraph_spanning(escaped_query) + r"</mark>", re.IGNORECASE),
         ]
 
     @staticmethod
     def _build_sup_patterns(escaped_query: str) -> list[re.Pattern]:
         """Detect <sup>text</sup>. Unicode superscripts handled separately."""
         return [
-            re.compile(r"<sup>" + escaped_query + r"</sup>", re.IGNORECASE),
+            re.compile(r"<sup[^>]*>" + _paragraph_spanning(escaped_query) + r"</sup>", re.IGNORECASE),
         ]
 
     @staticmethod
     def _build_sub_patterns(escaped_query: str) -> list[re.Pattern]:
         """Detect <sub>text</sub>. Unicode subscripts handled separately."""
         return [
-            re.compile(r"<sub>" + escaped_query + r"</sub>", re.IGNORECASE),
+            re.compile(r"<sub[^>]*>" + _paragraph_spanning(escaped_query) + r"</sub>", re.IGNORECASE),
         ]
 
     def _has_unicode_superscript(self, content: str) -> bool:
@@ -327,13 +404,29 @@ class FormattingRule(ParseTestRule):
         As a fallback, other formatting markers are stripped from the content
         while keeping the markers for the kind being tested, so the regex
         can match even when nested markup is adjacent to words (no space).
+
+        Both sides are quote-folded first. Content rules get that folding from
+        ``normalize_text``; matching raw markdown skips it, so an ASCII-quoted
+        rule could not match a faithful parse of a page printed with
+        typographic quotes (``"Bank"`` vs ``“Bank”``, ``Kellogg's`` vs
+        ``Kellogg’s``) — ground truth routinely failed its own styling rules
+        on nothing but the quote encoding. The fold is a 1:1 character
+        translation, so span boundaries and offsets are untouched.
         """
+        # The query is nothing but markdown markers (harvested from an ASCII
+        # banner), so it identifies no content and no output could ever satisfy
+        # it. Skip rather than score 0.0 - see ``is_degenerate_marker_text``.
+        # This covers both polarities: a degenerate ``is_not_*`` query would
+        # otherwise bank a free pass for an equally undefined reason.
+        if is_degenerate_marker_text(self.text):
+            raise RuleNotApplicable(f"{self.type} text {self.text!r} is markdown markers only")
+
         # Un-escape markdown backslash sequences (e.g. \~ → ~) so that
         # clean rule text can match content produced by parsers that emit
         # backslash-escaped punctuation.
-        md_clean = _MD_BACKSLASH_ESCAPE_RE.sub(r"\1", md_content)
+        md_clean = _normalize_quotes(_MD_BACKSLASH_ESCAPE_RE.sub(r"\1", md_content))
 
-        escaped_query = re.escape(self.text)
+        escaped_query = re.escape(_normalize_quotes(self.text))
         # Allow flexible whitespace *and* optional inline markup between words
         flexible_query = _make_markup_tolerant(escaped_query)
 
@@ -344,7 +437,9 @@ class FormattingRule(ParseTestRule):
         # being tested, then retry with a simple flexible-whitespace pattern.
         if not found:
             stripped = _strip_other_formatting(md_clean, self.formatting_kind)
-            simple_query = re.sub(r"\\ ", r"\\s+", escaped_query)
+            # str.replace, not re.sub: _WORD_WS contains \s, which re.sub
+            # rejects as a bad escape in a replacement template.
+            simple_query = escaped_query.replace(r"\ ", _WORD_WS)
             simple_patterns = self._FORMATTING_PATTERNS[self.formatting_kind](simple_query)  # type: ignore[operator]
             found = any(p.search(stripped) for p in simple_patterns)
 
@@ -400,6 +495,7 @@ _FORMATTING_TEST_TYPES = {
     TestType.IS_SUB.value,
     TestType.IS_NOT_SUB.value,
     TestType.MARK_COLOR.value,
+    TestType.TEXT_COLOR.value,
 }
 
 
@@ -440,7 +536,9 @@ class MarkColorRule(ParseTestRule):
     def run(self, md_content: str, normalized_content: str | None = None) -> tuple[bool, str]:
         """Check if text is inside a <mark> tag that contains the expected color."""
         escaped_query = re.escape(self.text)
-        flexible_query = _make_markup_tolerant(escaped_query)
+        # A <mark> tag pair may wrap multiple paragraphs, so the query's word
+        # gaps must be paragraph-spanning to match anywhere in the inner text.
+        flexible_query = _paragraph_spanning(_make_markup_tolerant(escaped_query))
         text_pattern = re.compile(flexible_query, re.IGNORECASE)
 
         for match in _MARK_TAG_PATTERN.finditer(md_content):
@@ -474,6 +572,280 @@ class MarkColorRule(ParseTestRule):
         )
 
 
+# ---------------------------------------------------------------------------
+# absent_unless_strikeout rule
+# ---------------------------------------------------------------------------
+
+# Regions of raw markdown that carry explicit strikeout markup. Text inside
+# these regions is "marked as deleted" and therefore allowed to remain.
+_STRUCK_REGION_PATTERNS = [
+    re.compile(r"~~[\s\S]+?~~"),
+    re.compile(r"<(s|del|strike)\b[^>]*>[\s\S]*?</\1>", re.IGNORECASE),
+    re.compile(
+        r"<(\w+)\b[^>]*text-decoration\s*:\s*line-through[^>]*>[\s\S]*?</\1>",
+        re.IGNORECASE,
+    ),
+]
+
+
+class AbsentUnlessStrikeoutRule(ParseTestRule):
+    """Deleted (struck) source text must not surface as regular content.
+
+    Passes when the text is absent from the output entirely, or when every
+    occurrence sits inside strikeout markup. Fails when the text appears as
+    plain, unmarked content — the case where deleted contract language reads
+    identically to current language downstream.
+    """
+
+    def __init__(self, rule_data: ParseAbsentUnlessStrikeoutRule | dict):
+        super().__init__(rule_data)
+        rule_data = cast(ParseAbsentUnlessStrikeoutRule, self._rule_data)
+
+        if self.type != TestType.ABSENT_UNLESS_STRIKEOUT.value:
+            raise ValueError(f"Invalid type for AbsentUnlessStrikeoutRule: {self.type}")
+
+        raw_text = rule_data.text
+        if not raw_text.strip():
+            raise ValueError("Text field cannot be empty")
+        self.text = raw_text.strip()
+
+    def run(self, md_content: str, normalized_content: str | None = None) -> tuple[bool, str]:
+        # Remove every explicitly-struck region, then look for the text in
+        # what remains. Whatever survives the removal is unmarked content.
+        visible = _MD_BACKSLASH_ESCAPE_RE.sub(r"\1", md_content)
+        for pattern in _STRUCK_REGION_PATTERNS:
+            visible = pattern.sub(" ", visible)
+
+        norm_query = normalize_text(self.text)
+        norm_visible = normalize_text(visible)
+        if norm_query and norm_query in norm_visible:
+            return (
+                False,
+                f"Deleted text '{self.text[:40]}' appears as regular content (not struck through and not removed)",
+            )
+        return True, ""
+
+
+class PresentAsStrikeoutRule(ParseTestRule):
+    """Deleted (struck) source text must be retained AND marked as struck.
+
+    Stricter counterpart of :class:`AbsentUnlessStrikeoutRule`: dropping the
+    text also fails. Passes only when the text appears inside strikeout
+    markup somewhere in the output. Region-based, so a struck span wider
+    than the rule text passes.
+    """
+
+    def __init__(self, rule_data: ParsePresentAsStrikeoutRule | dict):
+        super().__init__(rule_data)
+        rule_data = cast(ParsePresentAsStrikeoutRule, self._rule_data)
+
+        if self.type != TestType.PRESENT_AS_STRIKEOUT.value:
+            raise ValueError(f"Invalid type for PresentAsStrikeoutRule: {self.type}")
+
+        raw_text = rule_data.text
+        if not raw_text.strip():
+            raise ValueError("Text field cannot be empty")
+        self.text = raw_text.strip()
+
+    def run(self, md_content: str, normalized_content: str | None = None) -> tuple[bool, str]:
+        unescaped = _MD_BACKSLASH_ESCAPE_RE.sub(r"\1", md_content)
+        struck_parts: list[str] = []
+        for pattern in _STRUCK_REGION_PATTERNS:
+            struck_parts.extend(m.group(0) for m in pattern.finditer(unescaped))
+
+        norm_query = normalize_text(self.text)
+        if norm_query and norm_query in normalize_text(" ".join(struck_parts)):
+            return True, ""
+
+        if norm_query and norm_query in normalize_text(unescaped):
+            return (
+                False,
+                f"Deleted text '{self.text[:40]}' is present but not marked as struck",
+            )
+        return (
+            False,
+            f"Deleted text '{self.text[:40]}' was dropped from the output (expected retained inside strikeout markup)",
+        )
+
+
+# ---------------------------------------------------------------------------
+# text_color rule
+# ---------------------------------------------------------------------------
+
+# Any HTML tag with attributes wrapping inner text. Tag-agnostic because
+# parsers may express colored text via <span>, <font>, <mark>, <del>, <ins>, …
+_COLORABLE_TAG_PATTERN = re.compile(
+    r"<(\w+)\b([^>]*)>([\s\S]+?)</\1>",
+    re.IGNORECASE,
+)
+
+# Color value candidates inside a tag's attribute string: hex codes, rgb()
+# triples, or values following a color-ish attribute (style="color: red",
+# color="red", data-text-color="red").
+_HEX_COLOR_RE = re.compile(r"#([0-9a-fA-F]{6}|[0-9a-fA-F]{3})\b")
+_RGB_COLOR_RE = re.compile(r"rgb\s*\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)", re.IGNORECASE)
+_NAMED_COLOR_ATTR_RE = re.compile(r"color\s*[:=]\s*[\"']?\s*([a-zA-Z]+)", re.IGNORECASE)
+
+# Representative RGB for named colors parsers plausibly emit.
+_NAMED_COLOR_RGB: dict[str, tuple[int, int, int]] = {
+    "red": (255, 0, 0),
+    "darkred": (139, 0, 0),
+    "crimson": (220, 20, 60),
+    "salmon": (250, 128, 114),
+    # Palette names LlamaParse's structured `colors` annotation normalizes to
+    # (rehydrated into md by color_annotations.py) that were missing here.
+    "lightcoral": (240, 128, 128),
+    "goldenrod": (218, 165, 32),
+    "olive": (128, 128, 0),
+    "orange": (255, 165, 0),
+    "amber": (255, 191, 0),
+    "gold": (255, 215, 0),
+    "yellow": (255, 255, 0),
+    "green": (0, 128, 0),
+    "darkgreen": (0, 100, 0),
+    "lime": (0, 255, 0),
+    "teal": (0, 128, 128),
+    "cyan": (0, 255, 255),
+    "blue": (0, 0, 255),
+    "navy": (0, 0, 128),
+    "royalblue": (65, 105, 225),
+    "purple": (128, 0, 128),
+    "violet": (238, 130, 238),
+    "magenta": (255, 0, 255),
+    "pink": (255, 192, 203),
+    "brown": (165, 42, 42),
+    "maroon": (128, 0, 0),
+}
+
+
+def _rgb_to_hue_family(r: int, g: int, b: int) -> str | None:
+    """Classify an RGB value into a coarse hue family; None for grayscale."""
+    mx, mn = max(r, g, b), min(r, g, b)
+    if mx - mn < 30:  # too desaturated to carry revision meaning
+        return None
+    # Hue in degrees (0-360)
+    d = float(mx - mn)
+    if mx == r:
+        h = (60.0 * ((g - b) / d)) % 360.0
+    elif mx == g:
+        h = 60.0 * ((b - r) / d) + 120.0
+    else:
+        h = 60.0 * ((r - g) / d) + 240.0
+    if h < 20 or h >= 335:
+        return "red"
+    if h < 48:
+        return "orange"
+    if h < 72:
+        return "yellow"
+    if h < 165:
+        return "green"
+    if h < 200:
+        return "cyan"
+    if h < 262:
+        return "blue"
+    return "purple"
+
+
+# Families close enough on the hue wheel that a parser naming either is
+# accepted (e.g. amber #c69200 may reasonably be called orange or yellow).
+_ADJACENT_FAMILIES: set[frozenset[str]] = {
+    frozenset({"red", "orange"}),
+    frozenset({"orange", "yellow"}),
+    frozenset({"green", "cyan"}),
+    frozenset({"cyan", "blue"}),
+    frozenset({"blue", "purple"}),
+    frozenset({"purple", "red"}),
+}
+
+
+def _families_match(expected: str, found: str) -> bool:
+    if expected == found:
+        return True
+    return frozenset({expected, found}) in _ADJACENT_FAMILIES
+
+
+def _extract_color_families(attrs_str: str) -> set[str]:
+    """Collect hue families from every color-like value in a tag attribute string."""
+    families: set[str] = set()
+    for m in _HEX_COLOR_RE.finditer(attrs_str):
+        hx = m.group(1)
+        if len(hx) == 3:
+            hx = "".join(c * 2 for c in hx)
+        fam = _rgb_to_hue_family(int(hx[0:2], 16), int(hx[2:4], 16), int(hx[4:6], 16))
+        if fam:
+            families.add(fam)
+    for m in _RGB_COLOR_RE.finditer(attrs_str):
+        fam = _rgb_to_hue_family(int(m.group(1)), int(m.group(2)), int(m.group(3)))
+        if fam:
+            families.add(fam)
+    for m in _NAMED_COLOR_ATTR_RE.finditer(attrs_str):
+        name = m.group(1).lower()
+        if name in _NAMED_COLOR_RGB:
+            fam = _rgb_to_hue_family(*_NAMED_COLOR_RGB[name])
+            if fam:
+                families.add(fam)
+    return families
+
+
+class TextColorRule(ParseTestRule):
+    """Test rule verifying that text carries a specific text color.
+
+    Passes when the text is found inside any HTML tag whose attributes carry a
+    color in the expected hue family. The expected ``color`` is a family name
+    (``red``, ``orange``, ``yellow``, ``green``, ``cyan``, ``blue``,
+    ``purple``); attribute values may be named colors, hex codes or ``rgb()``
+    triples, and adjacent hue families are accepted.
+    """
+
+    def __init__(self, rule_data: ParseTextColorRule | dict):
+        super().__init__(rule_data)
+        rule_data = cast(ParseTextColorRule, self._rule_data)
+
+        if self.type != TestType.TEXT_COLOR.value:
+            raise ValueError(f"Invalid type for TextColorRule: {self.type}")
+
+        raw_text = rule_data.text
+        if not raw_text.strip():
+            raise ValueError("Text field cannot be empty")
+        self.text = raw_text.strip()
+
+        raw_color = rule_data.color
+        if not raw_color.strip():
+            raise ValueError("Color field cannot be empty")
+        self.color = raw_color.strip().lower()
+
+    def run(self, md_content: str, normalized_content: str | None = None) -> tuple[bool, str]:
+        escaped_query = re.escape(self.text)
+        # Colorable tag pairs may wrap multiple paragraphs: the query's word
+        # gaps must be paragraph-spanning to match anywhere in the inner text.
+        flexible_query = _paragraph_spanning(_make_markup_tolerant(escaped_query))
+        text_pattern = re.compile(flexible_query, re.IGNORECASE)
+
+        found_families: set[str] = set()
+        for match in _COLORABLE_TAG_PATTERN.finditer(md_content):
+            attrs_str = match.group(2)
+            inner_text = match.group(3)
+            if not attrs_str.strip():
+                continue
+            if not text_pattern.search(inner_text):
+                continue
+            families = _extract_color_families(attrs_str)
+            found_families |= families
+            if any(_families_match(self.color, f) for f in families):
+                return True, ""
+
+        if found_families:
+            return (
+                False,
+                f"Expected '{self.text[:40]}' to have text color '{self.color}', "
+                f"but found color families {sorted(found_families)} instead",
+            )
+        return (
+            False,
+            f"Expected '{self.text[:40]}' to have text color '{self.color}', but no colored markup found around it",
+        )
+
+
 def _strip_latex_delimiters(formula: str) -> str:
     stripped = formula.strip()
     if stripped.startswith("$$") and stripped.endswith("$$") and len(stripped) >= 4:
@@ -490,24 +862,95 @@ def _strip_latex_delimiters(formula: str) -> str:
 def _normalize_latex_formula(formula: str) -> str:
     body = _strip_latex_delimiters(formula)
     body = _unescape_html_entities(body)
+    # These commands only control presentation. The benchmark cares about the
+    # mathematical expression, not delimiter sizing, display style, spacing,
+    # or whether an equation number was emitted as ``\tag`` versus ``\eqno``.
+    body = re.sub(r"\\(?:left|right)(?=\s|[()\[\]{}|.]|$)", "", body)
+    body = re.sub(r"\\[dt]frac\b", r"\\frac", body)
+    body = re.sub(r"\\(?:leq|le)\b", r"\\le", body)
+    body = re.sub(r"\\(?:geq|ge)\b", r"\\ge", body)
+    body = re.sub(r"\\text\s*\{([^{}]*)\}", r"\1", body)
+    body = re.sub(r"\\(?:display|text|script|scriptscript)style\b", "", body)
+    body = re.sub(r"\\(?:quad|qquad|,|;|:|!|>|enspace|hspace\*?\{[^{}]*\})", "", body)
+    body = re.sub(r"\\[ \t]+", "", body)
+    body = re.sub(r"\\tag\s*\{[^{}]*\}", "", body)
+    body = re.sub(r"\\eqno\s*(?:\([^()]*\)|\{[^{}]*\}|\S+)", "", body)
+    for unicode_operator, latex_operator in (
+        ("−", "-"),
+        ("×", r"\times"),
+        ("÷", r"\div"),
+        ("≤", r"\le"),
+        ("≥", r"\ge"),
+    ):
+        body = body.replace(unicode_operator, latex_operator)
     body = re.sub(r"\s+", "", body)
     return body
 
 
-def _extract_latex_formulas(md_content: str) -> set[str]:
-    formulas: set[str] = set()
+def _looks_like_inline_latex(body: str) -> bool:
+    """Reject prose/currency accidentally paired by two dollar signs.
+
+    Inline math cannot cross a Markdown line or an HTML tag boundary. Within
+    that scope, a multi-word body needs an actual LaTeX/math signal; this keeps
+    ``$10 million ... $20 million`` from becoming one giant fake formula while
+    retaining valid simple expressions such as ``$x$``.
+    """
+
+    stripped = body.strip()
+    if not stripped:
+        return False
+    if not re.search(r"\s", stripped):
+        return True
+    return bool(re.search(r"\\[A-Za-z]+|[=+\-*/^_<>|{}]", stripped))
+
+
+def _extract_latex_formula_spans(md_content: str, *, include_implausible_inline: bool = False) -> list[tuple[str, str]]:
+    formulas: list[tuple[str, str]] = []
     block_dollar = re.compile(r"(?<!\\)\$\$(.+?)(?<!\\)\$\$", re.DOTALL)
-    inline_dollar = re.compile(r"(?<!\\)\$(?!\$)(.+?)(?<!\\)\$(?!\$)", re.DOTALL)
+    # Inline math is line-local and cannot consume HTML markup. A bounded body
+    # also prevents one unmatched currency sign from pairing far downstream.
+    inline_dollar = re.compile(r"(?<!\\)\$(?!\$)([^$\r\n]{1,500}?)(?<!\\)\$(?!\$)")
     inline_paren = re.compile(r"\\\((.+?)\\\)", re.DOTALL)
     block_bracket = re.compile(r"\\\[(.+?)\\\]", re.DOTALL)
 
     for candidate in _title_content_candidates(md_content):
-        for pattern in (block_dollar, inline_dollar, inline_paren, block_bracket):
-            for match in pattern.finditer(candidate):
-                normalized = _normalize_latex_formula(match.group(1))
-                if normalized:
-                    formulas.add(normalized)
+        for kind, pattern, search_areas in (
+            ("block", block_dollar, (candidate,)),
+            # Split only at syntactically plausible HTML tags. A raw ``<`` or
+            # ``>`` is common inside math and must not break dollar pairing,
+            # while tag boundaries must never let currency in adjacent table
+            # cells masquerade as one inline formula.
+            (
+                "inline",
+                inline_dollar,
+                re.split(r"<[/!?A-Za-z][^>\r\n]*>", candidate),
+            ),
+            ("inline", inline_paren, (candidate,)),
+            ("block", block_bracket, (candidate,)),
+        ):
+            for search_area in search_areas:
+                for match in pattern.finditer(search_area):
+                    body = match.group(1)
+                    if kind == "inline" and not include_implausible_inline and not _looks_like_inline_latex(body):
+                        continue
+                    normalized = _normalize_latex_formula(body)
+                    if normalized:
+                        formulas.append((body, normalized))
     return formulas
+
+
+def _extract_latex_formulas(md_content: str) -> set[str]:
+    return {normalized for _, normalized in _extract_latex_formula_spans(md_content)}
+
+
+def _normalize_formula_text_for_negative_match(text: str) -> str:
+    text = _strip_latex_delimiters(_unescape_html_entities(text))
+    text = re.sub(r"\\text\s*\{([^{}]*)\}", r"\1", text)
+    text = text.replace(r"\_", "_").replace(r"\$", "$")
+    text = re.sub(r"\\[A-Za-z]+", " ", text)
+    for marker in "{}$":
+        text = text.replace(marker, " ")
+    return normalize_text(text).strip()
 
 
 class LatexRule(ParseTestRule):
@@ -551,6 +994,30 @@ class LatexRule(ParseTestRule):
                 else f"Expected LaTeX formula '{self.formula[:80]}' not found.{placeholder_hint}"
             ),
         )
+
+
+class NotLatexRule(ParseTestRule):
+    """Check that formula-like source text was not wrapped as LaTeX."""
+
+    def __init__(self, rule_data: ParseNotLatexRule | dict):
+        super().__init__(rule_data)
+        rule_data = cast(ParseNotLatexRule, self._rule_data)
+        if self.type != TestType.IS_NOT_LATEX.value:
+            raise ValueError(f"Invalid type for NotLatexRule: {self.type}")
+        if not isinstance(rule_data.text, str) or not rule_data.text.strip():
+            raise ValueError("text must be a non-empty string")
+        self.text = rule_data.text.strip()
+        self.normalized_text = _normalize_formula_text_for_negative_match(self.text)
+
+    def run(self, md_content: str, normalized_content: str | None = None) -> tuple[bool, str]:
+        # Negative rules are intentionally stricter than positive discovery:
+        # even an implausible ``$400 billion$`` span is wrong attribution for
+        # an annotated currency target and must not be ignored as prose.
+        for body, _ in _extract_latex_formula_spans(md_content, include_implausible_inline=True):
+            normalized_body = _normalize_formula_text_for_negative_match(body)
+            if self.normalized_text and self.normalized_text in normalized_body:
+                return False, f"Expected '{self.text[:80]}' to remain ordinary text, but it was emitted as LaTeX"
+        return True, ""
 
 
 def _extract_fenced_code_blocks(md_content: str) -> list[tuple[str, str]]:
@@ -655,7 +1122,10 @@ def _extract_title_events(md_content: str) -> list[tuple[int, int, str]]:
     seen: set[tuple[int, int, str]] = set()
 
     html_heading_regex = re.compile(r"<h([1-6])[^>]*>\s*(.*?)\s*</h\1>", re.IGNORECASE)
-    html_bold_line_regex = re.compile(r"^\s*<b[^>]*>\s*(.*?)\s*</b>\s*$", re.IGNORECASE)
+    html_bold_line_regex = re.compile(
+        r"^\s*<(?P<tag>b|strong)[^>]*>\s*(?P<text>.*?)\s*</(?P=tag)>\s*$",
+        re.IGNORECASE,
+    )
     md_heading_regex = re.compile(r"^\s*(#{1,6})\s+(.+?)\s*$")
     md_bold_line_regex = re.compile(r"^\s*\*\*\s*(.+?)\s*\*\*\s*$")
 
@@ -693,7 +1163,7 @@ def _extract_title_events(md_content: str) -> list[tuple[int, int, str]]:
 
             html_bold_match = html_bold_line_regex.match(line)
             if html_bold_match:
-                bold_text = re.sub(r"<[^>]+>", " ", html_bold_match.group(1)).strip()
+                bold_text = re.sub(r"<[^>]+>", " ", html_bold_match.group("text")).strip()
                 normalized = _normalize_title_label(bold_text)
                 if normalized:
                     key = (line_idx, 7, normalized)
@@ -710,7 +1180,7 @@ class TitleLevelRule(ParseTestRule):
 
     A title is satisfied if the text appears either:
     - as a markdown/HTML heading (`#`, `##`, ..., `<h1>`, ..., `<h6>`), or
-    - as bold text (`**text**` or `<b>text</b>`).
+    - as bold text (`**text**`, `<b>text</b>`, or `<strong>text</strong>`).
 
     The `level` field is currently ignored for matching; any heading level
     (1-6) or standalone bold title line can satisfy the rule.
@@ -736,16 +1206,28 @@ class TitleLevelRule(ParseTestRule):
         Also tolerates escaped markup payloads (e.g. `&lt;h1&gt;...&lt;/h1&gt;`,
         `\\# Title`, `\\*\\*Title\\*\\*`) by checking decoded/de-escaped variants.
         """
+        # A title query that is nothing but markdown markers names no title -
+        # it came from an ASCII banner. Skip rather than score 0.0, which would
+        # otherwise pin ``normalized_title_accuracy`` on a correct parse.
+        if is_degenerate_marker_text(self.text):
+            raise RuleNotApplicable(f"is_title text {self.text!r} is markdown markers only")
+
         escaped = re.escape(self.text)
         # Allow flexible whitespace and optional inline markup between words
         flexible = _make_markup_tolerant(escaped)
 
+        # [ \t] and a line-confined query: heading text lives on one line, and
+        # both \s+ and the query's own word gaps would otherwise cross the
+        # newline and match a phrase that continues into the paragraph below.
         md_heading_pattern = re.compile(
-            r"^#{1,6}\s+" + flexible,
+            r"^#{1,6}[ \t]+" + _confined_to_line(flexible),
             re.MULTILINE | re.IGNORECASE,
         )
+        # HTML tag pairs may wrap multiple paragraphs, so their arms use
+        # paragraph-spanning query gaps; the markdown ** arm keeps the scoped
+        # gaps because emphasis cannot cross a blank line.
         html_heading_pattern = re.compile(
-            r"<h[1-6][^>]*>\s*" + flexible + r"\s*</h[1-6]>",
+            r"<h[1-6][^>]*>\s*" + _paragraph_spanning(flexible) + r"\s*</h[1-6]>",
             re.IGNORECASE,
         )
 
@@ -755,7 +1237,7 @@ class TitleLevelRule(ParseTestRule):
             re.MULTILINE | re.IGNORECASE,
         )
         html_bold_pattern = re.compile(
-            r"^\s*<b[^>]*>\s*" + flexible + r"\s*</b>\s*$",
+            r"^\s*<(?P<tag>b|strong)[^>]*>\s*" + _paragraph_spanning(flexible) + r"\s*</(?P=tag)>\s*$",
             re.MULTILINE | re.IGNORECASE,
         )
 
@@ -796,8 +1278,10 @@ class TitleHierarchyPercentRule(ParseTestRule):
         if self.type != TestType.TITLE_HIERARCHY_PERCENT.value:
             raise ValueError(f"Invalid type for TitleHierarchyPercentRule: {self.type}")
 
-        if not isinstance(rule_data.title_hierarchy, dict) or not rule_data.title_hierarchy:
-            raise ValueError("title_hierarchy must be a non-empty dictionary")
+        if not isinstance(rule_data.title_hierarchy, dict):
+            raise ValueError("title_hierarchy must be a dictionary")
+        # Emptiness is not rejected here: an empty hierarchy carries no
+        # constraint, which ``run`` reports as inapplicable rather than failed.
         self.title_hierarchy = rule_data.title_hierarchy
 
     @staticmethod
@@ -880,12 +1364,17 @@ class TitleHierarchyPercentRule(ParseTestRule):
                 first_level[title] = level
 
         expected_titles, edges = self._collect_constraints(self.title_hierarchy)
+        # No label survived normalization - the hierarchy is pure markup,
+        # whitespace, non-string keys, or empty. There is no constraint to
+        # check, so the rule is skipped rather than scored 0.0. (A hierarchy
+        # that IS defined but absent from the output falls through below and
+        # still scores 0.0, which is a real failure.)
         if not expected_titles:
-            return False, "title_hierarchy has no valid titles after normalization", 0.0
+            raise RuleNotApplicable("title_hierarchy has no valid titles after normalization")
 
         total_constraints = len(expected_titles) + len(edges)
         if total_constraints == 0:
-            return False, "title_hierarchy has no evaluable constraints", 0.0
+            raise RuleNotApplicable("title_hierarchy has no evaluable constraints")
 
         satisfied = 0
         failures: list[str] = []

--- a/src/parse_bench/evaluation/metrics/parse/rules_table.py
+++ b/src/parse_bench/evaluation/metrics/parse/rules_table.py
@@ -2,10 +2,13 @@
 
 import json
 import re
+import unicodedata
 from collections import Counter
+from html import unescape
 from typing import Any, cast
 
 import pandas as pd
+from bs4 import BeautifulSoup
 from rapidfuzz import fuzz
 from unidecode import unidecode
 
@@ -34,6 +37,7 @@ from parse_bench.test_cases.parse_rule_schemas import (
     ParseTableColspanRule,
     ParseTableHeaderChainRule,
     ParseTableLeftHeaderRule,
+    ParseTableMarkerCellsRule,
     ParseTableNoAboveRule,
     ParseTableNoBelowRule,
     ParseTableNoLeftRule,
@@ -47,6 +51,247 @@ from parse_bench.test_cases.parse_rule_schemas import (
     ParseTablesValuesRule,
     ParseTableTopHeaderRule,
 )
+
+_DEFAULT_TABLE_MARKER_ALIASES = {
+    "x",
+    "y",
+    "n",
+    "yes",
+    "no",
+    "check",
+    "checked",
+    "✓",
+    "✔",
+    "☑",
+    "✅",
+    "✗",
+    "✘",
+    "×",
+    "•",
+    "●",
+    "∙",
+    "○",
+    "◉",
+    "◦",
+    "■",
+    "□",
+    "▪",
+    "▫",
+    "◼",
+    "◻",
+    "◆",
+    "◇",
+    "♦",
+    "★",
+    "☆",
+    "→",
+    "←",
+    "↑",
+    "↓",
+    "▲",
+    "▼",
+    "+",
+    "!",
+    "selected",
+    "green",
+    "red",
+    "yellow",
+    "orange",
+    "grey",
+    "gray",
+    "green square",
+    "red square",
+    "yellow square",
+    "orange square",
+    "grey square",
+    "gray square",
+    "expert knowledge",
+    "good knowledge",
+    "basic knowledge",
+}
+_MARKDOWN_IMAGE_RE = re.compile(r"!\[[^\]]*\]\([^)]*\)", re.DOTALL)
+_BRACKETED_IMAGE_LABEL_RE = re.compile(r"\[\s*(?:icon|image)(?::[^\]]+)?\s*\]", re.IGNORECASE)
+_HTML_IMAGE_RE = re.compile(r"<img\b[^>]*>", re.IGNORECASE)
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+_HTML_IMAGE_CELL_SENTINEL = "llamacloud-bench-image-cell"
+_MARKER_LIST_TOKEN = "<marker-list>"
+
+
+def _preserve_html_image_cells(content: str) -> str:
+    """Replace images inside HTML cells with text visible to ``parse_html_tables``.
+
+    The generic HTML table parser intentionally extracts text with
+    ``BeautifulSoup.get_text()``, which drops ``<img>`` elements.  Work on a
+    private copy here so image presence is retained for this rule without
+    changing cell values seen by every other table evaluator.
+    """
+
+    if not _HTML_IMAGE_RE.search(content):
+        return content
+    soup = BeautifulSoup(content, "lxml")
+    changed = False
+    for cell in soup.find_all(["td", "th"]):
+        if cell.find("img") is None:
+            continue
+        cell.clear()
+        cell.append(_HTML_IMAGE_CELL_SENTINEL)
+        changed = True
+    return str(soup) if changed else content
+
+
+def _marker_cell_token(value: object, aliases: set[str], allow_ocr_glyphs: bool) -> str | None:
+    raw = unescape(str(value)).strip()
+    if not raw:
+        return None
+    if (
+        _HTML_IMAGE_CELL_SENTINEL in raw
+        or _MARKDOWN_IMAGE_RE.search(raw)
+        or _BRACKETED_IMAGE_LABEL_RE.search(raw)
+        or _HTML_IMAGE_RE.search(raw)
+    ):
+        return "<image>"
+
+    token = " ".join(_HTML_TAG_RE.sub("", raw).split()).casefold()
+    if not token:
+        return None
+    if token in aliases:
+        return token
+    marker_list = [part.strip() for part in re.split(r"[,;/]", token)]
+    if len(marker_list) > 1 and all(part in aliases for part in marker_list):
+        return _MARKER_LIST_TOKEN
+    # Markers are sometimes serialized beside their numeric or textual value,
+    # for example ``▲ 512.40`` or ``✓ Announced``.  Only accept a leading
+    # alias when it is punctuation/symbol-like; ordinary word aliases must
+    # still occupy the whole cell to avoid matching prose.
+    leading_token = token.split(maxsplit=1)[0]
+    if leading_token in aliases and all(unicodedata.category(char)[0] in {"P", "S"} for char in leading_token):
+        return leading_token
+    if len(token) >= 3 and (token[0], token[-1]) in {("[", "]"), ("(", ")"), ("{", "}")}:
+        inner = token[1:-1].strip()
+        if inner in aliases:
+            return inner
+    if not allow_ocr_glyphs or len(token) > 3 or any(char.isspace() or char.isdigit() for char in token):
+        return None
+
+    # Visual markers are frequently OCR'd as a non-ASCII glyph (for example
+    # Harley-Davidson's badge becomes Cyrillic Ө). Accept short non-ASCII
+    # glyphs, plus Unicode symbols/punctuation, but leave ordinary ASCII words
+    # and punctuation out so abbreviations and missing-value dashes do not
+    # become false markers. ASCII symbols must be configured as aliases.
+    if any(ord(char) > 127 for char in token):
+        return token
+    return None
+
+
+class TableMarkerCellsRule(ParseTestRule):
+    """Check that repeated icon-like values remain inside a table grid."""
+
+    def __init__(self, rule_data: ParseTableMarkerCellsRule | dict):
+        super().__init__(rule_data)
+        rule_data = cast(ParseTableMarkerCellsRule, self._rule_data)
+        if self.type != TestType.TABLE_MARKER_CELLS.value:
+            raise ValueError(f"Invalid type for TableMarkerCellsRule: {self.type}")
+        self.min_count = rule_data.min_count
+        self.min_distinct_rows = rule_data.min_distinct_rows
+        self.min_distinct_columns = rule_data.min_distinct_columns
+        self.marker_aliases = {
+            " ".join(unescape(alias).split()).casefold()
+            for alias in [*_DEFAULT_TABLE_MARKER_ALIASES, *rule_data.marker_aliases]
+            if alias.strip()
+        }
+        self.allow_repeated_ocr_glyphs = rule_data.allow_repeated_ocr_glyphs
+
+    def run(self, content: str, normalized_content: str | None = None) -> tuple[bool, str]:
+        tables = [*parse_markdown_tables(content), *parse_html_tables(_preserve_html_image_cells(content))]
+        if not tables:
+            self.result_details = {
+                "requirement": self._requirement_summary(),
+                "tables_inspected": 0,
+                "diagnosis": "The parser emitted no recognizable Markdown or HTML table.",
+            }
+            return False, "No tables found; icon-valued cells could not be evaluated"
+
+        best = (0, 0, 0)
+        best_table: dict[str, Any] = {}
+        for table_index, table in enumerate(tables, start=1):
+            positions_by_token: dict[str, list[tuple[int, int]]] = {}
+            for row in range(table.data.shape[0]):
+                for column in range(table.data.shape[1]):
+                    token = _marker_cell_token(
+                        table.data[row, column],
+                        self.marker_aliases,
+                        self.allow_repeated_ocr_glyphs,
+                    )
+                    if token is not None:
+                        positions_by_token.setdefault(token, []).append((row, column))
+
+            # A short OCR glyph only counts as a marker when it repeats. Known
+            # aliases and image-only cells are already semantically explicit.
+            positions = [
+                position
+                for token, token_positions in positions_by_token.items()
+                if token in self.marker_aliases or token in {"<image>", _MARKER_LIST_TOKEN} or len(token_positions) >= 2
+                for position in token_positions
+            ]
+            score = (
+                len(positions),
+                len({row for row, _ in positions}),
+                len({column for _, column in positions}),
+            )
+            table_details = {
+                "index": table_index,
+                "shape": f"{table.data.shape[0]} rows x {table.data.shape[1]} columns",
+                "marker_cells": score[0],
+                "marker_rows": score[1],
+                "marker_columns": score[2],
+                "recognized_tokens": {
+                    token: len(token_positions) for token, token_positions in sorted(positions_by_token.items())
+                },
+            }
+            if score > best or not best_table:
+                best = score
+                best_table = table_details
+            if (
+                score[0] >= self.min_count
+                and score[1] >= self.min_distinct_rows
+                and score[2] >= self.min_distinct_columns
+            ):
+                self.result_details = {
+                    "requirement": self._requirement_summary(),
+                    "tables_inspected": len(tables),
+                    "matching_table": table_details,
+                }
+                return True, ""
+
+        diagnosis = self._failure_diagnosis(best)
+        self.result_details = {
+            "requirement": self._requirement_summary(),
+            "tables_inspected": len(tables),
+            "best_table": best_table,
+            "diagnosis": diagnosis,
+        }
+
+        return (
+            False,
+            f"Icon-table rule failed: {diagnosis} "
+            f"Best table had {best[0]} marker cells across {best[1]} rows and {best[2]} columns; "
+            f"required {self._requirement_summary()}.",
+        )
+
+    def _requirement_summary(self) -> str:
+        return (
+            f">={self.min_count} marker cells across >={self.min_distinct_rows} rows "
+            f"and >={self.min_distinct_columns} columns"
+        )
+
+    def _failure_diagnosis(self, best: tuple[int, int, int]) -> str:
+        if best[0] < self.min_count:
+            if best[0] == 0:
+                return "tables were found, but no repeated recognized marker-only values remained in their cells."
+            return f"only {best[0]} recognized marker cells remained; at least {self.min_count} are required."
+        if best[1] < self.min_distinct_rows:
+            return f"markers occupied only {best[1]} table rows; at least {self.min_distinct_rows} are required."
+        return f"markers occupied only {best[2]} table column(s); at least {self.min_distinct_columns} are required."
 
 
 class TableRule(ParseTestRule):

--- a/src/parse_bench/evaluation/metrics/parse/rules_text.py
+++ b/src/parse_bench/evaluation/metrics/parse/rules_text.py
@@ -214,6 +214,20 @@ class BaselineRule(ParseTestRule):
 class TextOrderRule(ParseTestRule):
     """Test rule to verify that one text appears before another."""
 
+    # Residual HTML markup left behind by ``normalize_text`` (structural tags such
+    # as <table>/<tr>/<td>, which it does not touch). Order anchors are authored
+    # against plain markdown and routinely span a label and its value, so any page
+    # the parser renders as a table puts a `</td><td>` inside the anchor and the
+    # rule could never match. Substituting a SPACE — never the empty string —
+    # keeps cell contents from welding into one unmatchable token, and matches how
+    # the word/sentence bag rules already treat markup.
+    _HTML_TAG_PATTERN = re.compile(r"</?[^>]+>")
+
+    @classmethod
+    def _strip_html(cls, text: str) -> str:
+        """Replace residual HTML tags with a space and collapse the runs."""
+        return re.sub(r" +", " ", cls._HTML_TAG_PATTERN.sub(" ", text)).strip()
+
     def __init__(self, rule_data: ParseOrderRule | dict):
         super().__init__(rule_data)
         rule_data = cast(ParseOrderRule, self._rule_data)
@@ -235,6 +249,12 @@ class TextOrderRule(ParseTestRule):
 
         self.before = re.sub(r" +", " ", SentenceBagRule._MULTI_DOT_PATTERN.sub(" ", normalize_fn(before_for_match)))
         self.after = re.sub(r" +", " ", SentenceBagRule._MULTI_DOT_PATTERN.sub(" ", normalize_fn(after_for_match)))
+        # Strip markup on the rule side too, so anchor and content are compared in
+        # the same alphabet. Skipped for keep_formatting rules, whose whole point is
+        # to assert on the styling tags themselves.
+        if not self.keep_formatting:
+            self.before = self._strip_html(self.before)
+            self.after = self._strip_html(self.after)
         if not self.before.strip():
             raise ValueError("Before field cannot be empty")
         if not self.after.strip():
@@ -259,6 +279,8 @@ class TextOrderRule(ParseTestRule):
         else:
             normalized_content = normalize_text(content_for_match)
         normalized_content = re.sub(r" +", " ", SentenceBagRule._MULTI_DOT_PATTERN.sub(" ", normalized_content))
+        if not self.keep_formatting:
+            normalized_content = self._strip_html(normalized_content)
 
         # OPTIMIZATION: Try exact match first (O(n) vs O(n*m) for fuzzy)
         # This provides ~10-100x speedup for rules that match exactly

--- a/src/parse_bench/evaluation/metrics/parse/table_extraction.py
+++ b/src/parse_bench/evaluation/metrics/parse/table_extraction.py
@@ -9,6 +9,7 @@ dropped silently (model bug — dropped tables count as unmatched_expected
 for any GT they would have paired with, so the model still pays the score).
 """
 
+import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -16,6 +17,9 @@ from parse_bench.evaluation.metrics.parse.table_parsing import TableData, parse_
 
 if TYPE_CHECKING:
     from parse_bench.evaluation.metrics.parse.table_title_stripping import HeaderHints
+
+_TABLE_OPEN_RE = re.compile(r"<table(?=[>\s])", re.IGNORECASE)
+_TABLE_CLOSE_RE = re.compile(r"</table\s*>", re.IGNORECASE)
 
 
 def extract_html_tables(content: str) -> list[str]:
@@ -29,47 +33,31 @@ def extract_html_tables(content: str) -> list[str]:
         return []
 
     tables: list[str] = []
-    lower = content.lower()
     search_start = 0
     while True:
-        start = lower.find("<table", search_start)
-        if start == -1:
+        open_match = _TABLE_OPEN_RE.search(content, search_start)
+        if open_match is None:
             break
-        # Verify this is a real <table> tag, not e.g. <tabledata>
-        tag_name_end = start + len("<table")
-        if tag_name_end < len(lower) and lower[tag_name_end] not in (">", " ", "\t", "\n", "\r"):
-            search_start = start + 1
-            continue
+        start = open_match.start()
 
         # Track nesting depth to find the matching </table>
         depth = 0
-        pos = start
+        pos = open_match.end()
         end = -1
-        while pos < len(lower):
-            next_open = lower.find("<table", pos + 1)
-            next_close = lower.find("</table>", pos + 1)
-            if next_close == -1:
+        while pos < len(content):
+            next_open = _TABLE_OPEN_RE.search(content, pos)
+            next_close = _TABLE_CLOSE_RE.search(content, pos)
+            if next_close is None:
                 break
-            # Verify nested <table> is a real tag too
-            if next_open != -1 and next_open < next_close:
-                nested_name_end = next_open + len("<table")
-                if nested_name_end < len(lower) and lower[nested_name_end] not in (
-                    ">",
-                    " ",
-                    "\t",
-                    "\n",
-                    "\r",
-                ):
-                    pos = next_open  # Not a real tag, skip
-                    continue
+            if next_open is not None and next_open.start() < next_close.start():
                 depth += 1
-                pos = next_open
+                pos = next_open.end()
             else:
                 if depth == 0:
-                    end = next_close + len("</table>")
+                    end = next_close.end()
                     break
                 depth -= 1
-                pos = next_close
+                pos = next_close.end()
         if end == -1:
             tables.append(content[start:])
             break

--- a/src/parse_bench/evaluation/metrics/parse/table_pairing.py
+++ b/src/parse_bench/evaluation/metrics/parse/table_pairing.py
@@ -1,0 +1,87 @@
+"""Shared GT->pred table assignment for the table-similarity metrics.
+
+GriTS and TEDS both build an ``n_expected x n_actual`` cost matrix and solve a
+single document-global Hungarian assignment over it. On multi-page documents
+that recur near-identical tables across pages, the global assignment mis-pairs a
+GT table on one page with a prediction on another. When per-table page labels
+are available, ``assign_tables`` instead solves the assignment **per page** so a
+GT table only ever pairs with a prediction on the same page.
+
+The return shape mirrors ``scipy.optimize.linear_sum_assignment`` — a
+``(row_ind, col_ind)`` pair of equal-length index lists — so callers consume it
+exactly as before.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+import numpy as np
+from scipy.optimize import linear_sum_assignment
+
+
+def page_blocking_active(
+    expected_pages: list[int] | None,
+    actual_pages: list[int] | None,
+    n_expected: int,
+    n_actual: int,
+) -> bool:
+    """Return True when page-constrained matching can and should be applied.
+
+    Requires both page-label lists to be present and length-consistent with the
+    table counts. Any mismatch (missing labels, wrong length) falls back to the
+    document-global assignment, so the feature is self-disabling.
+    """
+    return (
+        expected_pages is not None
+        and actual_pages is not None
+        and len(expected_pages) == n_expected
+        and len(actual_pages) == n_actual
+    )
+
+
+def assign_tables(
+    cost_matrix: np.ndarray,
+    expected_pages: list[int] | None = None,
+    actual_pages: list[int] | None = None,
+) -> tuple[list[int], list[int]]:
+    """Solve the GT->pred table assignment minimizing total cost.
+
+    When ``expected_pages`` / ``actual_pages`` are provided and consistent with
+    ``cost_matrix.shape`` (see :func:`page_blocking_active`), the assignment is
+    solved independently per page: a GT table on page P can only pair with a
+    prediction on page P. GT tables whose page has no predictions are left
+    unmatched (they appear in neither returned list, so the caller scores them
+    as unmatched-expected). Otherwise a single global assignment is solved.
+
+    Returns ``(row_ind, col_ind)`` as index lists, mirroring
+    ``scipy.optimize.linear_sum_assignment``.
+    """
+    n_expected, n_actual = cost_matrix.shape
+
+    if not page_blocking_active(expected_pages, actual_pages, n_expected, n_actual):
+        row_ind, col_ind = linear_sum_assignment(cost_matrix)
+        return row_ind.tolist(), col_ind.tolist()
+
+    assert expected_pages is not None and actual_pages is not None  # narrowed by the guard above
+
+    pred_by_page: dict[int, list[int]] = defaultdict(list)
+    for j, page in enumerate(actual_pages):
+        pred_by_page[page].append(j)
+
+    gt_by_page: dict[int, list[int]] = defaultdict(list)
+    for i, page in enumerate(expected_pages):
+        gt_by_page[page].append(i)
+
+    row_out: list[int] = []
+    col_out: list[int] = []
+    for page, gt_idxs in gt_by_page.items():
+        pred_idxs = pred_by_page.get(page)
+        if not pred_idxs:
+            continue
+        sub = cost_matrix[np.ix_(gt_idxs, pred_idxs)]
+        sub_rows, sub_cols = linear_sum_assignment(sub)
+        for sr, sc in zip(sub_rows.tolist(), sub_cols.tolist(), strict=True):
+            row_out.append(gt_idxs[sr])
+            col_out.append(pred_idxs[sc])
+    return row_out, col_out

--- a/src/parse_bench/evaluation/metrics/parse/table_parsing.py
+++ b/src/parse_bench/evaluation/metrics/parse/table_parsing.py
@@ -22,6 +22,31 @@ _SUBSCRIPT_DIGITS = "\u2080\u2081\u2082\u2083\u2084\u2085\u2086\u2087\u2088\u208
 _ASCII_TO_SUPERSCRIPT = dict(zip("0123456789", _SUPERSCRIPT_DIGITS, strict=True))
 _ASCII_TO_SUBSCRIPT = dict(zip("0123456789", _SUBSCRIPT_DIGITS, strict=True))
 
+# The content-preserving inline styling elements, mirroring
+# ``_INLINE_STYLE_MARKER_RUN_RE`` in ``utils.py``.  ``sup``/``sub`` are excluded
+# for the same reason they are there: they are handled by _sup_sub_to_unicode.
+_INLINE_STYLE_TAGS = frozenset({"b", "i", "u", "s", "del", "strike", "ins", "mark", "span"})
+
+
+def _separate_abutting_inline_markers(cell: Tag) -> None:
+    """Insert a space between two abutting inline styling elements.
+
+    ``get_text()`` concatenates text nodes with no separator, so a byte-faithful
+    ``<u>105</u><s>103</s>`` extracts as ``105103`` and the two page numbers are
+    welded into one unmatchable token.  This is the cell-text counterpart of
+    ``_INLINE_STYLE_MARKER_RUN_RE`` in ``utils.py``: the whole-document path
+    folds such a run to a space, but a cell's text never reaches that path with
+    its markup intact once tables are replaced by their cell text.
+
+    A LONE marker still joins, exactly as in ``normalize_text`` - inline tags are
+    genuinely used intra-word (Japanese ``<u>`` opening mid-sentence) - so only
+    the boundary BETWEEN two marker elements is separated.
+    """
+    for tag in cell.find_all(lambda t: t.name in _INLINE_STYLE_TAGS):
+        nxt = tag.next_sibling
+        if isinstance(nxt, Tag) and nxt.name in _INLINE_STYLE_TAGS:
+            tag.insert_after(" ")
+
 
 def _sup_sub_to_unicode(cell: Tag) -> None:
     """Convert ``<sup>``/``<sub>`` digit content to Unicode equivalents.
@@ -58,6 +83,31 @@ class TableData:
     # answer "is (row, col) from a <th>?" without conflating span expansion
     # with hierarchical header levels in col_headers.
     header_cells: set[tuple[int, int]] = field(default_factory=set)
+    # Grid positions that only exist because a cell was expanded across a
+    # rowspan/colspan.  The originating position is *not* included, so callers
+    # that must visit each authored cell exactly once (e.g. bag-of-word
+    # extraction) can skip these without losing the cell itself.
+    spanned_cells: set[tuple[int, int]] = field(default_factory=set)
+    # Rows the source HTML placed inside an explicit <thead>. A subset of
+    # ``header_rows``, which also absorbs any row merely *containing* a <th> —
+    # including body rows whose label cell is a <th> row header. Keeping the
+    # authored <thead> separate lets header analysis tell "the document says
+    # this is part of the column-header block" from "this row happens to hold
+    # a <th>".
+    thead_rows: set[int] = field(default_factory=set)
+    # Rows the source HTML placed inside an explicit <tbody>. This preserves
+    # the distinction between an implicit top-level <th> header block and a
+    # body row that happens to use <th> for its row label.
+    tbody_rows: set[int] = field(default_factory=set)
+    # Rows the source HTML placed inside an explicit <tfoot>. Footer cells are
+    # never column headers for a chart value, even when malformed markup puts
+    # the footer before the body.
+    tfoot_rows: set[int] = field(default_factory=set)
+    # Rows containing an explicit HTML scope declaration. This preserves the
+    # author’s column-versus-row intent without changing generic <th> parsing.
+    column_scope_rows: set[int] = field(default_factory=set)
+    row_scope_rows: set[int] = field(default_factory=set)
+    caption: str = field(default="")  # <caption> text, which lives inside the table but outside any cell
     context_before: str = field(default="")  # Text before table (for chart titles)
     context_after: str = field(default="")  # Text after table (for captions)
 
@@ -266,6 +316,26 @@ def parse_html_tables(html_content: str) -> list[TableData]:
             nested.replace_with(nested.get_text(" ", strip=True))
 
         rows = table.find_all(["tr"])
+        # BeautifulSoup compares Tag instances structurally, so identical
+        # ``<tr>`` elements can compare equal. Provenance needs each source
+        # row's physical position, not the first structurally equal row.
+        row_indices = {id(row): row_idx for row_idx, row in enumerate(rows)}
+
+        # ``scope=colgroup`` and ``scope=rowgroup`` refer to the authored
+        # structural group, not merely to the cell's explicit span. Preserve
+        # those groups here so scoped headers can be expanded semantically
+        # without pretending that the source cell itself had a larger span.
+        colgroup_ranges: list[range] = []
+        next_col = 0
+        for colgroup in table.find_all("colgroup", recursive=False):
+            cols = colgroup.find_all("col", recursive=False)
+            width = 0
+            for col in cols:
+                width += int(col.get("span", 1))  # type: ignore[arg-type]
+            if not cols:
+                width = int(colgroup.get("span", 1))  # type: ignore[arg-type]
+            colgroup_ranges.append(range(next_col, next_col + width))
+            next_col += width
 
         # Extract <caption> text if present (used as chart title context)
         caption_elem = table.find("caption")
@@ -278,17 +348,37 @@ def parse_html_tables(html_content: str) -> list[TableData]:
         # Maps row index to all header cells to its left
         row_headers: dict[int, list[tuple[int, str]]] = {}
 
+        row_group_rows: dict[int, set[int]] = {}
+
         # Find rows inside thead tags - these are definitely header rows
-        thead = table.find("thead")
-        if thead:
-            thead_rows = thead.find_all("tr")
-            for tr in thead_rows:
-                if tr in rows:
-                    header_rows.add(rows.index(tr))
+        thead_row_indices: set[int] = set()
+        for thead in table.find_all("thead", recursive=False):
+            section_rows = {row_indices[id(tr)] for tr in thead.find_all("tr") if id(tr) in row_indices}
+            thead_row_indices |= section_rows
+            for row_idx in section_rows:
+                row_group_rows[row_idx] = section_rows
+        header_rows |= thead_row_indices
+
+        tbody_row_indices: set[int] = set()
+        for tbody in table.find_all("tbody", recursive=False):
+            section_rows = {row_indices[id(tr)] for tr in tbody.find_all("tr") if id(tr) in row_indices}
+            tbody_row_indices |= section_rows
+            for row_idx in section_rows:
+                row_group_rows[row_idx] = section_rows
+
+        tfoot_row_indices: set[int] = set()
+        for tfoot in table.find_all("tfoot", recursive=False):
+            section_rows = {row_indices[id(tr)] for tr in tfoot.find_all("tr") if id(tr) in row_indices}
+            tfoot_row_indices |= section_rows
+            for row_idx in section_rows:
+                row_group_rows[row_idx] = section_rows
 
         # Initialize a grid to track filled cells due to rowspan/colspan
         cell_grid = {}
         header_cells: set[tuple[int, int]] = set()
+        column_scope_rows: set[int] = set()
+        row_scope_rows: set[int] = set()
+        spanned_cells: set[tuple[int, int]] = set()
         col_span_info = {}  # Tracks which columns contain headers
         row_span_info = {}  # Tracks which rows contain headers
 
@@ -311,15 +401,23 @@ def parse_html_tables(html_content: str) -> list[TableData]:
                 # so that "Name<sup>1</sup>" becomes "Name¹", matching the
                 # representation when sources already use Unicode superscripts.
                 _sup_sub_to_unicode(cell)
+                # Two abutting inline markers are a token boundary, not a join.
+                _separate_abutting_inline_markers(cell)
                 cell_text = cell.get_text().strip()
 
                 # Check if this is a header cell
                 is_header = cell.name == "th"
+                scope = str(cell.get("scope", "")).lower()
                 if is_header:
                     header_rows.add(row_idx)
                     header_cols.add(col_idx)
                     col_span_info[col_idx] = True
                     row_span_info[row_idx] = True
+                    if row_idx not in tfoot_row_indices:
+                        if scope in {"col", "colgroup"}:
+                            column_scope_rows.add(row_idx)
+                        elif scope in {"row", "rowgroup"}:
+                            row_scope_rows.add(row_idx)
 
                 # Get rowspan and colspan
                 rowspan = int(cell.get("rowspan", 1))  # type: ignore[arg-type]
@@ -329,22 +427,35 @@ def parse_html_tables(html_content: str) -> list[TableData]:
                 for r in range(row_idx, row_idx + rowspan):
                     for c in range(col_idx, col_idx + colspan):
                         cell_grid[(r, c)] = cell_text
+                        if (r, c) != (row_idx, col_idx):
+                            spanned_cells.add((r, c))
                         if is_header:
                             header_cells.add((r, c))
 
                 # Update col_headers and row_headers if this is a header
-                if is_header:
+                if is_header and row_idx not in tfoot_row_indices:
                     # Add to col_headers for all columns this cell spans
-                    for c in range(col_idx, col_idx + colspan):
-                        if c not in col_headers:
-                            col_headers[c] = []
-                        col_headers[c].append((row_idx, cell_text))
+                    if scope not in {"row", "rowgroup"}:
+                        scoped_columns = range(col_idx, col_idx + colspan)
+                        if scope == "colgroup":
+                            scoped_columns = next(
+                                (group for group in colgroup_ranges if col_idx in group),
+                                scoped_columns,
+                            )
+                        for c in scoped_columns:
+                            if c not in col_headers:
+                                col_headers[c] = []
+                            col_headers[c].append((row_idx, cell_text))
 
                     # Add to row_headers for all rows this cell spans
-                    for r in range(row_idx, row_idx + rowspan):
-                        if r not in row_headers:
-                            row_headers[r] = []
-                        row_headers[r].append((col_idx, cell_text))
+                    if scope not in {"col", "colgroup"}:
+                        scoped_rows = set(range(row_idx, row_idx + rowspan))
+                        if scope == "rowgroup":
+                            scoped_rows = row_group_rows.get(row_idx, scoped_rows)
+                        for r in scoped_rows:
+                            if r not in row_headers:
+                                row_headers[r] = []
+                            row_headers[r].append((col_idx, cell_text))
 
                 col_idx += colspan
 
@@ -421,6 +532,13 @@ def parse_html_tables(html_content: str) -> list[TableData]:
                 col_headers=col_headers,
                 row_headers=row_headers,
                 header_cells=header_cells,
+                spanned_cells=spanned_cells,
+                thead_rows=thead_row_indices,
+                tbody_rows=tbody_row_indices,
+                tfoot_rows=tfoot_row_indices,
+                column_scope_rows=column_scope_rows,
+                row_scope_rows=row_scope_rows,
+                caption=caption_text,
                 context_before=context_before,
                 context_after=context_after,
             )

--- a/src/parse_bench/evaluation/metrics/parse/table_record_match_metric.py
+++ b/src/parse_bench/evaluation/metrics/parse/table_record_match_metric.py
@@ -33,7 +33,12 @@ from parse_bench.evaluation.metrics.parse.table_title_stripping import (
 from parse_bench.evaluation.metrics.parse.utils import (
     _normalize_sub_sup_for_table as _shared_normalize_sub_sup,
 )
-from parse_bench.evaluation.metrics.parse.utils import normalize_text
+from parse_bench.evaluation.metrics.parse.utils import (
+    _normalize_table_boolean_marker,
+    cells_match_leader_insensitive,
+    normalize_text,
+    strip_dot_leaders,
+)
 from parse_bench.schemas.evaluation import MetricValue
 
 logger = logging.getLogger(__name__)
@@ -86,12 +91,19 @@ def _normalize_trm_cell_text(text: str) -> str:
        - "1,000%"  → "1000%"
        - "1,000,000" → "1000000"
        - But NOT "Smith, John" (commas between non-digit chars are preserved)
+    4. Normalize whole-cell boolean markers ("✓", "✗", "●", "[yes]",
+       "[no]") to yes/no.
     """
+    marker = _normalize_table_boolean_marker(text)
+    if marker != text:
+        return marker
+
     # --- leader dots (e.g. "Item ......... 5" or "Item . . . . 5") ---
     # These are visual fillers whose exact count is meaningless; strip them
-    # so ground-truth and prediction don't diverge on dot count.
-    text = re.sub(r"(?:\.\s){2,}\.?", "", text)  # ". . . ." style
-    text = re.sub(r"\.{2,}", "", text)  # "........" style
+    # so ground-truth and prediction don't diverge on dot count. The run
+    # definition lives in ``utils.strip_dot_leaders`` and is shared with
+    # ``normalize_cell_text`` so GriTS and TRM cannot drift apart on it.
+    text = strip_dot_leaders(text)
     text = re.sub(r"  +", " ", text).strip()  # collapse leftover whitespace
 
     # --- whitespace around punctuation ---
@@ -112,6 +124,14 @@ def _normalize_trm_cell_text(text: str) -> str:
     return text
 
 
+def _normalize_trm_table_text(text: str) -> str:
+    """Normalize one TRM table cell/header while preserving marker order."""
+    text = _normalize_sub_sup_for_table(text)
+    text = _normalize_table_boolean_marker(text)
+    text = normalize_text(text)
+    return _normalize_trm_cell_text(text)
+
+
 def normalize_table(table: TableData) -> TableData:
     """Normalize all cell text in a table for comparison.
 
@@ -127,24 +147,14 @@ def normalize_table(table: TableData) -> TableData:
     normalized = np.empty_like(table.data)
     for r in range(n_rows):
         for c in range(n_cols):
-            val = str(table.data[r, c])
-            val = _normalize_sub_sup_for_table(val)
-            val = normalize_text(val)
-            val = _normalize_trm_cell_text(val)
-            normalized[r, c] = val
+            normalized[r, c] = _normalize_trm_table_text(str(table.data[r, c]))
     # Normalize col_headers and row_headers metadata to match data cell normalization
     normalized_col_headers: dict[int, list[tuple[int, str]]] = {}
     for col_idx, entries in table.col_headers.items():
-        normalized_col_headers[col_idx] = [
-            (row_idx, _normalize_trm_cell_text(normalize_text(_normalize_sub_sup_for_table(text))))
-            for row_idx, text in entries
-        ]
+        normalized_col_headers[col_idx] = [(row_idx, _normalize_trm_table_text(text)) for row_idx, text in entries]
     normalized_row_headers: dict[int, list[tuple[int, str]]] = {}
     for row_idx, entries in table.row_headers.items():
-        normalized_row_headers[row_idx] = [
-            (col_idx, _normalize_trm_cell_text(normalize_text(_normalize_sub_sup_for_table(text))))
-            for col_idx, text in entries
-        ]
+        normalized_row_headers[row_idx] = [(col_idx, _normalize_trm_table_text(text)) for col_idx, text in entries]
 
     # Drop columns whose data cells AND header entries are all literally
     # empty strings after normalization. Such columns add noise to header
@@ -192,6 +202,12 @@ def normalize_table(table: TableData) -> TableData:
         col_headers=normalized_col_headers,
         row_headers=normalized_row_headers,
         header_cells=header_cells,
+        thead_rows=table.thead_rows,
+        tbody_rows=table.tbody_rows,
+        tfoot_rows=table.tfoot_rows,
+        column_scope_rows=table.column_scope_rows,
+        row_scope_rows=table.row_scope_rows,
+        caption=table.caption,
         context_before=table.context_before,
         context_after=table.context_after,
     )
@@ -202,12 +218,19 @@ def cell_score(expected: str, actual: str) -> float:
 
     Assumes both values have already been normalized by normalize_table()
     (normalize_text + _normalize_trm_cell_text applied upfront).
+
+    Equality is checked leader-insensitively: two cells that differ only in a
+    trailing run of dots/periods ("Acme Inc." vs "Acme Inc", "3." vs "3") are
+    the same cell. Only the *tail* is discounted, so "3.1.4" never collapses
+    onto "3.14" and "192.168.1.1" never onto "192.168.1" — see
+    ``utils.cells_match_leader_insensitive`` for why this lives here rather
+    than in the normalizer.
     """
     if _is_empty_or_nan(expected) and _is_empty_or_nan(actual):
         return 1.0
     if _is_empty_or_nan(expected) or _is_empty_or_nan(actual):
         return 0.0
-    return 1.0 if expected == actual else 0.0
+    return 1.0 if cells_match_leader_insensitive(expected, actual, normalize=_normalize_trm_cell_text) else 0.0
 
 
 # ===========================================================================
@@ -462,6 +485,17 @@ def _align_columns_header_core(
             pk_empty = _is_empty_or_nan(pk) or pk in pred_synthetic
             if gk_empty != pk_empty:
                 sim[i, j] = 0.0  # empty vs non-empty = no match
+            elif not gk_empty and cells_match_leader_insensitive(gt_norm[i], pred_norm[j]):
+                # Two keys that differ only by a trailing dot/period run name
+                # the same column. The fuzzy ratio alone does not always say
+                # so: it is length-relative, and a short key pair such as
+                # "no." / "no" scores 0.80, under the 0.9 threshold, which
+                # would unmatch the column and zero every cell in it. Cells
+                # are already compared this way in ``cell_score``; keying has
+                # to agree or a row pairs on cells it then cannot score.
+                # ``gk_empty`` is false here and equals ``pk_empty``, so both
+                # keys are non-empty — an empty pair keeps its fuzzy score.
+                sim[i, j] = 1.0
             else:
                 sim[i, j] = fuzz.ratio(gt_norm[i], pred_norm[j]) / 100.0
 
@@ -960,7 +994,7 @@ def _resolve_header_row_values(
     header_lookup: dict[tuple[int, int], str] = {}
     for col_idx, entries in table.col_headers.items():
         for row_idx, text in entries:
-            header_lookup[(col_idx, row_idx)] = _normalize_trm_cell_text(normalize_text(text.strip()))
+            header_lookup[(col_idx, row_idx)] = _normalize_trm_table_text(text.strip())
 
     result: list[list[str]] = []
     for row_idx in sorted(header.col_header_rows):

--- a/src/parse_bench/evaluation/metrics/parse/table_splitting.py
+++ b/src/parse_bench/evaluation/metrics/parse/table_splitting.py
@@ -138,6 +138,11 @@ def build_sub_table(
         col_headers=sub_col_headers,
         row_headers={},
         header_cells=sub_header_cells,
+        thead_rows=set(pred_table.thead_rows),
+        tbody_rows={r for r in pred_table.tbody_rows if r < last_nonempty},
+        tfoot_rows={r for r in pred_table.tfoot_rows if r < last_nonempty},
+        column_scope_rows={r for r in pred_table.column_scope_rows if r < last_nonempty},
+        row_scope_rows={r for r in pred_table.row_scope_rows if r < last_nonempty},
     )
 
 

--- a/src/parse_bench/evaluation/metrics/parse/table_title_stripping.py
+++ b/src/parse_bench/evaluation/metrics/parse/table_title_stripping.py
@@ -58,16 +58,74 @@ def detect_td_title_rows(table: TableData, nominal_header_rows: set[int]) -> set
     return set()
 
 
+def _is_row_header_only(table: TableData, r: int, n_cols: int, row_header_cols: set[int]) -> bool:
+    """True when row ``r``'s ``<th>`` content lives only in row-header columns.
+
+    Rows with no ``<th>`` content at all are not affected — they are handled
+    by the ordinary ``nominal_header_rows`` test — and neither are rows that
+    contribute a ``<th>`` outside the row-header columns, which is what a
+    genuine column-header row does.
+
+    A row the source HTML placed inside ``<thead>`` is exempt. There the
+    document has *said* the row belongs to the column-header block, and a
+    label-column header whose sibling cells are empty (``<th>Use Category/
+    Use Type</th>`` over 25 empty ``<td>``) is a real header row of exactly
+    this shape. Only ``<tbody>`` rows are read as section labels.
+    """
+    if not row_header_cols or r in table.thead_rows:
+        return False
+    th_content_cols = {c for c in range(n_cols) if (r, c) in table.header_cells and str(table.data[r, c]).strip()}
+    return bool(th_content_cols) and th_content_cols <= row_header_cols
+
+
+def find_row_header_cols(table: TableData) -> set[int]:
+    """Columns that carry ``<th>`` *row* headers rather than column headers.
+
+    A column qualifies when some row is unambiguously a data row — it has a
+    non-``<th>`` cell with content — and that row's cell in this column comes
+    from a ``<th>``. That is the HTML row-header idiom::
+
+        <tr><th>Cash</th><td>1,777</td><td>555</td></tr>
+
+    Marking up a row label as ``<th>`` is valid HTML and semantically right,
+    so a prediction that does it must not be read as declaring extra *column*
+    header rows. ``find_col_header_rows`` uses this to discount the
+    ``<th>``-ness such a column contributes to section rows whose data cells
+    happen to be empty (``<tr><th>Assets</th><td></td><td></td></tr>``).
+    """
+    n_rows, n_cols = table.data.shape
+    row_header_cols: set[int] = set()
+    for r in range(n_rows):
+        has_non_th_content = any(
+            str(table.data[r, c]).strip() and (r, c) not in table.header_cells for c in range(n_cols)
+        )
+        if not has_non_th_content:
+            continue
+        for c in range(n_cols):
+            if (r, c) in table.header_cells:
+                row_header_cols.add(c)
+    return row_header_cols
+
+
 def find_col_header_rows(table: TableData, nominal_header_rows: set[int], td_title_rows: set[int]) -> set[int]:
     """Identify the leading block of consecutive full-width <th> header rows.
 
     Starts scanning after any <td> title rows. Stops at the first row that
     either isn't marked as a header or has partial <th> coverage with novel
     (non-header) values in non-<th> columns (dual-axis data rows).
+
+    A row whose only ``<th>`` cells sit in a *row-header* column (see
+    ``find_row_header_cols``) also stops the scan, even when its remaining
+    cells are empty. Such a row is a section label inside the body — the
+    ``<th>`` marks it as the row's header, not as another level of column
+    header — and swallowing it into the header block would fold its text into
+    every column key and unmatch the label column against a ground truth that
+    spells the same rows with ``<td>``.
     """
     n_rows, n_cols = table.data.shape
     first_possible_header = max(td_title_rows) + 1 if td_title_rows else 0
     leading_header_end = first_possible_header
+    row_header_cols = find_row_header_cols(table)
 
     for r in range(first_possible_header, n_rows):
         if r not in nominal_header_rows:
@@ -76,6 +134,8 @@ def find_col_header_rows(table: TableData, nominal_header_rows: set[int], td_tit
             str(table.data[r, c]).strip() and (r, c) not in table.header_cells for c in range(n_cols)
         )
         if has_non_th_content:
+            break
+        if _is_row_header_only(table, r, n_cols, row_header_cols):
             break
         leading_header_end = r + 1
 
@@ -377,6 +437,12 @@ def _remove_rows(table: TableData, rows_to_remove: frozenset[int]) -> tuple[Tabl
         col_headers=new_col_headers,
         row_headers=new_row_headers,
         header_cells=new_header_cells,
+        thead_rows={old_to_new[r] for r in table.thead_rows if r in old_to_new},
+        tbody_rows={old_to_new[r] for r in table.tbody_rows if r in old_to_new},
+        tfoot_rows={old_to_new[r] for r in table.tfoot_rows if r in old_to_new},
+        column_scope_rows={old_to_new[r] for r in table.column_scope_rows if r in old_to_new},
+        row_scope_rows={old_to_new[r] for r in table.row_scope_rows if r in old_to_new},
+        caption=table.caption,
         context_before=table.context_before,
         context_after=table.context_after,
     )

--- a/src/parse_bench/evaluation/metrics/parse/teds_metric.py
+++ b/src/parse_bench/evaluation/metrics/parse/teds_metric.py
@@ -21,10 +21,10 @@ import numpy as np
 from apted import APTED, Config
 from apted.helpers import Tree
 from lxml import etree, html
-from scipy.optimize import linear_sum_assignment
 
 from parse_bench.evaluation.metrics.base import Metric
 from parse_bench.evaluation.metrics.parse import fast_tree_edit
+from parse_bench.evaluation.metrics.parse.table_pairing import assign_tables, page_blocking_active
 from parse_bench.evaluation.metrics.parse.utils import normalize_cell_text
 from parse_bench.schemas.evaluation import MetricValue
 
@@ -416,6 +416,9 @@ class TEDSMetric(Metric):
         self,
         expected: str,
         actual: str,
+        *,
+        expected_pages: list[int] | None = None,
+        actual_pages: list[int] | None = None,
         **kwargs: Any,
     ) -> list[MetricValue]:
         """
@@ -428,6 +431,13 @@ class TEDSMetric(Metric):
         Args:
             expected: Expected markdown with HTML tables (ground truth)
             actual: Actual markdown with HTML tables (from inference)
+            expected_pages: Optional page number (1-indexed) per GT table, aligned
+                with the tables extracted from ``expected``. When supplied with
+                ``actual_pages`` (and length-consistent), table matching is solved
+                per page so a GT table only pairs with a prediction on the same
+                page. Omit for the document-global assignment.
+            actual_pages: Optional page number per predicted table, aligned with
+                the tables extracted from ``actual``.
             kwargs: Additional parameters (not used)
 
         Returns:
@@ -471,34 +481,43 @@ class TEDSMetric(Metric):
         teds_calculator = TEDS(variants=self.variants)
         n_expected = len(expected_tables)
         n_actual = len(actual_tables)
-        total_pairs = n_expected * n_actual
+
+        # When per-table page labels are supplied, only same-page pairs are
+        # eligible to match — so only those need a (costly) TEDS comparison.
+        blocked = page_blocking_active(expected_pages, actual_pages, n_expected, n_actual)
+        allowed_pairs = [
+            (i, j)
+            for i in range(n_expected)
+            for j in range(n_actual)
+            if not blocked or expected_pages[i] == actual_pages[j]  # type: ignore[index]
+        ]
+        total_pairs = len(allowed_pairs)
 
         print(
-            f"  TEDS: comparing {n_expected} expected x {n_actual} actual = {total_pairs} table pair(s)",
+            f"  TEDS: comparing {n_expected} expected x {n_actual} actual = {total_pairs} table pair(s)"
+            f"{' (same-page only)' if blocked else ''}",
             flush=True,
         )
 
         # Build cost matrix (negative TEDS scores for minimization)
         # Rows: expected tables, Columns: actual tables
-        # Also store full results to avoid recomputation later
+        # Also store full results to avoid recomputation later. Disallowed
+        # (cross-page) cells keep cost 0.0 and are never read.
         cost_matrix = np.zeros((n_expected, n_actual))
         results_cache: dict[tuple[int, int], tuple[dict[str, float], int, int]] = {}
 
         # Use TEDS-Content for matching if available, else first variant
         matching_variant = TEDS_CONTENT if TEDS_CONTENT in self.variants else next(iter(sorted(self.variants)))
 
-        pair_idx = 0
-        for i, gt_table in enumerate(expected_tables):
-            for j, pred_table in enumerate(actual_tables):
-                pair_idx += 1
-                if total_pairs > 1:
-                    print(f"  TEDS: table pair {pair_idx}/{total_pairs}", flush=True)
-                scores, gt_nodes, pred_nodes = teds_calculator.evaluate(pred_table, gt_table)
-                results_cache[(i, j)] = (scores, gt_nodes, pred_nodes)
-                cost_matrix[i, j] = -scores[matching_variant]
+        for pair_idx, (i, j) in enumerate(allowed_pairs, start=1):
+            if total_pairs > 1:
+                print(f"  TEDS: table pair {pair_idx}/{total_pairs}", flush=True)
+            scores, gt_nodes, pred_nodes = teds_calculator.evaluate(actual_tables[j], expected_tables[i])
+            results_cache[(i, j)] = (scores, gt_nodes, pred_nodes)
+            cost_matrix[i, j] = -scores[matching_variant]
 
-        # Solve assignment problem using Hungarian algorithm
-        row_ind, col_ind = linear_sum_assignment(cost_matrix)
+        # Solve assignment (per page when page labels are supplied, else global).
+        row_ind, col_ind = assign_tables(cost_matrix, expected_pages, actual_pages)
 
         # Build one MetricValue per variant
         metric_values: list[MetricValue] = []
@@ -513,15 +532,17 @@ class TEDSMetric(Metric):
                 scores, gt_nodes, pred_nodes = results_cache[(gt_idx_int, pred_idx_int)]
                 score = scores[variant]
                 per_table_scores.append(score)
-                per_table_details.append(
-                    {
-                        "gt_table_index": gt_idx_int,
-                        "pred_table_index": pred_idx_int,
-                        "score": score,
-                        "gt_nodes": gt_nodes,
-                        "pred_nodes": pred_nodes,
-                    }
-                )
+                detail: dict[str, Any] = {
+                    "gt_table_index": gt_idx_int,
+                    "pred_table_index": pred_idx_int,
+                    "score": score,
+                    "gt_nodes": gt_nodes,
+                    "pred_nodes": pred_nodes,
+                }
+                if blocked:
+                    detail["gt_page"] = expected_pages[gt_idx_int]  # type: ignore[index]
+                    detail["pred_page"] = actual_pages[pred_idx_int]  # type: ignore[index]
+                per_table_details.append(detail)
                 matched_gt_indices.add(gt_idx_int)
 
             # If there are unmatched expected tables, count them as 0

--- a/src/parse_bench/evaluation/metrics/parse/test_rules.py
+++ b/src/parse_bench/evaluation/metrics/parse/test_rules.py
@@ -68,15 +68,20 @@ from parse_bench.evaluation.metrics.parse.rules_form import (  # noqa: F401
 # Formatting rules
 from parse_bench.evaluation.metrics.parse.rules_formatting import (  # noqa: F401
     _FORMATTING_TEST_TYPES,
+    AbsentUnlessStrikeoutRule,
     CodeBlockRule,
     FormattingRule,
     LatexRule,
     MarkColorRule,
+    NotLatexRule,
     PageSectionRule,
+    PresentAsStrikeoutRule,
+    TextColorRule,
     TitleHierarchyPercentRule,
     TitleLevelRule,
 )
 
+# List rules
 # Table rules
 from parse_bench.evaluation.metrics.parse.rules_table import (  # noqa: F401
     TableAdjacentDownRule,

--- a/src/parse_bench/evaluation/metrics/parse/test_types.py
+++ b/src/parse_bench/evaluation/metrics/parse/test_types.py
@@ -30,6 +30,7 @@ class TestType(StrEnum):
     TABLES_VALUES = "tables_values"
     TABLES_NUM_ROWS = "tables_num_rows"
     TABLES_NUM_COLS = "tables_num_cols"
+    TABLE_MARKER_CELLS = "table_marker_cells"
     MATH = "math"
     # Table hierarchy test types
     TABLE_COLSPAN = "table_colspan"
@@ -61,15 +62,22 @@ class TestType(StrEnum):
     IS_MARK = "is_mark"
     IS_NOT_MARK = "is_not_mark"
     MARK_COLOR = "mark_color"
+    TEXT_COLOR = "text_color"
+    ABSENT_UNLESS_STRIKEOUT = "absent_unless_strikeout"
+    PRESENT_AS_STRIKEOUT = "present_as_strikeout"
     IS_SUP = "is_sup"
     IS_NOT_SUP = "is_not_sup"
     IS_SUB = "is_sub"
     IS_NOT_SUB = "is_not_sub"
     IS_LATEX = "is_latex"
+    IS_NOT_LATEX = "is_not_latex"
     IS_CODE_BLOCK = "is_code_block"
     # Title / heading level test
     IS_TITLE = "is_title"
     TITLE_HIERARCHY_PERCENT = "title_hierarchy_percent"
+    HEADING_STRUCTURE = "heading_structure"
+    # List item nesting level test (CommonMark list semantics)
+    LIST_LEVEL = "list_level"
     # Page header / footer tests
     IS_HEADER = "is_header"
     IS_FOOTER = "is_footer"
@@ -85,3 +93,11 @@ class TestType(StrEnum):
     ROTATE_CHECK = "rotate_check"
     # Form field (key/value, checkbox, signature) extraction
     FORM_FIELD = "form_field"
+    # Watermark suppression plus preservation of nearby document text.
+    WATERMARK_REMOVAL = "watermark_removal"
+    # Diagrams rendered as mermaid: graph semantics (nodes/edges), anchor relations, page-level count.
+    DIAGRAM_GRAPH = "diagram_graph"
+    DIAGRAM_EDGE = "diagram_edge"
+    DIAGRAM_COUNT = "diagram_count"
+    # Page furniture: running header, running footer, printed page number, and leakage into the body.
+    PAGE_DECORATION = "page_decoration"

--- a/src/parse_bench/evaluation/metrics/parse/text_similarity_metric.py
+++ b/src/parse_bench/evaluation/metrics/parse/text_similarity_metric.py
@@ -43,15 +43,12 @@ class TextSimilarityMetric(Metric):
         levenshtein = Levenshtein()
         result = levenshtein(expected, actual)
 
-        # Convert to similarity score (0.0 to 1.0)
-        # Levenshtein returns a score where higher is better
-        # We normalize it to 0-1 range
-        max_len = max(len(expected), len(actual))
-        if max_len == 0:
-            similarity = 1.0
-        else:
-            # Levenshtein score is typically normalized, but we ensure 0-1 range
-            similarity = max(0.0, min(1.0, result.score / 100.0))
+        # autoevals ``Levenshtein`` already returns a normalized score in
+        # [0, 1] (1.0 identical, 0.0 fully disjoint), so use it directly.
+        # Clamp only as a defensive guard against float drift — do NOT divide
+        # by 100 (that collapsed every value by two orders of magnitude, e.g.
+        # 0.76 -> 0.0076).
+        similarity = max(0.0, min(1.0, result.score))
 
         return MetricValue(
             metric_name=self.name,

--- a/src/parse_bench/evaluation/metrics/parse/utils.py
+++ b/src/parse_bench/evaluation/metrics/parse/utils.py
@@ -2,6 +2,7 @@
 
 import re
 import unicodedata
+from collections.abc import Callable
 
 _SINGLE_QUOTE_CHARS = (
     "‘’‚‛"  # curly / low-9 / high-reversed-9
@@ -41,9 +42,14 @@ _QUOTE_TRANSLATION_TABLE = str.maketrans(
     }
 )
 
-# Ranges of CJK base characters whose combining marks (dakuten, handakuten)
-# must be preserved during NFD accent stripping.
-_CJK_BASE_RANGES = (
+# Ranges of base characters whose combining marks are load-bearing: deleting the
+# mark changes the word.  Covers the Japanese voicing marks (dakuten/handakuten)
+# and the abugida scripts, where vowel signs, tone marks and viramas are written
+# as combining marks (Thai, Khmer, Devanagari matras, Indic virama).
+# Latin / Greek / Cyrillic are deliberately absent: folding their accents to
+# ASCII is the intended normalization.  Arabic/Hebrew are absent too, because
+# their harakat / niqqud are optional pointing, so stripping them is forgiving.
+_MARK_PRESERVING_BASE_RANGES = (
     ("\u3040", "\u309f"),  # Hiragana
     ("\u30a0", "\u30ff"),  # Katakana
     ("\u4e00", "\u9fff"),  # CJK Unified Ideographs
@@ -51,14 +57,62 @@ _CJK_BASE_RANGES = (
     ("\uf900", "\ufaff"),  # CJK Compatibility Ideographs
     ("\uac00", "\ud7af"),  # Hangul Syllables
     ("\u1100", "\u11ff"),  # Hangul Jamo
+    ("\u0900", "\u097f"),  # Devanagari
+    ("\u0980", "\u09ff"),  # Bengali
+    ("\u0a00", "\u0a7f"),  # Gurmukhi
+    ("\u0a80", "\u0aff"),  # Gujarati
+    ("\u0b00", "\u0b7f"),  # Oriya
     ("\u0b80", "\u0bff"),  # Tamil
+    ("\u0c00", "\u0c7f"),  # Telugu
     ("\u0c80", "\u0cff"),  # Kannada
+    ("\u0d00", "\u0d7f"),  # Malayalam
+    ("\u0d80", "\u0dff"),  # Sinhala
+    ("\u0e00", "\u0e7f"),  # Thai
+    ("\u0e80", "\u0eff"),  # Lao
+    ("\u1000", "\u109f"),  # Myanmar
+    ("\u1780", "\u17ff"),  # Khmer
 )
 
+_COMBINING_MARK_CATEGORIES = frozenset({"Mn", "Mc", "Me"})
 
-def _is_cjk_base_char(ch: str) -> bool:
-    """Return True if *ch* is a CJK/Kana/Hangul/Indic base character."""
-    return any(lo <= ch <= hi for lo, hi in _CJK_BASE_RANGES)
+
+def _is_mark_preserving_base_char(ch: str) -> bool:
+    """Return True if combining marks on *ch* must survive normalization."""
+    return any(lo <= ch <= hi for lo, hi in _MARK_PRESERVING_BASE_RANGES)
+
+
+def _build_preserved_mark_class() -> str:
+    """Regex character-class body for the marks kept by :func:`normalize_text`.
+
+    Derived from :data:`_MARK_PRESERVING_BASE_RANGES` so the tokenizer and the
+    normalizer can never drift: a mark that survives normalization is also a
+    word character, and therefore never splits the word it belongs to.
+    """
+    codepoints = [
+        cp
+        for lo, hi in _MARK_PRESERVING_BASE_RANGES
+        for cp in range(ord(lo), ord(hi) + 1)
+        if unicodedata.category(chr(cp)) in _COMBINING_MARK_CATEGORIES
+    ]
+    codepoints.sort()
+    parts: list[str] = []
+    start = prev = codepoints[0]
+    for cp in codepoints[1:] + [0]:
+        if cp == prev + 1:
+            prev = cp
+            continue
+        parts.append(f"\\u{start:04x}" if start == prev else f"\\u{start:04x}-\\u{prev:04x}")
+        start = prev = cp
+    return "".join(parts)
+
+
+PRESERVED_COMBINING_MARK_CLASS = _build_preserved_mark_class()
+
+# The shared word-character class.  Must be used by every tokenizer and every
+# word-boundary check on both the evaluation and the annotation side so that a
+# ground-truth "word" and a document token are cut the same way.
+WORD_CHAR_CLASS = rf"[\w{PRESERVED_COMBINING_MARK_CLASS}]"
+NON_WORD_CHAR_CLASS = rf"[^\w{PRESERVED_COMBINING_MARK_CLASS}]"
 
 
 # ---------------------------------------------------------------------------
@@ -94,10 +148,58 @@ _UNICODE_SYMBOL_TABLE = str.maketrans(
     {char: canonical for chars, canonical in _UNICODE_SYMBOL_CLASSES for char in chars}
 )
 
+_TRUE_TABLE_MARKER_GLYPHS = frozenset(
+    {
+        "☑",
+        "▣",
+        "✓",
+        "✔",
+        "◉",
+        "●",
+        "•",
+        "⦿",
+    }
+)
+_FALSE_TABLE_MARKER_GLYPHS = frozenset({"☐", "□", "○", "◯", "✗", "✘", "✕", "✖", "×"})
+_TRUE_TABLE_MARKER_TEXT = frozenset({"yes", "x"})
+_FALSE_TABLE_MARKER_TEXT = frozenset({"no"})
+
 
 def _normalize_unicode_symbols(text: str) -> str:
     """Collapse Unicode symbol variants to their canonical forms."""
     return text.translate(_UNICODE_SYMBOL_TABLE)
+
+
+def _normalize_table_boolean_marker(text: str) -> str:
+    """Normalize whole-cell boolean markers to yes/no.
+
+    This is intentionally exact-cell scoped. It treats values like ``✓``,
+    ``✗``, ``●``, ``X``, ``[yes]``, and ``[no]`` as boolean table-cell markers,
+    but leaves mixed content such as ``● item`` untouched.
+    """
+    stripped = re.sub(r"\s+", " ", text).strip()
+    if not stripped:
+        return text
+
+    token = stripped.lower()
+    bracket_match = re.fullmatch(r"\[\s*(.*?)\s*\]", stripped)
+    if bracket_match:
+        stripped = bracket_match.group(1).strip()
+        token = stripped.lower()
+
+    if (
+        stripped in _TRUE_TABLE_MARKER_GLYPHS
+        or token in _TRUE_TABLE_MARKER_TEXT
+        or (bracket_match and token in {"x", "yes"})
+    ):
+        return "yes"
+    if (
+        stripped in _FALSE_TABLE_MARKER_GLYPHS
+        or token in _FALSE_TABLE_MARKER_TEXT
+        or (bracket_match and token in {"", "no"})
+    ):
+        return "no"
+    return text
 
 
 def _normalize_quotes(text: str) -> str:
@@ -117,6 +219,33 @@ _HTML_FORMATTING_RE = re.compile(
 
 # <span> tags (with optional attributes like style, color) — strip tag, keep content
 _HTML_SPAN_RE = re.compile(r"</?span\b[^>]*>", re.IGNORECASE)
+
+# Inline styling markers that ``normalize_text`` deletes while keeping their
+# content: the content-preserving HTML tags plus markdown ``~~``. ``<sup>`` and
+# ``<sub>`` are deliberately excluded — they delete their content too, which is
+# a different decision. The ``\b`` after each name keeps ``<b>`` from matching
+# ``<br>`` and ``<s>`` from matching ``<span>``/``<strike>``/``<sub>``.
+_INLINE_STYLE_MARKER = r"</?(?:b|i|u|s|del|strike|ins|mark|span)\b[^>]*>|~~"
+# A *run* of two or more abutting markers. One marker between two content
+# characters is an intra-token style change (Japanese ``<u>`` mid-sentence,
+# ``Shizuok<mark>a``) and must join; two abutting markers are the boundary
+# between two separately-styled tokens (``<u>103</u><s>101</s>``) and must
+# separate. The shipped GT corpora contain zero runs with content on both sides,
+# so this only ever changes prediction-side welds.
+_INLINE_STYLE_MARKER_RUN_RE = re.compile(f"(?:{_INLINE_STYLE_MARKER}){{2,}}", re.IGNORECASE)
+
+
+def _inline_style_run_to_separator(match: re.Match[str]) -> str:
+    """Replace a run of abutting inline markers with a single space.
+
+    A run at either end of the string separates nothing, so it collapses to the
+    empty string rather than padding the result — callers compare normalized
+    strings for equality.
+    """
+    if match.start() == 0 or match.end() == len(match.string):
+        return ""
+    return " "
+
 
 # Markdown bold: **text** or __text__
 _MD_BOLD_RE = re.compile(r"\*\*(.*?)\*\*|__(.*?)__")
@@ -169,8 +298,233 @@ _DASH_CHARS = str.maketrans(
     }
 )
 
+
+def _normalize_encoding_punctuation(text: str) -> str:
+    """Apply the shared quote and dash folds used by text and label matching."""
+    return _normalize_quotes(text).translate(_DASH_CHARS)
+
+
+_LABEL_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def normalize_label_punctuation(text: object | None) -> str:
+    """Fold encoding-only punctuation while preserving judge-facing label text.
+
+    This composes the same quote and dash equivalence tables used by the
+    deterministic text matcher, but deliberately keeps case, wording, and
+    markup intact for evidence shown to the judge.
+    """
+    if text is None:
+        return ""
+    normalized = _normalize_encoding_punctuation(str(text))
+    return _LABEL_WHITESPACE_RE.sub(" ", normalized).strip()
+
+
 # A cell consisting entirely of dash-like characters and whitespace
 _DASH_ONLY_RE = re.compile(r"^[\s\-–—‑‒−]+$")
+
+# A dot-leader run: two or more periods separated by nothing but blanks, e.g.
+# ``.....`` or ``. . . . .``. Typographic leaders whose dot count is a function
+# of column width, not of content, so the same label reaches the evaluator as
+# ``Total assets`` from one page and ``Total assets . . . . . . .`` from
+# another.
+#
+# Two alternatives, because a leader may or may not be introduced by a space:
+#
+# 1. A run *starting* at whitespace or the start of the string, whose periods
+#    may then be separated by blanks — ``Total assets . . . . .``.
+# 2. A *contiguous* run of two or more periods that ends at whitespace or the
+#    end of the string — ``Revenue.........``.
+#
+# Between them these spare every period that is content. In a decimal
+# (``1.5``), a European thousands separator (``1.234.567``), a version string
+# (``3.14.1``) and a dotted abbreviation (``U.S.``) the periods are single and
+# separated by non-blank characters. A run wedged between two word characters
+# (``A..B``) is punctuation, not typography, and matches neither alternative.
+#
+# A Unicode ellipsis (U+2026) is one glyph standing for three periods, so it
+# counts as a dot *and* as a complete run on its own: a transcriber choosing
+# ``…`` over ``...`` is making a font decision, not a content one.
+_DOT_CHAR = r"[.…]"
+# A "run" is either two-or-more dot characters (possibly blank-separated) or a
+# single ellipsis, which is already three dots' worth of glyph.
+_DOT_RUN = rf"(?:{_DOT_CHAR}(?:[^\S\n]*{_DOT_CHAR})+|…)"
+_DOT_LEADER_RE = re.compile(rf"(?:(?<=\s)|^){_DOT_RUN}|(?<=\S)(?:\.{{2,}}|…+)(?=\s|$)")
+
+# A leader that begins *attached* to its label, with no space between the label
+# and the first dot, and is then spaced out: ``Employed. . . . . . . .``. The
+# contiguous spelling of the very same glyph run (``Employed............``)
+# already loses every period to alternative 2 above, so without this the two
+# spellings normalize differently and a prediction is scored down purely for
+# how it spaced a filler. Requiring the label to be a period-free token
+# (``[^\s.…]+``) is what keeps a dotted abbreviation introducing a leader
+# intact — in ``E.O. .....................`` the token cannot span the ``.``,
+# so the pattern never engages and ``E.O.`` keeps its own period.
+_ATTACHED_DOT_LEADER_RE = re.compile(rf"(?<!\S)(?P<label>[^\s.…]+)\.(?:[^\S\n]*{_DOT_CHAR})+(?=\s|$)")
+
+# The same attached-leader shape, but for a label that already contains periods
+# of its own and so cannot match the period-free token above: ``3.14. . . .``,
+# ``1,234.56. . . .``, ``192.168.1.1. . . .``. Without this the leader's first
+# dot stays glued to the number and the cell normalizes to ``"3.14."`` — a
+# period that is in neither the content nor the leader, and one that the merely
+# spaced spelling (``3.14 . . . .``) does not produce.
+#
+# The label is required to end in a *digit*, which is what makes the assignment
+# unambiguous here while it is genuinely ambiguous for letters. A numeric token
+# never legitimately ends in a period, so a period between a digit and a run
+# can only belong to the run; ``E.O.`` and ``3.14.`` are the same *shape*, and
+# only the digit tells them apart. Alphabetic labels keep the conservative
+# treatment above, which is why ``"ft."`` and ``"in."`` — unit residue that
+# ``table_normalization_relaxed`` recognises *by* the period — are untouched.
+_ATTACHED_NUMERIC_DOT_LEADER_RE = re.compile(rf"(?<!\S)(?P<label>\S*\d)\.(?:[^\S\n]*{_DOT_CHAR})+(?=\s|$)")
+
+
+def strip_dot_leaders(text: str) -> str:
+    """Remove dot-leader runs from a table cell's text.
+
+    Shared by ``normalize_cell_text`` (GriTS / TEDS / header accuracy) and
+    ``_normalize_trm_cell_text`` (table record match) so the two table
+    metrics agree on what a leader run is. Applied symmetrically to ground
+    truth and prediction.
+
+    A run is replaced by the empty string, and the whitespace either side is
+    collapsed by the caller, so ``"Total assets . . . 5"`` and
+    ``"Total assets 5"`` normalize alike. A run wedged between two word
+    characters (``"A..B"``) is punctuation, not typography, and survives.
+
+    The result is independent of how the leader was *spaced*: ``"Employed...."``,
+    ``"Employed. . . ."``, ``"Employed ...."`` and ``"Employed…"`` all reduce to
+    ``"Employed"``. That invariant is the point — dot spacing is a property of
+    the transcription, never of the document, so it must not move a metric.
+
+    Idempotent: ``strip_dot_leaders(strip_dot_leaders(x)) == strip_dot_leaders(x)``.
+
+    Known boundary — a label whose own last character is a period
+    ------------------------------------------------------------
+    ``"Acme Inc. ...."`` reduces to ``"Acme Inc"``, dropping the
+    abbreviation's own period, while an undecorated ``"Acme Inc."`` keeps it.
+    The two are therefore *not* interchangeable **as text**.
+
+    That residual no longer costs anything on the exact-match submetrics: they
+    compare through :func:`cells_match_leader_insensitive`, which asks whether
+    two cells differ only in their trailing dot/period tail and never has to
+    decide who owns the period. The boundary below is a statement about this
+    function's *output text*, not about what the metrics score.
+
+    This is irreducible rather than an oversight. ``"Acme Inc....."`` is one
+    undifferentiated glyph run in which nothing marks how many of those dots
+    belonged to ``Inc.``, and ``"Employed. . . ."`` has exactly the same shape,
+    so no rule can separate the two cases. The tie is broken toward absorbing
+    the period because the alternative — keeping it — makes the *spaced* and
+    *contiguous* spellings of one leader normalize differently, which is a
+    strictly larger and already-measured harm.
+
+    The boundary covers exactly the cells where a period sits between the label
+    and the run and the two readings are indistinguishable by shape:
+
+    * a label whose final token ends in a period and has no other period
+      (``"Acme Inc."``, ``"Jr."``, ``"No."``, ``"ft."``) — absorbed for every
+      leader spelling;
+    * a *multi-period* abbreviation with a leader written contiguously
+      (``"U.S....."`` -> ``"U.S"``). Given a blank to separate them
+      (``"U.S. ....."``, ``"E.O. ....."``) the abbreviation keeps its period,
+      because the blank is the evidence that the period is the label's.
+
+    Numeric labels are *not* in the boundary, even though they have the same
+    shape, because a number never legitimately ends in a period — see
+    ``_ATTACHED_NUMERIC_DOT_LEADER_RE``. ``tests/.../test_table_dot_leaders.py``
+    pins the boundary, its per-cell cost, and the numeric exemption.
+    """
+    # Absorb the label-attached period first, so the spaced spelling of a
+    # leader reduces to the same text as its contiguous spelling.
+    text = _ATTACHED_NUMERIC_DOT_LEADER_RE.sub(r"\g<label>", text)
+    text = _ATTACHED_DOT_LEADER_RE.sub(r"\g<label>", text)
+    return _DOT_LEADER_RE.sub("", text)
+
+
+# Trailing decoration a dot leader can leave behind on either side of a
+# comparison: dot characters, blanks, and — crucially — a *single* final
+# period, which is below the two-dot threshold a run needs and so survives
+# ``strip_dot_leaders`` untouched. Anchored at the end of the cell, so no
+# interior period is ever in reach.
+_TRAILING_LEADER_RESIDUE_RE = re.compile(r"[.…\s]+$")
+
+
+def leader_insensitive_core(text: str) -> str:
+    """Return *text* with any trailing dot / ellipsis / blank run removed.
+
+    Unlike :func:`strip_dot_leaders` this also removes a *lone* final period,
+    so ``"Acme Inc."``, ``"Acme Inc"`` and ``"Acme Inc. ...."`` all reduce to
+    ``"Acme Inc"``. That is deliberately too aggressive to use as a
+    normalization — see :func:`cells_match_leader_insensitive` for why it is
+    only ever used to compare two cells, never to rewrite one.
+
+    Only the tail is touched: ``"192.168.1.1"``, ``"3.1.4"`` and ``"1.5"``
+    come back unchanged, because their periods are interior.
+    """
+    return _TRAILING_LEADER_RESIDUE_RE.sub("", text)
+
+
+def cells_match_leader_insensitive(
+    a: str,
+    b: str,
+    *,
+    normalize: Callable[[str], str] | None = None,
+) -> bool:
+    """Compare two already-normalized table cells, ignoring leader decoration.
+
+    Why this is a *comparison* and not another normalization
+    -------------------------------------------------------
+    When a single period sits between a label and a dot-leader run
+    (``"Acme Inc. ...."``), nothing in the glyph run says whether that period
+    closes the abbreviation or opens the leader — the two readings have the
+    same shape. :func:`strip_dot_leaders` has to pick one, and it absorbs the
+    period, so a decorated ``"Acme Inc. ...."`` reduces to ``"Acme Inc"``
+    while an undecorated ``"Acme Inc."`` keeps its period. On the exact-match
+    submetrics that residual costs the whole cell.
+
+    Mutation-level stripping cannot close that gap. The only exact closure is
+    to drop *every* cell-final period, and ``normalize_cell_text`` is shared
+    with ``table_normalization_relaxed``, whose ``_EMPTY_TEMPLATES`` depend on
+    the opposite convention: ``"ft."`` / ``"in."`` are recognised as unit
+    residue *by* their period, and that module's comment records that the
+    trailing-period strip "is intentionally NOT applied". This helper does not
+    contradict that comment — it changes no cell's text and feeds nothing
+    downstream. It only decides, at the moment two cells are compared for
+    equality, whether their difference is confined to leader decoration.
+
+    Because the question is asked symmetrically about a *pair*, the period's
+    owner never has to be decided: both sides give up their tail, so the two
+    readings can no longer disagree.
+
+    Dots-only cells
+    ---------------
+    A cell whose core is empty — ``"."``, or a cell that already normalized to
+    ``""`` — is **not** matched through this fallback against arbitrary text;
+    it falls back to plain equality. This keeps faith with the pinned decision
+    that a dots-only cell (``"..."``, ``"…"``) normalizes to the empty string:
+    two such cells still compare equal because they are *both* empty after
+    normalization, not because a stray dot was allowed to match a label.
+
+    Args:
+        a: One normalized cell's text.
+        b: The other normalized cell's text.
+        normalize: Optional re-normalizer applied to both cores. Needed where
+            trimming the tail can expose a token an *earlier* fold would have
+            rewritten — TRM's boolean-marker fold runs before leader stripping,
+            so ``"No."`` survives as ``"No."`` while ``"No. ..."`` reaches
+            ``"no"``; re-normalizing both cores lands them on the same text.
+    """
+    if a == b:
+        return True
+    core_a = leader_insensitive_core(a)
+    core_b = leader_insensitive_core(b)
+    if normalize is not None:
+        core_a = normalize(core_a)
+        core_b = normalize(core_b)
+    if not core_a or not core_b:
+        return False
+    return core_a == core_b
 
 
 def normalize_cell_text(text: str) -> str:
@@ -181,11 +535,12 @@ def normalize_cell_text(text: str) -> str:
     - Sup/sub tag conversion (<sup>x</sup> → x, ¹ → 1, etc.)
     - HTML formatting tag removal (<b>, <i>, <mark>, <em>, <strong>, etc.)
     - Markdown bold/italic/strikethrough removal
+    - Whole-cell boolean marker equivalence (✓/✗/●/[yes]/[no])
     - Unicode symbol equivalence (bullets, circled-x, etc.)
     - Quote / fullwidth punctuation canonicalization
     - Dash character normalization (en-dash, em-dash, etc. → ASCII hyphen)
     - Dash-only cells collapsed to a single "-"
-    - Dot-leader stripping (trailing runs of 2+ dots)
+    - Dot-leader stripping (runs of 2+ dots, contiguous or space-separated)
     - Whitespace collapsing and stripping
 
     Formatting is intentionally stripped (not preserved as a signal): in
@@ -204,19 +559,98 @@ def normalize_cell_text(text: str) -> str:
     text = _MD_BOLD_RE.sub(r"\1\2", text)
     text = _MD_ITALIC_RE.sub(r"\1\2", text)
     text = _MD_STRIKETHROUGH_RE.sub(r"\1", text)
+    # Whole-cell boolean markers before generic symbol folding, so open/closed
+    # circles remain distinguishable.
+    text = _normalize_table_boolean_marker(text)
     # Unicode symbol equivalence
     text = _normalize_unicode_symbols(text)
-    # Quote / fullwidth punctuation canonicalization
-    text = _normalize_quotes(text)
-    # Normalize dash characters to ASCII hyphen
-    text = text.translate(_DASH_CHARS)
-    # Strip trailing dot-leaders (2+ consecutive dots at end)
-    text = re.sub(r"\.{2,}\s*$", "", text)
+    # Quote / dash / fullwidth punctuation canonicalization shared with the
+    # plain-text and judge-evidence normalizers.
+    text = _normalize_encoding_punctuation(text)
+    # Strip dot-leaders — contiguous ("Total assets.....") or spaced
+    # ("Total assets . . . . ."). Shared with the TRM cell normalizer.
+    text = strip_dot_leaders(text)
     # Collapse whitespace and strip
     text = re.sub(r"\s+", " ", text).strip()
     # If cell is entirely dashes (after normalization), collapse to single dash
     if _DASH_ONLY_RE.match(text):
         return "-"
+    return text
+
+
+# ---------------------------------------------------------------------------
+# Relaxed-metric cell-text normalization (LI-8223)
+#
+# These transformations are applied ONLY on the relaxed metric path (via
+# ``table_normalization_relaxed.normalize_for_relaxed``) — never by the strict
+# GriTS / TRM / header-accuracy metrics, which keep using ``normalize_cell_text``
+# unchanged. ``relaxed_normalize_cell_text`` runs BEFORE the strict
+# ``normalize_cell_text`` (they compose), so it only needs to canonicalize the
+# few extra equivalences the strict pass leaves alone.
+# ---------------------------------------------------------------------------
+
+# Block / line-level tags whose removal must not concatenate adjacent tokens.
+# A list-item OPENING tag becomes a canonical bullet so that a ``<ul><li>`` list
+# and a literal ■-bulleted cell converge to the same "• A • B" shape; every
+# other structural tag becomes a plain space. Motivating page:
+# ``Low-Back-Guideline (1)_page2`` — GT emits literal ■ bullets while the
+# prediction emits ``<ul><li>`` items that ``get_text()`` fuses without spaces.
+_RELAXED_LIST_ITEM_OPEN_RE = re.compile(r"<li\b[^>]*>", re.IGNORECASE)
+_RELAXED_BLOCK_TAG_RE = re.compile(
+    r"</li>|</?ul\b[^>]*>|</?ol\b[^>]*>|</?p\b[^>]*>|<br\s*/?>",
+    re.IGNORECASE,
+)
+
+# Canonical bullet used by both the list-item injection and the geometric-bullet
+# homoglyph fold below (U+2022 BULLET).
+_RELAXED_CANONICAL_BULLET = "•"
+
+# Visually-equivalent codepoint folds applied only on the relaxed path.
+# Kept small, explicit, and commented with the motivating equivalence.
+_RELAXED_HOMOGLYPH_TABLE = str.maketrans(
+    {
+        "µ": "μ",  # µ MICRO SIGN -> μ GREEK SMALL LETTER MU
+        " ": " ",  # NBSP -> space
+        # Geometric bullet variants -> canonical bullet (U+2022).
+        # ONLY the square bullets fold here: strict _normalize_unicode_symbols already
+        # folds circle bullets for mixed-content cells, and folding whole-cell ●/○/◦
+        # would collide with _normalize_table_boolean_marker (● = yes, ○ = no) —
+        # a checked-vs-unchecked disagreement is a REAL content error and must not
+        # be normalized away on the relaxed path.
+        "■": _RELAXED_CANONICAL_BULLET,  # ■ BLACK SQUARE
+        "▪": _RELAXED_CANONICAL_BULLET,  # ▪ BLACK SMALL SQUARE
+    }
+)
+
+
+def relaxed_normalize_cell_text(text: str) -> str:
+    """Extra relaxed-only cell-text canonicalization (LI-8223 items 2 & 3).
+
+    Applied only on the relaxed metric path, before the strict
+    ``normalize_cell_text`` runs on top. Two folds:
+
+    * **Tag-strip separator injection** — replace block/line tags with a
+      separator so list items don't concatenate into one token. A ``<li>``
+      opener injects the canonical bullet (``•``); ``</li>``, ``<ul>``,
+      ``<ol>``, ``<p>``, ``<br>`` inject a space. Repeated whitespace is
+      collapsed afterwards.
+    * **Encoding punctuation folding** — use the shared quote/dash mapping so
+      this path cannot drift from strict table, plain-text, or judge matching.
+    * **Relaxed-only homoglyph folding** — map µ→μ, NBSP→space, and geometric
+      bullet variants → ``•``.
+
+    Idempotent and symmetric (applied identically to GT and prediction).
+    """
+    if not text:
+        return text
+    text = _RELAXED_LIST_ITEM_OPEN_RE.sub(f" {_RELAXED_CANONICAL_BULLET} ", text)
+    text = _RELAXED_BLOCK_TAG_RE.sub(" ", text)
+    # Keep quote/dash equivalence on the same canonical mapping as strict
+    # table, plain-text, and judge-evidence normalization.
+    text = _normalize_encoding_punctuation(text)
+    text = text.translate(_RELAXED_HOMOGLYPH_TABLE)
+    # Collapse the whitespace introduced by tag/NBSP substitution.
+    text = re.sub(r"\s+", " ", text).strip()
     return text
 
 
@@ -248,8 +682,17 @@ def normalize_text(md_content: str | None) -> str:
     # Normalize <br>, <br/>, and <br /> to spaces
     md_content = re.sub(r"<br\s*/?>", " ", md_content)
 
-    # Canonicalize Unicode quote variants early for robust text matching.
-    md_content = _normalize_quotes(md_content)
+    # Inline styling markers are deleted below (empty string), which is right for
+    # a single marker inside a token but welds two tokens together where two
+    # markers abut: "<u>103</u><s>101</s>" would become "103101" and every
+    # word/sentence/order rule would then report both page numbers as missing.
+    # Turn a run of abutting markers into a separator first; the whitespace
+    # collapse right below folds it into surrounding space.
+    md_content = _INLINE_STYLE_MARKER_RUN_RE.sub(_inline_style_run_to_separator, md_content)
+
+    # Canonicalize Unicode quote and dash variants early using the same mapping
+    # as table-cell and judge-evidence normalization.
+    md_content = _normalize_encoding_punctuation(md_content)
 
     # Normalize whitespace in the md_content
     md_content = re.sub(r"\s+", " ", md_content)
@@ -275,18 +718,21 @@ def normalize_text(md_content: str | None) -> str:
     # NFD decomposing separates base characters from combining marks
     md_content = unicodedata.normalize("NFD", md_content)
     # Remove combining characters (accents, diacritics) but KEEP combining marks
-    # that follow CJK base characters (e.g. Japanese dakuten ゙ and handakuten ゚
-    # which distinguish が from か, ぱ from は, etc.)
+    # whose base character needs them: the Japanese voicing marks (they
+    # distinguish ka from ga, ha from pa) and the vowel signs, tone marks and
+    # viramas of the abugida scripts, where deleting a mark changes the word.
+    # The base is tracked across stacks: Thai writes a tone mark on top of a
+    # vowel mark, so the character immediately preceding a mark is not the one
+    # that decides whether that mark is load-bearing.
     result_chars: list[str] = []
+    base_preserves_marks = False
     for char in md_content:
         if unicodedata.category(char) != "Mn":
             result_chars.append(char)
-        else:
-            # Keep combining mark if it follows a CJK base character
-            # (Hiragana \u3040-\u309f, Katakana \u30a0-\u30ff, CJK ideographs, Hangul)
-            if result_chars and _is_cjk_base_char(result_chars[-1]):
-                result_chars.append(char)
-            # else: strip (Latin/Cyrillic accents → ASCII)
+            base_preserves_marks = _is_mark_preserving_base_char(char)
+        elif base_preserves_marks:
+            result_chars.append(char)
+        # else: strip (Latin/Cyrillic accents -> ASCII)
     md_content = "".join(result_chars)
     # Convert back to NFC form for consistency
     md_content = unicodedata.normalize("NFC", md_content)
@@ -294,11 +740,6 @@ def normalize_text(md_content: str | None) -> str:
     # Dictionary of characters to replace: keys are fancy characters, values are ASCII equivalents
     replacements = {
         "＿": "_",
-        "–": "-",
-        "—": "-",
-        "‑": "-",
-        "‒": "-",
-        "−": "-",
         "…": "...",
         "<ins>": "",
         "</ins>": "",
@@ -347,10 +788,27 @@ def normalize_text(md_content: str | None) -> str:
     # This handles cases like "--" or "---" becoming "-"
     md_content = re.sub(r"-{2,}", "-", md_content)
 
-    # Strip trailing dot-leaders (e.g., "Operating income.........." → "Operating income")
-    # These are formatting dots used in tables to connect labels to values
-    # Only strip 2+ consecutive dots at the end to preserve grammatical periods ("Inc.")
-    md_content = re.sub(r"\.{2,}\s*$", "", md_content)
+    # Strip trailing dot-leaders (e.g., "Operating income.........." → "Operating income").
+    # These are formatting dots used in tables to connect labels to values.
+    # Only strip 2+ consecutive dots at the end to preserve grammatical periods ("Inc.").
+    #
+    # Implemented as a bounded right-to-left scan rather than the regex
+    # r"\.{2,}\s*$": that regex backtracks quadratically on pathological content
+    # holding one very long run of dots (e.g. a degenerate OCR page that emits
+    # 130k dot characters). On such input the greedy `\.{2,}` grabs the whole run
+    # at every start position and then gives it back a dot at a time when `\s*$`
+    # fails — ~66s for a single 130k-char string, and the metric re-normalizes
+    # per rule, so a single document could burn the entire 6h eval budget. The
+    # scan below is linear in the length of the trailing run and behaviourally
+    # identical.
+    _end = len(md_content)
+    while _end > 0 and md_content[_end - 1].isspace():
+        _end -= 1
+    _dot_start = _end
+    while _dot_start > 0 and md_content[_dot_start - 1] == ".":
+        _dot_start -= 1
+    if _end - _dot_start >= 2:
+        md_content = md_content[:_dot_start]
 
     # lowerCase the content for case-insensitive comparison
     md_content = md_content.lower()
@@ -390,8 +848,9 @@ def normalize_text_light(md_content: str | None) -> str:
     # Strip <span> tags (keep content) — these are layout wrappers, not styling
     md_content = _HTML_SPAN_RE.sub("", md_content)
 
-    # Canonicalize Unicode quote variants for robust matching while preserving styling.
-    md_content = _normalize_quotes(md_content)
+    # Canonicalize Unicode quote and dash variants using the shared mapping
+    # while preserving styling.
+    md_content = _normalize_encoding_punctuation(md_content)
 
     # Normalize whitespace (collapse multiple spaces/newlines to single space)
     md_content = re.sub(r"\s+", " ", md_content)
@@ -410,11 +869,6 @@ def normalize_text_light(md_content: str | None) -> str:
     # Keep dots, keep case, keep formatting tags
     replacements = {
         "＿": "_",
-        "–": "-",
-        "—": "-",
-        "‑": "-",
-        "‒": "-",
-        "−": "-",
         "…": "...",
         "\u00b5": "\u03bc",  # micro sign to greek mu
     }

--- a/src/parse_bench/test_cases/parse_rule_schemas.py
+++ b/src/parse_bench/test_cases/parse_rule_schemas.py
@@ -278,6 +278,17 @@ class ParseTablesNumColsRule(ParseRuleBase):
     actual_num_cols: int | None = None
 
 
+class ParseTableMarkerCellsRule(ParseRuleBase):
+    """Require icon-like values to survive as cells in one parsed table."""
+
+    type: Literal[TestType.TABLE_MARKER_CELLS.value]
+    min_count: int = Field(default=2, ge=1)
+    min_distinct_rows: int = Field(default=2, ge=1)
+    min_distinct_columns: int = Field(default=1, ge=1)
+    marker_aliases: list[str] = Field(default_factory=list)
+    allow_repeated_ocr_glyphs: bool = True
+
+
 class ParseTableColspanRule(ParseRuleBase, _HasAnchorCells):
     type: Literal[TestType.TABLE_COLSPAN.value]
     cell: str = ""
@@ -391,6 +402,43 @@ class ParseChartDataArrayDataRule(ParseRuleBase):
     csv_path: str | None = Field(default=None, alias="_csv_path")
 
 
+class ParseFormFieldRule(ParseRuleBase):
+    """Schema for `form_field` rules.
+
+    Locates a labeled field in the parsed markdown/HTML and checks its value.
+    Used for benchmarking form (key-value, checkbox, signature) extraction.
+
+    `label` may be a list of strings for table-like form cells where one
+    value is identified by multiple visible keys (for example a row label
+    plus a column label). Label-list order is not significant.
+
+    For repeated yes/no checkbox groups, use a label list containing the
+    question and option text, e.g. `["Multistage cement?", "No"]`, with
+    `value_type: "checkbox"` and `value: true` or `false`.
+
+    For repeated row fields such as open-hole intervals, use the existing
+    row-index form, e.g. `"FROM (row 1)"` and `"TO (row 1)"`. This works for
+    markdown tables and flattened parser output such as `FROM none TO RRC`.
+
+    `label_max_diffs` may be a number or a list aligned with `label` to allow
+    limited OCR/handwriting variation in key text after normalization.
+    `value_max_diffs` is the equivalent tolerance for the extracted value.
+
+    `value` may be a list of strings to declare acceptable alternatives for
+    genuinely ambiguous fields (e.g. illegible handwriting). The evaluator
+    passes if the parsed value matches *any* alternative. Use sparingly —
+    most rules should be a single string. List form is only for value_type
+    "text" and "signature".
+    """
+
+    type: Literal[TestType.FORM_FIELD.value]
+    label: str | list[str] = ""
+    label_max_diffs: int | float | list[int | float] = 0
+    value_max_diffs: int | float = 0
+    value: str | bool | list[str] = ""
+    value_type: Literal["text", "checkbox", "signature"] = "text"
+
+
 class ParseFormattingRule(ParseRuleBase):
     type: Literal[
         TestType.IS_UNDERLINE.value,
@@ -425,15 +473,86 @@ class ParseMarkColorRule(ParseRuleBase):
     color: str = ""
 
 
+class ParseAbsentUnlessStrikeoutRule(ParseRuleBase):
+    """Schema for `absent_unless_strikeout` rules.
+
+    For text deleted in a revision (struck through in the source document):
+    the parse should either omit the text entirely, or keep it explicitly
+    marked as struck (``~~text~~``, ``<s>``, ``<del>``, ``<strike>`` or a
+    ``text-decoration: line-through`` style). The rule FAILS when the text
+    appears as regular, unmarked content — the failure mode where deleted
+    contract language becomes indistinguishable from current language.
+    """
+
+    type: Literal[TestType.ABSENT_UNLESS_STRIKEOUT.value]
+    text: str = ""
+
+
+class ParsePresentAsStrikeoutRule(ParseRuleBase):
+    """Schema for `present_as_strikeout` rules.
+
+    Stricter counterpart of `absent_unless_strikeout`: deleted (struck)
+    source text must be RETAINED in the output AND sit inside explicit
+    strikeout markup. Fails both when the text is dropped entirely and when
+    it appears only as plain content. Region-based like
+    `absent_unless_strikeout`, so wider-than-GT struck spans pass.
+    """
+
+    type: Literal[TestType.PRESENT_AS_STRIKEOUT.value]
+    text: str = ""
+
+
+class ParseTextColorRule(ParseRuleBase):
+    """Schema for `text_color` rules.
+
+    Validates that text appears inside an HTML tag whose attributes carry a
+    text color matching the expected color family (e.g. ``red``, ``blue``,
+    ``green``, ``orange``). Attribute colors may be named colors, hex codes
+    (``#c69200``) or ``rgb()`` values; matching is done by hue family, not
+    exact value, so ``#ffa6a6`` satisfies ``red``.
+
+    Primary use: colored revision text in legal redlines, where color encodes
+    revision semantics (e.g. red struck = deleted, blue underlined = inserted).
+    """
+
+    type: Literal[TestType.TEXT_COLOR.value]
+    text: str = ""
+    color: str = ""
+
+
 class ParseTitleRule(ParseRuleBase):
     type: Literal[TestType.IS_TITLE.value]
     text: str = ""
     level: int | None = None
 
 
+class ParseListLevelRule(ParseRuleBase):
+    """Schema for `list_level` rules.
+
+    Validates that `text` appears as a list item at nesting level `level`
+    (1 = top level). Levels are computed from the output with CommonMark
+    list-item semantics (https://spec.commonmark.org/0.31.2/#list-items): a
+    nested item's marker must sit at or beyond the column of the first content
+    character of the item it nests under - there is no fixed space count.
+    HTML `<ul>/<ol>/<li>` nesting is accepted as equivalent. Deliberately not
+    evaluated for indentation inside table cells.
+    """
+
+    type: Literal[TestType.LIST_LEVEL.value]
+    text: str = ""
+    level: int | None = None
+
+
 class ParseLatexRule(ParseRuleBase):
     type: Literal[TestType.IS_LATEX.value]
-    formula: str = ""
+    formula: str
+
+
+class ParseNotLatexRule(ParseRuleBase):
+    """Formula-like text that must remain ordinary Markdown."""
+
+    type: Literal[TestType.IS_NOT_LATEX.value]
+    text: str
 
 
 class ParseCodeBlockRule(ParseRuleBase):
@@ -445,6 +564,22 @@ class ParseCodeBlockRule(ParseRuleBase):
 class ParseTitleHierarchyPercentRule(ParseRuleBase):
     type: Literal[TestType.TITLE_HIERARCHY_PERCENT.value]
     title_hierarchy: dict[str, Any] = Field(default_factory=dict)
+
+
+class HeadingExpectation(DictCompatPydanticModel):
+    """One visible page heading in reading order."""
+
+    text: str = Field(min_length=1)
+    level: int = Field(ge=1, le=6)
+
+
+class ParseHeadingStructureRule(ParseRuleBase):
+    """Complete ordered heading inventory for one transcribed page."""
+
+    type: Literal[TestType.HEADING_STRUCTURE.value]
+    # Empty is a meaningful negative annotation, so callers must state it
+    # explicitly instead of silently getting a no-headings rule after a typo.
+    headings: list[HeadingExpectation]
 
 
 class ParsePageSectionRule(ParseRuleBase):
@@ -468,23 +603,143 @@ class ParseRotateCheckRule(ParseRuleBase):
     value: int | float | str | None = None
 
 
-class ParseFormFieldRule(ParseRuleBase):
-    """Schema for `form_field` rules.
+class ParseWatermarkRemovalRule(ParseRuleBase):
+    """Score watermark suppression without rewarding destroyed body text."""
 
-    Locates a labeled field in the parsed markdown/HTML and checks its value.
-    Used for benchmarking form (key-value, checkbox, signature) extraction.
+    type: Literal[TestType.WATERMARK_REMOVAL.value]
+    page: int = Field(ge=1)
+    watermark_texts: list[str] = Field(min_length=1)
+    allowed_occurrences: list[int] | None = Field(
+        default=None,
+        description=(
+            "Maximum output occurrences allowed for each watermark phrase. Use this when the same phrase "
+            "also occurs legitimately in the page body; defaults to zero for every phrase."
+        ),
+    )
+    preserve_texts: list[str] = Field(min_length=1)
+    watermark_match_threshold: float = Field(default=0.80, ge=0.0, le=1.0)
+    preserve_match_threshold: float = Field(default=0.85, ge=0.0, le=1.0)
+    removal_pass_threshold: float = Field(default=1.0, ge=0.0, le=1.0)
+    preservation_pass_threshold: float = Field(default=0.80, ge=0.0, le=1.0)
 
-    `value` may be a list of strings to declare acceptable alternatives for
-    genuinely ambiguous fields (e.g. illegible handwriting). The evaluator
-    passes if the parsed value matches *any* alternative. Use sparingly —
-    most rules should be a single string. List form is only for value_type
-    "text" and "signature".
+    @model_validator(mode="after")
+    def validate_allowed_occurrences(self) -> ParseWatermarkRemovalRule:
+        if self.allowed_occurrences is None:
+            return self
+        if len(self.allowed_occurrences) != len(self.watermark_texts):
+            raise ValueError("allowed_occurrences must have one value per watermark_texts entry")
+        if any(value < 0 for value in self.allowed_occurrences):
+            raise ValueError("allowed_occurrences values must be non-negative")
+        return self
+
+
+class ParseDiagramGraphRule(ParseRuleBase):
+    """One diagram the parser must render as a mermaid block whose *graph* matches ``graph``.
+
+    Mermaid source is never compared: both sides are parsed into labelled nodes and edges,
+    nodes are aligned by fuzzy label similarity (Hungarian assignment) and edges are scored on
+    the aligned node ids. ``graph`` is ``{"nodes": [{"id","label"}], "edges": [{"from","to",
+    "label"?, "directed"?}], "groups"?: [{"id","label","members"}]}``. ``bbox`` is normalized
+    COCO ``[x, y, w, h]`` in page fractions, as for inline images.
     """
 
-    type: Literal[TestType.FORM_FIELD.value]
-    label: str = ""
-    value: str | bool | list[str] = ""
-    value_type: Literal["text", "checkbox", "signature"] = "text"
+    type: Literal[TestType.DIAGRAM_GRAPH.value]
+    graph: dict[str, Any] = Field(default_factory=dict, description="Ground-truth graph: nodes, edges, optional groups")
+    diagram_class: str = Field(default="flowchart", description="Annotated kind (flowchart, org_chart, process, ...)")
+    accepted_types: list[str] = Field(
+        default_factory=lambda: ["flowchart"],
+        description="Mermaid diagram types that may represent this figure (flowchart, state, sequence, mindmap, ...)",
+    )
+    bbox: list[float] = Field(default_factory=list, description="Normalized [x, y, w, h] of the diagram on the page")
+    caption: str | None = Field(default=None, description="Verbatim caption printed next to the diagram, if any")
+    reference_image: str | None = Field(default=None, description="Crop PNG next to the test case, for the report")
+    text_before: list[str] = Field(default_factory=list, description="Text lines just above the diagram, reading order")
+    text_after: list[str] = Field(default_factory=list, description="Text lines just below the diagram, reading order")
+    annotator_confidence: float | None = Field(default=None, description="Annotator confidence in the graph")
+    node_match_threshold: int = Field(
+        default=80, description="rapidfuzz token_set_ratio at or above which two labels align"
+    )
+    node_recall_threshold: float = Field(default=0.80, description="Minimum share of expected nodes found")
+    node_precision_threshold: float = Field(
+        default=0.70, description="Minimum share of predicted nodes that are expected"
+    )
+    edge_f1_threshold: float = Field(default=0.60, description="Minimum edge F1 over aligned nodes")
+    edge_label_threshold: int = Field(default=70, description="Fuzzy ratio for edge labels when the reference has one")
+
+    @field_validator("bbox")
+    @classmethod
+    def _validate_bbox(cls, v: list[float]) -> list[float]:
+        if v and (len(v) != 4 or any(not isinstance(x, (int, float)) for x in v)):
+            raise ValueError("bbox must be [x, y, w, h]")
+        return [float(x) for x in v]
+
+    @field_validator("graph")
+    @classmethod
+    def _validate_graph(cls, v: dict[str, Any]) -> dict[str, Any]:
+        nodes = v.get("nodes") or []
+        ids = {str(n.get("id")) for n in nodes if isinstance(n, dict)}
+        if not ids:
+            raise ValueError("graph must declare at least one node")
+        for e in v.get("edges") or []:
+            if str(e.get("from")) not in ids or str(e.get("to")) not in ids:
+                raise ValueError(f"edge {e} references an unknown node id")
+        return v
+
+
+class ParseDiagramEdgeRule(ParseRuleBase):
+    """One relation that must (or must not) hold between two labelled nodes of a mermaid diagram.
+
+    Anchors are the robust complement to the graph rule: they are cheap to annotate, easy to
+    verify by eye, and insensitive to how creatively the rest of the diagram was transcribed.
+    ``relation`` is ``edge`` (a direct link source→target), ``path`` (source reaches target
+    through any directed chain, tolerating inserted intermediate nodes) or ``no_edge``.
+    """
+
+    type: Literal[TestType.DIAGRAM_EDGE.value]
+    source: str = Field(description="Label of the source node")
+    target: str = Field(description="Label of the target node")
+    relation: Literal["edge", "path", "no_edge"] = Field(default="edge")
+    label: str | None = Field(default=None, description="Expected edge text (e.g. Yes / No), fuzzy-matched when set")
+    directed: bool = Field(default=True, description="False accepts the link in either direction")
+    diagram_id: str | None = Field(default=None, description="``id`` of the diagram_graph rule this anchor belongs to")
+    node_match_threshold: int = Field(default=80, description="rapidfuzz token_set_ratio to identify source/target")
+    edge_label_threshold: int = Field(default=70, description="Fuzzy ratio for the edge label when set")
+
+
+class ParseDiagramCountRule(ParseRuleBase):
+    """Page-level decision: the right number of *parseable* mermaid blocks, none where none belong.
+
+    ``expected_count`` is 0 on negative pages (charts, schematics, maps, infographics) where any
+    mermaid block fails the rule. Blocks that do not parse into at least one node count against
+    the page everywhere.
+    """
+
+    type: Literal[TestType.DIAGRAM_COUNT.value]
+    expected_count: int = Field(default=0, description="Number of mermaid blocks the page should carry")
+    strict: bool = Field(default=True, description="Penalise extra parseable blocks beyond expected_count")
+
+
+class ParsePageDecorationRule(ParseRuleBase):
+    """Running header, running footer and printed page number of one page.
+
+    ``None`` for a slot means the page has none and the parser must leave it empty; a string is
+    the verbatim furniture text (header/footer pieces joined by `` | `` in reading order). The
+    rule reads the parser's structured page fields when available, else the markdown tags, and
+    also checks that the furniture text does not remain in the body markdown.
+    """
+
+    type: Literal[TestType.PAGE_DECORATION.value]
+    header: str | None = Field(
+        default=None, description="Running header text, pieces joined by ' | '; None = no header"
+    )
+    footer: str | None = Field(
+        default=None, description="Running footer text, pieces joined by ' | '; None = no footer"
+    )
+    page_number: str | None = Field(default=None, description="Canonical printed page number (3, iv, A-3); None = none")
+    page_number_raw: str | None = Field(default=None, description="Page number as printed (Page 3 of 10), for leakage")
+    text_threshold: int = Field(default=85, description="token_set_ratio at or above which header/footer text matches")
+    leak_min_chars: int = Field(default=4, description="Furniture pieces shorter than this are not checked for leakage")
+    annotator_confidence: float | None = Field(default=None, description="Annotator confidence, informational")
 
 
 type ParseRule = (
@@ -510,6 +765,7 @@ type ParseRule = (
     | ParseTablesValuesRule
     | ParseTablesNumRowsRule
     | ParseTablesNumColsRule
+    | ParseTableMarkerCellsRule
     | ParseTableColspanRule
     | ParseTableRowspanRule
     | ParseTableSameRowRule
@@ -528,21 +784,32 @@ type ParseRule = (
     | ParseChartDataPointRule
     | ParseChartDataArrayLabelsRule
     | ParseChartDataArrayDataRule
+    | ParseFormFieldRule
     | ParseFormattingRule
     | ParseMarkColorRule
+    | ParseTextColorRule
+    | ParseAbsentUnlessStrikeoutRule
+    | ParsePresentAsStrikeoutRule
     | ParseLatexRule
+    | ParseNotLatexRule
     | ParseCodeBlockRule
     | ParseTitleRule
     | ParseTitleHierarchyPercentRule
+    | ParseHeadingStructureRule
+    | ParseListLevelRule
     | ParsePageSectionRule
     | ParseBagOfDigitPercentRule
     | ParseRotateCheckRule
-    | ParseFormFieldRule
+    | ParseWatermarkRemovalRule
+    | ParseDiagramGraphRule
+    | ParseDiagramEdgeRule
+    | ParseDiagramCountRule
+    | ParsePageDecorationRule
 )
 
 type ParseRuleInput = ParseRule | dict[str, Any]
 
-_RULE_TYPE_TO_MODEL: dict[str, type[ParseRule]] = {
+_RULE_TYPE_TO_MODEL: dict[str, type[ParseRuleBase]] = {
     TestType.PRESENT.value: ParsePresenceRule,
     TestType.ABSENT.value: ParsePresenceRule,
     TestType.UNEXPECTED_SENTENCE.value: ParseUnexpectedSentenceRule,
@@ -566,6 +833,7 @@ _RULE_TYPE_TO_MODEL: dict[str, type[ParseRule]] = {
     TestType.TABLES_VALUES.value: ParseTablesValuesRule,
     TestType.TABLES_NUM_ROWS.value: ParseTablesNumRowsRule,
     TestType.TABLES_NUM_COLS.value: ParseTablesNumColsRule,
+    TestType.TABLE_MARKER_CELLS.value: ParseTableMarkerCellsRule,
     TestType.TABLE_COLSPAN.value: ParseTableColspanRule,
     TestType.TABLE_ROWSPAN.value: ParseTableRowspanRule,
     TestType.TABLE_SAME_ROW.value: ParseTableSameRowRule,
@@ -584,6 +852,7 @@ _RULE_TYPE_TO_MODEL: dict[str, type[ParseRule]] = {
     TestType.CHART_DATA_POINT.value: ParseChartDataPointRule,
     TestType.CHART_DATA_ARRAY_LABELS.value: ParseChartDataArrayLabelsRule,
     TestType.CHART_DATA_ARRAY_DATA.value: ParseChartDataArrayDataRule,
+    TestType.FORM_FIELD.value: ParseFormFieldRule,
     TestType.IS_UNDERLINE.value: ParseFormattingRule,
     TestType.IS_NOT_UNDERLINE.value: ParseFormattingRule,
     TestType.IS_BOLD.value: ParseFormattingRule,
@@ -595,19 +864,29 @@ _RULE_TYPE_TO_MODEL: dict[str, type[ParseRule]] = {
     TestType.IS_MARK.value: ParseFormattingRule,
     TestType.IS_NOT_MARK.value: ParseFormattingRule,
     TestType.MARK_COLOR.value: ParseMarkColorRule,
+    TestType.TEXT_COLOR.value: ParseTextColorRule,
+    TestType.ABSENT_UNLESS_STRIKEOUT.value: ParseAbsentUnlessStrikeoutRule,
+    TestType.PRESENT_AS_STRIKEOUT.value: ParsePresentAsStrikeoutRule,
     TestType.IS_SUP.value: ParseFormattingRule,
     TestType.IS_NOT_SUP.value: ParseFormattingRule,
     TestType.IS_SUB.value: ParseFormattingRule,
     TestType.IS_NOT_SUB.value: ParseFormattingRule,
     TestType.IS_LATEX.value: ParseLatexRule,
+    TestType.IS_NOT_LATEX.value: ParseNotLatexRule,
     TestType.IS_CODE_BLOCK.value: ParseCodeBlockRule,
     TestType.IS_TITLE.value: ParseTitleRule,
     TestType.TITLE_HIERARCHY_PERCENT.value: ParseTitleHierarchyPercentRule,
+    TestType.HEADING_STRUCTURE.value: ParseHeadingStructureRule,
+    TestType.LIST_LEVEL.value: ParseListLevelRule,
     TestType.IS_HEADER.value: ParsePageSectionRule,
     TestType.IS_FOOTER.value: ParsePageSectionRule,
     TestType.BAG_OF_DIGIT_PERCENT.value: ParseBagOfDigitPercentRule,
     TestType.ROTATE_CHECK.value: ParseRotateCheckRule,
-    TestType.FORM_FIELD.value: ParseFormFieldRule,
+    TestType.WATERMARK_REMOVAL.value: ParseWatermarkRemovalRule,
+    TestType.DIAGRAM_GRAPH.value: ParseDiagramGraphRule,
+    TestType.DIAGRAM_EDGE.value: ParseDiagramEdgeRule,
+    TestType.DIAGRAM_COUNT.value: ParseDiagramCountRule,
+    TestType.PAGE_DECORATION.value: ParsePageDecorationRule,
 }
 
 
@@ -724,7 +1003,7 @@ def rule_to_dict(rule: ParseRuleInput | Any) -> dict[str, Any]:
     raise TypeError(f"Expected ParseRule or dict, got {type(rule)!r}")
 
 
-def coerce_parse_rule(rule_data: ParseRuleInput | Any) -> ParseRule:
+def coerce_parse_rule(rule_data: ParseRuleInput | Any) -> ParseRuleBase:
     """Coerce raw rule payloads into the typed parse rule model.
 
     Idempotent: already-typed rules are returned as-is.
@@ -749,7 +1028,7 @@ def coerce_parse_rule(rule_data: ParseRuleInput | Any) -> ParseRule:
     return model_cls.model_validate(rule_dict)
 
 
-def coerce_parse_rule_list(rules: list[dict[str, Any]] | list[ParseRule]) -> list[ParseRule]:
+def coerce_parse_rule_list(rules: list[dict[str, Any]] | list[ParseRule]) -> list[ParseRuleBase]:
     """Validate a list of parse rule payloads and return typed objects."""
 
     parsed: list[ParseRule] = []
@@ -760,7 +1039,7 @@ def coerce_parse_rule_list(rules: list[dict[str, Any]] | list[ParseRule]) -> lis
 
 def coerce_parse_rule_list_or_none(
     rules: list[dict[str, Any]] | list[ParseRule] | None,
-) -> list[ParseRule] | None:
+) -> list[ParseRuleBase] | None:
     """Coerce rule lists while preserving explicit None for optional fields."""
 
     if rules is None:

--- a/src/parse_bench/test_cases/schema.py
+++ b/src/parse_bench/test_cases/schema.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Discriminator, Field, Tag, field_validator
+from pydantic import BaseModel, ConfigDict, Discriminator, Field, SerializeAsAny, Tag, field_validator
 
 from parse_bench.test_cases.parse_rule_schemas import (
     ParseRule,
+    ParseRuleBase,
     coerce_parse_rule,
-    coerce_parse_rule_list_or_none,
 )
 
 # =============================================================================
@@ -223,10 +223,49 @@ class ExtractTestCase(BaseTestCase):
         return [rule for rule in self.test_rules if isinstance(rule, ExtractFieldTestRule)]
 
 
-class ParseTestCase(BaseTestCase):
-    """Test case for PARSE product type."""
+def _coerce_mixed_rule_list(
+    value: list[dict[str, Any]] | list[LayoutTestRule | SerializeAsAny[ParseRuleBase] | ExtractFieldTestRule] | None,
+) -> list[LayoutTestRule | SerializeAsAny[ParseRuleBase] | ExtractFieldTestRule]:
+    """Coerce a mixed rule list (dicts + typed models) into typed models.
 
-    test_rules: list[ParseRule] | None = Field(
+    ``ParseTestCase`` accepts layout rules (``type=layout``) and extract-field
+    rules (``type=extract_field``) alongside parse rules on the same
+    ``test_rules`` list, so one on-disk payload validates identically whether
+    the outer case is detector-shaped or parse-shaped. Parse-only consumers
+    filter the non-parse entries out before scoring.
+    """
+    if value is None:
+        return []
+
+    typed_rules: list[LayoutTestRule | SerializeAsAny[ParseRuleBase] | ExtractFieldTestRule] = []
+    for rule in value:
+        if isinstance(rule, (LayoutTestRule, ExtractFieldTestRule)):
+            typed_rules.append(rule)
+            continue
+
+        if isinstance(rule, dict):
+            rule_type = rule.get("type")
+            if rule_type == "layout":
+                typed_rules.append(LayoutTestRule.model_validate(rule))
+            elif rule_type == "extract_field":
+                typed_rules.append(ExtractFieldTestRule.model_validate(rule))
+            else:
+                typed_rules.append(coerce_parse_rule(rule))
+            continue
+
+        typed_rules.append(coerce_parse_rule(rule))
+
+    return typed_rules
+
+
+class ParseTestCase(BaseTestCase):
+    """Test case for PARSE product type.
+
+    Accepts parse rules (``present``, ``order``, ``table``, ...) as well as
+    layout and extract-field rules on the same ``test_rules`` list.
+    """
+
+    test_rules: list[LayoutTestRule | SerializeAsAny[ParseRuleBase] | ExtractFieldTestRule] | None = Field(
         default=None,
         description="List of rule-based test definitions (from test.json test_rules)",
     )
@@ -275,12 +314,33 @@ class ParseTestCase(BaseTestCase):
         ),
     )
 
+    metadata: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Additional metadata (doc_category, complexity_rank, expected_pages for page-aware table matching, etc.)"
+        ),
+    )
+
     @field_validator("test_rules", mode="before")
     @classmethod
-    def _coerce_parse_rules(cls, value: list[dict[str, Any]] | None) -> list[ParseRule] | None:
+    def _coerce_rules(
+        cls, value: list[dict[str, Any]] | None
+    ) -> list[LayoutTestRule | SerializeAsAny[ParseRuleBase] | ExtractFieldTestRule] | None:
         if value is None:
             return None
-        return coerce_parse_rule_list_or_none(value)
+        return _coerce_mixed_rule_list(value)
+
+    def get_parse_rules(self) -> list[ParseRuleBase]:
+        """Return only the parse rules from ``test_rules`` (layout/extract-field rules excluded)."""
+        if not self.test_rules:
+            return []
+        return [rule for rule in self.test_rules if not isinstance(rule, (LayoutTestRule, ExtractFieldTestRule))]
+
+    def get_extract_field_rules(self) -> list[ExtractFieldTestRule]:
+        """Return only the typed ``extract_field`` rules from ``test_rules``."""
+        if not self.test_rules:
+            return []
+        return [rule for rule in self.test_rules if isinstance(rule, ExtractFieldTestRule)]
 
 
 class LayoutDetectionTestCase(BaseTestCase):

--- a/tests/parse_bench/evaluation/evaluators/test_parse_evaluator_layout_rule_filter.py
+++ b/tests/parse_bench/evaluation/evaluators/test_parse_evaluator_layout_rule_filter.py
@@ -1,0 +1,382 @@
+"""Regression tests for ParseEvaluator layout-rule filtering.
+
+PR #731 (M5b) widened ``ParseTestCase.test_rules`` to accept layout rule
+models alongside parse rules. Without filtering, ``ParseEvaluator`` would
+route layout rules through the parse rule factory, which can't build them —
+each layout rule was counted as a spurious failure, depressing
+``rule_pass_rate`` on any mixed dataset.
+
+See the Devin review on PR #731:
+https://github.com/run-llama/experimental/pull/731#discussion_r3120682402
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import patch
+
+from parse_bench.evaluation.evaluators.parse import ParseEvaluator
+from parse_bench.schemas.evaluation import MetricValue
+from parse_bench.schemas.parse_output import (
+    LayoutItemIR,
+    LayoutSegmentIR,
+    ParseLayoutPageIR,
+    ParseOutput,
+)
+from parse_bench.schemas.pipeline_io import InferenceRequest, InferenceResult
+from parse_bench.schemas.product import ProductType
+from parse_bench.test_cases.parse_rule_schemas import coerce_parse_rule
+from parse_bench.test_cases.schema import LayoutTestRule, ParseTestCase
+
+
+def _make_inference_result(
+    markdown: str = "alpha beta gamma",
+    layout_pages: list[ParseLayoutPageIR] | None = None,
+    grounded_pages: list[dict[str, Any]] | None = None,
+    raw_output: dict[str, Any] | None = None,
+    pipeline_name: str = "test_pipeline",
+) -> InferenceResult:
+    return InferenceResult(
+        request=InferenceRequest(
+            example_id="grp/doc",
+            source_file_path="doc.pdf",
+            product_type=ProductType.PARSE,
+        ),
+        pipeline_name=pipeline_name,
+        product_type=ProductType.PARSE,
+        raw_output=raw_output or {},
+        output=ParseOutput(
+            example_id="grp/doc",
+            pipeline_name="test_pipeline",
+            markdown=markdown,
+            layout_pages=layout_pages or [],
+            grounded_pages=grounded_pages or [],
+        ),
+        started_at=datetime.now(UTC),
+        completed_at=datetime.now(UTC),
+        latency_in_ms=1,
+    )
+
+
+def _make_layout_rule(canonical_class: str = "Text") -> LayoutTestRule:
+    return LayoutTestRule(
+        page=1,
+        bbox=[0.1, 0.1, 0.2, 0.2],
+        canonical_class=canonical_class,
+    )
+
+
+def _make_parse_test_case(test_rules: list) -> ParseTestCase:
+    # ``model_construct`` bypasses ``ParseTestCase``'s parse-rule-only validator
+    # so tests can inject mixed-rule lists matching the post-M5b on-disk shape.
+    return ParseTestCase.model_construct(
+        test_id="grp/doc",
+        group="grp",
+        file_path="doc.pdf",
+        test_rules=test_rules,
+    )
+
+
+def _rule_only_evaluator() -> ParseEvaluator:
+    """Evaluator with every table/text metric disabled so ``evaluate`` exercises
+    only the rule-based branch under test."""
+    return ParseEvaluator(
+        enable_rule_based=True,
+        enable_text_similarity=False,
+        enable_teds=False,
+        enable_grits=False,
+        enable_header_accuracy=False,
+        enable_structural_consistency=False,
+        enable_table_record_match=False,
+        enable_table_composite=False,
+    )
+
+
+def test_mixed_rules_filter_layout_before_rule_metric() -> None:
+    """Layout rules are stripped before the parse rule-based metric runs."""
+    parse_rule_a = coerce_parse_rule({"type": "present", "text": "alpha"})
+    parse_rule_b = coerce_parse_rule({"type": "present", "text": "beta"})
+    layout_rule = _make_layout_rule()
+
+    test_case = _make_parse_test_case([parse_rule_a, layout_rule, parse_rule_b])
+    inference_result = _make_inference_result(markdown="alpha beta gamma")
+
+    evaluator = _rule_only_evaluator()
+
+    with patch.object(
+        evaluator._rule_metric,
+        "compute",
+        wraps=evaluator._rule_metric.compute,
+    ) as mock_compute:
+        result = evaluator.evaluate(inference_result, test_case)
+
+    assert mock_compute.call_count == 1
+    forwarded = mock_compute.call_args.kwargs["expected"]
+    assert forwarded == [parse_rule_a, parse_rule_b]
+    assert all(not isinstance(r, LayoutTestRule) for r in forwarded)
+
+    rule_pass = next(m for m in result.metrics if m.metric_name == "rule_pass_rate")
+    # Two parse rules, both present in the markdown → pass_rate 1.0 on the
+    # filtered 2-rule denominator (NOT 2/3).
+    assert rule_pass.value == 1.0
+    assert rule_pass.metadata.get("total") == 2
+
+
+def test_only_layout_rules_skips_rule_based_branch(caplog) -> None:
+    """When only layout rules are present, the rule-based branch is skipped
+    entirely — no rule_pass_rate=1.0 emitted for zero parse rules."""
+    layout_rule = _make_layout_rule()
+
+    test_case = _make_parse_test_case([layout_rule])
+    inference_result = _make_inference_result(markdown="non-empty markdown content")
+
+    evaluator = _rule_only_evaluator()
+
+    with patch.object(evaluator._rule_metric, "compute") as mock_compute:
+        with caplog.at_level("DEBUG", logger="parse_bench.evaluation.evaluators.parse"):
+            result = evaluator.evaluate(inference_result, test_case)
+
+    assert mock_compute.call_count == 0
+    assert all(m.metric_name != "rule_pass_rate" for m in result.metrics)
+    assert any("only layout rules present" in rec.message for rec in caplog.records)
+
+
+def test_only_parse_rules_unchanged_from_pre_fix() -> None:
+    """Regression guard: with only parse rules, behavior is identical to
+    the pre-fix path."""
+    parse_rule = coerce_parse_rule({"type": "present", "text": "alpha"})
+
+    test_case = _make_parse_test_case([parse_rule])
+    inference_result = _make_inference_result(markdown="alpha beta gamma")
+
+    evaluator = _rule_only_evaluator()
+
+    with patch.object(
+        evaluator._rule_metric,
+        "compute",
+        wraps=evaluator._rule_metric.compute,
+    ) as mock_compute:
+        result = evaluator.evaluate(inference_result, test_case)
+
+    assert mock_compute.call_count == 1
+    forwarded = mock_compute.call_args.kwargs["expected"]
+    assert forwarded == [parse_rule]
+
+    rule_pass = next(m for m in result.metrics if m.metric_name == "rule_pass_rate")
+    assert rule_pass.value == 1.0
+    assert rule_pass.metadata.get("total") == 1
+
+
+def test_empty_test_rules_markdown_only_skips_rule_branch(caplog) -> None:
+    """Existing behavior: empty ``test_rules`` + ``expected_markdown`` skips
+    the rule-based branch and emits the 'not provided' debug log."""
+    test_case = ParseTestCase(
+        test_id="grp/doc",
+        group="grp",
+        file_path="doc.pdf",
+        test_rules=[],
+        expected_markdown="# Ground truth heading\n",
+    )
+    inference_result = _make_inference_result(markdown="# Ground truth heading\n")
+
+    evaluator = _rule_only_evaluator()
+
+    with patch.object(evaluator._rule_metric, "compute") as mock_compute:
+        with caplog.at_level("DEBUG", logger="parse_bench.evaluation.evaluators.parse"):
+            _ = evaluator.evaluate(inference_result, test_case)
+
+    assert mock_compute.call_count == 0
+    assert any("test_rules not provided" in rec.message for rec in caplog.records)
+
+
+def test_mixed_rules_layout_failure_does_not_poison_metric() -> None:
+    """Without the filter, a failing layout rule (ValueError from the parse
+    factory) would be caught and counted as failed, depressing pass_rate.
+    With the filter, only the parse rule counts toward the denominator."""
+    parse_rule = coerce_parse_rule({"type": "present", "text": "alpha"})
+    layout_rules = [_make_layout_rule() for _ in range(5)]
+
+    test_case = _make_parse_test_case([parse_rule, *layout_rules])
+    inference_result = _make_inference_result(markdown="alpha beta gamma")
+
+    evaluator = _rule_only_evaluator()
+
+    result = evaluator.evaluate(inference_result, test_case)
+    rule_pass = next(
+        (m for m in result.metrics if m.metric_name == "rule_pass_rate"),
+        None,
+    )
+    assert rule_pass is not None
+    # Without the filter: 1 pass / 6 total = 0.1667. With the filter: 1 / 1 = 1.0.
+    assert rule_pass.value == 1.0
+    assert rule_pass.metadata.get("total") == 1
+
+
+def test_metric_value_is_metricvalue_instance() -> None:
+    """Guard that the wrapping code still returns a MetricValue (not a list)
+    when the filter is in effect — downstream code destructures this object."""
+    parse_rule = coerce_parse_rule({"type": "present", "text": "alpha"})
+    test_case = _make_parse_test_case([parse_rule, _make_layout_rule()])
+    inference_result = _make_inference_result(markdown="alpha")
+
+    evaluator = _rule_only_evaluator()
+
+    result = evaluator.evaluate(inference_result, test_case)
+    rule_pass = next(m for m in result.metrics if m.metric_name == "rule_pass_rate")
+    assert isinstance(rule_pass, MetricValue)
+
+
+# ---------------------------------------------------------------------------
+# Detector-only vs pure-parse gating (Devin PR #757, Finding 1)
+# ---------------------------------------------------------------------------
+#
+# The ``has_markdown`` gate introduced in M5b was too broad: any pipeline that
+# returned empty markdown (including *broken* pure-parse pipelines) skipped
+# every text metric and returned ``success=True`` with an empty metric list.
+# The intended behaviour is to skip text metrics *only* for legitimate
+# detector-only outputs (layout rules present + populated ``layout_pages``
+# + empty markdown). Broken pure-parse pipelines must still surface a failure
+# signal (``rule_pass_rate=0``).
+
+
+def _layout_page_with_one_item() -> ParseLayoutPageIR:
+    return ParseLayoutPageIR(
+        page_number=1,
+        width=100.0,
+        height=100.0,
+        items=[
+            LayoutItemIR(
+                type="text",
+                bbox=LayoutSegmentIR(x=0.1, y=0.1, w=0.2, h=0.2, label="Text"),
+            )
+        ],
+    )
+
+
+def test_broken_pure_parse_pipeline_emits_zero_rule_pass_rate() -> None:
+    """Regression (PR #757 Finding 1): a pure-parse test + broken pipeline
+    (empty markdown, empty layout_pages) must still emit ``rule_pass_rate=0``
+    rather than silently returning an empty metric list."""
+    parse_rule = coerce_parse_rule({"type": "present", "text": "alpha"})
+    test_case = _make_parse_test_case([parse_rule])
+    inference_result = _make_inference_result(markdown="", layout_pages=[])
+
+    evaluator = _rule_only_evaluator()
+    result = evaluator.evaluate(inference_result, test_case)
+
+    rule_pass = next(
+        (m for m in result.metrics if m.metric_name == "rule_pass_rate"),
+        None,
+    )
+    assert rule_pass is not None, "rule_pass_rate must be emitted for broken pure-parse runs"
+    assert rule_pass.value == 0.0
+
+
+def test_detector_only_output_still_skips_text_metrics() -> None:
+    """Existing M5b behaviour: detector-only output (layout rule + populated
+    ``layout_pages`` + empty markdown) skips text metrics entirely."""
+    layout_rule = _make_layout_rule()
+    test_case = _make_parse_test_case([layout_rule])
+    inference_result = _make_inference_result(
+        markdown="",
+        layout_pages=[_layout_page_with_one_item()],
+    )
+
+    evaluator = _rule_only_evaluator()
+    result = evaluator.evaluate(inference_result, test_case)
+
+    assert all(m.metric_name != "rule_pass_rate" for m in result.metrics)
+
+
+def test_line_word_layout_rules_do_not_make_output_detector_only() -> None:
+    """Line/word layout rules should not suppress text metrics for parse tests.
+
+    Only region-level layout rules identify detector-only outputs. Granular OCR
+    rules can coexist with parse rules, so an empty-markdown parse run should
+    still emit text-metric failures instead of being silently skipped.
+    """
+    parse_rule = coerce_parse_rule({"type": "present", "text": "alpha"})
+    word_rule = LayoutTestRule(
+        id="word-1",
+        page=1,
+        bbox=[0.1, 0.1, 0.1, 0.05],
+        canonical_class="Text",
+        content={"type": "text", "text": "alpha"},
+        granularity="word",
+    )
+    test_case = _make_parse_test_case([parse_rule, word_rule])
+    inference_result = _make_inference_result(
+        markdown="",
+        layout_pages=[_layout_page_with_one_item()],
+    )
+
+    evaluator = _rule_only_evaluator()
+    result = evaluator.evaluate(inference_result, test_case)
+
+    rule_pass = next((m for m in result.metrics if m.metric_name == "rule_pass_rate"), None)
+    assert rule_pass is not None
+    assert rule_pass.value == 0.0
+
+
+def _layout_page_without_items() -> ParseLayoutPageIR:
+    return ParseLayoutPageIR(page_number=1, width=100.0, height=100.0, items=[])
+
+
+def test_pipeline_emitting_no_layout_pages_is_still_skipped() -> None:
+    """Text-only providers keep their metrics absent, not zeroed.
+
+    They never claimed a layout capability, so scoring them zero on every
+    layout document would be a leaderboard change, not a bug fix.
+    """
+    test_case = _make_parse_test_case([_make_layout_rule()])
+    inference_result = _make_inference_result(layout_pages=[])
+
+    result = _rule_only_evaluator().evaluate(inference_result, test_case)
+
+    assert all(m.metric_name != "layout_element_rule_pass_rate" for m in result.metrics)
+
+
+def _attributed_layout_page(text: str) -> ParseLayoutPageIR:
+    return ParseLayoutPageIR(
+        page_number=1,
+        width=100.0,
+        height=100.0,
+        md=text,
+        items=[
+            LayoutItemIR(
+                type="text",
+                value=text,
+                bbox=LayoutSegmentIR(
+                    x=10.0,
+                    y=10.0,
+                    w=20.0,
+                    h=20.0,
+                    label="text",
+                    confidence=1.0,
+                ),
+                layout_segments=[
+                    LayoutSegmentIR(
+                        x=10.0,
+                        y=10.0,
+                        w=20.0,
+                        h=20.0,
+                        label="text",
+                        confidence=1.0,
+                        start_index=0,
+                        end_index=max(0, len(text) - 1),
+                    )
+                ],
+            )
+        ],
+    )
+
+
+def _attribution_rule(text: str) -> LayoutTestRule:
+    return LayoutTestRule(
+        page=1,
+        bbox=[0.1, 0.1, 0.2, 0.2],
+        canonical_class="Text",
+        content={"type": "text", "text": text},
+        ro_index=0,
+    )

--- a/tests/parse_bench/evaluation/evaluators/test_parse_evaluator_styling_rollup.py
+++ b/tests/parse_bench/evaluation/evaluators/test_parse_evaluator_styling_rollup.py
@@ -1,0 +1,14 @@
+"""Regression tests for the normalized text-styling rollup."""
+
+import pytest
+
+from parse_bench.evaluation.evaluators.parse import _styling_f_beta_score
+
+
+def test_styling_f_beta_penalizes_negative_rule_failure_more_heavily() -> None:
+    false_styling_score = _styling_f_beta_score(pos_score=1.0, neg_score=0.5)
+    missed_styling_score = _styling_f_beta_score(pos_score=0.5, neg_score=1.0)
+
+    assert false_styling_score == pytest.approx(5 / 9)
+    assert missed_styling_score == pytest.approx(5 / 6)
+    assert false_styling_score < missed_styling_score

--- a/tests/parse_bench/evaluation/evaluators/test_parse_evaluator_table_pages.py
+++ b/tests/parse_bench/evaluation/evaluators/test_parse_evaluator_table_pages.py
@@ -1,0 +1,273 @@
+"""Tests for page-native table matching wired through ParseEvaluator.
+
+Covers ``_predicted_markdown_and_pages`` (predicted tables sourced from
+``output.pages``) and the end-to-end behavior when a parse test case carries the
+native per-page GT field ``metadata["expected_pages"]``: GriTS pairs tables within
+the same page, and the predicted side does not depend on the flat
+``output.markdown`` ordering.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from parse_bench.evaluation.evaluators.parse import (
+    ParseEvaluator,
+    _gt_markdown_and_pages,
+    _predicted_markdown_and_pages,
+)
+from parse_bench.evaluation.metrics.parse.grits_metric import GriTSMetric
+from parse_bench.evaluation.metrics.parse.table_extraction import extract_html_tables, extract_normalized_tables
+from parse_bench.evaluation.metrics.parse.teds_metric import TEDSMetric
+from parse_bench.schemas.parse_output import PageIR, ParseOutput
+from parse_bench.schemas.pipeline_io import InferenceRequest, InferenceResult
+from parse_bench.schemas.product import ProductType
+from parse_bench.test_cases.schema import ParseTestCase
+
+
+class _PageAwareParseTestCase(ParseTestCase):
+    """``ParseTestCase`` carrying the optional ``metadata`` bag the evaluator reads
+    ``expected_pages`` from. Declared here so the page-aware path is exercised
+    even while the public ``ParseTestCase`` schema has no ``metadata`` field."""
+
+    metadata: dict[str, Any] | None = None
+
+
+# Two same-structure 2x2 tables with disjoint content.
+_T_ALPHA = "<table><tr><td>a1</td><td>a2</td></tr><tr><td>a3</td><td>a4</td></tr></table>"
+_T_BETA = "<table><tr><td>b1</td><td>b2</td></tr><tr><td>b3</td><td>b4</td></tr></table>"
+_T_CHECKMARK = (
+    "<table><thead><tr><th>Options</th><th>Comp 1 (*)</th></tr></thead>"
+    "<tbody><tr><td>Automatic Transmission</td><td>[no]</td></tr>"
+    "<tr><td>Overdrive</td><td>[yes]</td></tr></tbody></table>"
+)
+_T_CHECKMARK_FLIPPED = _T_CHECKMARK.replace(
+    "<td>Automatic Transmission</td><td>[no]</td>",
+    "<td>Automatic Transmission</td><td>[yes]</td>",
+)
+
+
+def _parse_output(
+    page_markdowns: list[str],
+    *,
+    document_markdown: str | None = None,
+    job_id: str | None = None,
+    page_indices: list[int] | None = None,
+) -> ParseOutput:
+    """ParseOutput with per-page markdown. ``document_markdown`` overrides the
+    flat ``output.markdown`` (defaults to the page concatenation) so tests can
+    deliberately desync it from the pages."""
+    indices = page_indices if page_indices is not None else list(range(len(page_markdowns)))
+    pages = [PageIR(page_index=i, markdown=md) for i, md in zip(indices, page_markdowns, strict=True)]
+    return ParseOutput(
+        example_id="grp/doc",
+        pipeline_name="test_pipeline",
+        markdown=document_markdown if document_markdown is not None else "\n\n".join(page_markdowns),
+        pages=pages,
+        job_id=job_id,
+    )
+
+
+def _inference_result(output: ParseOutput) -> InferenceResult:
+    return InferenceResult(
+        request=InferenceRequest(
+            example_id="grp/doc",
+            source_file_path="doc.pdf",
+            product_type=ProductType.PARSE,
+        ),
+        pipeline_name="test_pipeline",
+        product_type=ProductType.PARSE,
+        raw_output={},
+        output=output,
+        started_at=datetime.now(UTC),
+        completed_at=datetime.now(UTC),
+        latency_in_ms=1,
+    )
+
+
+def _test_case_pages(pages: list[tuple[int, str]], *, document_markdown: str | None = None) -> ParseTestCase:
+    """Page-aware GT: ``pages`` = [(page_num, markdown), ...]. ``document_markdown``
+    overrides the flat ``expected_markdown`` (defaults to the per-page concatenation)
+    so tests can deliberately desync it from the per-page GT."""
+    metadata: dict = {"expected_pages": [{"page": p, "markdown": md} for p, md in pages]}
+    return _PageAwareParseTestCase.model_construct(
+        test_id="grp/doc",
+        group="grp",
+        file_path="doc.pdf",
+        expected_markdown=document_markdown if document_markdown is not None else "\n\n".join(md for _, md in pages),
+        metadata=metadata,
+    )
+
+
+def _test_case_blob(expected_markdown: str) -> ParseTestCase:
+    """Non-page-aware GT: a single concatenated blob with no page metadata."""
+    return ParseTestCase.model_construct(
+        test_id="grp/doc",
+        group="grp",
+        file_path="doc.pdf",
+        expected_markdown=expected_markdown,
+        metadata=None,
+    )
+
+
+def _by_name(metrics) -> dict[str, float]:
+    return {m.metric_name: m.value for m in metrics}
+
+
+def _grits_meta(metrics):
+    return next(m.metadata for m in metrics if m.metric_name == "grits_con")
+
+
+# --- metadata-only evaluator routing --------------------------------------
+
+
+def test_predicted_markdown_and_pages_sources_from_pages():
+    out = _parse_output([_T_ALPHA, "", _T_BETA + _T_BETA])  # p1:1 table, p2:0, p3:2 tables
+    md, labels = _predicted_markdown_and_pages(out)
+    assert labels == [1, 3, 3]
+    assert len(extract_html_tables(md)) == 3
+
+
+def test_predicted_markdown_and_pages_none_when_no_pages():
+    out = ParseOutput(example_id="grp/doc", pipeline_name="p", markdown=_T_ALPHA, pages=[])
+    assert _predicted_markdown_and_pages(out) is None
+
+
+def test_gt_markdown_and_pages_built_together_order_agnostic():
+    # Pages listed out of order: labels follow the entries and the markdown is
+    # concatenated to match — no assumption that pages ascend.
+    field = [{"page": 5, "markdown": _T_BETA}, {"page": 2, "markdown": _T_ALPHA + _T_ALPHA}]
+    md, labels = _gt_markdown_and_pages(field)
+    assert labels == [5, 2, 2]
+    assert len(extract_html_tables(md)) == 3
+
+
+# --- end-to-end through ParseEvaluator -------------------------------------
+
+
+def test_page_metadata_constrains_grits_pairing():
+    # GT: alpha@1, beta@2. Prediction: beta@1, alpha@2 (cross-page look-alikes).
+    evaluator = ParseEvaluator()  # grits on, teds off (sequential path)
+    test_case = _test_case_pages([(1, _T_ALPHA), (2, _T_BETA)])
+    result = evaluator.evaluate(_inference_result(_parse_output([_T_BETA, _T_ALPHA])), test_case)
+
+    meta = _grits_meta(result.metrics)
+    # Same-page pairing only — no detail crosses pages.
+    for d in meta["per_table_details"]:
+        if d.get("pred_table_index") is not None:
+            assert d["gt_page"] == d["pred_page"]
+    # alpha-vs-beta on each page is an imperfect match, so grits_con < 1.0.
+    assert _by_name(result.metrics)["grits_con"] < 1.0
+
+
+def test_table_metrics_penalize_a_flipped_checkmark():
+    """Content metrics must see a single mark flip even when shape is unchanged."""
+
+    expected, _ = extract_normalized_tables(_T_CHECKMARK, side="expected")
+    actual, _ = extract_normalized_tables(_T_CHECKMARK_FLIPPED, side="actual")
+
+    grits = GriTSMetric().compute(expected, actual)
+    teds = TEDSMetric().compute(_T_CHECKMARK, _T_CHECKMARK_FLIPPED)
+
+    assert next(metric.value for metric in grits if metric.metric_name == "grits_con") < 1.0
+    assert next(metric.value for metric in teds if metric.metric_name == "teds") < 1.0
+    # Structural-only scores are expected to remain perfect: the regression
+    # guard is specifically the content-bearing variants above.
+    assert next(metric.value for metric in teds if metric.metric_name == "teds_struct") == 1.0
+
+
+def test_page_aware_metrics_surface_missing_and_extra_page_tables():
+    """A missing table cannot pair across pages; cardinalities expose an extra."""
+
+    evaluator = ParseEvaluator(enable_teds=True)
+    test_case = _test_case_pages([(11, _T_ALPHA), (14, _T_BETA)])
+    # Page 11 is missing; page 14 has the correct table plus an extra table.
+    output = _parse_output(["", _T_BETA + _T_ALPHA], page_indices=[10, 13])
+    result = evaluator.evaluate(_inference_result(output), test_case)
+
+    grits = _grits_meta(result.metrics)
+    teds = next(metric for metric in result.metrics if metric.metric_name == "teds")
+    assert _by_name(result.metrics)["grits_con"] == 0.5
+    assert teds.value == 0.5
+    assert grits["tables_found_expected"] == 2
+    assert grits["tables_found_actual"] == 2
+    assert grits["tables_matched"] == 1
+    matched = [detail for detail in grits["per_table_details"] if detail.get("pred_table_index") is not None]
+    assert len(matched) == 1
+    assert matched[0]["gt_page"] == matched[0]["pred_page"] == 14
+    assert teds.metadata["tables_found_actual"] == 2
+    assert teds.metadata["tables_matched"] == 1
+
+
+def test_predicted_tables_sourced_from_pages_not_document_markdown():
+    # THE regression that proves the fix: output.markdown is ordered DIFFERENTLY
+    # from output.pages. The old approach (tables from output.markdown, labels
+    # from output.pages, joined by index) would mislabel the pages and mispair;
+    # sourcing predicted tables from output.pages keeps it correct.
+    evaluator = ParseEvaluator()
+    test_case = _test_case_pages([(1, _T_ALPHA), (2, _T_BETA)])
+    output = _parse_output(
+        [_T_ALPHA, _T_BETA],  # pages: alpha@1, beta@2 (correct)
+        document_markdown=_T_BETA + _T_ALPHA,  # flat markdown reversed (would mislead a positional join)
+    )
+    result = evaluator.evaluate(_inference_result(output), test_case)
+
+    assert _by_name(result.metrics)["grits_con"] == 1.0  # alpha@1<->alpha@1, beta@2<->beta@2
+    for d in _grits_meta(result.metrics)["per_table_details"]:
+        if d.get("pred_table_index") is not None:
+            assert d["gt_page"] == d["pred_page"]
+
+
+def test_gt_tables_sourced_from_expected_pages_not_blob():
+    # GT side, mirror of the predicted-side regression: expected_pages is listed
+    # out of page order AND the expected_markdown blob is in yet another order.
+    # GT tables must be sourced from expected_pages (page intrinsic), so matching
+    # stays correct regardless of order.
+    evaluator = ParseEvaluator()
+    test_case = _test_case_pages(
+        [(2, _T_BETA), (1, _T_ALPHA)],  # pages listed out of order
+        document_markdown=_T_ALPHA + _T_BETA,  # flat blob in a different order again
+    )
+    result = evaluator.evaluate(_inference_result(_parse_output([_T_ALPHA, _T_BETA])), test_case)
+
+    assert _by_name(result.metrics)["grits_con"] == 1.0  # alpha@1<->alpha@1, beta@2<->beta@2
+    for d in _grits_meta(result.metrics)["per_table_details"]:
+        if d.get("pred_table_index") is not None:
+            assert d["gt_page"] == d["pred_page"]
+
+
+def test_no_page_metadata_matches_globally():
+    # No page labels -> global matching cross-pairs the identical content and
+    # scores 1.0 (normal-dataset behavior).
+    evaluator = ParseEvaluator()
+    test_case = _test_case_blob(_T_ALPHA + _T_BETA)
+    result = evaluator.evaluate(_inference_result(_parse_output([_T_BETA, _T_ALPHA])), test_case)
+
+    assert _by_name(result.metrics)["grits_con"] == 1.0
+
+
+def test_normal_multipage_doc_single_blob_gt_stays_global():
+    # Backward-compat guard: a multi-page prediction but a single-blob GT with no
+    # page metadata must match GLOBALLY (not be page-blocked), so the cross-page
+    # look-alikes still pair and score 1.0 — identical to pre-page-aware behavior.
+    evaluator = ParseEvaluator()
+    test_case = _test_case_blob(_T_ALPHA + _T_BETA)
+    output = _parse_output([_T_BETA, _T_ALPHA])  # prediction genuinely spans 2 pages
+    result = evaluator.evaluate(_inference_result(output), test_case)
+    assert _by_name(result.metrics)["grits_con"] == 1.0
+
+
+def test_empty_pages_falls_back_to_global():
+    # output.pages empty -> page-blocking disabled (global matching, score 1.0).
+    evaluator = ParseEvaluator()
+    test_case = _test_case_pages([(1, _T_ALPHA), (2, _T_BETA)])
+    output = ParseOutput(
+        example_id="grp/doc",
+        pipeline_name="test_pipeline",
+        markdown=_T_BETA + _T_ALPHA,
+        pages=[],
+    )
+    result = evaluator.evaluate(_inference_result(output), test_case)
+
+    assert _by_name(result.metrics)["grits_con"] == 1.0  # fell back to global cross-pairing

--- a/tests/parse_bench/evaluation/metrics/parse/test_chart_data_point_rule.py
+++ b/tests/parse_bench/evaluation/metrics/parse/test_chart_data_point_rule.py
@@ -1,0 +1,825 @@
+from __future__ import annotations
+
+import pytest
+
+from parse_bench.evaluation.metrics.parse.rules_chart import (
+    ChartDataPointRule,
+    extract_numeric_parts,
+)
+from parse_bench.evaluation.metrics.parse.table_parsing import (
+    parse_html_tables,
+)
+
+# ---------------------------------------------------------------------------
+# extract_numeric_parts
+# ---------------------------------------------------------------------------
+
+
+class TestExtractNumericParts:
+    def test_composite_with_parenthetical_percentage(self):
+        assert extract_numeric_parts("25 (13.0%)") == ["25", "13.0%"]
+
+    def test_composite_comma_separated(self):
+        assert extract_numeric_parts("25, 13.0%") == ["25", "13.0%"]
+
+    def test_single_number(self):
+        assert extract_numeric_parts("25") == ["25"]
+
+    def test_single_percentage(self):
+        assert extract_numeric_parts("13.0%") == ["13.0%"]
+
+    def test_no_numbers(self):
+        assert extract_numeric_parts("hello world") == []
+
+    def test_negative_number(self):
+        assert extract_numeric_parts("-5 (2.3%)") == ["-5", "2.3%"]
+
+    def test_thousands_separator(self):
+        assert extract_numeric_parts("1,234 (56.7%)") == ["1,234", "56.7%"]
+
+
+# ---------------------------------------------------------------------------
+# parse_html_tables – colspan/rowspan grid alignment
+# ---------------------------------------------------------------------------
+
+EGDI_HTML = """\
+<table>
+  <thead>
+    <tr>
+      <th rowspan="2">Year</th>
+      <th colspan="2">Very high EGDI</th>
+      <th colspan="2">High EGDI</th>
+      <th colspan="2">Middle EGDI</th>
+      <th colspan="2">Low EGDI</th>
+    </tr>
+    <tr>
+      <th>Number</th><th>Percentage</th>
+      <th>Number</th><th>Percentage</th>
+      <th>Number</th><th>Percentage</th>
+      <th>Number</th><th>Percentage</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr><td>2014</td><td>25</td><td>13.0%</td><td>62</td><td>32.1%</td><td>74</td><td>38.3%</td><td>32</td><td>16.6%</td></tr>
+    <tr><td>2016</td><td>29</td><td>15.0%</td><td>75</td><td>38.9%</td><td>57</td><td>29.5%</td><td>32</td><td>16.6%</td></tr>
+    <tr><td>2018</td><td>40</td><td>20.7%</td><td>73</td><td>37.8%</td><td>65</td><td>33.7%</td><td>15</td><td>7.8%</td></tr>
+    <tr><td>2022</td><td>60</td><td>31.1%</td><td>73</td><td>37.8%</td><td>53</td><td>27.5%</td><td>7</td><td>3.6%</td></tr>
+    <tr><td>2024</td><td>76</td><td>39.4%</td><td>62</td><td>32.1%</td><td>44</td><td>22.8%</td><td>11</td><td>5.7%</td></tr>
+  </tbody>
+</table>
+"""
+
+
+class TestParseHtmlTablesColspan:
+    """Verify that colspan/rowspan tables produce a correctly aligned grid."""
+
+    def test_grid_dimensions(self):
+        tables = parse_html_tables(EGDI_HTML)
+        assert len(tables) == 1
+        arr = tables[0].data
+        # 2 header rows + 5 data rows = 7 rows, 9 columns (Year + 4×2)
+        assert arr.shape == (7, 9)
+
+    def test_header_row0_spans_correctly(self):
+        """Row 0 should have 'Very high EGDI' in both col 1 and col 2."""
+        arr = parse_html_tables(EGDI_HTML)[0].data
+        assert arr[0, 0] == "Year"
+        assert arr[0, 1] == "Very high EGDI"
+        assert arr[0, 2] == "Very high EGDI"  # colspan=2 fills both
+        assert arr[0, 3] == "High EGDI"
+        assert arr[0, 4] == "High EGDI"
+
+    def test_header_row1_sub_headers(self):
+        """Row 1 col 0 should be 'Year' (from rowspan=2), rest are sub-headers."""
+        arr = parse_html_tables(EGDI_HTML)[0].data
+        assert arr[1, 0] == "Year"  # rowspan=2 from row 0
+        assert arr[1, 1] == "Number"
+        assert arr[1, 2] == "Percentage"
+        assert arr[1, 3] == "Number"
+
+    def test_data_row_alignment(self):
+        """Data rows should align with the grid columns."""
+        arr = parse_html_tables(EGDI_HTML)[0].data
+        assert arr[2, 0] == "2014"
+        assert arr[2, 1] == "25"
+        assert arr[2, 2] == "13.0%"
+        assert arr[2, 3] == "62"
+
+    def test_col_headers_include_parent_and_sub(self):
+        """col_headers for column 1 should include both 'Very high EGDI' and 'Number'."""
+        td = parse_html_tables(EGDI_HTML)[0]
+        headers_col1 = td.col_headers.get(1, [])
+        header_texts = [text for _, text in headers_col1]
+        assert "Very high EGDI" in header_texts
+        assert "Number" in header_texts
+
+
+# ---------------------------------------------------------------------------
+# ChartDataPointRule – composite value + multi-row header integration
+# ---------------------------------------------------------------------------
+
+
+class TestChartDataPointRuleComposite:
+    """End-to-end tests for composite value matching against colspan tables."""
+
+    def test_composite_value_found(self):
+        rule = ChartDataPointRule(
+            {
+                "type": "chart_data_point",
+                "value": "25 (13.0%)",
+                "labels": ["Very high EGDI", "2014"],
+                "normalize_numbers": True,
+            }
+        )
+        passed, msg, score = rule.run(EGDI_HTML)
+        assert passed, f"Expected pass but got: {msg}"
+        assert score == 1.0
+
+    def test_composite_value_middle_egdi(self):
+        rule = ChartDataPointRule(
+            {
+                "type": "chart_data_point",
+                "value": "74 (38.3%)",
+                "labels": ["Middle EGDI", "2014"],
+                "normalize_numbers": True,
+            }
+        )
+        passed, msg, score = rule.run(EGDI_HTML)
+        assert passed, f"Expected pass but got: {msg}"
+
+    def test_composite_value_high_egdi_2018(self):
+        rule = ChartDataPointRule(
+            {
+                "type": "chart_data_point",
+                "value": "73 (37.8%)",
+                "labels": ["High EGDI", "2018"],
+                "normalize_numbers": True,
+            }
+        )
+        passed, msg, score = rule.run(EGDI_HTML)
+        assert passed, f"Expected pass but got: {msg}"
+
+    def test_composite_value_very_high_2024(self):
+        rule = ChartDataPointRule(
+            {
+                "type": "chart_data_point",
+                "value": "76 (39.4%)",
+                "labels": ["Very high EGDI", "2024"],
+                "normalize_numbers": True,
+            }
+        )
+        passed, msg, score = rule.run(EGDI_HTML)
+        assert passed, f"Expected pass but got: {msg}"
+
+    def test_composite_value_low_egdi_2022(self):
+        rule = ChartDataPointRule(
+            {
+                "type": "chart_data_point",
+                "value": "7 (3.6%)",
+                "labels": ["Low EGDI", "2022"],
+                "normalize_numbers": True,
+            }
+        )
+        passed, msg, score = rule.run(EGDI_HTML)
+        assert passed, f"Expected pass but got: {msg}"
+
+    def test_wrong_label_fails(self):
+        rule = ChartDataPointRule(
+            {
+                "type": "chart_data_point",
+                "value": "25 (13.0%)",
+                "labels": ["Low EGDI", "2014"],
+                "normalize_numbers": True,
+            }
+        )
+        passed, msg, score = rule.run(EGDI_HTML)
+        assert not passed
+
+    def test_simple_value_still_works(self):
+        """Non-composite values should still match directly."""
+        simple_html = """\
+        <table>
+          <thead><tr><th>Category</th><th>Value</th></tr></thead>
+          <tbody><tr><td>Alpha</td><td>42</td></tr></tbody>
+        </table>
+        """
+        rule = ChartDataPointRule(
+            {
+                "type": "chart_data_point",
+                "value": "42",
+                "labels": ["Alpha"],
+                "normalize_numbers": True,
+            }
+        )
+        passed, msg, score = rule.run(simple_html)
+        assert passed, f"Expected pass but got: {msg}"
+
+
+# ---------------------------------------------------------------------------
+# ChartDataPointRule – candidate-local label association
+# ---------------------------------------------------------------------------
+
+
+def _chart_rule(value: str, labels: list[str], **overrides: object) -> ChartDataPointRule:
+    return ChartDataPointRule({"type": "chart_data_point", "value": value, "labels": labels, **overrides})
+
+
+TDR_SHORT_YEAR_HTML = """\
+<table>
+  <caption>Profit shares, 2003–2023</caption>
+  <thead><tr><th>series</th><th>time</th><th>Percentage of GDP</th></tr></thead>
+  <tbody>
+    <tr><td>Developed countries</td><td>2008</td><td>35.4</td></tr>
+    <tr><td>Developing countries</td><td>2008</td><td>43.9</td></tr>
+    <tr><td>Developed countries</td><td>2013</td><td>36.2</td></tr>
+    <tr><td>Developing countries</td><td>2013</td><td>42.8</td></tr>
+    <tr><td>Developed countries</td><td>2018</td><td>36.6</td></tr>
+    <tr><td>Developing countries</td><td>2018</td><td>42.8</td></tr>
+    <tr><td>Developed countries</td><td>2023</td><td>37.5</td></tr>
+    <tr><td>Developing countries</td><td>2009</td><td>42</td></tr>
+  </tbody>
+</table>
+"""
+
+
+class TestChartDataPointRuleCandidateScope:
+    @pytest.mark.parametrize(
+        ("rule_id", "value", "labels"),
+        [
+            ("6e8111febcee9313", "35.4", ["08", "Developed countries"]),
+            ("47ae484dae89bd02", "43.9", ["08", "Developing countries"]),
+            ("3b541111e18251ba", "36.2", ["13", "Developed countries"]),
+            ("7edf15f4a202c4bc", "42.8", ["13", "Developing countries"]),
+            ("cb54981ef59399df", "36.6", ["18", "Developed countries"]),
+            ("c2fcad4000b813ca", "42.8", ["18", "Developing countries"]),
+            ("be7daa129968d42a", "37.5", ["23", "Developed countries"]),
+            ("1ba4437111b8bcf6", "42", ["09", "Developing countries"]),
+        ],
+        ids=[
+            "6e8111febcee9313",
+            "47ae484dae89bd02",
+            "3b541111e18251ba",
+            "7edf15f4a202c4bc",
+            "cb54981ef59399df",
+            "c2fcad4000b813ca",
+            "be7daa129968d42a",
+            "1ba4437111b8bcf6",
+        ],
+    )
+    def test_two_digit_year_suffix_matches_candidate_local_four_digit_year(
+        self,
+        rule_id: str,
+        value: str,
+        labels: list[str],
+    ) -> None:
+        passed, message, score = _chart_rule(value, labels).run(TDR_SHORT_YEAR_HTML)
+
+        assert passed, f"{rule_id}: {message}"
+        assert score == 1.0
+        assert "candidate-local scope" in message
+
+    @pytest.mark.parametrize("candidate_year", ["1908", "20090", "2009.0"])
+    def test_two_digit_year_suffix_rejects_non_equivalent_numeric_tokens(self, candidate_year: str) -> None:
+        table = f"""\
+<table>
+  <thead><tr><th>Series</th><th>Year</th><th>Value</th></tr></thead>
+  <tbody><tr><td>Target</td><td>{candidate_year}</td><td>42</td></tr></tbody>
+</table>
+"""
+
+        passed, message, score = _chart_rule("42", ["Target", "09"]).run(table)
+
+        assert not passed, message
+        assert score == 0.0
+
+    def test_two_digit_year_suffix_does_not_borrow_caption_or_unrelated_body_row(self) -> None:
+        table = """\
+<p>Unrelated discussion of results from 2009.</p>
+<table>
+  <caption>Archive for 2009</caption>
+  <thead><tr><th>Series</th><th>Year</th><th>Value</th></tr></thead>
+  <tbody>
+    <tr><td>Other</td><td>2009</td><td>17</td></tr>
+    <tr><td>Target</td><td>2010</td><td>42</td></tr>
+  </tbody>
+</table>
+"""
+
+        passed, message, score = _chart_rule("42", ["Target", "09"]).run(table)
+
+        assert not passed, message
+        assert score == 0.0
+
+    def test_eu27_collision_does_not_borrow_another_value_row(self) -> None:
+        table = """\
+| Country | Year | Value |
+| --- | --- | --- |
+| EU27 | 2014 | 24.425 |
+| Greece | 2022 | 17 |
+| Germany | 2022 | 17 |
+"""
+        passed, message, score = _chart_rule("17", ["EU27", "2022"]).run(table)
+
+        assert not passed
+        assert score == 0.0
+        assert message.startswith("Value found but labels not associated:")
+        assert "found with all labels" not in message
+
+    def test_full_length_wrong_year_collision_fails(self) -> None:
+        table = """\
+| Country | Year | Value |
+| --- | --- | --- |
+| Hungary | 2014 | 29 |
+| Poland | 2022 | 11 |
+"""
+        passed, _, score = _chart_rule("29", ["Hungary", "2022"]).run(table)
+
+        assert not passed
+        assert score == 0.0
+
+    def test_exact_target_reports_the_target_candidate(self) -> None:
+        table = """\
+| Country | Year | Value |
+| --- | --- | --- |
+| EU27 | 2022 | 17 |
+| Greece | 2022 | 17 |
+"""
+        passed, message, score = _chart_rule("17", ["EU27", "2022"]).run(table)
+
+        assert passed, message
+        assert score == 1.0
+        assert "candidate-local scope at (1, 2)" in message
+
+    def test_column_oriented_table_uses_candidate_row_and_column_header(self) -> None:
+        table = """\
+| Year | EU27 | Greece |
+| --- | --- | --- |
+| 2022 | 17 | 19 |
+"""
+        passed, message, _ = _chart_rule("17", ["EU27", "2022"]).run(table)
+
+        assert passed, message
+
+    def test_transposed_series_by_year_table_passes(self) -> None:
+        table = """\
+| Series | 2021 | 2022 |
+| --- | --- | --- |
+| EU27 | 16 | 17 |
+"""
+        passed, message, _ = _chart_rule("17", ["EU27", "2022"]).run(table)
+
+        assert passed, message
+
+    def test_horizontal_records_table_passes(self) -> None:
+        table = """\
+| Country | 2021 | 2022 |
+| --- | --- | --- |
+| EU27 | 16 | 17 |
+| Greece | 15 | 18 |
+"""
+        passed, message, _ = _chart_rule("17", ["EU27", "2022"]).run(table)
+
+        assert passed, message
+
+    def test_rowspan_row_header_and_column_header_pass(self) -> None:
+        table = """\
+<table>
+  <thead><tr><th>Country</th><th>Year</th><th>Value</th></tr></thead>
+  <tbody>
+    <tr><th rowspan="2">EU27</th><td>2022</td><td>17</td></tr>
+    <tr><td>2023</td><td>18</td></tr>
+  </tbody>
+</table>
+"""
+        passed, message, _ = _chart_rule("17", ["EU27", "2022"]).run(table)
+
+        assert passed, message
+
+    def test_mixed_cell_thead_keeps_every_authored_header_level(self) -> None:
+        table = """\
+<table>
+  <thead><tr><td>2022</td></tr><tr><th>Q1</th></tr></thead>
+  <tbody><tr><td>17</td></tr></tbody>
+</table>
+"""
+
+        passed, message, score = _chart_rule("17", ["2022", "Q1"]).run(table)
+
+        assert passed, message
+        assert score == 1.0
+
+    def test_top_level_th_header_row_without_thead_supplies_column_label(self) -> None:
+        table = "<table><tr><th>Country</th><th>2022</th></tr><tr><td>EU27</td><td>17</td></tr></table>"
+
+        passed, message, score = _chart_rule("17", ["EU27", "2022"]).run(table)
+
+        assert passed, message
+        assert score == 1.0
+
+    def test_leading_td_title_does_not_hide_top_level_header(self) -> None:
+        table = """\
+<table>
+  <tr><td colspan="2">Population</td></tr>
+  <tr><th>Country</th><th>2022</th></tr>
+  <tr><td>EU27</td><td>17</td></tr>
+</table>
+"""
+
+        passed, message, score = _chart_rule("17", ["EU27", "2022"]).run(table)
+
+        assert passed, message
+        assert score == 1.0
+
+    def test_leading_empty_row_does_not_hide_top_level_header(self) -> None:
+        table = (
+            "<table><tr><td></td><td></td></tr><tr><th>Country</th><th>2022</th></tr>"
+            "<tr><td>EU27</td><td>17</td></tr></table>"
+        )
+
+        passed, message, score = _chart_rule("17", ["EU27", "2022"]).run(table)
+
+        assert passed, message
+        assert score == 1.0
+
+    def test_identical_tbody_row_does_not_shadow_top_level_header_provenance(self) -> None:
+        table = """\
+<table>
+  <tr><th>2022</th></tr>
+  <tbody><tr><th>2022</th></tr><tr><td>17</td></tr></tbody>
+</table>
+"""
+
+        passed, message, score = _chart_rule("17", ["2022"]).run(table)
+
+        assert passed, message
+        assert score == 1.0
+
+    def test_lxml_recovered_top_level_th_header_row_supplies_column_label(self) -> None:
+        table = "<table><tr><th>Country<th>2022</tr><tr><td>EU27<td>17</tr></table>"
+
+        passed, message, score = _chart_rule("17", ["EU27", "2022"]).run(table)
+
+        assert passed, message
+        assert score == 1.0
+
+    def test_top_level_mixed_header_accepts_empty_corner_td(self) -> None:
+        table = "<table><tr><td></td><th>2022</th></tr><tr><th>EU27</th><td>17</td></tr></table>"
+
+        passed, message, score = _chart_rule("17", ["EU27", "2022"]).run(table)
+
+        assert passed, message
+        assert score == 1.0
+
+    def test_top_level_mixed_header_rejects_nonempty_corner_td(self) -> None:
+        table = "<table><tr><td>Country</td><th>2022</th></tr><tr><td>EU27</td><td>17</td></tr></table>"
+
+        passed, message, score = _chart_rule("17", ["EU27", "2022"]).run(table)
+
+        assert not passed
+        assert score == 0.0
+        assert message.startswith("Value found but labels not associated:")
+
+    def test_tbody_th_does_not_become_a_column_label_for_later_value(self) -> None:
+        table = """\
+<table><tbody>
+  <tr><th>Other</th><td>2022</td></tr>
+  <tr><td>Target</td><td>17</td></tr>
+</tbody></table>
+"""
+        passed, message, score = _chart_rule("17", ["Target", "2022"]).run(table)
+
+        assert not passed
+        assert score == 0.0
+        assert message.startswith("Value found but labels not associated:")
+
+    def test_tbody_th_only_row_does_not_become_an_implicit_header_block(self) -> None:
+        table = "<table><tbody><tr><th>Country</th><th>2022</th></tr><tr><td>EU27</td><td>17</td></tr></tbody></table>"
+
+        passed, message, score = _chart_rule("17", ["EU27", "2022"]).run(table)
+
+        assert not passed
+        assert score == 0.0
+        assert message.startswith("Value found but labels not associated:")
+
+    def test_tfoot_th_does_not_become_an_implicit_header_block(self) -> None:
+        table = "<table><tfoot><tr><th>2022</th></tr></tfoot><tbody><tr><td>17</td></tr></tbody></table>"
+
+        passed, message, score = _chart_rule("17", ["2022"]).run(table)
+
+        assert not passed
+        assert score == 0.0
+        assert message.startswith("Value found but labels not associated:")
+
+    def test_scope_row_does_not_become_an_implicit_column_header(self) -> None:
+        table = '<table><tr><th scope="row">2022</th><td></td></tr><tr><td>Target</td><td>17</td></tr></table>'
+
+        passed, _, score = _chart_rule("17", ["Target", "2022"]).run(table)
+
+        assert not passed
+        assert score == 0.0
+
+    def test_scope_row_in_thead_does_not_become_a_column_header(self) -> None:
+        table = (
+            '<table><thead><tr><th scope="row">Wrong</th><td>Series</td></tr></thead>'
+            "<tbody><tr><td>17</td><td>Target</td></tr></tbody></table>"
+        )
+
+        passed, _, score = _chart_rule("17", ["Wrong", "Target"]).run(table)
+
+        assert not passed
+        assert score == 0.0
+
+    def test_scope_row_in_thead_keeps_adjacent_td_column_header(self) -> None:
+        table = (
+            '<table><thead><tr><th scope="row">Row label</th><td>2022</td></tr></thead>'
+            "<tbody><tr><td>Target</td><td>17</td></tr></tbody></table>"
+        )
+
+        passed, message, score = _chart_rule("17", ["Target", "2022"]).run(table)
+
+        assert passed, message
+        assert score == 1.0
+
+    def test_value_before_a_later_thead_fails_without_crashing(self) -> None:
+        table = (
+            "<table><tbody><tr><td>Target</td><td>17</td></tr></tbody>"
+            "<thead><tr><th>Series</th><th>2022</th></tr></thead></table>"
+        )
+
+        passed, _, score = _chart_rule("17", ["Target", "2022"]).run(table)
+
+        assert not passed
+        assert score == 0.0
+
+    def test_scope_col_in_tbody_is_an_authored_column_header(self) -> None:
+        table = (
+            '<table><tbody><tr><th scope="col">Series</th><th scope="col">2022</th></tr>'
+            "<tr><td>Target</td><td>17</td></tr></tbody></table>"
+        )
+
+        passed, message, score = _chart_rule("17", ["Target", "2022"]).run(table)
+
+        assert passed, message
+        assert score == 1.0
+
+    def test_scope_colgroup_expands_to_the_authored_column_group(self) -> None:
+        table = """\
+<table>
+  <colgroup span="2"></colgroup>
+  <thead><tr><th scope="colgroup">Group A</th><th>Year</th></tr></thead>
+  <tbody><tr><td>18</td><td>17</td></tr></tbody>
+</table>
+"""
+
+        passed, message, score = _chart_rule("17", ["Group A", "Year"]).run(table)
+
+        assert passed, message
+        assert score == 1.0
+
+    def test_scope_rowgroup_expands_to_later_rows_in_the_authored_group(self) -> None:
+        table = """\
+<table><tbody>
+  <tr><th scope="rowgroup">Group A</th><td>2022</td><td>17</td></tr>
+  <tr><td>2023</td><td>18</td></tr>
+</tbody></table>
+"""
+
+        passed, message, score = _chart_rule("18", ["Group A", "2023"]).run(table)
+
+        assert passed, message
+        assert score == 1.0
+
+    def test_scoped_tfoot_header_does_not_leak_to_body_candidate(self) -> None:
+        table = '<table><tfoot><tr><th scope="col">2022</th></tr></tfoot><tbody><tr><td>17</td></tr></tbody></table>'
+
+        passed, message, score = _chart_rule("17", ["2022"]).run(table)
+
+        assert not passed
+        assert score == 0.0
+        assert message.startswith("Value found but labels not associated:")
+
+    def test_all_td_table_preserves_a_unique_vertical_header_association(self) -> None:
+        table = "<table><tr><td>Year</td><td>2022</td></tr><tr><td>Target</td><td>17</td></tr></table>"
+
+        passed, message, score = _chart_rule("17", ["Target", "2022"]).run(table)
+
+        assert passed, message
+        assert score == 1.0
+        assert "unique all-td row/column scope" in message
+
+    def test_all_td_table_rejects_an_ambiguous_vertical_header_association(self) -> None:
+        table = (
+            "<table><tr><td>Year</td><td>2022</td><td>2022</td></tr>"
+            "<tr><td>Target</td><td>17</td><td>17</td></tr></table>"
+        )
+
+        passed, message, score = _chart_rule("17", ["Target", "2022"]).run(table)
+
+        assert not passed
+        assert score == 0.0
+        assert message.startswith("Value found but labels not associated:")
+
+    def test_later_thead_replaces_stale_header_block(self) -> None:
+        table = """\
+<table>
+  <thead><tr><th>Series</th><th>2014</th></tr></thead>
+  <tbody><tr><td>Old</td><td>17</td></tr></tbody>
+  <thead><tr><th>Series</th><th>2022</th></tr></thead>
+  <tbody><tr><td>Target</td><td>18</td></tr></tbody>
+</table>
+"""
+
+        current_passed, current_message, _ = _chart_rule("18", ["Target", "2022"]).run(table)
+        stale_passed, _, stale_score = _chart_rule("18", ["Target", "2014"]).run(table)
+
+        assert current_passed, current_message
+        assert not stale_passed
+        assert stale_score == 0.0
+
+    def test_tfoot_rowspan_cannot_leak_to_a_body_candidate(self) -> None:
+        table = (
+            '<table><tfoot><tr><th rowspan="2">2022</th><td>Footer</td></tr></tfoot>'
+            "<tbody><tr><td>Target</td><td>17</td></tr></tbody></table>"
+        )
+
+        passed, _, score = _chart_rule("17", ["Target", "2022"]).run(table)
+
+        assert not passed
+        assert score == 0.0
+
+    def test_tbody_th_in_value_column_does_not_leak_to_later_value(self) -> None:
+        table = """\
+<table><tbody>
+  <tr><td>EU27</td><td>2014</td><th>EU27</th></tr>
+  <tr><td>Greece</td><td>2022</td><td>17</td></tr>
+</tbody></table>
+"""
+        passed, message, score = _chart_rule("17", ["EU27", "2022"]).run(table)
+
+        assert not passed
+        assert score == 0.0
+        assert message.startswith("Value found but labels not associated:")
+
+    def test_context_title_augments_a_coherent_candidate_scope(self) -> None:
+        table = """\
+## Chart identity: EU27 outcomes
+
+| Country | Value |
+| --- | --- |
+| Greece | 17 |
+"""
+        passed, message, _ = _chart_rule("17", ["Greece", "EU27 outcomes"]).run(table)
+
+        assert passed, message
+        assert "title labels ['eu27 outcomes'] in context" in message
+
+    def test_generic_formatted_context_cannot_repair_data_labels_from_different_rows(self) -> None:
+        table = """\
+**EU27 in 2022**
+
+| Country | Year | Value |
+| --- | --- | --- |
+| EU27 | 2014 | 17 |
+| Greece | 2022 | 19 |
+"""
+        passed, _, score = _chart_rule("17", ["EU27", "2022"]).run(table)
+
+        assert not passed
+        assert score == 0.0
+
+    def test_heading_identity_remains_valid_when_label_also_occurs_in_table(self) -> None:
+        table = """\
+## Germany overview
+
+| Country | Year | Value |
+| --- | --- | --- |
+| France | 2022 | 17 |
+| Germany | 2021 | 18 |
+"""
+
+        passed, message, score = _chart_rule("17", ["France", "2022", "Germany"]).run(table)
+
+        assert passed, message
+        assert score == 1.0
+        assert "title labels ['germany'] in context" in message
+
+    def test_caption_identity_remains_valid_when_label_also_occurs_in_table(self) -> None:
+        table = """\
+<table>
+  <caption>Earthquakes overview</caption>
+  <thead><tr><th>Series</th><th>Value</th></tr></thead>
+  <tbody><tr><td>Floods</td><td>17</td></tr><tr><td>Earthquakes</td><td>18</td></tr></tbody>
+</table>
+"""
+
+        passed, message, score = _chart_rule("17", ["Floods", "Earthquakes"]).run(table)
+
+        assert passed, message
+        assert score == 1.0
+        assert "title labels ['earthquakes'] in context" in message
+
+    def test_punctuation_and_short_exact_labels_remain_valid(self) -> None:
+        table = """\
+| Series | Value |
+| --- | --- |
+| U.S. | 7 |
+| EU-27 | 17 |
+"""
+        us_passed, us_message, _ = _chart_rule("7", ["US"]).run(table)
+        eu_passed, eu_message, _ = _chart_rule("17", ["EU 27"]).run(table)
+        combined_us_table = """\
+| Series | Value |
+| --- | --- |
+| U.S. total | 8 |
+"""
+        combined_us_passed, combined_us_message, _ = _chart_rule("8", ["US"]).run(combined_us_table)
+        hyphenated_q1_table = """\
+| Quarter | Value |
+| --- | --- |
+| Q1-2024 | 9 |
+"""
+        slash_delimited_q1_table = hyphenated_q1_table.replace("Q1-2024", "Q1/2024").replace("9", "10")
+        hyphenated_q1_passed, hyphenated_q1_message, _ = _chart_rule("9", ["Q1"]).run(hyphenated_q1_table)
+        slash_delimited_q1_passed, slash_delimited_q1_message, _ = _chart_rule("10", ["Q1"]).run(
+            slash_delimited_q1_table
+        )
+
+        assert us_passed, us_message
+        assert eu_passed, eu_message
+        assert combined_us_passed, combined_us_message
+        assert hyphenated_q1_passed, hyphenated_q1_message
+        assert slash_delimited_q1_passed, slash_delimited_q1_message
+        assert not _chart_rule("7", ["EU27"])._label_matches("EU27", "7")
+        assert not _chart_rule("27", ["EU27"])._label_matches("EU27", "27")
+
+    def test_short_label_as_a_distinct_combined_cell_token_remains_valid(self) -> None:
+        table = """\
+| Quarter | Value |
+| --- | --- |
+| Q1 2024 | 4.2 |
+"""
+
+        passed, message, score = _chart_rule("4.2", ["Q1"]).run(table)
+
+        assert passed, message
+        assert score == 1.0
+
+    def test_short_delimited_label_matches_a_longer_candidate_local_cell(self) -> None:
+        table = """\
+| Series | Value |
+| --- | --- |
+| N/A total | 4.2 |
+"""
+
+        passed, message, score = _chart_rule("4.2", ["N/A"]).run(table)
+
+        assert passed, message
+        assert score == 1.0
+
+    def test_semantically_different_label_fails(self) -> None:
+        table = """\
+| Degree | Value |
+| --- | --- |
+| Bachelor's degree | 42 |
+"""
+        passed, _, score = _chart_rule("42", ["Master's degree"]).run(table)
+
+        assert not passed
+        assert score == 0.0
+
+    def test_three_part_composite_value_uses_the_first_part_as_anchor(self) -> None:
+        table = """\
+| Country | Year | Count | Share | Rate |
+| --- | --- | --- | --- | --- |
+| EU27 | 2022 | 25 | 13.0% | 40 |
+"""
+        passed, message, _ = _chart_rule("25 (13.0%) 40", ["EU27", "2022"], normalize_numbers=True).run(table)
+
+        assert passed, message
+        assert "(1, 2)" in message
+
+    def test_numeric_tolerance_keeps_candidate_association(self) -> None:
+        within = """\
+| Country | Year | Value |
+| --- | --- | --- |
+| EU27 | 2022 | 101 |
+"""
+        outside = within.replace("101", "103")
+        rule = _chart_rule("100", ["EU27", "2022"], normalize_numbers=True, relative_tolerance=0.02)
+
+        assert rule.run(within)[0]
+        assert not rule.run(outside)[0]
+
+    def test_later_correct_duplicate_value_is_selected(self) -> None:
+        table = """\
+| Country | Year | Value |
+| --- | --- | --- |
+| EU27 | 2014 | 17 |
+| Greece | 2022 | 17 |
+| EU27 | 2022 | 17 |
+"""
+        passed, message, score = _chart_rule("17", ["EU27", "2022"]).run(table)
+
+        assert passed, message
+        assert score == 1.0
+        assert "candidate-local scope at (3, 2)" in message

--- a/tests/parse_bench/evaluation/metrics/parse/test_chart_label_punctuation.py
+++ b/tests/parse_bench/evaluation/metrics/parse/test_chart_label_punctuation.py
@@ -1,0 +1,98 @@
+"""Encoding-only punctuation must never decide a chart label match (issue #2314).
+
+Two halves are covered here:
+
+1. The deterministic label-matching path already folds typographic punctuation via
+   ``normalize_text``. These tests lock that in so a future normalization change
+   cannot silently reintroduce the defect.
+2. The judge evidence builder now folds the same punctuation on BOTH sides, so the
+   LLM judge is never handed a pure encoding difference to arbitrate.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from parse_bench.evaluation.metrics.parse.utils import normalize_label_punctuation, normalize_text
+
+# --------------------------------------------------------------------------
+# normalize_label_punctuation
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("typographic", "ascii_form"),
+    [
+        # Curly vs straight apostrophe -- the defect reported in issue #2314.
+        ("’26F", "'26F"),
+        ("Bachelor’s degree", "Bachelor's degree"),
+        ("‘26F", "'26F"),
+        # Curly vs straight double quote.
+        ("“Net zero” scenario", '"Net zero" scenario'),
+        # En dash and em dash vs ASCII hyphen.
+        ("2024–2030", "2024-2030"),
+        ("2024—2030", "2024-2030"),
+    ],
+)
+def test_typographic_punctuation_folds_to_ascii(typographic: str, ascii_form: str) -> None:
+    assert normalize_label_punctuation(typographic) == normalize_label_punctuation(ascii_form)
+
+
+@pytest.mark.parametrize(
+    ("typographic", "ascii_form"),
+    [
+        ("′26F", "'26F"),
+        ("2024‑2030", "2024-2030"),
+        ("2024‒2030", "2024-2030"),
+        ("2024−2030", "2024-2030"),
+    ],
+)
+def test_deterministic_quote_and_dash_variants_fold_for_judge_evidence(
+    typographic: str,
+    ascii_form: str,
+) -> None:
+    assert normalize_label_punctuation(typographic) == normalize_label_punctuation(ascii_form)
+
+
+@pytest.mark.parametrize(
+    ("typographic", "expected"),
+    [
+        ("’26F", "'26f"),
+        ("“Net zero” scenario", '"net zero" scenario'),
+        ("2024‑2030", "2024-2030"),
+        ("2024‒2030", "2024-2030"),
+        ("2024–2030", "2024-2030"),
+        ("2024—2030", "2024-2030"),
+        ("2024−2030", "2024-2030"),
+    ],
+)
+def test_normalize_text_folds_same_quote_and_dash_variants(
+    typographic: str,
+    expected: str,
+) -> None:
+    """Prove the deterministic utility emits the intended canonical form."""
+    assert normalize_text(typographic) == expected
+
+
+def test_internal_whitespace_runs_collapse_and_trim() -> None:
+    assert normalize_label_punctuation("  Data   center\tsemiconductors \n") == "Data center semiconductors"
+
+
+def test_case_and_wording_are_preserved() -> None:
+    """Unlike normalize_text, this must stay legible for judge-facing evidence."""
+    assert normalize_label_punctuation("Data Center Semiconductors") == "Data Center Semiconductors"
+
+
+def test_none_normalizes_to_empty_string() -> None:
+    assert normalize_label_punctuation(None) == ""
+
+
+def test_genuinely_different_labels_still_differ() -> None:
+    """Negative case: normalization must not collapse distinct labels."""
+    assert normalize_label_punctuation("Bachelor’s degree") != normalize_label_punctuation("Master's degree")
+    assert normalize_label_punctuation("’26F") != normalize_label_punctuation("'27F")
+
+
+# --------------------------------------------------------------------------
+# Deterministic rule path -- regression lock
+# --------------------------------------------------------------------------

--- a/tests/parse_bench/evaluation/metrics/parse/test_degenerate_marker_rules.py
+++ b/tests/parse_bench/evaluation/metrics/parse/test_degenerate_marker_rules.py
@@ -1,0 +1,201 @@
+"""Text-query rules whose text is pure markdown markers must be skipped, not scored 0.0.
+
+The annotation pass harvests rule text from ASCII banners and decorative rules,
+producing rules such as ``is_title`` with text ``"**"`` or ``is_bold`` with text
+``"*"``. ``normalize_text`` reduces such text to markers or to nothing, so the
+query can never identify content in any output: the rule is unsatisfiable by
+construction and permanently scores 0.0. Those zeros pin
+``normalized_title_accuracy`` and ``normalized_text_styling``, and through them
+``semantic_formatting``, on documents that parsed correctly.
+
+This is the sibling family of the ``title_hierarchy_percent`` case fixed in
+#2296, and it reuses that PR's ``RuleNotApplicable`` mechanism: the rule emits
+no result at all, so it leaves every numerator and every denominator.
+
+Rules whose text merely *contains* markers around real words stay real,
+failable constraints.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from parse_bench.evaluation.metrics.parse.rule_based_metric import RuleBasedMetric
+from parse_bench.evaluation.metrics.parse.rules_base import RuleNotApplicable
+from parse_bench.evaluation.metrics.parse.test_rules import (
+    FormattingRule,
+    TitleLevelRule,
+)
+
+# Content that genuinely satisfies the well-formed rules used as guards below.
+_GOOD_CONTENT = """
+# Executive Summary
+
+**Revenue** grew, and *margins* held.
+"""
+
+
+def _rule(rule_type: str, text: str):
+    payload = {"type": rule_type, "text": text}
+    if rule_type == "is_title":
+        return TitleLevelRule(payload)
+    return FormattingRule(payload)
+
+
+# ---------------------------------------------------------------------------
+# The degenerate family: text is nothing but markdown markers
+# ---------------------------------------------------------------------------
+
+# Every rule type observed carrying degenerate text in text_extended/v1.0.
+_DEGENERATE_TYPES = ["is_title", "is_bold", "is_italic", "is_sup"]
+
+# ``"*"`` and ``"**"`` are the texts actually observed in the corpus; the others
+# are the rest of the marker class the annotation tool strips (``[*_~]``).
+_DEGENERATE_TEXTS = ["*", "**", "~~", "~", "_", "__", "***", "* *"]
+
+
+@pytest.mark.parametrize("rule_type", _DEGENERATE_TYPES)
+@pytest.mark.parametrize("text", _DEGENERATE_TEXTS)
+def test_marker_only_text_is_skipped(rule_type: str, text: str) -> None:
+    """Pure-marker text carries no query, so the rule is inapplicable."""
+    with pytest.raises(RuleNotApplicable):
+        _rule(rule_type, text).run(_GOOD_CONTENT)
+
+
+def test_triple_star_is_skipped_boundary() -> None:
+    """Boundary: ``"***"`` normalizes to ``"*"`` - still marker-only, still skipped.
+
+    This is deliberately *wider* than the guard #2296 used for
+    ``title_hierarchy_percent``, which skips only when a label normalizes to the
+    empty string and therefore keeps ``"***"`` as a real (failing) label. The
+    two differ because the shapes differ: a hierarchy is a set of labels where a
+    single odd one still participates in real parent/child constraints, whereas
+    these rules are a *single* text query - if that query is markers, 100% of
+    the rule is degenerate and there is nothing left to measure. On
+    text_extended/v1.0 the divergence covers 0 rules: the only hierarchy whose
+    labels are all degenerate is the all-empty one #2296 already skips.
+    """
+    with pytest.raises(RuleNotApplicable):
+        _rule("is_bold", "***").run(_GOOD_CONTENT)
+
+
+def test_negative_polarity_is_also_skipped() -> None:
+    """``is_not_bold "*"`` would otherwise trivially *pass* for a degenerate reason.
+
+    The degeneracy is a property of the query, not of the polarity, so it is
+    excluded rather than banked as a free pass.
+    """
+    with pytest.raises(RuleNotApplicable):
+        _rule("is_not_bold", "*").run(_GOOD_CONTENT)
+
+
+def test_whitespace_only_text_still_rejected_at_construction() -> None:
+    """Unchanged: blank text never builds a rule in the first place."""
+    with pytest.raises(ValueError):
+        _rule("is_bold", "   ")
+
+
+# ---------------------------------------------------------------------------
+# Guards: real rules must keep behaving exactly as before
+# ---------------------------------------------------------------------------
+
+
+def test_text_containing_markers_still_runs() -> None:
+    """``"*Important*"`` normalizes to ``Important`` - a real query, not markers."""
+    rule = _rule("is_bold", "*Important*")
+    passed, _ = rule.run("Plain text with no emphasis at all.\n")
+    assert passed is False
+
+
+def test_real_bold_rule_still_passes() -> None:
+    passed, _ = _rule("is_bold", "Revenue").run(_GOOD_CONTENT)
+    assert passed is True
+
+
+def test_real_italic_rule_still_passes() -> None:
+    passed, _ = _rule("is_italic", "margins").run(_GOOD_CONTENT)
+    assert passed is True
+
+
+def test_real_title_rule_still_passes() -> None:
+    passed, _ = _rule("is_title", "Executive Summary").run(_GOOD_CONTENT)
+    assert passed is True
+
+
+def test_real_bold_miss_still_fails() -> None:
+    """A well-defined rule the output does not satisfy is a real failure."""
+    passed, _ = _rule("is_bold", "Revenue").run("Revenue grew.\n")
+    assert passed is False
+
+
+def test_single_marker_inside_words_is_not_degenerate() -> None:
+    """A star adjacent to real text keeps the rule evaluable."""
+    with_text = _rule("is_bold", "* Revenue")
+    passed, _ = with_text.run("Plain text.\n")
+    assert passed is False
+
+
+# ---------------------------------------------------------------------------
+# Aggregation: skipped rules leave numerator *and* denominator
+# ---------------------------------------------------------------------------
+
+
+def _degenerate_payloads() -> list[dict]:
+    """The exact family observed on text_ocr/bold and text_sparse/agenda_sparse."""
+    return [
+        {"type": "is_title", "text": "*"},
+        {"type": "is_bold", "text": "*"},
+        {"type": "is_italic", "text": "*"},
+    ]
+
+
+def _real_payload() -> dict:
+    return {"type": "is_bold", "text": "Revenue"}
+
+
+def test_degenerate_rules_absent_from_rule_results() -> None:
+    metric = RuleBasedMetric()
+    result = metric.compute(expected=[_real_payload(), *_degenerate_payloads()], actual=_GOOD_CONTENT)
+    types = [r.get("type") for r in result.metadata["rule_results"]]
+    assert types == ["is_bold"]
+
+
+def test_degenerate_rules_do_not_change_aggregate() -> None:
+    """Adding the degenerate family to a document must not move any number."""
+    metric = RuleBasedMetric()
+    without = metric.compute(expected=[_real_payload()], actual=_GOOD_CONTENT)
+    with_degenerate = metric.compute(
+        expected=[_real_payload(), *_degenerate_payloads()],
+        actual=_GOOD_CONTENT,
+    )
+
+    assert with_degenerate.value == without.value == 1.0
+    assert with_degenerate.metadata["total"] == without.metadata["total"] == 1
+    assert with_degenerate.metadata["passed"] == without.metadata["passed"] == 1
+
+
+def test_skipped_count_is_reported() -> None:
+    metric = RuleBasedMetric()
+    result = metric.compute(expected=[_real_payload(), *_degenerate_payloads()], actual=_GOOD_CONTENT)
+    assert result.metadata["skipped_inapplicable"] == 3
+
+
+def test_document_with_only_degenerate_rules_is_not_penalised() -> None:
+    metric = RuleBasedMetric()
+    result = metric.compute(expected=_degenerate_payloads(), actual=_GOOD_CONTENT)
+    assert result.value == 1.0
+    assert result.metadata["total"] == 0
+    assert result.metadata["rule_results"] == []
+
+
+def test_real_styling_rules_still_aggregated() -> None:
+    """Guard: defined styling rules keep contributing, pass or fail."""
+    metric = RuleBasedMetric()
+    result = metric.compute(
+        expected=[{"type": "is_bold", "text": "Revenue"}],
+        actual="Revenue grew.\n",
+    )
+    types = [r.get("type") for r in result.metadata["rule_results"]]
+    assert types == ["is_bold"]
+    assert result.metadata["total"] == 1
+    assert result.value == 0.0

--- a/tests/parse_bench/evaluation/metrics/parse/test_form_field_rule.py
+++ b/tests/parse_bench/evaluation/metrics/parse/test_form_field_rule.py
@@ -44,6 +44,17 @@ class TestTextValueMatching:
         passed, _, _ = self._rule("Last Name", "Collins").run(md)
         assert passed
 
+    def test_label_before_bold_value_match(self):
+        md = "Well No. **Z-5** Name of Lease **W. H. Portwood** No. of Acres **80**\n"
+        assert self._rule("Well No.", "Z-5").run(md)[0]
+        assert self._rule("Name of Lease", "W. H. Portwood").run(md)[0]
+        assert self._rule("No. of Acres", "80").run(md)[0]
+
+    def test_explicit_colon_wins_over_label_before_bold_fallback(self):
+        md = "**Name of Lease**: W. H. Portwood\nName of Lease **Wrong Lease**\n"
+        passed, _, _ = self._rule("Name of Lease", "W. H. Portwood").run(md)
+        assert passed
+
     def test_plain_colon_match(self):
         md = "Last Name: Collins\n"
         passed, _, _ = self._rule("Last Name", "Collins").run(md)
@@ -82,6 +93,155 @@ class TestTextValueMatching:
         md = "**Last Nam:** Collins\n"
         passed, _, _ = self._rule("Last Name", "Collins").run(md)
         assert passed
+
+    def test_value_normalization_ignores_separators(self):
+        md = "**Operator P-5 No.:** 253-385\n"
+        passed, _, _ = self._rule("Operator P-5 No.", "253 385").run(md)
+        assert passed
+
+    def test_value_tolerance_defaults_to_zero(self):
+        md = "**Operator P-5 No.:** 253386\n"
+        passed, expl, _ = self._rule("Operator P-5 No.", "253385").run(md)
+        assert not passed
+        assert "expected" in expl and "got" in expl
+
+    def test_value_tolerance_uses_value_max_diffs(self):
+        md = "**Operator P-5 No.:** 253386\n"
+        rule = FormFieldRule(
+            {
+                "type": "form_field",
+                "label": "Operator P-5 No.",
+                "value": "253385",
+                "value_type": "text",
+                "value_max_diffs": 1,
+            }
+        )
+        passed, _, _ = rule.run(md)
+        assert passed
+
+    def test_value_tolerance_respects_value_max_diffs_limit(self):
+        md = "**Operator P-5 No.:** 253487\n"
+        rule = FormFieldRule(
+            {
+                "type": "form_field",
+                "label": "Operator P-5 No.",
+                "value": "253385",
+                "value_type": "text",
+                "value_max_diffs": 1,
+            }
+        )
+        passed, expl, _ = rule.run(md)
+        assert not passed
+        assert "expected" in expl and "got" in expl
+
+
+class TestMultiLabelFormFields:
+    def _rule(self, label, value) -> FormFieldRule:
+        return FormFieldRule({"type": "form_field", "label": label, "value": value, "value_type": "text"})
+
+    def test_multilabel_table_match_is_order_insensitive(self):
+        md = (
+            "| Item | PLUG #1 | PLUG #2 |\n"
+            "|---|---|---|\n"
+            "| \\*19. Cementing Date | 1992 9-29 | |\n"
+            "| \\*22. Sacks of Cement Used (each plug) | 55 | |\n"
+        )
+        assert self._rule(["PLUG #1", "Cementing Date"], "1992 9-29").run(md)[0]
+        assert self._rule(["Cementing Date", "PLUG #1"], "1992 9-29").run(md)[0]
+
+    def test_multilabel_table_requires_the_same_value_cell(self):
+        md = (
+            "| Item | PLUG #1 | PLUG #2 |\n"
+            "|---|---|---|\n"
+            "| \\*19. Cementing Date | 1992 9-29 | |\n"
+            "| \\*22. Sacks of Cement Used (each plug) | 55 | |\n"
+        )
+        passed, expl, _ = self._rule(["PLUG #2", "Cementing Date"], "1992 9-29").run(md)
+        assert not passed
+        assert "expected" in expl and "got" in expl
+
+    def test_multilabel_table_matches_headers_with_context_prefixes(self):
+        md = (
+            "| CEMENTING TO PLUG AND ABANDON DATA: | CEMENTING TO PLUG AND ABANDON DATA:<br/>PLUG #1 | "
+            "CEMENTING TO PLUG AND ABANDON DATA:<br/>PLUG #2 |\n"
+            "|---|---|---|\n"
+            "| \\\\*19. Cementing Date | 3/11/02 | 3/11/02 |\n"
+            "| \\\\*22. Sacks of Cement Used (each plug) | 30 | 60 |\n"
+        )
+        assert self._rule(["PLUG #2", "Sacks of Cement Used"], "60").run(md)[0]
+
+    def test_multilabel_html_table_match(self):
+        html = (
+            "<table>"
+            "<thead><tr><th>Item</th><th>PLUG #1</th><th>PLUG #2</th></tr></thead>"
+            "<tbody>"
+            "<tr><td>Cementing Date</td><td>1992 9-29</td><td></td></tr>"
+            "<tr><td>Depth to Bottom of Tubing or Drill Pipe (ft.)</td><td>399</td><td>650</td></tr>"
+            "</tbody></table>"
+        )
+        assert self._rule(["PLUG #1", "Cementing Date"], "1992 9-29").run(html)[0]
+        assert self._rule(["PLUG #2", "Cementing Date"], "").run(html)[0]
+        assert self._rule(["PLUG #2", "Depth to Bottom of Tubing or Drill Pipe (ft.)"], "650").run(html)[0]
+
+    def test_multilabel_html_table_requires_same_value_cell(self):
+        html = (
+            "<table>"
+            "<thead><tr><th>Item</th><th>PLUG #1</th><th>PLUG #2</th></tr></thead>"
+            "<tbody>"
+            "<tr><td>Cementing Date</td><td>1992 9-29</td><td></td></tr>"
+            "<tr><td>Depth to Bottom of Tubing or Drill Pipe (ft.)</td><td>399</td><td>650</td></tr>"
+            "</tbody></table>"
+        )
+        passed, expl, _ = self._rule(["PLUG #2", "Cementing Date"], "1992 9-29").run(html)
+        assert not passed
+        assert "expected '1992 9-29', got ''" in expl
+
+    def test_multilabel_key_tolerance_defaults_to_zero(self):
+        md = "| Item | PLUG #1 |\n|---|---|\n| \\*19. Cementing Date | 1992 9-29 |\n"
+        passed, expl, _ = self._rule(["PLUG #1", "Cementing Dote"], "1992 9-29").run(md)
+        assert not passed
+        assert "label not found" in expl
+
+    def test_multilabel_key_tolerance_uses_label_max_diffs(self):
+        md = "| Item | PLUG #1 |\n|---|---|\n| \\*19. Cementing Date | 1992 9-29 |\n"
+        rule = FormFieldRule(
+            {
+                "type": "form_field",
+                "label": ["PLUG #1", "Cementing Dote"],
+                "label_max_diffs": [0, 1],
+                "value": "1992 9-29",
+                "value_type": "text",
+            }
+        )
+        assert rule.run(md)[0]
+
+    def test_multilabel_key_tolerance_is_index_specific(self):
+        md = "| Item | PLUG #1 |\n|---|---|\n| \\*19. Cementing Date | 1992 9-29 |\n"
+        rule = FormFieldRule(
+            {
+                "type": "form_field",
+                "label": ["PLUG #1", "Cementing Dote"],
+                "label_max_diffs": [1, 0],
+                "value": "1992 9-29",
+                "value_type": "text",
+            }
+        )
+        passed, expl, _ = rule.run(md)
+        assert not passed
+        assert "label not found" in expl
+
+    def test_multilabel_blank_label_keeps_label_tolerance_alignment(self):
+        md = "| Item | PLUG #1 |\n|---|---|\n| \\*19. Cementing Date | 1992 9-29 |\n"
+        rule = FormFieldRule(
+            {
+                "type": "form_field",
+                "label": ["PLUG #1", "", "Cementing Dote"],
+                "label_max_diffs": [0, 0, 1],
+                "value": "1992 9-29",
+                "value_type": "text",
+            }
+        )
+        assert rule.run(md)[0]
 
 
 class TestHtmlCellNeighborFallback:
@@ -578,6 +738,50 @@ class TestInlineCheckboxGroups:
         assert passed
 
 
+class TestInlineYesNoCheckboxGroups:
+    def _rule(self, label: str | list[str], value: bool) -> FormFieldRule:
+        return FormFieldRule({"type": "form_field", "label": label, "value": value, "value_type": "checkbox"})
+
+    def test_multilabel_yes_no_option_checked(self):
+        md = "Multistage cement?  Yes [ ] No [x]\n"
+        passed, _, _ = self._rule(["Multistage cement?", "No"], True).run(md)
+        assert passed
+        passed, _, _ = self._rule(["Multistage cement?", "Yes"], False).run(md)
+        assert passed
+
+    def test_multilabel_yes_no_option_rejects_wrong_checked_option(self):
+        md = "Multistage cement?  Yes [x] No [ ]\n"
+        passed, expl, _ = self._rule(["Multistage cement?", "No"], True).run(md)
+        assert not passed
+        assert "expected True, got False" in expl
+
+    def test_multilabel_yes_no_option_rejects_neither_checked(self):
+        md = "Multistage cement?  Yes [ ] No [ ]\n"
+        passed, expl, _ = self._rule(["Multistage cement?", "No"], True).run(md)
+        assert not passed
+        assert "expected True, got False" in expl
+
+    def test_multilabel_yes_no_option_handles_numbered_form_line(self):
+        md = "27. Multiple completion? Yes [ ] No [x]\n"
+        passed, _, _ = self._rule(["Multiple completion?", "No"], True).run(md)
+        assert passed
+        passed, _, _ = self._rule(["Multiple completion?", "Yes"], False).run(md)
+        assert passed
+
+    def test_multilabel_yes_no_disambiguates_repeated_options(self):
+        md = (
+            "27. Multiple completion? Yes [ ] No [x]\n"
+            "35. Any Oil and Gas Productive Zone within two miles? Yes [x] No [ ]\n"
+        )
+        passed, _, _ = self._rule(["Multiple completion?", "No"], True).run(md)
+        assert passed
+        passed, _, _ = self._rule(["Any Oil and Gas Productive Zone within two miles?", "Yes"], True).run(md)
+        assert passed
+        passed, expl, _ = self._rule(["Multiple completion?", "Yes"], True).run(md)
+        assert not passed
+        assert "expected True, got False" in expl
+
+
 # ---------------------------------------------------------------------------
 # Inline bold-colon multi-pair  (**First:** Maya **Last:** Collins)
 # ---------------------------------------------------------------------------
@@ -868,6 +1072,52 @@ class TestMultiColumnTableRowLabel:
         )
         passed, _, _ = self._rule("Course Title (row 2)", "Records Management 101").run(md)
         assert passed
+
+    def test_open_hole_from_to_markdown_table(self):
+        md = (
+            "**30. LIST ALL OPEN HOLE AND/OR PERFORATED INTERVALS**\n\n"
+            "| FROM | TO |\n"
+            "| ---- | -- |\n"
+            "| none reported | RRC |\n"
+            "| | |\n"
+        )
+        passed, _, _ = self._rule("FROM (row 1)", "none reported").run(md)
+        assert passed
+        passed, _, _ = self._rule("TO (row 1)", "RRC").run(md)
+        assert passed
+        passed, _, _ = self._rule("FROM (row 2)", "").run(md)
+        assert passed
+
+    def test_open_hole_from_to_flattened_line(self):
+        md = "30. LIST ALL OPEN HOLE AND/OR PERFORATED INTERVALS\nFROM none reported TO RRC\nFROM      TO\n"
+        passed, _, _ = self._rule("FROM (row 1)", "none reported").run(md)
+        assert passed
+        passed, _, _ = self._rule("TO (row 1)", "RRC").run(md)
+        assert passed
+        passed, _, _ = self._rule("FROM (row 2)", "").run(md)
+        assert passed
+        passed, _, _ = self._rule("TO (row 2)", "").run(md)
+        assert passed
+
+    def test_open_hole_from_to_flattened_line_multiple_rows(self):
+        md = "30. LIST ALL OPEN HOLE AND/OR PERFORATED INTERVALS\nFROM none reported TO RRC\nFROM 100 ft TO 200 ft\n"
+        passed, _, _ = self._rule("FROM (row 1)", "none reported").run(md)
+        assert passed
+        passed, _, _ = self._rule("TO (row 1)", "RRC").run(md)
+        assert passed
+        passed, _, _ = self._rule("FROM (row 2)", "100 ft").run(md)
+        assert passed
+        passed, _, _ = self._rule("TO (row 2)", "200 ft").run(md)
+        assert passed
+        passed, expl, _ = self._rule("TO (row 1)", "200 ft").run(md)
+        assert not passed
+        assert "expected '200 ft', got 'RRC'" in expl
+
+    def test_open_hole_from_to_flattened_line_wrong_row_fails(self):
+        md = "30. LIST ALL OPEN HOLE AND/OR PERFORATED INTERVALS\nFROM none reported TO RRC\nFROM 100 TO 200\n"
+        passed, expl, _ = self._rule("TO (row 1)", "200").run(md)
+        assert not passed
+        assert "expected '200', got 'RRC'" in expl
 
 
 class TestEmptyExpectedValue:

--- a/tests/parse_bench/evaluation/metrics/parse/test_grits_metric.py
+++ b/tests/parse_bench/evaluation/metrics/parse/test_grits_metric.py
@@ -1,0 +1,802 @@
+"""Tests for the GriTS (Grid Table Similarity) metric.
+
+Includes sanity checks with hand-crafted tables to verify:
+- Identical tables score 1.0
+- Spanning cells (rowspan/colspan) are handled correctly
+- Missing/extra rows and columns are penalized
+- Empty and malformed inputs are handled gracefully
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "src"))
+
+from parse_bench.evaluation.metrics.parse.grits_metric import (  # noqa: E402
+    GriTSMetric,
+    _bbox_iou,
+    _compute_fscore,
+    _lcs_similarity,
+    cells_to_grid,
+    grits_from_html,
+    html_to_cells,
+)
+from parse_bench.evaluation.metrics.parse.table_extraction import (  # noqa: E402
+    extract_html_tables,
+    extract_table_pairs,
+)
+
+
+def _compute(metric: GriTSMetric, expected: str, actual: str):
+    """Helper: extract tables from markdown and run GriTSMetric.compute."""
+    expected_tables, actual_tables, _ = extract_table_pairs(expected, actual)
+    return metric.compute(expected_tables, actual_tables)
+
+
+# =============================================================================
+# Test tables
+# =============================================================================
+
+# Simple 2x2 table
+SIMPLE_2X2 = """<table>
+<tr><td>A</td><td>B</td></tr>
+<tr><td>C</td><td>D</td></tr>
+</table>"""
+
+# Same structure, different content
+SIMPLE_2X2_DIFF_CONTENT = """<table>
+<tr><td>X</td><td>Y</td></tr>
+<tr><td>Z</td><td>W</td></tr>
+</table>"""
+
+# 2x2 with one cell changed
+SIMPLE_2X2_ONE_CHANGED = """<table>
+<tr><td>A</td><td>B</td></tr>
+<tr><td>C</td><td>CHANGED</td></tr>
+</table>"""
+
+# 3x3 table (different dimensions than 2x2)
+SIMPLE_3X3 = """<table>
+<tr><td>A</td><td>B</td><td>C</td></tr>
+<tr><td>D</td><td>E</td><td>F</td></tr>
+<tr><td>G</td><td>H</td><td>I</td></tr>
+</table>"""
+
+# Table with colspan
+TABLE_WITH_COLSPAN = """<table>
+<tr><td colspan="2">Header</td></tr>
+<tr><td>A</td><td>B</td></tr>
+</table>"""
+
+# Same structure as colspan table but without spanning
+TABLE_NO_COLSPAN = """<table>
+<tr><td>Header</td><td>Header</td></tr>
+<tr><td>A</td><td>B</td></tr>
+</table>"""
+
+# Table with rowspan
+TABLE_WITH_ROWSPAN = """<table>
+<tr><td rowspan="2">Label</td><td>Val1</td></tr>
+<tr><td>Val2</td></tr>
+</table>"""
+
+# Table with both colspan and rowspan
+TABLE_COMPLEX_SPAN = """<table>
+<tr><td colspan="2">Title</td><td>Col3</td></tr>
+<tr><td rowspan="2">R1</td><td>A</td><td>B</td></tr>
+<tr><td>C</td><td>D</td></tr>
+</table>"""
+
+# Table with header tags
+TABLE_WITH_HEADERS = """<table>
+<tr><th>Name</th><th>Value</th></tr>
+<tr><td>Alpha</td><td>100</td></tr>
+<tr><td>Beta</td><td>200</td></tr>
+</table>"""
+
+# Same structure and content as TABLE_WITH_HEADERS but using td instead of th
+TABLE_WITHOUT_HEADERS = """<table>
+<tr><td>Name</td><td>Value</td></tr>
+<tr><td>Alpha</td><td>100</td></tr>
+<tr><td>Beta</td><td>200</td></tr>
+</table>"""
+
+# Table with extra row appended
+TABLE_EXTRA_ROW = """<table>
+<tr><td>A</td><td>B</td></tr>
+<tr><td>C</td><td>D</td></tr>
+<tr><td>E</td><td>F</td></tr>
+</table>"""
+
+# Table with extra column
+TABLE_EXTRA_COL = """<table>
+<tr><td>A</td><td>B</td><td>X</td></tr>
+<tr><td>C</td><td>D</td><td>Y</td></tr>
+</table>"""
+
+# Realistic data table (financial report style)
+FINANCIAL_TABLE_GT = """<table>
+<tr><th>Item</th><th>Q1</th><th>Q2</th><th>Q3</th></tr>
+<tr><td>Revenue</td><td>$1.2M</td><td>$1.5M</td><td>$1.8M</td></tr>
+<tr><td>Expenses</td><td>$0.8M</td><td>$0.9M</td><td>$1.0M</td></tr>
+<tr><td>Profit</td><td>$0.4M</td><td>$0.6M</td><td>$0.8M</td></tr>
+</table>"""
+
+# Same financial table with OCR-like errors in some cells
+FINANCIAL_TABLE_OCR = """<table>
+<tr><th>Item</th><th>Q1</th><th>Q2</th><th>Q3</th></tr>
+<tr><td>Revenue</td><td>$1.2M</td><td>$1.5M</td><td>$1.8M</td></tr>
+<tr><td>Expenses</td><td>$0.8M</td><td>$O.9M</td><td>$1.0M</td></tr>
+<tr><td>Profit</td><td>$0.4M</td><td>$0.6M</td><td>$O.8M</td></tr>
+</table>"""
+
+
+# Table with gaps — large colspan that doesn't tile cleanly with other rows.
+# This triggers the inhomogeneous numpy array bug when dtype=object is not used.
+TABLE_WITH_GAPS = """<table>
+<tr><td colspan="3">Wide Header</td></tr>
+<tr><td>A</td><td>B</td><td>C</td></tr>
+<tr><td colspan="2">Merged</td><td>D</td></tr>
+</table>"""
+
+# Tables with unoccupied grid cells (gaps).
+# Row 1 has only 1 cell but the grid is 2 columns wide, leaving (1,1) empty.
+TABLE_WITH_UNOCCUPIED_CELLS = """<table>
+<tr><td>A</td><td>B</td></tr>
+<tr><td>C</td></tr>
+</table>"""
+
+# Different gap structure for cross-table comparison
+TABLE_WITH_UNOCCUPIED_CELLS_2 = """<table>
+<tr><td>X</td><td>Y</td></tr>
+<tr><td>Z</td></tr>
+</table>"""
+
+# A table mimicking a complex invoice: many rows, irregular spanning
+TABLE_INVOICE_COMPLEX = """<table>
+<tr><th colspan="4">Invoice #12345</th></tr>
+<tr><th>Item</th><th>Qty</th><th>Price</th><th>Total</th></tr>
+<tr><td>Widget A</td><td>10</td><td>$5.00</td><td>$50.00</td></tr>
+<tr><td>Widget B</td><td>5</td><td>$12.00</td><td>$60.00</td></tr>
+<tr><td colspan="3">Subtotal</td><td>$110.00</td></tr>
+<tr><td colspan="3">Tax (10%)</td><td>$11.00</td></tr>
+<tr><td colspan="3">Total</td><td>$121.00</td></tr>
+</table>"""
+
+
+# =============================================================================
+# Low-level utility tests
+# =============================================================================
+
+
+class TestBboxIou:
+    def test_identical_boxes(self):
+        assert _bbox_iou([0, 0, 1, 1], [0, 0, 1, 1]) == 1.0
+
+    def test_no_overlap(self):
+        assert _bbox_iou([0, 0, 1, 1], [2, 2, 3, 3]) == 0.0
+
+    def test_partial_overlap(self):
+        iou = _bbox_iou([0, 0, 2, 2], [1, 1, 3, 3])
+        # intersection = 1x1 = 1, bbox union = [0,0,3,3] = 9
+        assert abs(iou - 1.0 / 9.0) < 1e-9
+
+    def test_empty_input(self):
+        assert _bbox_iou([], [0, 0, 1, 1]) == 0.0
+        assert _bbox_iou([0, 0, 1, 1], []) == 0.0
+
+
+class TestLcsSimilarity:
+    def test_identical_strings(self):
+        assert _lcs_similarity("hello", "hello") == 1.0
+
+    def test_empty_strings(self):
+        assert _lcs_similarity("", "") == 1.0
+
+    def test_one_empty(self):
+        assert _lcs_similarity("hello", "") == 0.0
+
+    def test_similar_strings(self):
+        sim = _lcs_similarity("$0.9M", "$O.9M")  # OCR-like error
+        assert 0.5 < sim < 1.0
+
+    def test_completely_different(self):
+        sim = _lcs_similarity("abc", "xyz")
+        assert sim == 0.0
+
+
+class TestComputeFscore:
+    def test_perfect(self):
+        f, p, r = _compute_fscore(10, 10, 10)
+        assert f == 1.0
+        assert p == 1.0
+        assert r == 1.0
+
+    def test_no_predictions(self):
+        f, p, r = _compute_fscore(0, 10, 0)
+        # precision=1 (no predictions), recall=0
+        assert p == 1.0
+        assert r == 0.0
+        assert f == 0.0
+
+    def test_no_ground_truth(self):
+        f, p, r = _compute_fscore(0, 0, 10)
+        # precision=0, recall=1 (no ground truth)
+        assert p == 0.0
+        assert r == 1.0
+        assert f == 0.0
+
+
+# =============================================================================
+# HTML parsing tests
+# =============================================================================
+
+
+class TestHtmlToCells:
+    def test_simple_table(self):
+        cells = html_to_cells(SIMPLE_2X2)
+        assert cells is not None
+        assert len(cells) == 4
+        texts = [c["cell_text"].strip() for c in cells]
+        assert set(texts) == {"A", "B", "C", "D"}
+
+    def test_colspan(self):
+        cells = html_to_cells(TABLE_WITH_COLSPAN)
+        assert cells is not None
+        # "Header" spans 2 columns, then A and B
+        header_cell = [c for c in cells if "Header" in c["cell_text"]][0]
+        assert header_cell["column_nums"] == [0, 1]
+        assert header_cell["row_nums"] == [0]
+
+    def test_rowspan(self):
+        cells = html_to_cells(TABLE_WITH_ROWSPAN)
+        assert cells is not None
+        label_cell = [c for c in cells if "Label" in c["cell_text"]][0]
+        assert label_cell["row_nums"] == [0, 1]
+        assert label_cell["column_nums"] == [0]
+
+    def test_invalid_html(self):
+        result = html_to_cells("not a table at all")
+        assert result is None
+
+    def test_header_detection(self):
+        cells = html_to_cells(TABLE_WITH_HEADERS)
+        assert cells is not None
+        header_cells = [c for c in cells if c["is_column_header"]]
+        assert len(header_cells) == 2
+        texts = {c["cell_text"].strip() for c in header_cells}
+        assert texts == {"Name", "Value"}
+
+
+class TestCellsToGrid:
+    def test_simple_grid(self):
+        cells = html_to_cells(SIMPLE_2X2)
+        grid = cells_to_grid(cells)
+        assert len(grid) == 2
+        assert len(grid[0]) == 2
+        assert grid[0][0].strip() == "A"
+        assert grid[1][1].strip() == "D"
+
+
+class TestExtractHtmlTables:
+    def test_single_table(self):
+        tables = extract_html_tables(SIMPLE_2X2)
+        assert len(tables) == 1
+
+    def test_multiple_tables(self):
+        content = f"Some text\n{SIMPLE_2X2}\nMore text\n{SIMPLE_3X3}\nEnd"
+        tables = extract_html_tables(content)
+        assert len(tables) == 2
+
+    def test_no_tables(self):
+        assert extract_html_tables("just plain text") == []
+
+    def test_empty_content(self):
+        assert extract_html_tables("") == []
+
+
+# =============================================================================
+# GriTS core algorithm tests
+# =============================================================================
+
+
+class TestGritsFromHtml:
+    def test_identical_tables(self):
+        """Identical tables should score 1.0 for content."""
+        result = grits_from_html(SIMPLE_2X2, SIMPLE_2X2)
+        assert result is not None
+        assert result["grits_con"] == pytest.approx(1.0)
+
+    def test_identical_with_spans(self):
+        """Identical tables with spanning cells should also score 1.0."""
+        result = grits_from_html(TABLE_WITH_COLSPAN, TABLE_WITH_COLSPAN)
+        assert result is not None
+        assert result["grits_con"] == pytest.approx(1.0)
+
+    def test_identical_complex_span(self):
+        """Complex spanning table compared to itself should be 1.0."""
+        result = grits_from_html(TABLE_COMPLEX_SPAN, TABLE_COMPLEX_SPAN)
+        assert result is not None
+        assert result["grits_con"] == pytest.approx(1.0)
+
+    def test_same_structure_different_content(self):
+        """Same topology, completely different content → GriTS_Con = 0.0."""
+        result = grits_from_html(SIMPLE_2X2, SIMPLE_2X2_DIFF_CONTENT)
+        assert result is not None
+        assert result["grits_con"] == pytest.approx(0.0)
+
+    def test_one_cell_changed(self):
+        """One cell changed out of four → high but not perfect content."""
+        result = grits_from_html(SIMPLE_2X2, SIMPLE_2X2_ONE_CHANGED)
+        assert result is not None
+        # 3 out of 4 cells match perfectly, the fourth has partial similarity
+        assert 0.7 < result["grits_con"] < 1.0
+
+    def test_different_dimensions(self):
+        """2x2 vs 3x3: some content can still be matched."""
+        result = grits_from_html(SIMPLE_2X2, SIMPLE_3X3)
+        assert result is not None
+        assert 0.0 < result["grits_con"] <= 1.0
+
+    def test_extra_row(self):
+        """Original 2x2 vs 3x2 (extra row)."""
+        result = grits_from_html(SIMPLE_2X2, TABLE_EXTRA_ROW)
+        assert result is not None
+        assert result["grits_con"] > 0.5
+
+    def test_extra_column(self):
+        """Original 2x2 vs 2x3 (extra column)."""
+        result = grits_from_html(SIMPLE_2X2, TABLE_EXTRA_COL)
+        assert result is not None
+        assert result["grits_con"] > 0.5
+
+    def test_th_vs_td(self):
+        """Headers (th) vs data cells (td) with same content."""
+        result = grits_from_html(TABLE_WITH_HEADERS, TABLE_WITHOUT_HEADERS)
+        assert result is not None
+        assert result["grits_con"] == pytest.approx(1.0)
+
+    def test_financial_table_with_ocr_errors(self):
+        """Realistic financial table with minor OCR errors."""
+        result = grits_from_html(FINANCIAL_TABLE_GT, FINANCIAL_TABLE_OCR)
+        assert result is not None
+        # 14 out of 16 cells match perfectly; 2 have 0->O substitution
+        assert result["grits_con"] > 0.9
+
+    def test_precision_recall(self):
+        """Verify precision and recall are reported and make sense."""
+        result = grits_from_html(SIMPLE_2X2, TABLE_EXTRA_ROW)
+        assert result is not None
+        # Pred has more cells than GT, so recall should be >= precision
+        assert result["grits_recall_con"] >= result["grits_precision_con"]
+
+    def test_symmetry(self):
+        """GriTS(A, B) F-score should equal GriTS(B, A)."""
+        result_ab = grits_from_html(SIMPLE_2X2, TABLE_EXTRA_ROW)
+        result_ba = grits_from_html(TABLE_EXTRA_ROW, SIMPLE_2X2)
+        assert result_ab is not None and result_ba is not None
+        assert result_ab["grits_con"] == pytest.approx(result_ba["grits_con"])
+
+    def test_invalid_html_returns_none(self):
+        """Invalid HTML should return None."""
+        result = grits_from_html("not html", SIMPLE_2X2)
+        assert result is None
+
+    def test_table_with_gaps_no_crash(self):
+        """Tables with irregular spanning should not crash with numpy errors."""
+        result = grits_from_html(TABLE_WITH_GAPS, TABLE_WITH_GAPS)
+        assert result is not None
+        assert result["grits_con"] == pytest.approx(1.0)
+
+    def test_complex_invoice_table(self):
+        """Complex invoice table with mixed spanning should work."""
+        result = grits_from_html(TABLE_INVOICE_COMPLEX, TABLE_INVOICE_COMPLEX)
+        assert result is not None
+        assert result["grits_con"] == pytest.approx(1.0)
+
+    def test_complex_invoice_vs_simple(self):
+        """Cross-comparison between complex and simple tables."""
+        result = grits_from_html(TABLE_INVOICE_COMPLEX, FINANCIAL_TABLE_GT)
+        assert result is not None
+        assert 0.0 <= result["grits_con"] <= 1.0
+
+
+# =============================================================================
+# GriTSMetric class tests (Metric interface)
+# =============================================================================
+
+
+def _find_metric(results, name):
+    """Helper: find a MetricValue by name in a list."""
+    for r in results:
+        if r.metric_name == name:
+            return r
+    raise AssertionError(f"Metric '{name}' not found in {[r.metric_name for r in results]}")
+
+
+class TestGriTSMetric:
+    def setup_method(self):
+        self.metric = GriTSMetric()
+
+    def test_boolean_marker_content_equivalence(self):
+        """Check/cross/dot markers should match textual boolean cells."""
+        expected = """<table>
+<tr><th>Dataset</th><th>TD</th><th>TR</th><th>Network</th><th>Flag</th></tr>
+<tr><td>Marmot</td><td>✓</td><td>✗</td><td>●</td><td>X</td></tr>
+</table>"""
+        actual = """<table>
+<tr><th>Dataset</th><th>TD</th><th>TR</th><th>Network</th><th>Flag</th></tr>
+<tr><td>Marmot</td><td>[yes]</td><td>[no]</td><td>[yes]</td><td>[yes]</td></tr>
+</table>"""
+
+        result = grits_from_html(expected, actual)
+
+        assert result is not None
+        assert result["grits_con"] == pytest.approx(1.0)
+
+    def test_name(self):
+        assert self.metric.name == "grits"
+
+    def test_returns_one_metric(self):
+        """compute() returns a single grits_con MetricValue."""
+        results = _compute(self.metric, SIMPLE_2X2, SIMPLE_2X2)
+        assert isinstance(results, list)
+        assert len(results) == 1
+        names = {r.metric_name for r in results}
+        assert names == {"grits_con"}
+
+    def test_identical_tables(self):
+        results = _compute(self.metric, SIMPLE_2X2, SIMPLE_2X2)
+        con = _find_metric(results, "grits_con")
+        assert con.value == pytest.approx(1.0)
+
+    def test_no_tables_in_expected(self):
+        results = _compute(self.metric, "no tables here", SIMPLE_2X2)
+        con = _find_metric(results, "grits_con")
+        assert con.value == 0.0
+        assert con.metadata["tables_found_expected"] == 0
+
+    def test_no_tables_in_actual(self):
+        results = _compute(self.metric, SIMPLE_2X2, "no tables here")
+        con = _find_metric(results, "grits_con")
+        assert con.value == 0.0
+        assert con.metadata["tables_found_actual"] == 0
+
+    def test_multiple_tables_matching(self):
+        """Multiple tables should be matched optimally via Hungarian algorithm."""
+        expected = f"{SIMPLE_2X2}\n{SIMPLE_3X3}"
+        actual = f"{SIMPLE_3X3}\n{SIMPLE_2X2}"  # Reversed order
+        results = _compute(self.metric, expected, actual)
+        con = _find_metric(results, "grits_con")
+        assert con.value == pytest.approx(1.0)
+        assert con.metadata["tables_matched"] == 2
+
+    def test_metadata_has_per_table_details(self):
+        results = _compute(self.metric, SIMPLE_2X2, SIMPLE_2X2)
+        con = _find_metric(results, "grits_con")
+        assert "per_table_details" in con.metadata
+        details = con.metadata["per_table_details"]
+        assert len(details) == 1
+        assert details[0]["grits_con"] == pytest.approx(1.0)
+
+    def test_value_range(self):
+        """All scores should be in [0, 1]."""
+        for actual in [SIMPLE_2X2, SIMPLE_2X2_DIFF_CONTENT, TABLE_EXTRA_ROW, SIMPLE_3X3]:
+            results = _compute(self.metric, SIMPLE_2X2, actual)
+            con = _find_metric(results, "grits_con")
+            assert 0.0 <= con.value <= 1.0
+
+
+# =============================================================================
+# Reference implementation comparison tests
+#
+# These compare our implementation against the Microsoft table-transformer
+# reference. The vendored file (_vendor_grits_reference.py) should be
+# removed before deploying.
+# =============================================================================
+
+# Import reference implementation (from microsoft/table-transformer)
+from parse_bench.evaluation.metrics.parse._vendor_grits_reference import (  # noqa: E402
+    grits_from_html as ref_grits_from_html,
+)
+from parse_bench.evaluation.metrics.parse._vendor_grits_reference import (  # noqa: E402
+    iou as ref_iou,
+)
+from parse_bench.evaluation.metrics.parse._vendor_grits_reference import (  # noqa: E402
+    lcs_similarity as ref_lcs_similarity,
+)
+
+# All table pairs to test against reference
+_REFERENCE_TEST_PAIRS = [
+    ("identical_2x2", SIMPLE_2X2, SIMPLE_2X2),
+    ("diff_content_2x2", SIMPLE_2X2, SIMPLE_2X2_DIFF_CONTENT),
+    ("one_changed_2x2", SIMPLE_2X2, SIMPLE_2X2_ONE_CHANGED),
+    ("2x2_vs_3x3", SIMPLE_2X2, SIMPLE_3X3),
+    ("colspan", TABLE_WITH_COLSPAN, TABLE_WITH_COLSPAN),
+    ("colspan_vs_no_colspan", TABLE_WITH_COLSPAN, TABLE_NO_COLSPAN),
+    ("rowspan", TABLE_WITH_ROWSPAN, TABLE_WITH_ROWSPAN),
+    ("complex_span", TABLE_COMPLEX_SPAN, TABLE_COMPLEX_SPAN),
+    ("extra_row", SIMPLE_2X2, TABLE_EXTRA_ROW),
+    ("extra_col", SIMPLE_2X2, TABLE_EXTRA_COL),
+    ("headers_th_vs_td", TABLE_WITH_HEADERS, TABLE_WITHOUT_HEADERS),
+    ("financial_ocr", FINANCIAL_TABLE_GT, FINANCIAL_TABLE_OCR),
+    ("reversed_extra_row", TABLE_EXTRA_ROW, SIMPLE_2X2),
+]
+
+
+class TestReferenceComparison:
+    """Compare our GriTS implementation against the Microsoft reference.
+
+    Every test pair should produce identical scores (within floating point
+    tolerance) for grits_top, grits_con, and their precision/recall variants.
+    """
+
+    @pytest.mark.parametrize(
+        "name,true_html,pred_html",
+        _REFERENCE_TEST_PAIRS,
+        ids=[p[0] for p in _REFERENCE_TEST_PAIRS],
+    )
+    def test_matches_reference(self, name, true_html, pred_html):
+        ours = grits_from_html(true_html, pred_html)
+        ref = ref_grits_from_html(true_html, pred_html)
+
+        assert ours is not None, f"Our implementation returned None for {name}"
+        assert ref is not None, f"Reference implementation returned None for {name}"
+
+        for key in [
+            "grits_con",
+            "grits_precision_con",
+            "grits_recall_con",
+            "grits_con_upper_bound",
+        ]:
+            assert ours[key] == pytest.approx(ref[key], abs=1e-9), (
+                f"{name}: {key} mismatch: ours={ours[key]}, ref={ref[key]}"
+            )
+
+
+class TestReferenceTimingComparison:
+    """Timing comparison between our implementation and the reference.
+
+    Not a correctness test — just prints timing info for manual inspection.
+    Uses a larger table to make timing differences visible.
+    """
+
+    # 6x4 table with mixed content for realistic timing
+    TIMING_TABLE_GT = """<table>
+<tr><th>Region</th><th>Q1</th><th>Q2</th><th>Q3</th></tr>
+<tr><td>North America</td><td>$12.3M</td><td>$14.1M</td><td>$15.8M</td></tr>
+<tr><td>Europe</td><td>$8.7M</td><td>$9.2M</td><td>$10.1M</td></tr>
+<tr><td>Asia Pacific</td><td>$6.4M</td><td>$7.8M</td><td>$8.9M</td></tr>
+<tr><td>Latin America</td><td>$2.1M</td><td>$2.5M</td><td>$3.0M</td></tr>
+<tr><td colspan="3">Total</td><td>$55.9M</td></tr>
+</table>"""
+
+    TIMING_TABLE_PRED = """<table>
+<tr><th>Region</th><th>Q1</th><th>Q2</th><th>Q3</th></tr>
+<tr><td>North America</td><td>$12.3M</td><td>$14.1M</td><td>$15.8M</td></tr>
+<tr><td>Europe</td><td>$8.7M</td><td>$9.2M</td><td>$1O.1M</td></tr>
+<tr><td>Asia Pacific</td><td>$6.4M</td><td>$7.8M</td><td>$8.9M</td></tr>
+<tr><td>Latin America</td><td>$2.1M</td><td>$2.5M</td><td>$3.OM</td></tr>
+<tr><td colspan="3">Total</td><td>$55.9M</td></tr>
+</table>"""
+
+    def test_timing_comparison(self):
+        """Compare wall-clock time of both implementations.
+
+        Runs each implementation multiple times and reports median timing.
+        This test always passes — it's purely informational.
+        """
+        import time
+
+        n_iterations = 20
+
+        # Warm up both implementations
+        grits_from_html(self.TIMING_TABLE_GT, self.TIMING_TABLE_PRED)
+        ref_grits_from_html(self.TIMING_TABLE_GT, self.TIMING_TABLE_PRED)
+
+        # Time our implementation
+        ours_times = []
+        for _ in range(n_iterations):
+            start = time.perf_counter()
+            grits_from_html(self.TIMING_TABLE_GT, self.TIMING_TABLE_PRED)
+            ours_times.append(time.perf_counter() - start)
+
+        # Time reference implementation
+        ref_times = []
+        for _ in range(n_iterations):
+            start = time.perf_counter()
+            ref_grits_from_html(self.TIMING_TABLE_GT, self.TIMING_TABLE_PRED)
+            ref_times.append(time.perf_counter() - start)
+
+        ours_median = sorted(ours_times)[n_iterations // 2]
+        ref_median = sorted(ref_times)[n_iterations // 2]
+
+        print(f"\n  Timing comparison (median of {n_iterations} runs, 6x4 table):")
+        print(f"    Our implementation: {ours_median * 1000:.2f} ms")
+        print(f"    Reference (MS):     {ref_median * 1000:.2f} ms")
+        print(f"    Ratio (ours/ref):   {ours_median / ref_median:.2f}x")
+
+
+# =============================================================================
+# Unoccupied grid cell tests (crash regression)
+#
+# Tables with gaps (grid positions not covered by any <td>/<th>) produce
+# scalar 0 at those positions. Before the fix, the reference implementation
+# crashed: iou() called Rect(0) → TypeError, lcs_similarity() called
+# len(0) → TypeError. Both now gracefully return 0.0 for those cells.
+# =============================================================================
+
+
+class TestUnoccupiedGridCells:
+    """Verify both implementations handle tables with unoccupied grid cells.
+
+    Before the fix, the reference's iou(0, ...) → Rect(0) → TypeError
+    crashed the entire grits_from_html call, scoring both GriTS_Top and
+    GriTS_Con as 0.0 for the whole table pair. Our implementation was
+    already safe. After the fix, both survive and produce real scores.
+    """
+
+    def test_ref_iou_scalar_zero(self):
+        """Reference iou() should handle scalar inputs, not crash.
+
+        Before fix: Rect(0) → TypeError
+        After fix:
+          - Both unoccupied (0 vs 0) → 1.0 (structural agreement)
+          - One occupied, one not → 0.0 (mismatch)
+        """
+        assert ref_iou(0, [0, 0, 1, 1]) == 0.0
+        assert ref_iou([0, 0, 1, 1], 0) == 0.0
+        assert ref_iou(0, 0) == 1.0  # both unoccupied = match
+        assert ref_iou(0.0, 0.0) == 1.0
+
+    def test_ref_lcs_similarity_scalar_zero(self):
+        """Reference lcs_similarity() should handle non-string inputs, not crash.
+
+        Before fix: len(0) → TypeError
+        After fix:  converts to str, computes similarity normally
+        """
+        assert ref_lcs_similarity(0, 0) == 1.0  # "0" vs "0"
+        assert ref_lcs_similarity("hello", 0) == ref_lcs_similarity("hello", "0")
+        assert ref_lcs_similarity(0, "hello") == ref_lcs_similarity("0", "hello")
+
+    def test_our_impl_identical_tables_with_gaps(self):
+        """Identical tables with gaps should score 1.0 for content."""
+        result = grits_from_html(TABLE_WITH_UNOCCUPIED_CELLS, TABLE_WITH_UNOCCUPIED_CELLS)
+        assert result is not None
+        assert result["grits_con"] == pytest.approx(1.0)
+
+    def test_ref_impl_identical_tables_with_gaps(self):
+        """Reference implementation now also survives tables with gaps.
+
+        Before fix: Rect(0) → TypeError → crashed → scored as 0.0
+        After fix:  identical tables score 1.0
+        """
+        result = ref_grits_from_html(TABLE_WITH_UNOCCUPIED_CELLS, TABLE_WITH_UNOCCUPIED_CELLS)
+        assert result is not None
+        assert result["grits_top"] == pytest.approx(1.0)
+        assert result["grits_con"] == pytest.approx(1.0)
+
+    def test_cross_table_gap_vs_no_gap(self):
+        """Table with gap vs table without — scores should be real, not crash."""
+        ours = grits_from_html(TABLE_WITH_UNOCCUPIED_CELLS, SIMPLE_2X2)
+        ref = ref_grits_from_html(TABLE_WITH_UNOCCUPIED_CELLS, SIMPLE_2X2)
+        assert ours is not None
+        assert ref is not None
+        # GriTS_Con should match (both use LCS, same logic now)
+        assert ours["grits_con"] == pytest.approx(ref["grits_con"], abs=1e-9)
+
+    def test_gap_vs_gap_different_content(self):
+        """Two tables with same gap structure but different content."""
+        ours = grits_from_html(TABLE_WITH_UNOCCUPIED_CELLS, TABLE_WITH_UNOCCUPIED_CELLS_2)
+        ref = ref_grits_from_html(TABLE_WITH_UNOCCUPIED_CELLS, TABLE_WITH_UNOCCUPIED_CELLS_2)
+        assert ours is not None
+        assert ref is not None
+        # Different content but gap cells give partial credit → between 0 and 1
+        assert 0.0 < ours["grits_con"] < 1.0
+        # Both implementations agree on content score
+        assert ours["grits_con"] == pytest.approx(ref["grits_con"], abs=1e-9)
+
+
+# =============================================================================
+# extract_html_tables — incomplete table handling
+# =============================================================================
+
+
+def test_extract_html_tables_incomplete_table():
+    """An incomplete table (no closing </table>) should still be extracted."""
+    html = "<table><tr><td>A</td><td>B</td></tr>"
+    tables = extract_html_tables(html)
+    assert len(tables) == 1
+    assert "<td>A</td>" in tables[0]
+
+
+def test_extract_html_tables_incomplete_after_complete():
+    """A complete table followed by an incomplete one should yield 2 tables."""
+    html = "<table><tr><td>1</td></tr></table><table><tr><td>2</td></tr>"
+    tables = extract_html_tables(html)
+    assert len(tables) == 2
+
+
+# =============================================================================
+# Page-constrained matching (same-page table pairing)
+# =============================================================================
+
+# Two same-structure 2x2 tables with disjoint content. Cross-pairing identical
+# content scores 1.0; pairing alpha against beta scores low.
+_T_ALPHA = "<table><tr><td>a1</td><td>a2</td></tr><tr><td>a3</td><td>a4</td></tr></table>"
+_T_BETA = "<table><tr><td>b1</td><td>b2</td></tr><tr><td>b3</td><td>b4</td></tr></table>"
+
+
+def _pairing(grits_results):
+    return list(grits_results[0].metadata["pairing"])
+
+
+def test_page_blocking_prefers_same_page_over_better_cross_page_match():
+    metric = GriTSMetric()
+    # GT: alpha@page1, beta@page2.  Pred: beta@page1, alpha@page2.
+    expected = _T_ALPHA + _T_BETA
+    actual = _T_BETA + _T_ALPHA
+    exp_tables, act_tables, _ = extract_table_pairs(expected, actual)
+
+    # Global matching cross-pairs the identical content -> perfect score.
+    global_res = metric.compute(exp_tables, act_tables)
+    assert global_res[0].value == 1.0
+    assert set(_pairing(global_res)) == {(0, 1), (1, 0)}
+
+    # Page-blocked: alpha@1 must pair with beta@1, beta@2 with alpha@2 -> low.
+    blocked_res = metric.compute(exp_tables, act_tables, expected_pages=[1, 2], actual_pages=[1, 2])
+    assert set(_pairing(blocked_res)) == {(0, 0), (1, 1)}
+    assert blocked_res[0].value < 1.0
+    # per_table_details carry the page labels and never cross pages.
+    for d in blocked_res[0].metadata["per_table_details"]:
+        if d.get("pred_table_index") is not None:
+            assert d["gt_page"] == d["pred_page"]
+
+
+def test_page_blocking_unmatched_gt_page_scores_zero():
+    metric = GriTSMetric()
+    # GT alpha@1, beta@2; prediction only on page 1.
+    expected = _T_ALPHA + _T_BETA
+    actual = _T_ALPHA
+    exp_tables, act_tables, _ = extract_table_pairs(expected, actual)
+    res = metric.compute(exp_tables, act_tables, expected_pages=[1, 2], actual_pages=[1])
+    pairing = _pairing(res)
+    assert (0, 0) in pairing
+    assert (1, None) in pairing
+    # avg over 2 GT tables: 1.0 (matched) + 0.0 (unmatched page 2) = 0.5
+    assert res[0].value == 0.5
+
+
+def test_page_blocking_pred_only_page_is_ignored():
+    metric = GriTSMetric()
+    # GT alpha@1 only; predictions alpha@1 and beta@3.
+    expected = _T_ALPHA
+    actual = _T_ALPHA + _T_BETA
+    exp_tables, act_tables, _ = extract_table_pairs(expected, actual)
+    res = metric.compute(exp_tables, act_tables, expected_pages=[1], actual_pages=[1, 3])
+    assert res[0].value == 1.0  # the lone GT pairs cleanly; extra pred ignored
+    assert _pairing(res) == [(0, 0)]
+
+
+def test_page_blocking_noop_when_all_one_page():
+    metric = GriTSMetric()
+    expected = _T_ALPHA + _T_BETA
+    actual = _T_ALPHA + _T_BETA
+    exp_tables, act_tables, _ = extract_table_pairs(expected, actual)
+    plain = metric.compute(exp_tables, act_tables)
+    paged = metric.compute(exp_tables, act_tables, expected_pages=[1, 1], actual_pages=[1, 1])
+    assert plain[0].value == paged[0].value
+    assert _pairing(plain) == _pairing(paged)
+
+
+def test_page_blocking_length_mismatch_falls_back_to_global():
+    metric = GriTSMetric()
+    expected = _T_ALPHA + _T_BETA
+    actual = _T_BETA + _T_ALPHA
+    exp_tables, act_tables, _ = extract_table_pairs(expected, actual)
+    # expected_pages too short -> page blocking disabled -> global cross-pairing.
+    res = metric.compute(exp_tables, act_tables, expected_pages=[1], actual_pages=[1, 2])
+    assert res[0].value == 1.0
+    assert set(_pairing(res)) == {(0, 1), (1, 0)}

--- a/tests/parse_bench/evaluation/metrics/parse/test_grits_perf_equivalence.py
+++ b/tests/parse_bench/evaluation/metrics/parse/test_grits_perf_equivalence.py
@@ -1,0 +1,85 @@
+"""Equivalence guards for the GriTS performance optimizations.
+
+Both optimizations are perf-only and MUST NOT change any metric value:
+
+- The ``factored_2dmss`` kernel has three modes (``BENCH_GRITS_KERNEL``):
+  ``slow`` (original dict path), ``memo`` (memoized dict build), and ``array``
+  (vectorized reward tensor + list DP, the default). All three must return
+  bit-identical scores AND alignment maps.
+- ``BENCH_GRITS_PAIR_WORKERS`` distributes the per-table-pair scoring across
+  processes, page by page — ``GriTSMetric.compute`` must return the same
+  ``grits_con`` and the same ``pairing`` as the sequential path.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "src"))
+
+import parse_bench.evaluation.metrics.parse.grits_metric as G  # noqa: E402
+from parse_bench.evaluation.metrics.parse.grits_metric import (  # noqa: E402
+    grits_con_from_table_data,
+)
+from parse_bench.evaluation.metrics.parse.table_extraction import (  # noqa: E402
+    extract_table_pairs,
+)
+
+# Four distinct tables: repeated cell values (so the memo cache is exercised),
+# different dimensions, and mismatched content (so grits_con != 1.0 and the
+# alignment tie-breaking matters).
+T_A = "<table><tr><td>A</td><td>A</td></tr><tr><td>B</td><td>A</td></tr></table>"
+T_A_PERTURBED = "<table><tr><td>A</td><td>A</td></tr><tr><td>B</td><td>X</td></tr></table>"
+T_WIDE = "<table><tr><td>h</td><td>h</td><td>h</td></tr><tr><td>1</td><td>2</td><td>3</td></tr></table>"
+T_TALL = "<table><tr><td>k</td><td>v</td></tr><tr><td>k</td><td>w</td></tr><tr><td>k</td><td>x</td></tr></table>"
+
+
+def _table_datas(html: str):
+    exp, act, _ = extract_table_pairs(html, html)
+    return exp[0].table_data, act[0].table_data
+
+
+def test_kernel_modes_are_bit_identical(monkeypatch):
+    """slow / memo / array kernels return identical scores AND alignment maps."""
+    pairs = [
+        (T_A, T_A),  # identical
+        (T_A, T_A_PERTURBED),  # one cell differs (con < 1.0)
+        (T_A, T_WIDE),  # dimension mismatch
+        (T_TALL, T_WIDE),  # both dims differ
+    ]
+    keys = [
+        "grits_con",
+        "grits_precision_con",
+        "grits_recall_con",
+        "grits_con_upper_bound",
+        "_con_row_alignment",
+        "_con_col_alignment",
+    ]
+    for gt_html, pred_html in pairs:
+        gt = _table_datas(gt_html)[0]
+        pred = _table_datas(pred_html)[0]
+
+        results = {}
+        for mode in ("slow", "memo", "array"):
+            monkeypatch.setenv("BENCH_GRITS_KERNEL", mode)
+            results[mode] = grits_con_from_table_data(gt, pred)
+            assert results[mode] is not None
+
+        for mode in ("memo", "array"):
+            for k in keys:
+                assert results["slow"][k] == results[mode][k], (
+                    f"{mode}.{k} diverged from slow on {gt_html!r} vs {pred_html!r}: "
+                    f"{results['slow'][k]} != {results[mode][k]}"
+                )
+
+
+def test_legacy_fast_kernel_flag_still_disables(monkeypatch):
+    """BENCH_GRITS_FAST_KERNEL=0 forces the slow path (back-compat)."""
+    gt, pred = _table_datas(T_A)[0], _table_datas(T_A_PERTURBED)[0]
+    monkeypatch.delenv("BENCH_GRITS_KERNEL", raising=False)
+    monkeypatch.setenv("BENCH_GRITS_FAST_KERNEL", "0")
+    assert G._kernel_mode() == "slow"
+    slow = grits_con_from_table_data(gt, pred)
+    monkeypatch.setenv("BENCH_GRITS_FAST_KERNEL", "1")
+    assert G._kernel_mode() == "array"
+    arr = grits_con_from_table_data(gt, pred)
+    assert slow["grits_con"] == arr["grits_con"]

--- a/tests/parse_bench/evaluation/metrics/parse/test_grits_trm_composite.py
+++ b/tests/parse_bench/evaluation/metrics/parse/test_grits_trm_composite.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from parse_bench.evaluation.evaluators.parse import ParseEvaluator
+from parse_bench.schemas.evaluation import MetricValue
+
+
+def _mv(name: str, value: float) -> MetricValue:
+    return MetricValue(metric_name=name, value=value)
+
+
+def _composite(metrics: list[MetricValue]) -> MetricValue | None:
+    out = ParseEvaluator._compute_grits_trm_composite(metrics, trm_unsupported=False)
+    return out[0] if out else None
+
+
+def test_composite_average_when_both_present() -> None:
+    metrics = [_mv("grits_con", 0.8), _mv("table_record_match", 0.6)]
+    result = ParseEvaluator._compute_grits_trm_composite(metrics, trm_unsupported=False)
+    assert len(result) == 1
+    assert result[0].metric_name == "grits_trm_composite"
+    assert abs(result[0].value - 0.7) < 1e-9
+    assert result[0].metadata["fallback"] is None
+
+
+def test_composite_falls_back_to_grits_when_trm_unsupported() -> None:
+    metrics = [_mv("grits_con", 0.42), _mv("table_record_match", 0.99)]
+    result = ParseEvaluator._compute_grits_trm_composite(metrics, trm_unsupported=True)
+    assert len(result) == 1
+    assert result[0].value == 0.42
+    assert result[0].metadata["fallback"] == "grits_only"
+    assert result[0].metadata["reason"] == "trm_unsupported"
+
+
+def test_composite_falls_back_when_trm_missing() -> None:
+    metrics = [_mv("grits_con", 0.42)]
+    result = ParseEvaluator._compute_grits_trm_composite(metrics, trm_unsupported=False)
+    assert len(result) == 1
+    assert result[0].value == 0.42
+    assert result[0].metadata["reason"] == "trm_missing"
+
+
+def test_composite_empty_when_grits_missing() -> None:
+    metrics = [_mv("table_record_match", 0.6)]
+    result = ParseEvaluator._compute_grits_trm_composite(metrics, trm_unsupported=False)
+    assert result == []
+
+
+def test_composite_no_actual_tables_zero_case() -> None:
+    # Both inputs zero (no-actual-tables fallback) → composite is derived 0.0
+    metrics = [_mv("grits_con", 0.0), _mv("table_record_match", 0.0)]
+    result = ParseEvaluator._compute_grits_trm_composite(metrics, trm_unsupported=False)
+    assert len(result) == 1
+    assert result[0].value == 0.0
+    assert result[0].metadata["fallback"] is None

--- a/tests/parse_bench/evaluation/metrics/parse/test_header_accuracy_metric.py
+++ b/tests/parse_bench/evaluation/metrics/parse/test_header_accuracy_metric.py
@@ -1,0 +1,1830 @@
+"""Tests for the header accuracy metric."""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "src"))
+
+from parse_bench.evaluation.metrics.parse.header_accuracy_metric import (
+    SUBMETRIC_KEYS,
+    HeaderAccuracyMetric,
+    HeaderAccuracyMetricGenerous,
+    HeaderBlock,
+    HeaderCell,
+    _apply_generous_header_normalization,
+    _block_edge_distance,
+    _block_edge_vector,
+    _block_extent_iou,
+    _build_text_lookup,
+    _detailed_header_composite_for_table_pair,
+    _direction_similarity,
+    _find_contiguous_groups,
+    _find_header_blocks,
+    _header_block_relative_position_score,
+    _header_cell_count_score,
+    _header_content_bag_score,
+    _header_data_alignment_score,
+    _header_grits_score,
+    _header_hierarchy_depth,
+    _header_hierarchy_depth_score,
+    _header_perfect_score,
+    _is_bottom_left_block,
+    _match_blocks,
+    _parse_header_cells,
+    _promote_bottom_left_to_header,
+    _promote_top_row_to_header,
+    compute_header_composite_for_table_pair,
+)
+
+# =============================================================================
+# Test tables
+# =============================================================================
+
+# Simple table with th headers
+TABLE_SIMPLE_HEADERS = """<table>
+<tr><th>Name</th><th>Value</th></tr>
+<tr><td>Alpha</td><td>100</td></tr>
+<tr><td>Beta</td><td>200</td></tr>
+</table>"""
+
+# Same structure but td instead of th (no headers)
+TABLE_NO_HEADERS = """<table>
+<tr><td>Name</td><td>Value</td></tr>
+<tr><td>Alpha</td><td>100</td></tr>
+<tr><td>Beta</td><td>200</td></tr>
+</table>"""
+
+# Same headers, different body
+TABLE_SAME_HEADERS_DIFF_BODY = """<table>
+<tr><th>Name</th><th>Value</th></tr>
+<tr><td>Gamma</td><td>300</td></tr>
+<tr><td>Delta</td><td>400</td></tr>
+</table>"""
+
+# Different header text, same structure
+TABLE_DIFF_HEADER_TEXT = """<table>
+<tr><th>Label</th><th>Amount</th></tr>
+<tr><td>Alpha</td><td>100</td></tr>
+<tr><td>Beta</td><td>200</td></tr>
+</table>"""
+
+# Extra header column
+TABLE_EXTRA_HEADER_COL = """<table>
+<tr><th>Name</th><th>Value</th><th>Unit</th></tr>
+<tr><td>Alpha</td><td>100</td><td>kg</td></tr>
+</table>"""
+
+# Multi-row header with colspan
+TABLE_MULTI_ROW_HEADER = """<table>
+<tr><th colspan="2">Financial Summary</th></tr>
+<tr><th>Item</th><th>Amount</th></tr>
+<tr><td>Revenue</td><td>$1M</td></tr>
+</table>"""
+
+# Same multi-row header
+TABLE_MULTI_ROW_HEADER_SAME = """<table>
+<tr><th colspan="2">Financial Summary</th></tr>
+<tr><th>Item</th><th>Amount</th></tr>
+<tr><td>Expenses</td><td>$0.5M</td></tr>
+</table>"""
+
+# Multi-row header with wrong colspan
+TABLE_MULTI_ROW_HEADER_WRONG_SPAN = """<table>
+<tr><th>Financial Summary</th><th></th></tr>
+<tr><th>Item</th><th>Amount</th></tr>
+<tr><td>Revenue</td><td>$1M</td></tr>
+</table>"""
+
+# Table with row headers (th in first column)
+TABLE_ROW_HEADERS = """<table>
+<tr><th>Category</th><td>Q1</td><td>Q2</td></tr>
+<tr><th>Revenue</th><td>$1M</td><td>$2M</td></tr>
+<tr><th>Cost</th><td>$0.5M</td><td>$0.8M</td></tr>
+</table>"""
+
+# Table with both row and column headers (two blocks)
+TABLE_TWO_HEADER_BLOCKS = """<table>
+<tr><th></th><th>Q1</th><th>Q2</th></tr>
+<tr><th>Revenue</th><td>$1M</td><td>$2M</td></tr>
+<tr><th>Cost</th><td>$0.5M</td><td>$0.8M</td></tr>
+</table>"""
+
+# Table with thead
+TABLE_WITH_THEAD = """<table>
+<thead>
+<tr><td>Name</td><td>Value</td></tr>
+</thead>
+<tbody>
+<tr><td>Alpha</td><td>100</td></tr>
+</tbody>
+</table>"""
+
+# Table with formatting in headers
+TABLE_FORMATTED_HEADERS = """<table>
+<tr><th><b>Name</b></th><th><i>Value</i></th></tr>
+<tr><td>Alpha</td><td>100</td></tr>
+</table>"""
+
+# Table with strikethrough in headers
+TABLE_STRIKETHROUGH_HEADERS = """<table>
+<tr><th><s>Name</s></th><th><del>Value</del></th></tr>
+<tr><td>Alpha</td><td>100</td></tr>
+</table>"""
+
+
+# --- Tables for header_data_alignment tests ---
+
+# 3-column table with unique data (forces deterministic GriTS alignment)
+TABLE_3COL = """<table>
+<tr><th>Name</th><th>Age</th><th>City</th></tr>
+<tr><td>Alice</td><td>30</td><td>NYC</td></tr>
+<tr><td>Bob</td><td>25</td><td>LA</td></tr>
+</table>"""
+
+# Extra empty <td> in header row — pushes header cols 1,2 to positions 2,3
+TABLE_3COL_EXTRA_TD = """<table>
+<tr><th>Name</th><td></td><th>Age</th><th>City</th></tr>
+<tr><td>Alice</td><td>30</td><td>NYC</td><td></td></tr>
+<tr><td>Bob</td><td>25</td><td>LA</td><td></td></tr>
+</table>"""
+
+# Same layout but the extra cell is a <th> instead of <td>
+TABLE_3COL_EXTRA_TH = """<table>
+<tr><th>Name</th><th></th><th>Age</th><th>City</th></tr>
+<tr><td>Alice</td><td>30</td><td>NYC</td><td></td></tr>
+<tr><td>Bob</td><td>25</td><td>LA</td><td></td></tr>
+</table>"""
+
+# Same content as TABLE_3COL but all headers are <td> (no th at all)
+TABLE_3COL_NO_TH = """<table>
+<tr><td>Name</td><td>Age</td><td>City</td></tr>
+<tr><td>Alice</td><td>30</td><td>NYC</td></tr>
+<tr><td>Bob</td><td>25</td><td>LA</td></tr>
+</table>"""
+
+# Two extra empty cells at different positions in the header row:
+# one after Name and one after Age.  Data rows also have 5 columns
+# (empty cells at positions 1 and 3) so the table is rectangular.
+#
+# GT grid (3 cols):         Pred grid (5 cols):
+#   Name  Age  City           Name  ""  Age  ""  City
+#   Alice 30   NYC            Alice 30  NYC  ""  ""
+#   Bob   25   LA             Bob   25  LA   ""  ""
+#
+# GriTS col alignment (data-dominated):
+#   col 0→0 ("alice"↔"alice", "bob"↔"bob", "name"↔"name")
+#   col 1→1 ("30"↔"30", "25"↔"25" dominate over "age"↔"")
+#   col 2→2 ("nyc"↔"nyc", "la"↔"la" dominate over "city"↔"age")
+#
+# Header text check at mapped positions:
+#   "name" at (0,0) → pred (0,0) = "name" → match
+#   "age"  at (0,1) → pred (0,1) = ""     → mismatch
+#   "city" at (0,2) → pred (0,2) = "age"  → mismatch
+# Score = 1/3
+TABLE_3COL_TWO_EXTRA_SPREAD = """<table>
+<tr><th>Name</th><td></td><th>Age</th><td></td><th>City</th></tr>
+<tr><td>Alice</td><td>30</td><td>NYC</td><td></td><td></td></tr>
+<tr><td>Bob</td><td>25</td><td>LA</td><td></td><td></td></tr>
+</table>"""
+
+# Two extra empty cells both inserted before the first header.
+# Data rows also have 5 columns (empty cells at positions 0 and 1).
+#
+# GT grid (3 cols):         Pred grid (5 cols):
+#   Name  Age  City           ""  ""  Name  Age  City
+#   Alice 30   NYC            ""  ""  Alice 30   NYC
+#   Bob   25   LA             ""  ""  Bob   25   LA
+#
+# GriTS col alignment (data-dominated):
+#   col 0→2 ("alice"↔"alice", "bob"↔"bob", "name"↔"name")
+#   col 1→3 ("30"↔"30", "25"↔"25", "age"↔"age")
+#   col 2→4 ("nyc"↔"nyc", "la"↔"la", "city"↔"city")
+#
+# Header text check: all 3 headers map to correct text → score = 1.0
+TABLE_3COL_TWO_EXTRA_LEADING = """<table>
+<tr><td></td><td></td><th>Name</th><th>Age</th><th>City</th></tr>
+<tr><td></td><td></td><td>Alice</td><td>30</td><td>NYC</td></tr>
+<tr><td></td><td></td><td>Bob</td><td>25</td><td>LA</td></tr>
+</table>"""
+
+# Two extra empty cells both at the end of each row.
+# The extra cells don't displace any headers.
+#
+# GriTS col alignment:
+#   col 0→0, col 1→1, col 2→2  (content matches perfectly in first 3 cols)
+#
+# All headers at mapped positions have correct text → score = 1.0
+TABLE_3COL_TWO_EXTRA_TRAILING = """<table>
+<tr><th>Name</th><th>Age</th><th>City</th><td></td><td></td></tr>
+<tr><td>Alice</td><td>30</td><td>NYC</td><td></td><td></td></tr>
+<tr><td>Bob</td><td>25</td><td>LA</td><td></td><td></td></tr>
+</table>"""
+
+# Extra empty row inserted before the header row.
+# Data content is unchanged so column alignment is perfect.
+#
+# GriTS row alignment:
+#   row 0→1 (header content "name"↔"name", "age"↔"age", "city"↔"city"
+#            outweigh "name"↔"", "age"↔"", "city"↔"")
+#   row 1→2, row 2→3
+#
+# Headers at (0,0),(0,1),(0,2) map to (1,0),(1,1),(1,2) in pred,
+# which have "name","age","city" → all match → score = 1.0
+TABLE_3COL_EXTRA_ROW = """<table>
+<tr><td></td><td></td><td></td></tr>
+<tr><th>Name</th><th>Age</th><th>City</th></tr>
+<tr><td>Alice</td><td>30</td><td>NYC</td></tr>
+<tr><td>Bob</td><td>25</td><td>LA</td></tr>
+</table>"""
+
+
+# =============================================================================
+# Header cell parsing tests
+# =============================================================================
+
+
+class TestParseHeaderCells:
+    def test_simple_th_headers(self):
+        cells, rows, cols = _parse_header_cells(TABLE_SIMPLE_HEADERS)
+        assert len(cells) == 2
+        texts = {c.text for c in cells}
+        assert "name" in texts  # normalized to lowercase
+        assert "value" in texts
+
+    def test_no_headers(self):
+        cells, rows, cols = _parse_header_cells(TABLE_NO_HEADERS)
+        assert len(cells) == 0
+
+    def test_thead_marks_headers(self):
+        cells, rows, cols = _parse_header_cells(TABLE_WITH_THEAD)
+        assert len(cells) == 2
+        texts = {c.text for c in cells}
+        assert "name" in texts
+        assert "value" in texts
+
+    def test_colspan_header(self):
+        cells, rows, cols = _parse_header_cells(TABLE_MULTI_ROW_HEADER)
+        spanning = [c for c in cells if c.colspan == 2]
+        assert len(spanning) == 1
+        assert "financial summary" in spanning[0].text
+
+    def test_row_headers(self):
+        cells, rows, cols = _parse_header_cells(TABLE_ROW_HEADERS)
+        assert len(cells) == 3  # Category, Revenue, Cost
+        assert rows == 3
+        assert cols == 3
+
+    def test_formatting_stripped(self):
+        """Bold/italic/strikethrough formatting should be stripped."""
+        plain_cells, _, _ = _parse_header_cells(TABLE_SIMPLE_HEADERS)
+        bold_cells, _, _ = _parse_header_cells(TABLE_FORMATTED_HEADERS)
+        strike_cells, _, _ = _parse_header_cells(TABLE_STRIKETHROUGH_HEADERS)
+
+        plain_texts = sorted(c.text for c in plain_cells)
+        bold_texts = sorted(c.text for c in bold_cells)
+        strike_texts = sorted(c.text for c in strike_cells)
+
+        assert plain_texts == bold_texts
+        assert plain_texts == strike_texts
+
+
+# =============================================================================
+# Header block detection tests
+# =============================================================================
+
+
+class TestFindHeaderBlocks:
+    def test_single_header_row(self):
+        cells, _, _ = _parse_header_cells(TABLE_SIMPLE_HEADERS)
+        blocks = _find_header_blocks(cells)
+        assert len(blocks) == 1
+        assert len(blocks[0].cells) == 2
+
+    def test_multi_row_header(self):
+        cells, _, _ = _parse_header_cells(TABLE_MULTI_ROW_HEADER)
+        blocks = _find_header_blocks(cells)
+        # Colspan cell in row 0 + two cells in row 1 = one contiguous block
+        assert len(blocks) == 1
+        assert len(blocks[0].cells) == 3
+
+    def test_two_header_blocks(self):
+        cells, _, _ = _parse_header_cells(TABLE_TWO_HEADER_BLOCKS)
+        blocks = _find_header_blocks(cells)
+        # The corner th, top row ths, and left column ths are all adjacent
+        # so they should form one block
+        assert len(blocks) == 1
+
+    def test_no_headers(self):
+        cells, _, _ = _parse_header_cells(TABLE_NO_HEADERS)
+        blocks = _find_header_blocks(cells)
+        assert len(blocks) == 0
+
+
+# =============================================================================
+# Block matching tests
+# =============================================================================
+
+
+class TestMatchBlocks:
+    def test_identical_blocks(self):
+        cells, _, _ = _parse_header_cells(TABLE_SIMPLE_HEADERS)
+        blocks = _find_header_blocks(cells)
+        gt_to_pred, grits_scores = _match_blocks(blocks, blocks)
+        assert len(gt_to_pred) == 1
+        assert gt_to_pred[0] == 0
+        assert grits_scores[(0, 0)] == pytest.approx(1.0)
+
+    def test_empty_blocks(self):
+        gt_to_pred, grits_scores = _match_blocks([], [])
+        assert gt_to_pred == {}
+        assert grits_scores == {}
+
+    def test_no_pred_blocks(self):
+        cells, _, _ = _parse_header_cells(TABLE_SIMPLE_HEADERS)
+        blocks = _find_header_blocks(cells)
+        gt_to_pred, grits_scores = _match_blocks(blocks, [])
+        assert gt_to_pred == {}
+
+    def test_extent_iou_tiebreak_same_content(self):
+        """When two pred blocks have identical content, prefer positional match."""
+        # GT: block at top-left, block at bottom-right
+        gt_block_top = HeaderBlock(
+            cells=[HeaderCell(text="x", row=0, col=0, rowspan=1, colspan=1)],
+            min_row=0,
+            max_row=1,
+            min_col=0,
+            max_col=1,
+        )
+        gt_block_bot = HeaderBlock(
+            cells=[HeaderCell(text="x", row=5, col=5, rowspan=1, colspan=1)],
+            min_row=5,
+            max_row=6,
+            min_col=5,
+            max_col=6,
+        )
+        # Pred: same content "x" at both positions (GriTS-Con ties)
+        pred_block_top = HeaderBlock(
+            cells=[HeaderCell(text="x", row=0, col=0, rowspan=1, colspan=1)],
+            min_row=0,
+            max_row=1,
+            min_col=0,
+            max_col=1,
+        )
+        pred_block_bot = HeaderBlock(
+            cells=[HeaderCell(text="x", row=5, col=5, rowspan=1, colspan=1)],
+            min_row=5,
+            max_row=6,
+            min_col=5,
+            max_col=6,
+        )
+        gt_to_pred, _ = _match_blocks(
+            [gt_block_top, gt_block_bot],
+            [pred_block_top, pred_block_bot],
+            gt_rows=6,
+            gt_cols=6,
+            pred_rows=6,
+            pred_cols=6,
+        )
+        # Tiebreaker should match top↔top (0↔0) and bot↔bot (1↔1)
+        assert gt_to_pred[0] == 0
+        assert gt_to_pred[1] == 1
+
+    def test_content_overrides_position(self):
+        """GriTS-Con should still win over position when content differs."""
+        # GT: block A at top, block B at bottom
+        gt_block_top = HeaderBlock(
+            cells=[HeaderCell(text="alpha", row=0, col=0, rowspan=1, colspan=1)],
+            min_row=0,
+            max_row=1,
+            min_col=0,
+            max_col=1,
+        )
+        gt_block_bot = HeaderBlock(
+            cells=[HeaderCell(text="beta", row=5, col=0, rowspan=1, colspan=1)],
+            min_row=5,
+            max_row=6,
+            min_col=0,
+            max_col=1,
+        )
+        # Pred: "beta" at top position, "alpha" at bottom — content swapped
+        pred_block_top = HeaderBlock(
+            cells=[HeaderCell(text="beta", row=0, col=0, rowspan=1, colspan=1)],
+            min_row=0,
+            max_row=1,
+            min_col=0,
+            max_col=1,
+        )
+        pred_block_bot = HeaderBlock(
+            cells=[HeaderCell(text="alpha", row=5, col=0, rowspan=1, colspan=1)],
+            min_row=5,
+            max_row=6,
+            min_col=0,
+            max_col=1,
+        )
+        gt_to_pred, _ = _match_blocks(
+            [gt_block_top, gt_block_bot],
+            [pred_block_top, pred_block_bot],
+            gt_rows=6,
+            gt_cols=1,
+            pred_rows=6,
+            pred_cols=1,
+        )
+        # Content match should win: "alpha" GT top (0) ↔ "alpha" pred bot (1)
+        assert gt_to_pred[0] == 1
+        assert gt_to_pred[1] == 0
+
+
+class TestBlockExtentIou:
+    def test_identical_blocks(self):
+        b = HeaderBlock(min_row=0, max_row=2, min_col=0, max_col=3)
+        assert _block_extent_iou(b, b, 4, 4, 4, 4) == pytest.approx(1.0)
+
+    def test_non_overlapping_blocks(self):
+        b1 = HeaderBlock(min_row=0, max_row=1, min_col=0, max_col=1)
+        b2 = HeaderBlock(min_row=3, max_row=4, min_col=3, max_col=4)
+        assert _block_extent_iou(b1, b2, 4, 4, 4, 4) == pytest.approx(0.0)
+
+    def test_partial_overlap(self):
+        b1 = HeaderBlock(min_row=0, max_row=2, min_col=0, max_col=2)
+        b2 = HeaderBlock(min_row=1, max_row=3, min_col=1, max_col=3)
+        iou = _block_extent_iou(b1, b2, 4, 4, 4, 4)
+        # Intersection: [0.25,0.25]-[0.5,0.5] = 0.0625
+        # Each area: 0.25, union: 0.5 - 0.0625 = 0.4375
+        assert 0.0 < iou < 0.5
+
+
+# =============================================================================
+# Submetric tests
+# =============================================================================
+
+
+class TestHeaderCellCountScore:
+    def test_identical(self):
+        gt, _, _ = _parse_header_cells(TABLE_SIMPLE_HEADERS)
+        assert _header_cell_count_score(gt, gt) == 1.0
+
+    def test_no_headers_both(self):
+        assert _header_cell_count_score([], []) == 1.0
+
+    def test_missing_all(self):
+        gt, _, _ = _parse_header_cells(TABLE_SIMPLE_HEADERS)
+        assert _header_cell_count_score(gt, []) == 0.0
+
+    def test_extra_header(self):
+        gt, _, _ = _parse_header_cells(TABLE_SIMPLE_HEADERS)  # 2 headers
+        pred, _, _ = _parse_header_cells(TABLE_EXTRA_HEADER_COL)  # 3 headers
+        score = _header_cell_count_score(gt, pred)
+        assert score == pytest.approx(2.0 / 3.0)
+
+
+class TestHeaderContentBagScore:
+    def test_identical(self):
+        gt, _, _ = _parse_header_cells(TABLE_SIMPLE_HEADERS)
+        assert _header_content_bag_score(gt, gt) == 1.0
+
+    def test_completely_different(self):
+        gt, _, _ = _parse_header_cells(TABLE_SIMPLE_HEADERS)
+        pred, _, _ = _parse_header_cells(TABLE_DIFF_HEADER_TEXT)
+        assert _header_content_bag_score(gt, pred) == 0.0
+
+    def test_partial_match(self):
+        gt, _, _ = _parse_header_cells(TABLE_EXTRA_HEADER_COL)  # Name, Value, Unit
+        pred, _, _ = _parse_header_cells(TABLE_SIMPLE_HEADERS)  # Name, Value
+        # GT has 3 cells, pred matches 2 of them
+        score = _header_content_bag_score(gt, pred)
+        assert score == pytest.approx(2.0 / 3.0)
+
+    def test_formatting_normalized(self):
+        """Bold/italic headers should match plain headers exactly."""
+        gt, _, _ = _parse_header_cells(TABLE_SIMPLE_HEADERS)
+        pred, _, _ = _parse_header_cells(TABLE_FORMATTED_HEADERS)
+        assert _header_content_bag_score(gt, pred) == 1.0
+
+    def test_strikethrough_normalized(self):
+        """Strikethrough headers should match plain headers exactly."""
+        gt, _, _ = _parse_header_cells(TABLE_SIMPLE_HEADERS)
+        pred, _, _ = _parse_header_cells(TABLE_STRIKETHROUGH_HEADERS)
+        assert _header_content_bag_score(gt, pred) == 1.0
+
+
+class TestPerfectHeaderScore:
+    def test_identical(self):
+        gt, _, _ = _parse_header_cells(TABLE_SIMPLE_HEADERS)
+        assert _header_perfect_score(gt, gt) == 1.0
+
+    def test_different_count(self):
+        gt, _, _ = _parse_header_cells(TABLE_SIMPLE_HEADERS)
+        pred, _, _ = _parse_header_cells(TABLE_EXTRA_HEADER_COL)
+        assert _header_perfect_score(gt, pred) == 0.0
+
+    def test_same_structure_diff_text(self):
+        gt, _, _ = _parse_header_cells(TABLE_SIMPLE_HEADERS)
+        pred, _, _ = _parse_header_cells(TABLE_DIFF_HEADER_TEXT)
+        assert _header_perfect_score(gt, pred) == 0.0
+
+    def test_same_headers_diff_body(self):
+        gt, _, _ = _parse_header_cells(TABLE_SIMPLE_HEADERS)
+        pred, _, _ = _parse_header_cells(TABLE_SAME_HEADERS_DIFF_BODY)
+        assert _header_perfect_score(gt, pred) == 1.0
+
+    def test_wrong_colspan(self):
+        gt, _, _ = _parse_header_cells(TABLE_MULTI_ROW_HEADER)
+        pred, _, _ = _parse_header_cells(TABLE_MULTI_ROW_HEADER_WRONG_SPAN)
+        assert _header_perfect_score(gt, pred) == 0.0
+
+
+class TestHeaderBlockGritsScore:
+    def test_identical(self):
+        gt, _, _ = _parse_header_cells(TABLE_SIMPLE_HEADERS)
+        gt_blocks = _find_header_blocks(gt)
+        gt_to_pred, grits_scores = _match_blocks(gt_blocks, gt_blocks)
+        score = _header_grits_score(gt_blocks, gt_blocks, gt_to_pred, grits_scores)
+        assert score == pytest.approx(1.0)
+
+    def test_no_blocks(self):
+        assert _header_grits_score([], [], {}, {}) == 1.0
+
+    def test_missing_blocks(self):
+        gt, _, _ = _parse_header_cells(TABLE_SIMPLE_HEADERS)
+        gt_blocks = _find_header_blocks(gt)
+        assert _header_grits_score(gt_blocks, [], {}, {}) == 0.0
+
+
+class TestBlockEdgeDistance:
+    def test_non_overlapping_horizontal(self):
+        """Blocks separated horizontally: distance is column gap."""
+        a = HeaderBlock(min_row=0, max_row=2, min_col=0, max_col=2)
+        b = HeaderBlock(min_row=0, max_row=2, min_col=5, max_col=7)
+        assert _block_edge_distance(a, b) == pytest.approx(3.0)
+
+    def test_non_overlapping_vertical(self):
+        """Blocks separated vertically: distance is row gap."""
+        a = HeaderBlock(min_row=0, max_row=2, min_col=0, max_col=2)
+        b = HeaderBlock(min_row=6, max_row=8, min_col=0, max_col=2)
+        assert _block_edge_distance(a, b) == pytest.approx(4.0)
+
+    def test_non_overlapping_diagonal(self):
+        """Blocks separated diagonally: Euclidean distance of gaps."""
+        a = HeaderBlock(min_row=0, max_row=2, min_col=0, max_col=2)
+        b = HeaderBlock(min_row=5, max_row=7, min_col=5, max_col=7)
+        # Gap: dr=3, dc=3
+        assert _block_edge_distance(a, b) == pytest.approx((3**2 + 3**2) ** 0.5)
+
+    def test_adjacent_blocks(self):
+        """Blocks sharing an edge have distance 0."""
+        a = HeaderBlock(min_row=0, max_row=2, min_col=0, max_col=3)
+        b = HeaderBlock(min_row=2, max_row=4, min_col=0, max_col=3)
+        assert _block_edge_distance(a, b) == pytest.approx(0.0)
+
+    def test_overlapping_blocks(self):
+        """Overlapping blocks have distance 0."""
+        a = HeaderBlock(min_row=0, max_row=3, min_col=0, max_col=3)
+        b = HeaderBlock(min_row=1, max_row=4, min_col=1, max_col=4)
+        assert _block_edge_distance(a, b) == pytest.approx(0.0)
+
+    def test_same_block(self):
+        """Same block has distance 0."""
+        a = HeaderBlock(min_row=2, max_row=5, min_col=2, max_col=5)
+        assert _block_edge_distance(a, a) == pytest.approx(0.0)
+
+
+class TestBlockEdgeVector:
+    def test_b_below_and_right(self):
+        a = HeaderBlock(min_row=0, max_row=2, min_col=0, max_col=2)
+        b = HeaderBlock(min_row=5, max_row=7, min_col=5, max_col=7)
+        dr, dc = _block_edge_vector(a, b)
+        assert dr == pytest.approx(3.0)  # b is below a
+        assert dc == pytest.approx(3.0)  # b is right of a
+
+    def test_b_above_and_left(self):
+        a = HeaderBlock(min_row=5, max_row=7, min_col=5, max_col=7)
+        b = HeaderBlock(min_row=0, max_row=2, min_col=0, max_col=2)
+        dr, dc = _block_edge_vector(a, b)
+        assert dr == pytest.approx(-3.0)  # b is above a
+        assert dc == pytest.approx(-3.0)  # b is left of a
+
+    def test_overlapping_in_row(self):
+        """Blocks overlapping in rows → dr=0, only column gap."""
+        a = HeaderBlock(min_row=0, max_row=3, min_col=0, max_col=2)
+        b = HeaderBlock(min_row=1, max_row=4, min_col=5, max_col=7)
+        dr, dc = _block_edge_vector(a, b)
+        assert dr == pytest.approx(0.0)  # overlapping rows
+        assert dc == pytest.approx(3.0)
+
+    def test_adjacent(self):
+        """Adjacent blocks have zero vector."""
+        a = HeaderBlock(min_row=0, max_row=2, min_col=0, max_col=3)
+        b = HeaderBlock(min_row=2, max_row=4, min_col=0, max_col=3)
+        dr, dc = _block_edge_vector(a, b)
+        assert dr == pytest.approx(0.0)
+        assert dc == pytest.approx(0.0)
+
+    def test_vector_magnitude_matches_distance(self):
+        """Edge vector magnitude should equal edge distance."""
+        a = HeaderBlock(min_row=0, max_row=2, min_col=0, max_col=2)
+        b = HeaderBlock(min_row=5, max_row=7, min_col=5, max_col=7)
+        dr, dc = _block_edge_vector(a, b)
+        assert (dr**2 + dc**2) ** 0.5 == pytest.approx(_block_edge_distance(a, b))
+
+
+class TestDirectionSimilarity:
+    def test_parallel_vectors(self):
+        """Vectors in same direction → 1.0."""
+        assert _direction_similarity(1.0, 0.0, 2.0, 0.0) == pytest.approx(1.0)
+
+    def test_opposite_vectors(self):
+        """Vectors in opposite directions → 0.0."""
+        assert _direction_similarity(1.0, 0.0, -1.0, 0.0) == pytest.approx(0.0)
+
+    def test_perpendicular_vectors(self):
+        """Perpendicular vectors → 0.5."""
+        assert _direction_similarity(1.0, 0.0, 0.0, 1.0) == pytest.approx(0.5)
+
+    def test_zero_gt_vector(self):
+        """Zero GT vector → 1.0 (direction irrelevant)."""
+        assert _direction_similarity(0.0, 0.0, 1.0, 1.0) == pytest.approx(1.0)
+
+    def test_zero_pred_vector(self):
+        """Zero pred vector → 1.0 (direction irrelevant)."""
+        assert _direction_similarity(1.0, 1.0, 0.0, 0.0) == pytest.approx(1.0)
+
+    def test_both_zero(self):
+        """Both zero → 1.0."""
+        assert _direction_similarity(0.0, 0.0, 0.0, 0.0) == pytest.approx(1.0)
+
+    def test_diagonal_same_direction(self):
+        """Same diagonal direction → 1.0."""
+        assert _direction_similarity(3.0, 4.0, 6.0, 8.0) == pytest.approx(1.0)
+
+    def test_diagonal_opposite(self):
+        """Opposite diagonal → 0.0."""
+        assert _direction_similarity(3.0, 4.0, -3.0, -4.0) == pytest.approx(0.0)
+
+
+class TestHeaderBlockRelativePositionScore:
+    def test_single_block(self):
+        """Single block should return all 1.0."""
+        gt, _, _ = _parse_header_cells(TABLE_SIMPLE_HEADERS)
+        gt_blocks = _find_header_blocks(gt)
+        gt_to_pred, _ = _match_blocks(gt_blocks, gt_blocks)
+        prox, dirn = _header_block_relative_position_score(gt_blocks, gt_blocks, gt_to_pred, 3, 2, 3, 2)
+        assert prox == 1.0
+        assert dirn == 1.0
+
+    def test_identical_multi_block(self):
+        """Identical multi-block table should score 1.0."""
+        gt, rows, cols = _parse_header_cells(TABLE_TWO_HEADER_BLOCKS)
+        gt_blocks = _find_header_blocks(gt)
+        gt_to_pred, _ = _match_blocks(gt_blocks, gt_blocks)
+        prox, dirn = _header_block_relative_position_score(gt_blocks, gt_blocks, gt_to_pred, rows, cols, rows, cols)
+        assert prox == pytest.approx(1.0)
+        assert dirn == pytest.approx(1.0)
+
+    def test_no_matched_blocks(self):
+        """GT has blocks but pred has none — block count mismatch returns 0."""
+        gt, _, _ = _parse_header_cells(TABLE_SIMPLE_HEADERS)
+        gt_blocks = _find_header_blocks(gt)
+        prox, dirn = _header_block_relative_position_score(gt_blocks, [], {}, 3, 2, 3, 2)
+        assert prox == 0.0
+
+    def test_swapped_direction_penalised(self):
+        """Blocks with swapped direction should get low direction score."""
+        # GT: block A at top-left, block B at bottom-right
+        gt_a = HeaderBlock(
+            cells=[HeaderCell(text="a", row=0, col=0, rowspan=1, colspan=1)],
+            min_row=0,
+            max_row=1,
+            min_col=0,
+            max_col=1,
+        )
+        gt_b = HeaderBlock(
+            cells=[HeaderCell(text="b", row=5, col=5, rowspan=1, colspan=1)],
+            min_row=5,
+            max_row=6,
+            min_col=5,
+            max_col=6,
+        )
+        # Pred: block A at bottom-right, block B at top-left (swapped)
+        pred_a = HeaderBlock(
+            cells=[HeaderCell(text="a", row=5, col=5, rowspan=1, colspan=1)],
+            min_row=5,
+            max_row=6,
+            min_col=5,
+            max_col=6,
+        )
+        pred_b = HeaderBlock(
+            cells=[HeaderCell(text="b", row=0, col=0, rowspan=1, colspan=1)],
+            min_row=0,
+            max_row=1,
+            min_col=0,
+            max_col=1,
+        )
+        prox, dirn = _header_block_relative_position_score(
+            [gt_a, gt_b],
+            [pred_a, pred_b],
+            {0: 0, 1: 1},
+            6,
+            6,
+            6,
+            6,
+        )
+        # Direction should be 0.0 (opposite), proximity ~1.0 (same distance)
+        assert dirn == pytest.approx(0.0)
+        assert prox == pytest.approx(1.0)
+
+
+# =============================================================================
+# Composite score tests
+# =============================================================================
+
+
+class TestComputeHeaderAccuracyForTablePair:
+    def test_identical_tables(self):
+        scores = compute_header_composite_for_table_pair(TABLE_SIMPLE_HEADERS, TABLE_SIMPLE_HEADERS)
+        assert scores["header_composite_v3"] == pytest.approx(1.0)
+        assert scores["header_perfect"] == 1.0
+        assert scores["header_content_bag"] == 1.0
+        assert scores["header_cell_count"] == 1.0
+        assert scores["header_block_proximity"] == pytest.approx(1.0)
+        assert scores["header_block_relative_direction"] == pytest.approx(1.0)
+
+    def test_no_headers_both(self):
+        scores = compute_header_composite_for_table_pair(TABLE_NO_HEADERS, TABLE_NO_HEADERS)
+        assert scores["header_composite_v3"] == pytest.approx(1.0)
+
+    def test_headers_vs_no_headers(self):
+        scores = compute_header_composite_for_table_pair(TABLE_SIMPLE_HEADERS, TABLE_NO_HEADERS)
+        assert scores["header_cell_count"] == 0.0
+        assert scores["header_content_bag"] == 0.0
+        assert scores["header_perfect"] == 0.0
+        assert scores["header_composite_v3"] < 0.5
+
+    def test_same_headers_diff_body(self):
+        scores = compute_header_composite_for_table_pair(TABLE_SIMPLE_HEADERS, TABLE_SAME_HEADERS_DIFF_BODY)
+        assert scores["header_perfect"] == 1.0
+        assert scores["header_content_bag"] == 1.0
+        assert scores["header_composite_v3"] == pytest.approx(1.0)
+
+    def test_multi_row_header_identical(self):
+        scores = compute_header_composite_for_table_pair(TABLE_MULTI_ROW_HEADER, TABLE_MULTI_ROW_HEADER_SAME)
+        assert scores["header_perfect"] == 1.0
+        assert scores["header_composite_v3"] == pytest.approx(1.0)
+
+    def test_has_all_submetrics(self):
+        scores = compute_header_composite_for_table_pair(TABLE_SIMPLE_HEADERS, TABLE_SIMPLE_HEADERS)
+        for key in SUBMETRIC_KEYS:
+            assert key in scores, f"Missing submetric: {key}"
+
+
+# =============================================================================
+# Metric class tests
+# =============================================================================
+
+
+def _find_metric(results, name):
+    for r in results:
+        if r.metric_name == name:
+            return r
+    raise AssertionError(f"Metric '{name}' not found in {[r.metric_name for r in results]}")
+
+
+class TestHeaderAccuracyMetric:
+    def setup_method(self):
+        self.metric = HeaderAccuracyMetric()
+
+    def test_name(self):
+        assert self.metric.name == "header_composite_v3"
+
+    def test_identical_tables(self):
+        results = self.metric.compute(expected=TABLE_SIMPLE_HEADERS, actual=TABLE_SIMPLE_HEADERS)
+        ha = _find_metric(results, "header_composite_v3")
+        assert ha.value == pytest.approx(1.0)
+
+    def test_no_tables_in_expected(self):
+        results = self.metric.compute(expected="no tables", actual=TABLE_SIMPLE_HEADERS)
+        ha = _find_metric(results, "header_composite_v3")
+        assert ha.value == 0.0
+
+    def test_no_tables_in_actual(self):
+        results = self.metric.compute(expected=TABLE_SIMPLE_HEADERS, actual="no tables")
+        ha = _find_metric(results, "header_composite_v3")
+        assert ha.value == 0.0
+
+    def test_multiple_tables(self):
+        expected = f"{TABLE_SIMPLE_HEADERS}\n{TABLE_MULTI_ROW_HEADER}"
+        actual = f"{TABLE_MULTI_ROW_HEADER}\n{TABLE_SIMPLE_HEADERS}"
+        results = self.metric.compute(expected=expected, actual=actual)
+        ha = _find_metric(results, "header_composite_v3")
+        # Hungarian matching should pair them correctly
+        assert ha.value == pytest.approx(1.0)
+
+    def test_returns_submetrics(self):
+        results = self.metric.compute(expected=TABLE_SIMPLE_HEADERS, actual=TABLE_SIMPLE_HEADERS)
+        names = {r.metric_name for r in results}
+        for key in SUBMETRIC_KEYS:
+            assert key in names, f"Missing submetric result: {key}"
+
+    def test_value_range(self):
+        for actual in [TABLE_SIMPLE_HEADERS, TABLE_NO_HEADERS, TABLE_DIFF_HEADER_TEXT]:
+            results = self.metric.compute(expected=TABLE_SIMPLE_HEADERS, actual=actual)
+            for r in results:
+                assert 0.0 <= r.value <= 1.0, f"{r.metric_name} out of range: {r.value}"
+
+    def test_table_pairs_parameter(self):
+        """When table_pairs is provided, use those pairs directly."""
+        pairs = [(TABLE_SIMPLE_HEADERS, TABLE_SIMPLE_HEADERS)]
+        results = self.metric.compute(expected="ignored", actual="ignored", table_pairs=pairs)
+        ha = _find_metric(results, "header_composite_v3")
+        assert ha.value == pytest.approx(1.0)
+
+    def test_table_pairs_with_unmatched(self):
+        """Unmatched GT tables (empty pred) should score 0."""
+        pairs = [(TABLE_SIMPLE_HEADERS, "")]
+        results = self.metric.compute(expected="ignored", actual="ignored", table_pairs=pairs)
+        ha = _find_metric(results, "header_composite_v3")
+        assert ha.value == 0.0
+
+
+# =============================================================================
+# Block detail format tests
+# =============================================================================
+
+
+class TestBlockDetailFormat:
+    def test_block_details_show_unique_cells(self):
+        """Block details should show unique cell texts when available."""
+        _, details = _detailed_header_composite_for_table_pair(TABLE_SIMPLE_HEADERS, TABLE_SIMPLE_HEADERS)
+        grits_lines = details["header_grits"]
+        detail_text = "\n".join(grits_lines)
+        assert "expected [" in detail_text
+        assert "predicted [" in detail_text
+
+    def test_block_details_fallback_to_position(self):
+        """Block details should fall back to row/col ranges when cells have no text."""
+        # Build two tables with empty header text — triggers positional fallback
+        gt_html = "<table><tr><th></th><th></th></tr><tr><td>A</td><td>B</td></tr></table>"
+        pred_html = "<table><tr><th></th><th></th></tr><tr><td>C</td><td>D</td></tr></table>"
+        _, details = _detailed_header_composite_for_table_pair(gt_html, pred_html)
+        grits_lines = details["header_grits"]
+        detail_text = "\n".join(grits_lines)
+        # Fallback path should show positional info instead of cell texts
+        assert "rows [" in detail_text
+        assert "cols [" in detail_text
+        assert "expected [" not in detail_text
+
+
+# =============================================================================
+# Extra header penalty tests (block_relative_position)
+# =============================================================================
+
+
+class TestRelativePositionExtraHeaderPenalty:
+    """block_relative_position should penalise extra predicted header blocks."""
+
+    def _make_block(self, text: str, row: int, col: int) -> HeaderBlock:
+        cell = HeaderCell(text=text, row=row, col=col, rowspan=1, colspan=1)
+        return HeaderBlock(
+            cells=[cell],
+            min_row=row,
+            max_row=row + 1,
+            min_col=col,
+            max_col=col + 1,
+        )
+
+    def test_identical_two_blocks(self):
+        """Two identical blocks → 1.0."""
+        gt = [self._make_block("a", 0, 0), self._make_block("b", 5, 5)]
+        prox, dirn = _header_block_relative_position_score(gt, gt, {0: 0, 1: 1}, 6, 6, 6, 6)
+        assert prox == pytest.approx(1.0)
+        assert dirn == pytest.approx(1.0)
+
+    def test_extra_pred_blocks_penalise(self):
+        """Extra pred blocks lower score via denominator."""
+        gt = [self._make_block("a", 0, 0), self._make_block("b", 5, 5)]
+        pred = [
+            self._make_block("a", 0, 0),
+            self._make_block("b", 5, 5),
+            self._make_block("c", 10, 10),
+        ]
+        prox, dirn = _header_block_relative_position_score(gt, pred, {0: 0, 1: 1}, 11, 11, 11, 11)
+        # 1 matched pair scores 1.0 each, denominator = max(1, 3) = 3
+        assert prox == pytest.approx(1.0 / 3.0)
+        assert dirn == pytest.approx(1.0 / 3.0)
+
+    def test_one_gt_two_pred_blocks(self):
+        """1 GT block, 2 pred blocks → 0 matched pairs / 1 total → score=0."""
+        gt = [self._make_block("a", 0, 0)]
+        pred = [self._make_block("a", 0, 0), self._make_block("x", 5, 5)]
+        prox, dirn = _header_block_relative_position_score(gt, pred, {0: 0}, 6, 6, 6, 6)
+        # gt_pairs=0, pred_pairs=1, total=1, 0 matched pairs → 0/1
+        assert prox == pytest.approx(0.0)
+
+    def test_no_extra_blocks_perfect(self):
+        """Same number of blocks, identical positions → 1.0."""
+        gt = [
+            self._make_block("a", 0, 0),
+            self._make_block("b", 0, 5),
+            self._make_block("c", 5, 0),
+        ]
+        prox, dirn = _header_block_relative_position_score(gt, gt, {0: 0, 1: 1, 2: 2}, 6, 6, 6, 6)
+        assert prox == pytest.approx(1.0)
+        assert dirn == pytest.approx(1.0)
+
+
+# =============================================================================
+# Header hierarchy depth tests
+# =============================================================================
+
+
+class TestHeaderHierarchyDepth:
+    def test_no_headers(self):
+        assert _header_hierarchy_depth([]) == 0
+
+    def test_single_row_no_colspan(self):
+        """Single row of simple headers → depth 1."""
+        cells = [
+            HeaderCell(text="a", row=0, col=0, rowspan=1, colspan=1),
+            HeaderCell(text="b", row=0, col=1, rowspan=1, colspan=1),
+        ]
+        assert _header_hierarchy_depth(cells) == 1
+
+    def test_two_level_hierarchy(self):
+        """Spanning header + leaf headers → depth 2."""
+        cells = [
+            HeaderCell(text="group", row=0, col=0, rowspan=1, colspan=2),
+            HeaderCell(text="a", row=1, col=0, rowspan=1, colspan=1),
+            HeaderCell(text="b", row=1, col=1, rowspan=1, colspan=1),
+        ]
+        assert _header_hierarchy_depth(cells) == 2
+
+    def test_three_level_hierarchy(self):
+        """Three levels of nesting → depth 3."""
+        cells = [
+            HeaderCell(text="top", row=0, col=0, rowspan=1, colspan=4),
+            HeaderCell(text="mid1", row=1, col=0, rowspan=1, colspan=2),
+            HeaderCell(text="mid2", row=1, col=2, rowspan=1, colspan=2),
+            HeaderCell(text="a", row=2, col=0, rowspan=1, colspan=1),
+            HeaderCell(text="b", row=2, col=1, rowspan=1, colspan=1),
+            HeaderCell(text="c", row=2, col=2, rowspan=1, colspan=1),
+            HeaderCell(text="d", row=2, col=3, rowspan=1, colspan=1),
+        ]
+        assert _header_hierarchy_depth(cells) == 3
+
+    def test_rowspan_does_not_add_depth(self):
+        """A cell with rowspan=2 + colspan=2 spanning two rows, with leaf cells
+        in the rows it spans, should still be depth 2 (not 3).
+
+        row 0: <th rowspan="2" colspan="2">A</th> <th colspan="2">B</th>
+        row 1:                                     <th>C</th> <th>D</th>
+        row 2: <th>E</th> <th>F</th>
+        """
+        cells = [
+            HeaderCell(text="A", row=0, col=0, rowspan=2, colspan=2),
+            HeaderCell(text="B", row=0, col=2, rowspan=1, colspan=2),
+            HeaderCell(text="C", row=1, col=2, rowspan=1, colspan=1),
+            HeaderCell(text="D", row=1, col=3, rowspan=1, colspan=1),
+            HeaderCell(text="E", row=2, col=0, rowspan=1, colspan=1),
+            HeaderCell(text="F", row=2, col=1, rowspan=1, colspan=1),
+        ]
+        assert _header_hierarchy_depth(cells) == 2
+
+    def test_from_html_two_level(self):
+        """Parse actual HTML and check depth."""
+        cells, _, _ = _parse_header_cells(TABLE_MULTI_ROW_HEADER)
+        assert _header_hierarchy_depth(cells) == 2
+
+    def test_from_html_single_row(self):
+        """Simple single-row header → depth 1."""
+        cells, _, _ = _parse_header_cells(TABLE_SIMPLE_HEADERS)
+        assert _header_hierarchy_depth(cells) == 1
+
+
+class TestHeaderHierarchyDepthScore:
+    def test_both_zero(self):
+        assert _header_hierarchy_depth_score([], []) == 1.0
+
+    def test_same_depth(self):
+        cells = [
+            HeaderCell(text="group", row=0, col=0, rowspan=1, colspan=2),
+            HeaderCell(text="a", row=1, col=0, rowspan=1, colspan=1),
+            HeaderCell(text="b", row=1, col=1, rowspan=1, colspan=1),
+        ]
+        assert _header_hierarchy_depth_score(cells, cells) == 1.0
+
+    def test_depth_2_vs_1(self):
+        gt = [
+            HeaderCell(text="group", row=0, col=0, rowspan=1, colspan=2),
+            HeaderCell(text="a", row=1, col=0, rowspan=1, colspan=1),
+            HeaderCell(text="b", row=1, col=1, rowspan=1, colspan=1),
+        ]
+        pred = [
+            HeaderCell(text="a", row=0, col=0, rowspan=1, colspan=1),
+            HeaderCell(text="b", row=0, col=1, rowspan=1, colspan=1),
+        ]
+        # min(2,1)/max(2,1) = 0.5
+        assert _header_hierarchy_depth_score(gt, pred) == pytest.approx(0.5)
+
+    def test_gt_zero_pred_nonzero(self):
+        pred = [HeaderCell(text="a", row=0, col=0, rowspan=1, colspan=1)]
+        assert _header_hierarchy_depth_score([], pred) == 0.0
+
+    def test_gt_nonzero_pred_zero(self):
+        gt = [HeaderCell(text="a", row=0, col=0, rowspan=1, colspan=1)]
+        assert _header_hierarchy_depth_score(gt, []) == 0.0
+
+    def test_depth_3_vs_1(self):
+        gt = [
+            HeaderCell(text="top", row=0, col=0, rowspan=1, colspan=4),
+            HeaderCell(text="mid", row=1, col=0, rowspan=1, colspan=2),
+            HeaderCell(text="mid2", row=1, col=2, rowspan=1, colspan=2),
+            HeaderCell(text="a", row=2, col=0, rowspan=1, colspan=1),
+            HeaderCell(text="b", row=2, col=1, rowspan=1, colspan=1),
+            HeaderCell(text="c", row=2, col=2, rowspan=1, colspan=1),
+            HeaderCell(text="d", row=2, col=3, rowspan=1, colspan=1),
+        ]
+        pred = [
+            HeaderCell(text="a", row=0, col=0, rowspan=1, colspan=1),
+            HeaderCell(text="b", row=0, col=1, rowspan=1, colspan=1),
+        ]
+        # min(3,1)/max(3,1) = 1/3
+        assert _header_hierarchy_depth_score(gt, pred) == pytest.approx(1.0 / 3.0)
+
+
+# =============================================================================
+# Malformed HTML parsing tests (lxml robustness)
+# =============================================================================
+
+
+TABLE_MALFORMED_TH_TD_MISMATCH = """<table>
+<tr><th>Name</th><th>Value</td></tr>
+<tr><td>Alpha</td><td>100</td></tr>
+</table>"""
+
+
+class TestMalformedHtmlParsing:
+    def test_mismatched_th_td_tags(self):
+        """lxml should handle <th>...</td> mismatches gracefully."""
+        cells, rows, cols = _parse_header_cells(TABLE_MALFORMED_TH_TD_MISMATCH)
+        texts = {c.text for c in cells}
+        assert "name" in texts
+        assert "value" in texts
+
+
+# =============================================================================
+# Header data alignment tests
+# =============================================================================
+
+
+class TestHeaderDataAlignment:
+    """Tests for the header_data_alignment submetric."""
+
+    def test_perfect_alignment(self):
+        """Identical tables -> GriTS aligns perfectly -> score 1.0."""
+        from parse_bench.evaluation.metrics.parse.grits_metric import (
+            grits_from_html,
+        )
+
+        result = grits_from_html(TABLE_SIMPLE_HEADERS, TABLE_SIMPLE_HEADERS)
+        assert result is not None
+        row_map = result["_con_row_alignment"]
+        col_map = result["_con_col_alignment"]
+
+        gt_cells, _, _ = _parse_header_cells(TABLE_SIMPLE_HEADERS)
+        pred_text_lookup = _build_text_lookup(TABLE_SIMPLE_HEADERS)
+        score = _header_data_alignment_score(gt_cells, pred_text_lookup, row_map, col_map)
+        assert score == 1.0
+
+    def test_extra_td_in_header_row(self):
+        """Extra <td> in header row displaces headers -> score 1/3."""
+        from parse_bench.evaluation.metrics.parse.grits_metric import (
+            grits_from_html,
+        )
+
+        result = grits_from_html(TABLE_3COL, TABLE_3COL_EXTRA_TD)
+        assert result is not None
+        row_map = result["_con_row_alignment"]
+        col_map = result["_con_col_alignment"]
+
+        gt_cells, _, _ = _parse_header_cells(TABLE_3COL)
+        pred_text_lookup = _build_text_lookup(TABLE_3COL_EXTRA_TD)
+        score = _header_data_alignment_score(gt_cells, pred_text_lookup, row_map, col_map)
+        assert score == pytest.approx(1 / 3, abs=0.01)
+
+    def test_extra_th_in_header_row(self):
+        """Extra <th> in header row -- same displacement, same score as extra <td>."""
+        from parse_bench.evaluation.metrics.parse.grits_metric import (
+            grits_from_html,
+        )
+
+        result = grits_from_html(TABLE_3COL, TABLE_3COL_EXTRA_TH)
+        assert result is not None
+        row_map = result["_con_row_alignment"]
+        col_map = result["_con_col_alignment"]
+
+        gt_cells, _, _ = _parse_header_cells(TABLE_3COL)
+        pred_text_lookup = _build_text_lookup(TABLE_3COL_EXTRA_TH)
+        score = _header_data_alignment_score(gt_cells, pred_text_lookup, row_map, col_map)
+        assert score == pytest.approx(1 / 3, abs=0.01)
+
+    def test_headers_converted_to_td(self):
+        """All <th> converted to <td> but text/positions unchanged -> 1.0."""
+        from parse_bench.evaluation.metrics.parse.grits_metric import (
+            grits_from_html,
+        )
+
+        result = grits_from_html(TABLE_3COL, TABLE_3COL_NO_TH)
+        assert result is not None
+        row_map = result["_con_row_alignment"]
+        col_map = result["_con_col_alignment"]
+
+        gt_cells, _, _ = _parse_header_cells(TABLE_3COL)
+        pred_text_lookup = _build_text_lookup(TABLE_3COL_NO_TH)
+        score = _header_data_alignment_score(gt_cells, pred_text_lookup, row_map, col_map)
+        assert score == 1.0
+
+    def test_no_gt_headers(self):
+        """No GT headers -> 1.0 (vacuously correct)."""
+        score = _header_data_alignment_score([], {}, {0: 0}, {0: 0})
+        assert score == 1.0
+
+    def test_empty_alignment_maps(self):
+        """Empty alignment maps -> 0.0."""
+        gt_cells, _, _ = _parse_header_cells(TABLE_SIMPLE_HEADERS)
+        pred_text_lookup = _build_text_lookup(TABLE_SIMPLE_HEADERS)
+        score = _header_data_alignment_score(gt_cells, pred_text_lookup, {}, {})
+        assert score == 0.0
+
+    def test_grits_emits_alignment_keys(self):
+        """grits_from_html result contains _con_row/col_alignment keys."""
+        from parse_bench.evaluation.metrics.parse.grits_metric import (
+            grits_from_html,
+        )
+
+        result = grits_from_html(TABLE_SIMPLE_HEADERS, TABLE_SIMPLE_HEADERS)
+        assert result is not None
+        assert "_con_row_alignment" in result
+        assert "_con_col_alignment" in result
+        assert isinstance(result["_con_row_alignment"], dict)
+        assert isinstance(result["_con_col_alignment"], dict)
+
+    def test_end_to_end_with_grits_alignment(self):
+        """End-to-end: GriTS alignment -> _detailed_header_composite_for_table_pair."""
+        from parse_bench.evaluation.metrics.parse.grits_metric import (
+            grits_from_html,
+        )
+
+        gt = TABLE_SIMPLE_HEADERS
+        pred = TABLE_SAME_HEADERS_DIFF_BODY
+        grits_result = grits_from_html(gt, pred)
+        assert grits_result is not None
+
+        scores, details = _detailed_header_composite_for_table_pair(
+            gt,
+            pred,
+            row_map=grits_result["_con_row_alignment"],
+            col_map=grits_result["_con_col_alignment"],
+        )
+        assert "header_data_alignment" in scores
+        assert scores["header_data_alignment"] == 1.0
+        assert "grits" in details["header_data_alignment"][0].lower()
+
+    def test_fallback_path_emits_standalone_detail(self):
+        """Without GriTS alignment, fallback computes its own and labels it."""
+        scores, details = _detailed_header_composite_for_table_pair(
+            TABLE_SIMPLE_HEADERS,
+            TABLE_SIMPLE_HEADERS,
+            row_map=None,
+            col_map=None,
+        )
+        assert "header_data_alignment" in scores
+        assert scores["header_data_alignment"] == 1.0
+        assert "standalone" in details["header_data_alignment"][0].lower()
+
+    def test_metric_class_alignment_source_metadata(self):
+        """HeaderAccuracyMetric.compute() records alignment_source in metadata."""
+        from parse_bench.evaluation.metrics.parse.grits_metric import (
+            grits_from_html,
+        )
+
+        gt = TABLE_SIMPLE_HEADERS
+        grits_result = grits_from_html(gt, gt)
+        assert grits_result is not None
+        row_map = grits_result["_con_row_alignment"]
+        col_map = grits_result["_con_col_alignment"]
+
+        metric = HeaderAccuracyMetric()
+
+        # With GriTS alignment
+        results = metric.compute(
+            expected=gt,
+            actual=gt,
+            table_pairs=[(gt, gt)],
+            table_alignments=[(row_map, col_map)],
+        )
+        alignment_mv = [r for r in results if r.metric_name == "header_data_alignment"]
+        assert len(alignment_mv) == 1
+        assert alignment_mv[0].value == 1.0
+        composite_mv = [r for r in results if r.metric_name == "header_composite_v3"]
+        assert composite_mv[0].metadata.get("alignment_source") == "grits"
+
+        # Without alignment -> fallback
+        results_fb = metric.compute(
+            expected=gt,
+            actual=gt,
+            table_pairs=[(gt, gt)],
+            table_alignments=None,
+        )
+        composite_fb = [r for r in results_fb if r.metric_name == "header_composite_v3"]
+        assert composite_fb[0].metadata.get("alignment_source") == "fallback"
+
+    def test_in_composite_keys(self):
+        """header_data_alignment is included in _COMPOSITE_KEYS."""
+        from parse_bench.evaluation.metrics.parse.header_accuracy_metric import (
+            _COMPOSITE_KEYS,
+        )
+
+        assert "header_data_alignment" in _COMPOSITE_KEYS
+
+    def test_two_extra_cells_spread_across_header(self):
+        """Two extra empty cells at different points in the header row.
+
+        Extra cells after "Name" and after "Age" displace later headers.
+        GriTS col alignment is data-dominated (2 data rows vs 1 header row),
+        so col 0->0, col 1->1, col 2->2.
+
+        Header text at mapped positions:
+          "name" at (0,0) -> pred (0,0) = "name" -> match
+          "age"  at (0,1) -> pred (0,1) = ""     -> mismatch
+          "city" at (0,2) -> pred (0,2) = "age"  -> mismatch
+        Score = 1/3.
+        """
+        from parse_bench.evaluation.metrics.parse.grits_metric import (
+            grits_from_html,
+        )
+
+        result = grits_from_html(TABLE_3COL, TABLE_3COL_TWO_EXTRA_SPREAD)
+        assert result is not None
+        row_map = result["_con_row_alignment"]
+        col_map = result["_con_col_alignment"]
+
+        gt_cells, _, _ = _parse_header_cells(TABLE_3COL)
+        pred_text_lookup = _build_text_lookup(TABLE_3COL_TWO_EXTRA_SPREAD)
+        score = _header_data_alignment_score(gt_cells, pred_text_lookup, row_map, col_map)
+        assert score == pytest.approx(1 / 3, abs=0.01)
+
+    def test_two_extra_cells_leading(self):
+        """Two extra empty cells before the first header.
+
+        All data and header content shifts right uniformly, so GriTS
+        aligns col 0->2, col 1->3, col 2->4. All header text matches
+        at the mapped positions -> score = 1.0.
+        """
+        from parse_bench.evaluation.metrics.parse.grits_metric import (
+            grits_from_html,
+        )
+
+        result = grits_from_html(TABLE_3COL, TABLE_3COL_TWO_EXTRA_LEADING)
+        assert result is not None
+        row_map = result["_con_row_alignment"]
+        col_map = result["_con_col_alignment"]
+
+        gt_cells, _, _ = _parse_header_cells(TABLE_3COL)
+        pred_text_lookup = _build_text_lookup(TABLE_3COL_TWO_EXTRA_LEADING)
+        score = _header_data_alignment_score(gt_cells, pred_text_lookup, row_map, col_map)
+        assert score == 1.0
+
+    def test_two_extra_cells_trailing(self):
+        """Two extra empty cells at the end of each row.
+
+        No displacement of existing content, so GriTS aligns
+        col 0->0, col 1->1, col 2->2. All headers match -> score = 1.0.
+        """
+        from parse_bench.evaluation.metrics.parse.grits_metric import (
+            grits_from_html,
+        )
+
+        result = grits_from_html(TABLE_3COL, TABLE_3COL_TWO_EXTRA_TRAILING)
+        assert result is not None
+        row_map = result["_con_row_alignment"]
+        col_map = result["_con_col_alignment"]
+
+        gt_cells, _, _ = _parse_header_cells(TABLE_3COL)
+        pred_text_lookup = _build_text_lookup(TABLE_3COL_TWO_EXTRA_TRAILING)
+        score = _header_data_alignment_score(gt_cells, pred_text_lookup, row_map, col_map)
+        assert score == 1.0
+
+    def test_extra_row_before_header(self):
+        """Extra empty row before header row shifts headers down.
+
+        GriTS row alignment maps row 0->1 (content match outweighs
+        the empty row), so headers at mapped positions still match.
+        Score = 1.0.
+        """
+        from parse_bench.evaluation.metrics.parse.grits_metric import (
+            grits_from_html,
+        )
+
+        result = grits_from_html(TABLE_3COL, TABLE_3COL_EXTRA_ROW)
+        assert result is not None
+        row_map = result["_con_row_alignment"]
+        col_map = result["_con_col_alignment"]
+
+        gt_cells, _, _ = _parse_header_cells(TABLE_3COL)
+        pred_text_lookup = _build_text_lookup(TABLE_3COL_EXTRA_ROW)
+        score = _header_data_alignment_score(gt_cells, pred_text_lookup, row_map, col_map)
+        assert score == 1.0
+
+
+# =============================================================================
+# Tests for generous header normalization
+# =============================================================================
+
+
+class TestPromoteTopRowToHeader:
+    """Tests for _promote_top_row_to_header."""
+
+    def test_basic(self):
+        html = "<table><tr><td>A</td><td>B</td></tr><tr><td>1</td><td>2</td></tr></table>"
+        result = _promote_top_row_to_header(html)
+        from bs4 import BeautifulSoup
+
+        soup = BeautifulSoup(result, "lxml")
+        rows = soup.find_all("tr")
+        assert all(c.name == "th" for c in rows[0].find_all(["th", "td"]))
+        assert all(c.name == "td" for c in rows[1].find_all(["th", "td"]))
+
+    def test_no_rows(self):
+        html = "<table></table>"
+        result = _promote_top_row_to_header(html)
+        assert "table" in result
+
+    def test_already_th(self):
+        html = "<table><tr><th>A</th></tr></table>"
+        result = _promote_top_row_to_header(html)
+        from bs4 import BeautifulSoup
+
+        soup = BeautifulSoup(result, "lxml")
+        rows = soup.find_all("tr")
+        assert all(c.name == "th" for c in rows[0].find_all(["th", "td"]))
+
+
+class TestApplyGenerousNormalization:
+    """Tests for _apply_generous_header_normalization."""
+
+    def test_gt_no_headers(self):
+        """When GT has no headers, pred is returned unchanged."""
+        gt = "<table><tr><td>A</td></tr></table>"
+        pred = "<table><tr><td>X</td></tr></table>"
+        result = _apply_generous_header_normalization(gt, pred)
+        assert result == pred
+
+    def test_pred_has_headers(self):
+        """When pred already has headers, pred is returned unchanged."""
+        gt = TABLE_SIMPLE_HEADERS
+        pred = TABLE_SIMPLE_HEADERS
+        result = _apply_generous_header_normalization(gt, pred)
+        assert result == pred
+
+    def test_promotes(self):
+        """When GT has headers and pred has none, top row is promoted."""
+        gt = TABLE_SIMPLE_HEADERS
+        pred = TABLE_NO_HEADERS
+        result = _apply_generous_header_normalization(gt, pred)
+        cells, _, _ = _parse_header_cells(result)
+        assert len(cells) > 0
+
+    def test_both_no_headers(self):
+        """When both GT and pred have no headers, pred is returned unchanged."""
+        gt = TABLE_NO_HEADERS
+        pred = TABLE_NO_HEADERS
+        result = _apply_generous_header_normalization(gt, pred)
+        assert result == pred
+
+    def test_gt_no_headers_pred_has_headers(self):
+        """When GT has no headers but pred does, pred is returned unchanged."""
+        gt = TABLE_NO_HEADERS
+        pred = TABLE_SIMPLE_HEADERS
+        result = _apply_generous_header_normalization(gt, pred)
+        assert result == pred
+
+
+class TestHeaderAccuracyMetricGenerous:
+    """Tests for HeaderAccuracyMetricGenerous."""
+
+    def test_returns_single_composite(self):
+        """compute() returns exactly one MetricValue named header_composite_v3_generous."""
+        metric = HeaderAccuracyMetricGenerous()
+        results = metric.compute(
+            expected=TABLE_SIMPLE_HEADERS,
+            actual=TABLE_SIMPLE_HEADERS,
+            table_pairs=[(TABLE_SIMPLE_HEADERS, TABLE_SIMPLE_HEADERS)],
+        )
+        assert len(results) == 1
+        assert results[0].metric_name == "exp_header_composite_v3_generous"
+
+    def test_equals_base_when_pred_has_headers(self):
+        """When pred has headers, generous == base (normalization is a no-op)."""
+        base = HeaderAccuracyMetric()
+        generous = HeaderAccuracyMetricGenerous()
+        pairs = [(TABLE_SIMPLE_HEADERS, TABLE_SIMPLE_HEADERS)]
+        base_results = base.compute(
+            expected=TABLE_SIMPLE_HEADERS,
+            actual=TABLE_SIMPLE_HEADERS,
+            table_pairs=pairs,
+        )
+        gen_results = generous.compute(
+            expected=TABLE_SIMPLE_HEADERS,
+            actual=TABLE_SIMPLE_HEADERS,
+            table_pairs=pairs,
+        )
+        base_composite = next(r for r in base_results if r.metric_name == "header_composite_v3")
+        gen_composite = gen_results[0]
+        assert gen_composite.value == pytest.approx(base_composite.value)
+
+    def test_generous_gte_base_when_pred_missing_headers(self):
+        """When pred has no headers but GT does, generous >= base."""
+        base = HeaderAccuracyMetric()
+        generous = HeaderAccuracyMetricGenerous()
+        pairs = [(TABLE_SIMPLE_HEADERS, TABLE_NO_HEADERS)]
+        base_results = base.compute(
+            expected=TABLE_SIMPLE_HEADERS,
+            actual=TABLE_NO_HEADERS,
+            table_pairs=pairs,
+        )
+        gen_results = generous.compute(
+            expected=TABLE_SIMPLE_HEADERS,
+            actual=TABLE_NO_HEADERS,
+            table_pairs=pairs,
+        )
+        base_composite = next(r for r in base_results if r.metric_name == "header_composite_v3")
+        gen_composite = gen_results[0]
+        assert gen_composite.value >= base_composite.value
+
+    def test_end_to_end_top_and_bottom_left_headers(self):
+        """Table with top headers + bottom-left row headers in GT, pred has only <td>.
+
+        Generous score should be higher than base score because both top-row
+        and bottom-left promotions fire.
+        """
+        gt = """<table>
+<tr><th>Name</th><th>Value</th></tr>
+<tr><th>Alpha</th><td>100</td></tr>
+<tr><th>Beta</th><td>200</td></tr>
+</table>"""
+        pred = """<table>
+<tr><td>Name</td><td>Value</td></tr>
+<tr><td>Alpha</td><td>100</td></tr>
+<tr><td>Beta</td><td>200</td></tr>
+</table>"""
+        base = HeaderAccuracyMetric()
+        generous = HeaderAccuracyMetricGenerous()
+        pairs = [(gt, pred)]
+        base_results = base.compute(expected=gt, actual=pred, table_pairs=pairs)
+        gen_results = generous.compute(expected=gt, actual=pred, table_pairs=pairs)
+        base_composite = next(r for r in base_results if r.metric_name == "header_composite_v3")
+        gen_composite = gen_results[0]
+        assert gen_composite.value > base_composite.value
+
+
+# =============================================================================
+# Tests for _is_bottom_left_block
+# =============================================================================
+
+
+class TestIsBottomLeftBlock:
+    def test_rectangular_bottom_left(self):
+        """Rectangular block at col 0, rows 2–4 in a 4-row table → True."""
+        block = HeaderBlock(
+            cells=[
+                HeaderCell(text="a", row=2, col=0, rowspan=1, colspan=1),
+                HeaderCell(text="b", row=3, col=0, rowspan=1, colspan=1),
+            ],
+            min_row=2,
+            max_row=4,
+            min_col=0,
+            max_col=1,
+        )
+        assert _is_bottom_left_block(block, num_rows=4) is True
+
+    def test_touches_top_row(self):
+        """Block at col 0, rows 0–2 (touches top row) → False."""
+        block = HeaderBlock(
+            cells=[
+                HeaderCell(text="a", row=0, col=0, rowspan=1, colspan=1),
+                HeaderCell(text="b", row=1, col=0, rowspan=1, colspan=1),
+            ],
+            min_row=0,
+            max_row=2,
+            min_col=0,
+            max_col=1,
+        )
+        assert _is_bottom_left_block(block, num_rows=2) is False
+
+    def test_not_leftmost_col(self):
+        """Block at col 1, rows 2–4 (not leftmost col) → False."""
+        block = HeaderBlock(
+            cells=[
+                HeaderCell(text="a", row=2, col=1, rowspan=1, colspan=1),
+                HeaderCell(text="b", row=3, col=1, rowspan=1, colspan=1),
+            ],
+            min_row=2,
+            max_row=4,
+            min_col=1,
+            max_col=2,
+        )
+        assert _is_bottom_left_block(block, num_rows=4) is False
+
+    def test_does_not_reach_bottom_row(self):
+        """Block at col 0, rows 2–3 in a 4-row table (doesn't reach bottom) → False."""
+        block = HeaderBlock(
+            cells=[
+                HeaderCell(text="a", row=2, col=0, rowspan=1, colspan=1),
+            ],
+            min_row=2,
+            max_row=3,
+            min_col=0,
+            max_col=1,
+        )
+        assert _is_bottom_left_block(block, num_rows=4) is False
+
+    def test_l_shaped_not_rectangular(self):
+        """L-shaped block at col 0 rows 2–4 + col 1 row 3 only → False."""
+        block = HeaderBlock(
+            cells=[
+                HeaderCell(text="a", row=2, col=0, rowspan=1, colspan=1),
+                HeaderCell(text="b", row=3, col=0, rowspan=1, colspan=1),
+                HeaderCell(text="c", row=3, col=1, rowspan=1, colspan=1),
+            ],
+            min_row=2,
+            max_row=4,
+            min_col=0,
+            max_col=2,
+        )
+        # Expected area = 2*2=4, but only 3 positions occupied → not rectangular
+        assert _is_bottom_left_block(block, num_rows=4) is False
+
+    def test_rectangular_two_columns(self):
+        """Rectangular block spanning 2 columns, rows 2–4 in a 4-row table → True."""
+        block = HeaderBlock(
+            cells=[
+                HeaderCell(text="a", row=2, col=0, rowspan=1, colspan=1),
+                HeaderCell(text="b", row=2, col=1, rowspan=1, colspan=1),
+                HeaderCell(text="c", row=3, col=0, rowspan=1, colspan=1),
+                HeaderCell(text="d", row=3, col=1, rowspan=1, colspan=1),
+            ],
+            min_row=2,
+            max_row=4,
+            min_col=0,
+            max_col=2,
+        )
+        assert _is_bottom_left_block(block, num_rows=4) is True
+
+
+# =============================================================================
+# Tests for _find_contiguous_groups
+# =============================================================================
+
+
+class TestFindContiguousGroups:
+    def test_single_position(self):
+        groups = _find_contiguous_groups({(0, 0)})
+        assert len(groups) == 1
+        assert groups[0] == {(0, 0)}
+
+    def test_two_adjacent(self):
+        groups = _find_contiguous_groups({(0, 0), (0, 1)})
+        assert len(groups) == 1
+        assert len(groups[0]) == 2
+
+    def test_two_non_adjacent(self):
+        groups = _find_contiguous_groups({(0, 0), (5, 5)})
+        assert len(groups) == 2
+        assert all(len(g) == 1 for g in groups)
+
+    def test_l_shaped(self):
+        groups = _find_contiguous_groups({(0, 0), (1, 0), (1, 1)})
+        assert len(groups) == 1
+        assert len(groups[0]) == 3
+
+    def test_empty(self):
+        groups = _find_contiguous_groups(set())
+        assert len(groups) == 0
+
+
+# =============================================================================
+# Tests for _promote_bottom_left_to_header
+# =============================================================================
+
+
+class TestPromoteBottomLeftToHeader:
+    def test_matching_text_promoted(self):
+        """GT has bottom-left header block with matching pred text → promoted.
+
+        The GT must have a gap row between top headers and bottom-left block
+        so they form separate blocks (otherwise they merge into one block
+        touching the top row).
+        """
+        gt = """<table>
+<tr><th>Name</th><th>Value</th></tr>
+<tr><td>x</td><td>1</td></tr>
+<tr><th>Alpha</th><td>100</td></tr>
+<tr><th>Beta</th><td>200</td></tr>
+</table>"""
+        pred = """<table>
+<tr><th>Name</th><th>Value</th></tr>
+<tr><td>x</td><td>1</td></tr>
+<tr><td>Alpha</td><td>100</td></tr>
+<tr><td>Beta</td><td>200</td></tr>
+</table>"""
+        result = _promote_bottom_left_to_header(gt, pred)
+        cells, _, _ = _parse_header_cells(result)
+        # Should have promoted Alpha and Beta to <th>
+        texts = {c.text for c in cells}
+        assert "alpha" in texts
+        assert "beta" in texts
+
+    def test_low_similarity_no_promotion(self):
+        """GT has bottom-left header block, pred text very different → no promotion."""
+        gt = """<table>
+<tr><th>Name</th><th>Value</th></tr>
+<tr><td>x</td><td>1</td></tr>
+<tr><th>Alpha</th><td>100</td></tr>
+<tr><th>Beta</th><td>200</td></tr>
+</table>"""
+        pred = """<table>
+<tr><th>Name</th><th>Value</th></tr>
+<tr><td>x</td><td>1</td></tr>
+<tr><td>XXXXX</td><td>100</td></tr>
+<tr><td>YYYYY</td><td>200</td></tr>
+</table>"""
+        result = _promote_bottom_left_to_header(gt, pred)
+        cells, _, _ = _parse_header_cells(result)
+        # Only top-row headers should exist, no promotion happened
+        texts = {c.text for c in cells}
+        assert "xxxxx" not in texts
+        assert "yyyyy" not in texts
+
+    def test_threshold_boundary_below(self):
+        """Similarity just below 0.8 → no promotion."""
+        # "abcde" vs "abcXY" → LCS="abc"=3, sim=2*3/(5+5)=0.6 < 0.8
+        gt = """<table>
+<tr><th>Name</th><th>Value</th></tr>
+<tr><td>x</td><td>1</td></tr>
+<tr><th>abcde</th><td>100</td></tr>
+</table>"""
+        pred = """<table>
+<tr><th>Name</th><th>Value</th></tr>
+<tr><td>x</td><td>1</td></tr>
+<tr><td>abcXY</td><td>100</td></tr>
+</table>"""
+        result = _promote_bottom_left_to_header(gt, pred)
+        cells, _, _ = _parse_header_cells(result)
+        texts = {c.text for c in cells}
+        assert "abcxy" not in texts
+
+    def test_threshold_boundary_above(self):
+        """Similarity >= 0.8 → promotion happens."""
+        # "abcde" vs "abcdf" → LCS="abcd"=4, sim=2*4/(5+5)=0.8 >= 0.8
+        gt = """<table>
+<tr><th>Name</th><th>Value</th></tr>
+<tr><td>x</td><td>1</td></tr>
+<tr><th>abcde</th><td>100</td></tr>
+</table>"""
+        pred = """<table>
+<tr><th>Name</th><th>Value</th></tr>
+<tr><td>x</td><td>1</td></tr>
+<tr><td>abcdf</td><td>100</td></tr>
+</table>"""
+        result = _promote_bottom_left_to_header(gt, pred)
+        cells, _, _ = _parse_header_cells(result)
+        texts = {c.text for c in cells}
+        assert "abcdf" in texts
+
+    def test_pred_already_has_bl_headers(self):
+        """GT has bottom-left block, pred already has <th> there → no change."""
+        gt = """<table>
+<tr><th>Name</th><th>Value</th></tr>
+<tr><td>x</td><td>1</td></tr>
+<tr><th>Alpha</th><td>100</td></tr>
+<tr><th>Beta</th><td>200</td></tr>
+</table>"""
+        pred = """<table>
+<tr><th>Name</th><th>Value</th></tr>
+<tr><td>x</td><td>1</td></tr>
+<tr><th>Alpha</th><td>100</td></tr>
+<tr><th>Beta</th><td>200</td></tr>
+</table>"""
+        result = _promote_bottom_left_to_header(gt, pred)
+        assert result == pred
+
+    def test_no_bottom_left_block_in_gt(self):
+        """GT has no bottom-left block → no promotion."""
+        gt = """<table>
+<tr><th>Name</th><th>Value</th></tr>
+<tr><td>Alpha</td><td>100</td></tr>
+</table>"""
+        pred = """<table>
+<tr><th>Name</th><th>Value</th></tr>
+<tr><td>Alpha</td><td>100</td></tr>
+</table>"""
+        result = _promote_bottom_left_to_header(gt, pred)
+        assert result == pred
+
+    def test_contiguity_selects_group_with_pred_bottom_left(self):
+        """Matching cells in two non-contiguous groups; only the group
+        containing (pred_bottom_row, 0) gets promoted."""
+        # GT: 5 rows, bottom-left block spans rows 2-4 col 0
+        gt = """<table>
+<tr><th>H1</th><th>H2</th></tr>
+<tr><td>data</td><td>data</td></tr>
+<tr><th>Alpha</th><td>100</td></tr>
+<tr><td>data</td><td>data</td></tr>
+<tr><th>Beta</th><td>200</td></tr>
+</table>"""
+        # Pred: same layout, all <td>
+        pred = """<table>
+<tr><th>H1</th><th>H2</th></tr>
+<tr><td>data</td><td>data</td></tr>
+<tr><td>Alpha</td><td>100</td></tr>
+<tr><td>data</td><td>data</td></tr>
+<tr><td>Beta</td><td>200</td></tr>
+</table>"""
+        result = _promote_bottom_left_to_header(gt, pred)
+        cells, _, _ = _parse_header_cells(result)
+        texts = {c.text for c in cells}
+        # "beta" should be promoted (bottom-left of pred)
+        assert "beta" in texts
+
+    def test_pred_bottom_left_no_match_no_promotion(self):
+        """GT has bottom-left block but pred cell at (pred_bottom_row, 0)
+        doesn't match → no promotion even if other cells match."""
+        gt = """<table>
+<tr><th>Name</th><th>Value</th></tr>
+<tr><td>x</td><td>1</td></tr>
+<tr><th>Alpha</th><td>100</td></tr>
+<tr><th>Beta</th><td>200</td></tr>
+</table>"""
+        pred = """<table>
+<tr><th>Name</th><th>Value</th></tr>
+<tr><td>x</td><td>1</td></tr>
+<tr><td>Alpha</td><td>100</td></tr>
+<tr><td>ZZZZZ</td><td>200</td></tr>
+</table>"""
+        result = _promote_bottom_left_to_header(gt, pred)
+        cells, _, _ = _parse_header_cells(result)
+        texts = {c.text for c in cells}
+        # Alpha matches but Beta/ZZZZZ don't; since (2,0) doesn't match,
+        # and the contiguous group with (2,0) doesn't exist, nothing promoted
+        assert "alpha" not in texts
+
+    def test_truncated_pred(self):
+        """GT has 5 rows, pred has 3 rows. GT bottom-left block spans rows 3–4.
+        Pred has matching text at rows 1–2 col 0. The contiguous group containing
+        (2, 0) (pred's bottom row) gets promoted."""
+        gt = """<table>
+<tr><th>Name</th><th>Value</th></tr>
+<tr><td>x</td><td>1</td></tr>
+<tr><td>y</td><td>2</td></tr>
+<tr><th>Alpha</th><td>100</td></tr>
+<tr><th>Beta</th><td>200</td></tr>
+</table>"""
+        # Pred is truncated - only 3 rows, with Alpha/Beta at rows 1-2
+        pred = """<table>
+<tr><th>Name</th><th>Value</th></tr>
+<tr><td>Alpha</td><td>100</td></tr>
+<tr><td>Beta</td><td>200</td></tr>
+</table>"""
+        result = _promote_bottom_left_to_header(gt, pred)
+        # The GT bottom-left block is at rows 3-4 col 0, but pred rows 1-2 col 0
+        # have matching text. However, positions (3,0) and (4,0) don't exist in pred,
+        # so pred_text_lookup won't match them. This test documents the behavior:
+        # since the GT block positions don't map to pred positions, no promotion.
+        cells, _, _ = _parse_header_cells(result)
+        # No promotion expected because the GT block's positions (3,0),(4,0)
+        # don't exist in pred's text lookup
+        texts = {c.text for c in cells}
+        assert "name" in texts  # top-row headers still there
+
+    def test_wider_pred_match(self):
+        """GT has rectangular bottom-left block (rows 2–3, col 0).
+        Pred has matching text at rows 2–3 cols 0–1 (wider than GT block).
+        Contiguous group contains (pred_bottom_row, 0) → all matching cells promoted."""
+        gt = """<table>
+<tr><th>Name</th><th>Value</th><th>Extra</th></tr>
+<tr><td>x</td><td>1</td><td>a</td></tr>
+<tr><th>Alpha</th><td>100</td><td>b</td></tr>
+<tr><th>Beta</th><td>200</td><td>c</td></tr>
+</table>"""
+        pred = """<table>
+<tr><th>Name</th><th>Value</th><th>Extra</th></tr>
+<tr><td>x</td><td>1</td><td>a</td></tr>
+<tr><td>Alpha</td><td>100</td><td>b</td></tr>
+<tr><td>Beta</td><td>200</td><td>c</td></tr>
+</table>"""
+        result = _promote_bottom_left_to_header(gt, pred)
+        cells, _, _ = _parse_header_cells(result)
+        texts = {c.text for c in cells}
+        assert "alpha" in texts
+        assert "beta" in texts

--- a/tests/parse_bench/evaluation/metrics/parse/test_merge_preceding_titles.py
+++ b/tests/parse_bench/evaluation/metrics/parse/test_merge_preceding_titles.py
@@ -1,0 +1,168 @@
+"""Tests for merge_preceding_titles_into_tables."""
+
+from bs4 import BeautifulSoup
+
+from parse_bench.evaluation.metrics.parse.table_parsing import (
+    merge_preceding_titles_into_tables,
+)
+
+
+def _extract_first_table_rows(html_content: str) -> list[list[str]]:
+    """Helper: extract text of each cell in each row of the first table."""
+    soup = BeautifulSoup(html_content, "lxml")
+    table = soup.find("table")
+    if not table:
+        return []
+    rows = []
+    for tr in table.find_all("tr"):
+        cells = [c.get_text(strip=True) for c in tr.find_all(["th", "td"])]
+        rows.append(cells)
+    return rows
+
+
+def test_title_merged_when_gt_has_colspan_row():
+    """Preceding heading in prediction should be merged when GT has a colspan title row."""
+    expected = """
+<table>
+    <tr><th colspan="3">My Table Title</th></tr>
+    <tr><th>A</th><th>B</th><th>C</th></tr>
+    <tr><td>1</td><td>2</td><td>3</td></tr>
+</table>
+"""
+    actual = """
+<h2>My Table Title</h2>
+<table>
+    <tr><th>A</th><th>B</th><th>C</th></tr>
+    <tr><td>1</td><td>2</td><td>3</td></tr>
+</table>
+"""
+    result = merge_preceding_titles_into_tables(expected, actual)
+    rows = _extract_first_table_rows(result)
+    # First row should be the merged title
+    assert rows[0] == ["My Table Title"]
+    # Second row should be headers
+    assert rows[1] == ["A", "B", "C"]
+    # Title heading should be removed from content
+    assert "<h2>" not in result or "My Table Title" not in result.split("<table")[0]
+
+
+def test_no_merge_when_gt_has_no_colspan_row():
+    """Should not merge when GT table doesn't start with a full-width row."""
+    expected = """
+<table>
+    <tr><th>A</th><th>B</th><th>C</th></tr>
+    <tr><td>1</td><td>2</td><td>3</td></tr>
+</table>
+"""
+    actual = """
+<h2>Some Heading</h2>
+<table>
+    <tr><th>A</th><th>B</th><th>C</th></tr>
+    <tr><td>1</td><td>2</td><td>3</td></tr>
+</table>
+"""
+    result = merge_preceding_titles_into_tables(expected, actual)
+    rows = _extract_first_table_rows(result)
+    # First row should still be headers, no title row added
+    assert rows[0] == ["A", "B", "C"]
+
+
+def test_no_merge_when_prediction_already_has_colspan_row():
+    """Should not merge when prediction already has a full-width first row."""
+    expected = """
+<table>
+    <tr><th colspan="3">Title</th></tr>
+    <tr><th>A</th><th>B</th><th>C</th></tr>
+</table>
+"""
+    actual = """
+<table>
+    <tr><th colspan="3">Title</th></tr>
+    <tr><th>A</th><th>B</th><th>C</th></tr>
+</table>
+"""
+    result = merge_preceding_titles_into_tables(expected, actual)
+    rows = _extract_first_table_rows(result)
+    # Should not have duplicated the title row
+    assert rows[0] == ["Title"]
+    assert rows[1] == ["A", "B", "C"]
+    assert len(rows) == 2
+
+
+def test_fuzzy_match_title():
+    """Titles should match even with minor differences."""
+    expected = """
+<table>
+    <tr><th colspan="3">Rate Schedule Item Changes</th></tr>
+    <tr><th>A</th><th>B</th><th>C</th></tr>
+</table>
+"""
+    actual = """
+<h2>Rate Schedule Item Changes</h2>
+<table>
+    <tr><th>A</th><th>B</th><th>C</th></tr>
+    <tr><td>1</td><td>2</td><td>3</td></tr>
+</table>
+"""
+    result = merge_preceding_titles_into_tables(expected, actual)
+    rows = _extract_first_table_rows(result)
+    assert rows[0] == ["Rate Schedule Item Changes"]
+
+
+def test_no_merge_when_preceding_text_doesnt_match():
+    """Should not merge when preceding text doesn't match any GT title."""
+    expected = """
+<table>
+    <tr><th colspan="3">Rate Schedule Item Changes</th></tr>
+    <tr><th>A</th><th>B</th><th>C</th></tr>
+</table>
+"""
+    actual = """
+<h2>Completely Different Title</h2>
+<table>
+    <tr><th>A</th><th>B</th><th>C</th></tr>
+</table>
+"""
+    result = merge_preceding_titles_into_tables(expected, actual)
+    rows = _extract_first_table_rows(result)
+    # No title should have been merged
+    assert rows[0] == ["A", "B", "C"]
+
+
+def test_empty_inputs():
+    """Should handle empty inputs gracefully."""
+    assert merge_preceding_titles_into_tables("", "some content") == "some content"
+    assert merge_preceding_titles_into_tables("some content", "") == ""
+
+
+def test_no_tables():
+    """Should return actual unchanged when no tables are present."""
+    expected = "<p>No tables here</p>"
+    actual = "<p>No tables here either</p>"
+    result = merge_preceding_titles_into_tables(expected, actual)
+    assert "No tables here either" in result
+
+
+def test_merge_with_thead():
+    """Title row should be inserted into thead when present."""
+    expected = """
+<table>
+    <tr><th colspan="2">Title Row</th></tr>
+    <tr><th>X</th><th>Y</th></tr>
+</table>
+"""
+    actual = """
+<p>Title Row</p>
+<table>
+    <thead>
+        <tr><th>X</th><th>Y</th></tr>
+    </thead>
+    <tbody>
+        <tr><td>1</td><td>2</td></tr>
+    </tbody>
+</table>
+"""
+    result = merge_preceding_titles_into_tables(expected, actual)
+    rows = _extract_first_table_rows(result)
+    assert rows[0] == ["Title Row"]
+    assert rows[1] == ["X", "Y"]

--- a/tests/parse_bench/evaluation/metrics/parse/test_normalize_cell_text.py
+++ b/tests/parse_bench/evaluation/metrics/parse/test_normalize_cell_text.py
@@ -1,0 +1,173 @@
+"""Tests for normalize_cell_text() in parse evaluation utils."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "src"))
+
+from parse_bench.evaluation.metrics.parse.utils import normalize_cell_text  # noqa: E402
+
+
+class TestHTMLFormattingStripping:
+    """Formatting markers are stripped on the GriTS side. Models routinely
+    emphasize totals/headers with bold while ground truth doesn't — treating
+    that as a content mismatch would penalize parsing quality for an
+    unrelated convention. ``<b>Total</b>``, ``**Total**``, and plain
+    ``Total`` all compare equal.
+    """
+
+    def test_mark_tag(self) -> None:
+        assert normalize_cell_text("<mark>highlighted</mark>") == "highlighted"
+
+    def test_bold_tag(self) -> None:
+        assert normalize_cell_text("<b>bold</b>") == "bold"
+
+    def test_italic_tag(self) -> None:
+        assert normalize_cell_text("<i>italic</i>") == "italic"
+
+    def test_em_tag(self) -> None:
+        assert normalize_cell_text("<em>em</em>") == "em"
+
+    def test_strong_tag(self) -> None:
+        assert normalize_cell_text("<strong>strong</strong>") == "strong"
+
+    def test_mixed_html_formatting(self) -> None:
+        assert normalize_cell_text("<b>bold</b> and <i>italic</i>") == "bold and italic"
+
+    def test_case_insensitive_tags(self) -> None:
+        assert normalize_cell_text("<B>bold</B>") == "bold"
+
+    def test_html_bold_equals_plain(self) -> None:
+        assert normalize_cell_text("<b>Total</b>") == normalize_cell_text("Total")
+
+
+class TestMarkdownStripping:
+    def test_bold_asterisks(self) -> None:
+        assert normalize_cell_text("**bold**") == "bold"
+
+    def test_bold_underscores(self) -> None:
+        assert normalize_cell_text("__bold__") == "bold"
+
+    def test_italic_asterisk(self) -> None:
+        assert normalize_cell_text("*italic*") == "italic"
+
+    def test_italic_underscore(self) -> None:
+        assert normalize_cell_text("_italic_") == "italic"
+
+    def test_strikethrough(self) -> None:
+        assert normalize_cell_text("~~struck~~") == "struck"
+
+    def test_md_bold_equals_plain(self) -> None:
+        assert normalize_cell_text("**Total**") == normalize_cell_text("Total")
+
+
+class TestSubSupConversion:
+    """P5: GriTS now applies TRM-style sup/sub conversion."""
+
+    def test_sup_tag_digit(self) -> None:
+        assert normalize_cell_text("x<sup>2</sup>") == "x2"
+
+    def test_sub_tag_digit(self) -> None:
+        assert normalize_cell_text("H<sub>2</sub>O") == "H2O"
+
+    def test_sub_tag_letter(self) -> None:
+        assert normalize_cell_text("H<sub>x</sub>O") == "HxO"
+
+    def test_unicode_superscript_to_ascii(self) -> None:
+        assert normalize_cell_text("x²") == "x2"
+
+    def test_unicode_subscript_to_ascii(self) -> None:
+        assert normalize_cell_text("H₂O") == "H2O"
+
+
+class TestNoLowercaseOrAccentStripping:
+    """Negative tests: GriTS does NOT lowercase or strip accents (TRM does)."""
+
+    def test_no_lowercasing(self) -> None:
+        assert normalize_cell_text("Hello World") == "Hello World"
+
+    def test_no_accent_stripping(self) -> None:
+        assert normalize_cell_text("Café") == "Café"
+
+
+class TestDotLeaderStripping:
+    def test_trailing_dots(self) -> None:
+        assert normalize_cell_text("Revenue.........") == "Revenue"
+
+    def test_trailing_dots_with_spaces(self) -> None:
+        assert normalize_cell_text("Revenue......   ") == "Revenue"
+
+    def test_single_dot_preserved(self) -> None:
+        assert normalize_cell_text("Inc.") == "Inc."
+
+    def test_mid_text_dots_preserved(self) -> None:
+        assert normalize_cell_text("A..B") == "A..B"
+
+
+class TestDashNormalization:
+    def test_dash_only_triple(self) -> None:
+        assert normalize_cell_text("---") == "-"
+
+    def test_dash_only_em_dash(self) -> None:
+        assert normalize_cell_text("\u2014") == "-"  # em-dash
+
+    def test_dash_only_en_dash_spaced(self) -> None:
+        assert normalize_cell_text("\u2013 \u2013") == "-"  # en-dash spaced
+
+    def test_dash_only_mixed(self) -> None:
+        assert normalize_cell_text("- - -") == "-"
+
+    def test_mixed_content_with_dashes_preserved(self) -> None:
+        assert normalize_cell_text("2020-01") == "2020-01"
+
+    def test_en_dash_in_content(self) -> None:
+        assert normalize_cell_text("2020\u201301") == "2020-01"
+
+    def test_minus_sign_normalized(self) -> None:
+        assert normalize_cell_text("\u2212" + "5") == "-5"  # minus sign
+
+
+class TestExistingBehavior:
+    def test_whitespace_collapsing(self) -> None:
+        assert normalize_cell_text("  hello   world  ") == "hello world"
+
+    def test_bullet_equivalence(self) -> None:
+        # BLACK CIRCLE → BULLET
+        assert normalize_cell_text("\u25cf item") == "\u2022 item"
+
+    def test_quote_normalization(self) -> None:
+        assert normalize_cell_text("\u201chello\u201d") == '"hello"'
+
+    def test_empty_string(self) -> None:
+        assert normalize_cell_text("") == ""
+
+    def test_no_lowercasing(self) -> None:
+        assert normalize_cell_text("Hello World") == "Hello World"
+
+    def test_no_accent_removal(self) -> None:
+        assert normalize_cell_text("caf\u00e9") == "caf\u00e9"
+
+
+class TestBooleanMarkerNormalization:
+    def test_check_and_cross_match_bracketed_yes_no(self) -> None:
+        assert normalize_cell_text("✓") == "yes"
+        assert normalize_cell_text("[yes]") == "yes"
+        assert normalize_cell_text("X") == "yes"
+        assert normalize_cell_text("x") == "yes"
+        assert normalize_cell_text("✗") == "no"
+        assert normalize_cell_text("[no]") == "no"
+
+    def test_filled_dot_matches_yes(self) -> None:
+        assert normalize_cell_text("●") == "yes"
+        assert normalize_cell_text("[yes]") == "yes"
+
+    def test_open_circle_matches_no(self) -> None:
+        assert normalize_cell_text("○") == "no"
+        assert normalize_cell_text("[no]") == "no"
+
+    def test_mixed_bullet_text_is_not_boolean_marker(self) -> None:
+        assert normalize_cell_text("● item") == "• item"
+
+    def test_numeric_cells_are_not_boolean_markers(self) -> None:
+        assert normalize_cell_text("1") == "1"
+        assert normalize_cell_text("0") == "0"

--- a/tests/parse_bench/evaluation/metrics/parse/test_normalize_text_inline_tag_separator.py
+++ b/tests/parse_bench/evaluation/metrics/parse/test_normalize_text_inline_tag_separator.py
@@ -1,0 +1,123 @@
+"""Tests for inline-styling-tag stripping in ``normalize_text``.
+
+``normalize_text`` deletes inline styling markers (``<b> <i> <u> <s> <del>
+<strike> <ins> <mark> <span>`` and ``~~``) while keeping their content. Deleting
+them with the *empty string* welds the two sides together, so a byte-faithful
+parser output like ``<u>103</u><s>101</s>`` normalizes to ``103101`` and every
+downstream word/sentence/order rule reports the page numbers as missing. The GT
+for the same page escapes the weld only because its annotation happened to be
+``~~103~~ 101`` — an author-typed space.
+
+**The rule, and why it is a *run* of markers rather than every marker.**
+Injecting a separator for *every* stripped tag is not safe: inline tags are used
+intra-word in the ground truth. Surveying the shipped text corpora
+(``text_extended/v1.0`` + ``text_core/v0.10``, 1120 GT markdown files) for tags
+with an alphanumeric character on *both* sides:
+
+* 22 single-tag intra-word hits — 21 of them Japanese, where ``<u>`` opens and
+  closes mid-sentence with no whitespace at all (``…とともに、<u>開催地としての
+  魅力…</u>取り組みが…`` in ``text_dense/underline.md``), and one Latin,
+  ``Shizuok<mark>a University)</mark>`` in ``text_misc/marks.md``, where the
+  highlight opens *inside* the word "Shizuoka".
+* **0** hits for a run of two or more abutting markers.
+
+So a single marker between two content characters marks a style change *within*
+one token and must stay a zero-width join; two or more abutting markers mark the
+boundary *between* two separately-styled tokens (``</u><s>``) and must become a
+separator. That rule fixes the weld and provably changes nothing in the GT
+corpus, which contains no multi-marker run with content on both sides.
+"""
+
+from __future__ import annotations
+
+from parse_bench.evaluation.metrics.parse.utils import normalize_text
+
+
+class TestMarkerRunSeparates:
+    """Two or more abutting inline markers separate two styled tokens."""
+
+    def test_close_then_open_does_not_weld(self) -> None:
+        # The motivating case: text_simple/strikeUnderline emits the underlined
+        # page number and the struck one adjacent, with no whitespace on the
+        # page. Both tokens must survive as separate tokens.
+        assert normalize_text("<u>103</u><s>101</s>") == "103 101"
+
+    def test_weld_inside_a_table_cell(self) -> None:
+        # Verbatim from the failing document; <td> is not stripped here (that is
+        # the caller's job) — only the welded numbers are this function's bug.
+        assert normalize_text("<td><u>103</u><s>101</s></td>") == "<td>103 101</td>"
+
+    def test_matches_the_ground_truth_spelling(self) -> None:
+        # GT wrote the same page as "~~103~~ 101". After the fix both spellings
+        # normalize to the same string, which is the whole point.
+        assert normalize_text("<u>103</u><s>101</s>") == normalize_text("~~103~~ 101")
+
+    def test_tilde_run_also_separates(self) -> None:
+        assert normalize_text("~~103~~<s>101</s>") == "103 101"
+
+    def test_open_open_run_separates(self) -> None:
+        assert normalize_text("103<u><s>101</s></u>") == "103 101"
+
+    def test_span_participates_in_a_run(self) -> None:
+        assert normalize_text('<span c="1">103</span><u>101</u>') == "103 101"
+
+    def test_run_at_the_string_edges_adds_no_padding(self) -> None:
+        # A run with no content on one side separates nothing; emitting a space
+        # there would only add leading/trailing padding for callers that compare
+        # normalized strings for equality.
+        assert normalize_text("<u><b>103</b></u>") == "103"
+
+
+class TestGroundTruthSideIsEssentiallyUnmoved:
+    """The same function normalizes GT rule text and prediction, so the fix must
+    barely move the GT side. Sweeping every rule payload in the shipped corpora
+    (562 ``.test.json`` files, 165946 rules, 343380 strings) exactly **one**
+    string normalizes differently — the nested run below, in
+    ``text_misc/edit2.test.json``. Re-scoring that document against the run it
+    came from leaves all 93 rules at the same verdict (70 pass) and CF at 0.8140.
+    """
+
+    def test_nested_run_separates(self) -> None:
+        # text_misc/edit2.md: "HO 04 61-<mark>~~10 00~~</mark>." — <mark>~~ and
+        # ~~</mark> are both runs, so the highlighted-and-struck token detaches
+        # from the hyphen before it and the period after it.
+        assert normalize_text("HO 04 61-<mark>~~10 00~~</mark>.") == "ho 04 61- 10 00 ."
+
+
+class TestSingleMarkerStillJoins:
+    """A lone marker is an intra-token style change — it must not split words."""
+
+    def test_latin_intra_word_tag_keeps_the_word_whole(self) -> None:
+        # text_misc/marks.md: "Shizuok<mark>a University)</mark>" — the mark
+        # opens inside "Shizuoka". A separator here would emit "shizuok a".
+        assert normalize_text("Shizuok<mark>a University)</mark>") == "shizuoka university)"
+
+    def test_latin_intra_word_underline(self) -> None:
+        assert normalize_text("re<u>do</u>ne") == "redone"
+
+    def test_japanese_mid_sentence_underline_is_not_split(self) -> None:
+        # text_dense/underline.md pattern: CJK runs have no whitespace at all,
+        # so every <u> boundary sits between two content characters. Splitting
+        # there would desynchronize GT and output on 21 separate occurrences.
+        assert normalize_text("魅力や集客力を高める</u>取り組みが") == "魅力や集客力を高める取り組みが"
+
+    def test_single_marker_next_to_a_space_is_unchanged(self) -> None:
+        assert normalize_text("<u>103</u> 101") == "103 101"
+
+
+class TestTagFreeContentIsUntouched:
+    """Guard: content with no inline markers normalizes exactly as before."""
+
+    def test_plain_sentence(self) -> None:
+        assert normalize_text("The quick brown fox.") == "the quick brown fox."
+
+    def test_table_markup_without_inline_tags(self) -> None:
+        assert normalize_text("<td>20121234</td><td>20121235</td>") == ("<td>20121234</td><td>20121235</td>")
+
+    def test_br_still_becomes_a_space(self) -> None:
+        assert normalize_text("line1<br>line2") == "line1 line2"
+
+    def test_sup_content_removal_is_unchanged(self) -> None:
+        # <sup>/<sub> delete their *content* too — a different decision, left
+        # alone here so this change stays confined to content-preserving tags.
+        assert normalize_text("84.1<sup>(2)</sup>") == "84.1"

--- a/tests/parse_bench/evaluation/metrics/parse/test_parse_combining_mark_tokenization.py
+++ b/tests/parse_bench/evaluation/metrics/parse/test_parse_combining_mark_tokenization.py
@@ -1,0 +1,125 @@
+"""Combining marks must survive normalization and stay attached to their base.
+
+Regression tests for the Thai/Indic grading defect: annotation-time tokenization
+split words at every combining mark while eval-time ``normalize_text`` deleted
+those marks, so a stored ground-truth "word" could never equal a document token.
+"""
+
+from __future__ import annotations
+
+import unicodedata
+from pathlib import Path
+
+import pytest
+
+from parse_bench.evaluation.metrics.parse.rules_bag import (
+    _tokenize_unicode_words,
+    _word_boundary_count,
+)
+from parse_bench.evaluation.metrics.parse.test_rules import MissingSpecificWordRule
+from parse_bench.evaluation.metrics.parse.utils import normalize_text
+
+# One real word per affected script.  Each contains at least one combining mark
+# (category Mn or Mc) that changes the word when deleted.
+THAI_WORD = "เทศบาลเมืองเพชรบูรณ์"  # "municipality of Phetchabun"
+THAI_SENTENCE = "สำนักงานเทศบาลเมืองเพชรบูรณ์ ขอแสดงความนับถือ"
+KHMER_WORD = "ភាសាខ្មែរ"  # "Khmer language"
+LAO_WORD = "ຄົນລາວ"  # "Lao people"
+MYANMAR_WORD = "မြန်မာဘာသာ"  # "Burmese language"
+DEVANAGARI_WORD = "हिन्दी"  # "Hindi"
+KANNADA_WORD = "ಕನ್ನಡ"  # "Kannada"
+TAMIL_WORD = "தமிழ்"  # "Tamil"
+
+MARKED_WORDS = [
+    pytest.param(THAI_WORD, id="thai"),
+    pytest.param(KHMER_WORD, id="khmer"),
+    pytest.param(LAO_WORD, id="lao"),
+    pytest.param(MYANMAR_WORD, id="myanmar"),
+    pytest.param(DEVANAGARI_WORD, id="devanagari"),
+    pytest.param(KANNADA_WORD, id="kannada"),
+    pytest.param(TAMIL_WORD, id="tamil"),
+]
+
+# The junk fragment the old annotation tokenizer stored for THAI_WORD: it stops
+# at the first combining mark (◌ื) instead of keeping the word whole.
+THAI_GT_FRAGMENT = "เทศบาลเม"
+
+_ANNOTATION_TOOL = Path(__file__).resolve().parents[4] / "text_annotation_tools" / "toBagOfWord.js"
+
+
+def _marks(text: str) -> list[str]:
+    return [ch for ch in text if unicodedata.category(ch) in {"Mn", "Mc", "Me"}]
+
+
+@pytest.mark.parametrize("word", MARKED_WORDS)
+def test_normalize_text_preserves_combining_marks(word: str) -> None:
+    """normalize_text must not delete marks that carry meaning in the script."""
+    assert _marks(word), "fixture word must contain combining marks"
+    assert normalize_text(word) == word
+
+
+@pytest.mark.parametrize("word", MARKED_WORDS)
+def test_marked_word_tokenizes_whole(word: str) -> None:
+    """A marked word survives normalization + tokenization as a single token."""
+    tokens = _tokenize_unicode_words(normalize_text(word))
+    assert tokens == [word]
+
+
+def test_thai_sentence_tokenizes_into_whole_words() -> None:
+    tokens = _tokenize_unicode_words(normalize_text(THAI_SENTENCE))
+    assert tokens == ["สำนักงานเทศบาลเมืองเพชรบูรณ์", "ขอแสดงความนับถือ"]
+    assert THAI_GT_FRAGMENT not in tokens
+
+
+def test_stacked_thai_marks_survive() -> None:
+    """Thai stacks a tone mark on top of a vowel mark; both must be kept."""
+    word = "เมื่อ"  # ม + ◌ื (vowel) + ◌่ (tone) + อ
+    assert len(_marks(word)) == 2
+    assert normalize_text(word) == word
+    assert _tokenize_unicode_words(normalize_text(word)) == [word]
+
+
+def test_thai_fragment_is_not_a_token_and_does_not_match_by_boundary() -> None:
+    """The old GT fragment must not spuriously pass either matching path."""
+    normalized = normalize_text(THAI_SENTENCE)
+    assert THAI_GT_FRAGMENT not in _tokenize_unicode_words(normalized)
+    assert _word_boundary_count(THAI_GT_FRAGMENT, normalized) == 0
+
+
+def test_missing_specific_word_rule_matches_whole_thai_word() -> None:
+    rule = MissingSpecificWordRule({"type": "missing_specific_word", "word": THAI_WORD})
+    passed, message = rule.run(f"# หัวข้อ\n\n{THAI_WORD} ขอแสดงความนับถือ\n")
+    assert passed, message
+
+
+@pytest.mark.parametrize("word", MARKED_WORDS)
+def test_missing_specific_word_rule_round_trips_every_script(word: str) -> None:
+    rule = MissingSpecificWordRule({"type": "missing_specific_word", "word": word})
+    passed, message = rule.run(f"เอกสาร {word} ทดสอบ")
+    assert passed, message
+
+
+# --- guards: unaffected scripts keep their existing behaviour -----------------
+
+
+def test_latin_accents_are_still_folded_to_ascii() -> None:
+    assert normalize_text("café Ångström naïve") == "cafe angstrom naive"
+    assert _tokenize_unicode_words(normalize_text("café")) == ["cafe"]
+
+
+def test_cjk_and_kana_behaviour_unchanged() -> None:
+    assert normalize_text("が ぱ 検査結果") == "が ぱ 検査結果"
+    assert _tokenize_unicode_words(normalize_text("検査abc結果")) == ["検査", "abc", "結果"]
+
+
+def test_latin_tokenization_unchanged() -> None:
+    assert _tokenize_unicode_words(normalize_text("Total revenue: 1,234 USD (net)")) == [
+        "total",
+        "revenue",
+        "234",
+        "usd",
+        "net",
+    ]
+
+
+# --- annotation side: the JS rule generator must agree with the evaluator ----

--- a/tests/parse_bench/evaluation/metrics/parse/test_parse_formatting_rule_paragraph_spans.py
+++ b/tests/parse_bench/evaluation/metrics/parse/test_parse_formatting_rule_paragraph_spans.py
@@ -1,0 +1,313 @@
+"""Paragraph-spanning regression tests for the HTML tag-pair detectors (LI-8524).
+
+The LI-8524 span-scoping fix rebuilt every flexible query's word gaps with
+``_WORD_WS``, which may wrap a single line break but never a paragraph break.
+That scope is right for markdown emphasis - a ``**``, ``*``, ``_`` or ``~~``
+span ends at a blank line - and for headings, but it silently narrowed the
+HTML tag-pair detectors too: a tag pair ends at its closing tag and
+legitimately wraps multiple paragraphs, so ``<u>alpha\n\nbeta</u>`` stopped
+matching the query ``alpha beta``.
+
+These tests pin the restored behaviour arm by arm: paragraph-spanning queries
+match inside tag pairs, the markdown delimiter arms stay paragraph-confined,
+and the ``is_not_*`` rules mirror both directions.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from parse_bench.evaluation.metrics.parse.test_rules import (
+    FormattingRule,
+    MarkColorRule,
+    TitleLevelRule,
+)
+
+QUERY = "alpha beta"
+
+# Every HTML tag-pair arm, exercised with a blank line inside the pair.
+TAG_PAIR_CASES = [
+    ("is_underline", "<u>alpha\n\nbeta</u>"),
+    ("is_underline", "<ins>alpha\n\nbeta</ins>"),
+    ("is_strikeout", "<s>alpha\n\nbeta</s>"),
+    ("is_strikeout", "<del>alpha\n\nbeta</del>"),
+    ("is_strikeout", "<strike>alpha\n\nbeta</strike>"),
+    ("is_sup", "<sup>alpha\n\nbeta</sup>"),
+    ("is_sub", "<sub>alpha\n\nbeta</sub>"),
+    ("is_mark", "<mark>alpha\n\nbeta</mark>"),
+    ("is_bold", "<b>alpha\n\nbeta</b>"),
+    ("is_bold", "<strong>alpha\n\nbeta</strong>"),
+    ("is_italic", "<i>alpha\n\nbeta</i>"),
+    ("is_italic", "<em>alpha\n\nbeta</em>"),
+]
+
+
+def test_reviewers_repro_underline_split_by_blank_line() -> None:
+    """The reported regression, verbatim: <u>alpha\n\nbeta</u> is underlined."""
+    rule = FormattingRule({"type": "is_underline", "text": QUERY})
+
+    passed, message = rule.run("<u>alpha\n\nbeta</u>")
+
+    assert passed
+    assert message == ""
+
+
+@pytest.mark.parametrize("tag", ["u", "ins"])
+def test_underline_rule_matches_target_inside_larger_span(tag: str) -> None:
+    """A focused target does not need to equal the producer's tag boundary."""
+    rule = FormattingRule({"type": "is_underline", "text": "intellectual"})
+
+    passed, message = rule.run(f"<{tag}>Timely disclose any intellectual property developed.</{tag}>")
+
+    assert passed
+    assert message == ""
+
+
+def test_not_underline_fails_when_target_is_inside_larger_span() -> None:
+    rule = FormattingRule({"type": "is_not_underline", "text": "intellectual"})
+
+    passed, message = rule.run("<u>Timely disclose any intellectual property developed.</u>")
+
+    assert not passed
+    assert "unexpectedly" in message
+
+
+def test_underline_containment_does_not_borrow_a_later_closing_tag() -> None:
+    """The query must be contained by one tag pair, not adjacent pairs."""
+    rule = FormattingRule({"type": "is_underline", "text": QUERY})
+
+    passed, _ = rule.run("<u>alpha</u> plain <u>beta</u>")
+
+    assert not passed
+
+
+@pytest.mark.parametrize("tag", ["s", "del", "strike"])
+def test_strikeout_rule_matches_target_inside_larger_html_span(tag: str) -> None:
+    rule = FormattingRule({"type": "is_strikeout", "text": "obsolete clause"})
+
+    passed, message = rule.run(f'<{tag} class="revision">The obsolete clause is removed.</{tag}>')
+
+    assert passed
+    assert message == ""
+
+
+def test_not_strikeout_fails_when_target_is_inside_larger_span() -> None:
+    rule = FormattingRule({"type": "is_not_strikeout", "text": "obsolete clause"})
+
+    passed, message = rule.run("~~The obsolete clause is removed.~~")
+
+    assert not passed
+    assert "unexpectedly" in message
+
+
+def test_strikeout_rule_accepts_css_line_through() -> None:
+    rule = FormattingRule({"type": "is_strikeout", "text": "obsolete clause"})
+
+    passed, message = rule.run(
+        '<span class="revision" style="color:red; text-decoration: line-through">The obsolete clause is removed.</span>'
+    )
+
+    assert passed
+    assert message == ""
+
+
+def test_strikeout_rule_rejects_mismatched_html_tags() -> None:
+    rule = FormattingRule({"type": "is_strikeout", "text": "obsolete clause"})
+
+    passed, _ = rule.run("<s>The obsolete clause is removed.</del>")
+
+    assert not passed
+
+
+def test_strikeout_containment_does_not_borrow_a_later_closing_tag() -> None:
+    rule = FormattingRule({"type": "is_strikeout", "text": QUERY})
+
+    passed, _ = rule.run("<s>alpha</s> plain <s>beta</s>")
+
+    assert not passed
+
+
+@pytest.mark.parametrize(("rule_type", "md"), TAG_PAIR_CASES)
+def test_tag_pair_matches_phrase_split_by_blank_line(rule_type: str, md: str) -> None:
+    """A tag pair wraps multiple paragraphs; the query may span the break."""
+    rule = FormattingRule({"type": rule_type, "text": QUERY})
+
+    passed, _ = rule.run(md)
+
+    assert passed
+
+
+@pytest.mark.parametrize(
+    ("kind", "md"),
+    [
+        ("sup", '<SUP class="x">alpha beta</sup>'),
+        ("sub", '<sub data-source="producer">alpha beta</sub>'),
+    ],
+)
+def test_sup_sub_tag_pairs_accept_opening_tag_attributes(kind: str, md: str) -> None:
+    positive_rule = FormattingRule({"type": f"is_{kind}", "text": QUERY})
+    negative_rule = FormattingRule({"type": f"is_not_{kind}", "text": QUERY})
+
+    positive_passed, positive_message = positive_rule.run(md)
+    negative_passed, negative_message = negative_rule.run(md)
+
+    assert positive_passed, positive_message
+    assert not negative_passed
+    assert "unexpectedly" in negative_message
+
+
+@pytest.mark.parametrize(
+    ("rule_type", "md"),
+    [
+        ("is_not_underline", "<u>alpha\n\nbeta</u>"),
+        ("is_not_strikeout", "<s>alpha\n\nbeta</s>"),
+        ("is_not_bold", "<b>alpha\n\nbeta</b>"),
+        ("is_not_bold", "<strong>alpha\n\nbeta</strong>"),
+    ],
+)
+def test_negative_rule_fails_when_tag_pair_spans_the_break(rule_type: str, md: str) -> None:
+    """Mirror direction: is_not_* must see the paragraph-spanning span too."""
+    rule = FormattingRule({"type": rule_type, "text": QUERY})
+
+    passed, message = rule.run(md)
+
+    assert not passed
+    assert "unexpectedly" in message
+
+
+# ---------------------------------------------------------------------------
+# The markdown delimiter arms keep their paragraph scope: GFM emphasis cannot
+# span a blank line (the delimiters end up in different paragraphs and render
+# literally), so a blank-line gap must NOT match even though the same content
+# inside an HTML tag pair does.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("rule_type", "md"),
+    [
+        ("is_strikeout", "~~alpha\n\nbeta~~"),
+        ("is_bold", "**alpha\n\nbeta**"),
+        ("is_italic", "*alpha\n\nbeta*"),
+        ("is_italic", "_alpha\n\nbeta_"),
+    ],
+)
+def test_markdown_delimiters_stay_paragraph_confined(rule_type: str, md: str) -> None:
+    rule = FormattingRule({"type": rule_type, "text": QUERY})
+
+    passed, _ = rule.run(md)
+
+    assert not passed
+
+
+def test_markdown_strikeout_still_wraps_a_single_line_break() -> None:
+    """The scoped gap allows one line break - only the blank line is out."""
+    rule = FormattingRule({"type": "is_strikeout", "text": QUERY})
+
+    passed, _ = rule.run("~~alpha\nbeta~~")
+
+    assert passed
+
+
+# ---------------------------------------------------------------------------
+# The colour rules search the tag pair's inner text with the same flexible
+# query, so they need the paragraph-spanning gaps too.
+# ---------------------------------------------------------------------------
+
+
+def test_mark_color_matches_phrase_split_by_blank_line() -> None:
+    rule = MarkColorRule({"type": "mark_color", "text": QUERY, "color": "yellow"})
+
+    passed, message = rule.run('<mark style="background-color: yellow">alpha\n\nbeta</mark>')
+
+    assert passed
+    assert message == ""
+
+
+def test_html_heading_title_matches_phrase_split_by_blank_line() -> None:
+    rule = TitleLevelRule({"type": "is_title", "text": QUERY})
+
+    passed, _ = rule.run("<h2>alpha\n\nbeta</h2>")
+
+    assert passed
+
+
+@pytest.mark.parametrize("tag", ["b", "strong"])
+def test_html_bold_title_matches_phrase_split_by_blank_line(tag: str) -> None:
+    rule = TitleLevelRule({"type": "is_title", "text": QUERY})
+
+    passed, _ = rule.run(f"<{tag}>alpha\n\nbeta</{tag}>")
+
+    assert passed
+
+
+def test_markdown_bold_title_stays_paragraph_confined() -> None:
+    rule = TitleLevelRule({"type": "is_title", "text": QUERY})
+
+    passed, _ = rule.run("**alpha\n\nbeta**")
+
+    assert not passed
+
+
+# ---------------------------------------------------------------------------
+# Line endings must not change the paragraph scope: a blank line terminated
+# with CRLF (or a mix of CRLF and LF) is the same paragraph break as \n\n.
+# The guards used to key on bare \n\n, so Windows line endings let every
+# markdown arm leak across the break.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("rule_type", "md"),
+    [
+        ("is_bold", "**alpha\r\n\r\nbeta**"),
+        ("is_italic", "*alpha\r\n\r\nbeta*"),
+        ("is_italic", "_alpha\r\n\r\nbeta_"),
+        ("is_strikeout", "~~alpha\r\n\r\nbeta~~"),
+        # Mixed endings on the break, and a blank line with trailing spaces
+        ("is_bold", "**alpha\n\r\nbeta**"),
+        ("is_bold", "**alpha\r\n\nbeta**"),
+        ("is_bold", "**alpha\r\n \t \r\nbeta**"),
+    ],
+)
+def test_markdown_delimiters_stay_confined_across_crlf_breaks(rule_type: str, md: str) -> None:
+    rule = FormattingRule({"type": rule_type, "text": QUERY})
+
+    passed, _ = rule.run(md)
+
+    assert not passed
+
+
+@pytest.mark.parametrize("md", ["**A**x\n\ny**B**", "**A**x\r\n\r\ny**B**"])
+def test_tempered_gap_cannot_cross_a_paragraph_break(md: str) -> None:
+    """Both ** runs here are both-flanking, so only the blank-line guard keeps
+    the text between them from scoring as bold - with either line ending."""
+    rule = FormattingRule({"type": "is_bold", "text": "y"})
+
+    passed, _ = rule.run(md)
+
+    assert not passed
+
+
+@pytest.mark.parametrize(
+    ("rule_type", "md"),
+    [
+        ("is_bold", "**alpha\r\nbeta**"),
+        ("is_strikeout", "~~alpha\r\nbeta~~"),
+    ],
+)
+def test_markdown_span_still_wraps_a_single_crlf_line_break(rule_type: str, md: str) -> None:
+    """One CRLF line break inside a span is fine - only the blank line is out."""
+    rule = FormattingRule({"type": rule_type, "text": QUERY})
+
+    passed, _ = rule.run(md)
+
+    assert passed
+
+
+def test_tag_pair_matches_phrase_split_by_crlf_blank_line() -> None:
+    rule = FormattingRule({"type": "is_bold", "text": QUERY})
+
+    passed, _ = rule.run("<b>alpha\r\n\r\nbeta</b>")
+
+    assert passed

--- a/tests/parse_bench/evaluation/metrics/parse/test_parse_formatting_rule_quotes.py
+++ b/tests/parse_bench/evaluation/metrics/parse/test_parse_formatting_rule_quotes.py
@@ -1,0 +1,161 @@
+"""Typographic-quote folding regression tests for FormattingRule.
+
+``FormattingRule`` matches the *raw* markdown so the formatting markers are
+still present, which meant it was the one rule family that never saw the
+quote folding ``normalize_text`` applies for every content rule (and that
+``TitleLevelRule`` gets through its ``_normalize_title_label`` fallback).
+
+The consequence: a rule authored with ASCII quotes could not match a faithful
+parse of a page printed with typographic quotes, and vice versa. Ground truth
+markdown routinely failed its own styling rules for that reason alone.
+"""
+
+from __future__ import annotations
+
+from parse_bench.evaluation.metrics.parse.test_rules import FormattingRule
+
+# ---------------------------------------------------------------------------
+# ASCII rule text vs typographic content
+# ---------------------------------------------------------------------------
+
+
+def test_ascii_quoted_rule_matches_curly_quoted_bold_span() -> None:
+    """Rule stored with ASCII ``"``; page, GT, and output all print ``“ ”``."""
+    rule = FormattingRule({"type": "is_bold", "text": '"Word of the day"'})
+
+    passed, message = rule.run("**“Word of the day”**")
+
+    assert passed, message
+
+
+def test_ascii_apostrophe_rule_matches_curly_apostrophe_bold_span() -> None:
+    """The faithful parse reproduces the printed ``’``; the rule uses ``'``."""
+    rule = FormattingRule({"type": "is_bold", "text": "Kellogg's"})
+
+    passed, message = rule.run("Cereal maker **Kellogg’s** reported growth.")
+
+    assert passed, message
+
+
+def test_ascii_quoted_rule_matches_curly_quoted_html_bold_span() -> None:
+    """Folding is not markdown-specific: the HTML tag arm folds too."""
+    rule = FormattingRule({"type": "is_bold", "text": '"Word of the day"'})
+
+    passed, message = rule.run("<b>“Word of the day”</b>")
+
+    assert passed, message
+
+
+# ---------------------------------------------------------------------------
+# Typographic rule text vs ASCII content (the reverse direction)
+# ---------------------------------------------------------------------------
+
+
+def test_curly_quoted_rule_matches_ascii_quoted_bold_span() -> None:
+    rule = FormattingRule({"type": "is_bold", "text": "“Word of the day”"})
+
+    passed, message = rule.run('**"Word of the day"**')
+
+    assert passed, message
+
+
+def test_curly_apostrophe_rule_matches_ascii_apostrophe_italic_span() -> None:
+    rule = FormattingRule({"type": "is_italic", "text": "Kellogg’s"})
+
+    passed, message = rule.run("Cereal maker *Kellogg's* reported growth.")
+
+    assert passed, message
+
+
+def test_curly_quoted_rule_matches_ascii_quoted_strikeout_span() -> None:
+    rule = FormattingRule({"type": "is_strikeout", "text": "“Word”"})
+
+    passed, message = rule.run('~~"Word"~~ was removed.')
+
+    assert passed, message
+
+
+# ---------------------------------------------------------------------------
+# Non-Latin scripts: the defect is about the quote characters, not the text
+# ---------------------------------------------------------------------------
+
+
+def test_ascii_quoted_thai_rule_matches_curly_quoted_bold_span() -> None:
+    """The observed production case: a Thai motto bolded inside ``“ ”``."""
+    motto = "ยึดมั่นธรรมาภิบาล"
+    rule = FormattingRule({"type": "is_bold", "text": f'"{motto}"'})
+
+    passed, message = rule.run(f"**“{motto}”**")
+
+    assert passed, message
+
+
+# ---------------------------------------------------------------------------
+# Folding must not manufacture formatting that is not there
+# ---------------------------------------------------------------------------
+
+
+def test_genuinely_missing_bold_still_fails_with_ascii_rule_text() -> None:
+    rule = FormattingRule({"type": "is_bold", "text": '"Word of the day"'})
+
+    passed, message = rule.run("“Word of the day” is plain body text.")
+
+    assert not passed
+    assert "no bold formatting found" in message
+
+
+def test_genuinely_missing_bold_still_fails_with_curly_rule_text() -> None:
+    rule = FormattingRule({"type": "is_bold", "text": "Kellogg’s"})
+
+    passed, message = rule.run("Cereal maker Kellogg's reported growth.")
+
+    assert not passed
+    assert "no bold formatting found" in message
+
+
+def test_curly_quoted_text_outside_the_bold_span_still_fails() -> None:
+    """Folding changes characters, never span boundaries."""
+    rule = FormattingRule({"type": "is_bold", "text": '"Bank"'})
+
+    passed, _ = rule.run("“**Bank**” means the institution.")
+
+    assert not passed
+
+
+def test_is_not_bold_still_passes_when_the_curly_text_is_plain() -> None:
+    rule = FormattingRule({"type": "is_not_bold", "text": '"Word of the day"'})
+
+    passed, message = rule.run("“Word of the day” is plain body text.")
+
+    assert passed, message
+
+
+def test_is_not_bold_fails_once_the_curly_text_is_bold() -> None:
+    """The negative polarity has to see the folded match too."""
+    rule = FormattingRule({"type": "is_not_bold", "text": '"Word of the day"'})
+
+    passed, message = rule.run("**“Word of the day”**")
+
+    assert not passed
+    assert "unexpectedly had bold formatting" in message
+
+
+# ---------------------------------------------------------------------------
+# Quote-free documents are untouched
+# ---------------------------------------------------------------------------
+
+
+def test_quote_free_bold_match_is_unchanged() -> None:
+    rule = FormattingRule({"type": "is_bold", "text": "Population"})
+
+    passed, message = rule.run("**Population:** 12,000")
+
+    assert passed, message
+
+
+def test_quote_free_bold_miss_is_unchanged() -> None:
+    rule = FormattingRule({"type": "is_bold", "text": "Population"})
+
+    passed, _ = rule.run("Population: 12,000")
+
+    assert not passed

--- a/tests/parse_bench/evaluation/metrics/parse/test_parse_formatting_rule_span_scope.py
+++ b/tests/parse_bench/evaluation/metrics/parse/test_parse_formatting_rule_span_scope.py
@@ -1,0 +1,504 @@
+"""Span-scoping regression tests for FormattingRule (LI-8524).
+
+The inline-formatting detectors run with ``re.DOTALL`` so a span wrapping a
+line break is still detected. DOTALL also used to let the gaps inside those
+patterns run past the end of the span they started in, so the query text was
+scored as formatted while sitting in plain body prose:
+
+* the heading detector matched *any* heading anywhere earlier in the document
+  plus the query anywhere later;
+* the paired-delimiter and HTML-tag detectors anchored on one span's closing
+  delimiter and borrowed a later span's opening delimiter as their closer.
+
+These tests pin both directions: the false positives stay dead, and legitimate
+formatting — including multi-line spans — keeps matching.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from parse_bench.evaluation.metrics.parse.rules_formatting import _strip_other_formatting
+from parse_bench.evaluation.metrics.parse.test_rules import FormattingRule, TitleLevelRule
+
+QUERY = "plain paragraph containing the query text"
+
+
+# ---------------------------------------------------------------------------
+# The reported bug: a heading elsewhere in the document must not confer bold
+# ---------------------------------------------------------------------------
+
+
+def test_is_bold_rejects_plain_body_text_below_a_heading() -> None:
+    """The original report: one heading + query in plain prose scored as bold.
+
+    Also covers the ``_strip_other_formatting`` fallback path, which used to
+    collapse the whole document onto a single line and re-introduce the match
+    even once the regexes themselves were scoped to a line.
+    """
+    rule = FormattingRule({"type": "is_bold", "text": QUERY})
+
+    passed, message = rule.run(f"# Some Title\n\n{QUERY}")
+
+    assert not passed
+    assert "no bold formatting found" in message
+
+
+def test_is_bold_verdict_is_unchanged_by_an_unrelated_heading() -> None:
+    """The heading is irrelevant to the query, so it must not flip the verdict."""
+    rule = FormattingRule({"type": "is_bold", "text": QUERY})
+
+    without_heading, _ = rule.run(QUERY)
+    with_heading, _ = rule.run(f"# Some Title\n\n{QUERY}")
+
+    assert without_heading is False
+    assert with_heading == without_heading
+
+
+def test_is_bold_rejects_text_below_an_empty_heading_marker() -> None:
+    """``\\s`` matches newlines regardless of DOTALL, so ``#\\ntext`` also leaked."""
+    rule = FormattingRule({"type": "is_bold", "text": QUERY})
+
+    passed, _ = rule.run(f"#\n{QUERY}")
+
+    assert not passed
+
+
+def test_is_not_bold_passes_for_plain_body_text_below_a_heading() -> None:
+    """Mirror direction: is_not_bold used to fail spuriously on correct output."""
+    rule = FormattingRule({"type": "is_not_bold", "text": QUERY})
+
+    passed, message = rule.run(f"# Some Title\n\n{QUERY}")
+
+    assert passed
+    assert message == ""
+
+
+# ---------------------------------------------------------------------------
+# The query's own word gaps must not straddle a boundary the pattern cannot
+# cross: \s matches newlines regardless of DOTALL, so before _WORD_WS a phrase
+# starting on a heading line and finishing in the paragraph below scored the
+# whole phrase as bold (and as a title).
+# ---------------------------------------------------------------------------
+
+
+def test_is_bold_rejects_query_straddling_from_heading_into_body() -> None:
+    rule = FormattingRule({"type": "is_bold", "text": "Total revenue was 4.2M"})
+
+    passed, _ = rule.run("# Total\n\nrevenue was 4.2M")
+
+    assert not passed
+
+
+def test_is_bold_rejects_query_straddling_a_single_newline_after_heading() -> None:
+    """No blank line involved, so only line-confining the query catches this."""
+    rule = FormattingRule({"type": "is_bold", "text": "Total revenue"})
+
+    passed, _ = rule.run("# Total\nrevenue was 4.2M")
+
+    assert not passed
+
+
+def test_is_not_bold_passes_when_query_straddles_from_heading_into_body() -> None:
+    rule = FormattingRule({"type": "is_not_bold", "text": "Total revenue was 4.2M"})
+
+    passed, message = rule.run("# Total\n\nrevenue was 4.2M")
+
+    assert passed
+    assert message == ""
+
+
+def test_is_bold_rejects_query_straddling_a_paragraph_break_inside_a_span() -> None:
+    """``**alpha\\n\\nbeta**`` is two paragraphs, not one bold span."""
+    rule = FormattingRule({"type": "is_bold", "text": "alpha beta"})
+
+    passed, _ = rule.run("text **alpha\n\nbeta** more")
+
+    assert not passed
+
+
+def test_is_title_rejects_query_straddling_from_heading_into_body() -> None:
+    """TitleLevelRule's heading pattern had the identical straddle leak."""
+    rule = TitleLevelRule({"type": "is_title", "text": "Total revenue"})
+
+    assert not rule.run("# Total\nrevenue was 4.2M")[0]
+    assert not rule.run("# Total\n\nrevenue was 4.2M")[0]
+
+
+@pytest.mark.parametrize(
+    "content",
+    ["# Total revenue", "**Total revenue**", "<h2>Total revenue</h2>"],
+    ids=["md heading", "standalone bold line", "html heading"],
+)
+def test_is_title_still_detects_real_titles(content: str) -> None:
+    rule = TitleLevelRule({"type": "is_title", "text": "Total revenue"})
+
+    passed, message = rule.run(content)
+
+    assert passed, message
+
+
+def test_is_bold_still_detects_multiword_query_on_one_heading_line() -> None:
+    rule = FormattingRule({"type": "is_bold", "text": "Total revenue was 4.2M"})
+
+    passed, message = rule.run("# Total revenue was 4.2M")
+
+    assert passed, message
+
+
+def test_is_bold_still_detects_heading_with_markup_between_words() -> None:
+    """Line-confining the query must keep the inline-markup tolerance."""
+    rule = FormattingRule({"type": "is_bold", "text": "Total revenue"})
+
+    passed, message = rule.run("# **Total** revenue")
+
+    assert passed, message
+
+
+# ---------------------------------------------------------------------------
+# Text sitting between two unrelated formatted spans is not formatted
+# ---------------------------------------------------------------------------
+
+SPAN_FORMS = [
+    ("is_bold", "**Alpha**", "**Beta**"),
+    ("is_bold", "<b>Alpha</b>", "<b>Beta</b>"),
+    ("is_bold", "<strong>Alpha</strong>", "<strong>Beta</strong>"),
+    ("is_italic", "*Alpha*", "*Beta*"),
+    ("is_italic", "_Alpha_", "_Beta_"),
+    ("is_italic", "<i>Alpha</i>", "<i>Beta</i>"),
+    ("is_italic", "<em>Alpha</em>", "<em>Beta</em>"),
+]
+
+# Three separations, because each once defeated a different regex guard. The
+# pairing scanner rejects all three the same way - the two runs around the
+# plain text belong to different spans - but the shapes stay pinned separately
+# so a regression in any one of them is visible on its own.
+SEPARATIONS = [
+    ("paragraph break", "{a}\n\nplain body text\n\n{b}"),
+    ("adjacent lines", "{a}\nplain body text\n{b}"),
+    ("same line, table row", "| {a} | plain body text | {b} |"),
+]
+
+BETWEEN_SPANS_CASES = [
+    (f"{rule_type}: {sep_label}", rule_type, template.format(a=opening, b=closing))
+    for rule_type, opening, closing in SPAN_FORMS
+    for sep_label, template in SEPARATIONS
+]
+
+
+@pytest.mark.parametrize(
+    "label,rule_type,content",
+    BETWEEN_SPANS_CASES,
+    ids=[case[0] for case in BETWEEN_SPANS_CASES],
+)
+def test_formatting_rule_rejects_plain_text_between_two_spans(label: str, rule_type: str, content: str) -> None:
+    """Text between two spans is not formatted, however the spans are separated.
+
+    The borrowed-delimiter shape: the match starts at one span's CLOSING
+    delimiter and uses a later span's OPENING delimiter as its own closer.
+    """
+    rule = FormattingRule({"type": rule_type, "text": "plain body text"})
+
+    passed, _ = rule.run(content)
+
+    assert not passed, f"{label}: plain text between two spans scored as formatted"
+
+
+@pytest.mark.parametrize(
+    "rule_type,content",
+    [
+        ("is_bold", "| **Total** | 4.2M |"),
+        ("is_italic", "| *Total* | 4.2M |"),
+        ("is_italic", "| _Total_ | 4.2M |"),
+    ],
+)
+def test_formatting_rule_still_detects_a_formatted_table_cell(rule_type: str, content: str) -> None:
+    """The flanking guards must not reject a genuinely formatted cell."""
+    rule = FormattingRule({"type": rule_type, "text": "Total"})
+
+    passed, message = rule.run(content)
+
+    assert passed, message
+
+
+@pytest.mark.parametrize(
+    "rule_type,content",
+    [
+        ("is_bold", "**A**x y**B**"),
+        ("is_italic", "*A*x y*B*"),
+    ],
+)
+def test_pairing_resolves_delimiters_flanked_by_text_on_both_sides(rule_type: str, content: str) -> None:
+    """Formerly the pinned KNOWN LIMITATION of the flanking-guard regexes.
+
+    A delimiter run with non-whitespace on BOTH sides is simultaneously left-
+    and right-flanking, so no guard local to that run could tell which span it
+    belonged to, and ``x y`` here used to score as formatted. Delimiter-run
+    pairing resolves the ambiguity positionally - the run after ``A`` closes
+    the first span, the run before ``B`` opens the second - so the text
+    between the spans is plain and the spans themselves still match.
+    """
+    rule = FormattingRule({"type": rule_type, "text": "x y"})
+
+    assert not rule.run(content)[0]
+    assert FormattingRule({"type": rule_type, "text": "A"}).run(content)[0]
+    assert FormattingRule({"type": rule_type, "text": "B"}).run(content)[0]
+
+
+# ---------------------------------------------------------------------------
+# Whitespace padding just INSIDE the delimiters is cosmetic: parser output that
+# writes `** Total **` means bold Total, so the padded form must score exactly
+# like the tight one. Strict CommonMark would render it as literal asterisks,
+# but the evaluator scores parser intent, not CommonMark conformance. Padded
+# runs only join the pairing's second pass, over runs the strict pass left
+# unpaired, so a delimiter already serving a tight span can never be borrowed
+# by a padded match, and a padded pairing that would WRAP a strict span is
+# dropped outright - the between-spans false positives stay dead.
+# ---------------------------------------------------------------------------
+
+PADDED_EMPHASIS_CASES = [
+    ("** padded both sides", "is_bold", "** Total **"),
+    ("** padded after text", "is_bold", "**Total: **"),
+    ("** padded before text", "is_bold", "** Total**"),
+    ("** padded in a table cell", "is_bold", "| ** Total ** | 4.2M |"),
+    ("** padded mid-sentence", "is_bold", "Grand ** Total ** shown below."),
+    ("* padded both sides", "is_italic", "* Total *"),
+    ("_ padded both sides", "is_italic", "_ Total _"),
+    ("~~ padded both sides", "is_strikeout", "~~ Total ~~"),
+]
+
+
+@pytest.mark.parametrize(
+    "label,rule_type,content",
+    PADDED_EMPHASIS_CASES,
+    ids=[case[0] for case in PADDED_EMPHASIS_CASES],
+)
+def test_formatting_rule_treats_padded_delimiters_like_tight_ones(label: str, rule_type: str, content: str) -> None:
+    rule = FormattingRule({"type": rule_type, "text": "Total"})
+
+    passed, message = rule.run(content)
+
+    assert passed, f"{label}: {message}"
+
+
+@pytest.mark.parametrize(
+    "rule_type,content,inner,outer_words",
+    [
+        ("is_bold", "** foo **bold** bar **", "bold", ("foo", "bar")),
+        ("is_italic", "* one *mid* two *", "mid", ("one", "two")),
+    ],
+)
+def test_padded_runs_bracketing_a_tight_span_do_not_pair(
+    rule_type: str, content: str, inner: str, outer_words: tuple[str, str]
+) -> None:
+    """Two padded runs AROUND a tight span are its neighbors, not a wrapper.
+
+    The strict pass consumes the inner pair and leaves the outer runs, which
+    would then pair in the padded pass into a span swallowing the tight span
+    plus the plain text around it. That pairing is dropped: only the tight
+    span scores.
+    """
+    assert FormattingRule({"type": rule_type, "text": inner}).run(content)[0]
+    for word in outer_words:
+        assert not FormattingRule({"type": rule_type, "text": word}).run(content)[0], word
+
+
+def test_is_not_bold_fails_on_whitespace_padded_delimiters() -> None:
+    """Mirror direction: the padded shape counts as bold, so is_not_bold fails."""
+    rule = FormattingRule({"type": "is_not_bold", "text": "Total"})
+
+    passed, message = rule.run("** Total **")
+
+    assert not passed
+    assert "unexpectedly" in message
+
+
+# A padded delimiter run whose outer neighbor is punctuation, not whitespace:
+# a padded closer against a table pipe, before a colon, inside parentheses.
+# These are the same parser-output shapes as the padded cases above - only the
+# character just outside the span differs - so they must score the same way.
+PADDED_NEXT_TO_PUNCTUATION_CASES = [
+    ("padded closer against a table pipe", "is_bold", "|**Total **|"),
+    ("padded opener against a table pipe", "is_bold", "|** Total**|"),
+    ("padded closer before a colon", "is_bold", "**Total **: 4.2M"),
+    ("padded closer glued to trailing text", "is_bold", "**Total **4.2M"),
+    ("padded span inside parentheses", "is_bold", "(** Total **)"),
+    ("italic padded opener against a pipe", "is_italic", "|* Total*|"),
+    ("italic padded closer against a pipe", "is_italic", "|*Total *|"),
+    ("closer alone on the next line", "is_bold", "**Total\n**"),
+]
+
+
+@pytest.mark.parametrize(
+    "label,rule_type,content",
+    PADDED_NEXT_TO_PUNCTUATION_CASES,
+    ids=[case[0] for case in PADDED_NEXT_TO_PUNCTUATION_CASES],
+)
+def test_padded_emphasis_next_to_punctuation_still_matches(label: str, rule_type: str, content: str) -> None:
+    rule = FormattingRule({"type": rule_type, "text": "Total"})
+
+    passed, message = rule.run(content)
+
+    assert passed, f"{label}: {message}"
+
+
+def test_padded_cells_in_one_table_row_pair_within_their_own_cells() -> None:
+    """Two padded cells with plain text between them: each cell's query
+    matches, the text between the cells does not."""
+    row = "|**Total **| more |**Sum **|"
+
+    assert FormattingRule({"type": "is_bold", "text": "Total"}).run(row)[0]
+    assert FormattingRule({"type": "is_bold", "text": "Sum"}).run(row)[0]
+    assert not FormattingRule({"type": "is_bold", "text": "more"}).run(row)[0]
+
+
+def test_list_bullets_never_pair_into_an_italic_span() -> None:
+    """A line-leading * is a bullet, not emphasis. Italic padding is
+    horizontal-only (unlike ** and ~~, which may wrap one line break), so
+    bullets on consecutive lines cannot pair up and italicize the item text."""
+    md = "* first item\n* second item\n* third item"
+
+    assert not FormattingRule({"type": "is_italic", "text": "first item"}).run(md)[0]
+    assert not FormattingRule({"type": "is_italic", "text": "second item"}).run(md)[0]
+
+
+BORROWED_WITH_PADDING_CASES = [
+    ("is_bold", "**Alpha** plain body text **Beta**"),
+    ("is_italic", "*Alpha* plain body text *Beta*"),
+    ("is_italic", "_Alpha_ plain body text _Beta_"),
+    ("is_strikeout", "~~Alpha~~ plain body text ~~Beta~~"),
+    # Fully padded spans: every run here is whitespace-delimited on BOTH
+    # sides, so no per-run test can reject the borrowed pairing - only the
+    # pairing order keeps the middle text plain.
+    ("is_bold", "** Alpha ** plain body text ** Beta **"),
+    ("is_bold", "| ** Alpha ** | plain body text | ** Beta ** |"),
+    ("is_italic", "* Alpha * plain body text * Beta *"),
+    ("is_italic", "_ Alpha _ plain body text _ Beta _"),
+    ("is_strikeout", "~~ Alpha ~~ plain body text ~~ Beta ~~"),
+]
+
+
+@pytest.mark.parametrize(
+    "rule_type,content",
+    BORROWED_WITH_PADDING_CASES,
+    ids=[f"{case[0]}: {case[1][:20]}" for case in BORROWED_WITH_PADDING_CASES],
+)
+def test_padded_branch_does_not_resurrect_borrowed_delimiters(rule_type: str, content: str) -> None:
+    """The adversarial shape for padding tolerance: two spans on ONE line
+    separated by spaces, so the runs facing the query are whitespace-delimited
+    exactly like a padded span's own markers. Pairing resolves it
+    positionally: Alpha's closer and Beta's opener each pair within their own
+    span, so nothing is left to pair across the middle.
+    """
+    rule = FormattingRule({"type": rule_type, "text": "plain body text"})
+
+    passed, _ = rule.run(content)
+
+    assert not passed, "plain text between two spans scored as formatted"
+
+
+@pytest.mark.parametrize(
+    "rule_type,content",
+    [
+        ("is_bold", "<b> Total </b>"),
+        ("is_bold", "<strong> Total </strong>"),
+        ("is_italic", "<i> Total </i>"),
+    ],
+)
+def test_html_tags_accept_inner_padding(rule_type: str, content: str) -> None:
+    """Flanking guards apply to markdown delimiters only, never to tag pairs."""
+    rule = FormattingRule({"type": rule_type, "text": "Total"})
+
+    passed, message = rule.run(content)
+
+    assert passed, message
+
+
+# ---------------------------------------------------------------------------
+# True positives: real formatting must keep matching
+# ---------------------------------------------------------------------------
+
+TRUE_POSITIVE_CASES = [
+    ("query on a level-1 heading line", "is_bold", "Executive Summary", "# Executive Summary"),
+    ("closed atx heading", "is_bold", "Executive Summary", "### Executive Summary ###"),
+    ("heading surrounded by body text", "is_bold", "Executive Summary", "intro\n\n## Executive Summary\n\nbody"),
+    ("indented heading", "is_bold", "Executive Summary", "  ## Executive Summary"),
+    ("bolded with **", "is_bold", "Executive Summary", "**Executive Summary**"),
+    ("query is a substring of the bold span", "is_bold", "Population", "**Population:** 1,234"),
+    ("bolded with <b>", "is_bold", "Executive Summary", "<b>Executive Summary</b>"),
+    ("bolded with <strong>", "is_bold", "Executive Summary", "<strong>Executive Summary</strong>"),
+    ("italic with *", "is_italic", "Grazing Line", "*Grazing Line, NSW*"),
+    ("italic with _", "is_italic", "Grazing Line", "_Grazing Line, NSW_"),
+    ("italic with <i>", "is_italic", "Grazing Line", "<i>Grazing Line, NSW</i>"),
+    ("italic with <em>", "is_italic", "Grazing Line", "<em>Grazing Line, NSW</em>"),
+]
+
+
+@pytest.mark.parametrize(
+    "label,rule_type,text,content",
+    TRUE_POSITIVE_CASES,
+    ids=[case[0] for case in TRUE_POSITIVE_CASES],
+)
+def test_formatting_rule_still_detects_real_formatting(label: str, rule_type: str, text: str, content: str) -> None:
+    rule = FormattingRule({"type": rule_type, "text": text})
+
+    passed, message = rule.run(content)
+
+    assert passed, f"{label}: {message}"
+    assert message == ""
+
+
+# ---------------------------------------------------------------------------
+# Multi-line spans: the reason DOTALL is there in the first place
+# ---------------------------------------------------------------------------
+
+MULTILINE_SPAN_CASES = [
+    ("** span wrapping a line break", "is_bold", "alpha beta", "text **alpha\nbeta** more"),
+    ("<b> span wrapping a line break", "is_bold", "alpha beta", "<b>alpha\nbeta</b>"),
+    ("<strong> span wrapping a line break", "is_bold", "alpha beta", "<strong>alpha\nbeta</strong>"),
+    ("* span wrapping a line break", "is_italic", "alpha beta", "*alpha\nbeta*"),
+    ("<em> span wrapping a line break", "is_italic", "alpha beta", "<em>alpha\nbeta</em>"),
+]
+
+
+@pytest.mark.parametrize(
+    "label,rule_type,text,content",
+    MULTILINE_SPAN_CASES,
+    ids=[case[0] for case in MULTILINE_SPAN_CASES],
+)
+def test_formatting_rule_still_detects_multiline_spans(label: str, rule_type: str, text: str, content: str) -> None:
+    """Scoping a match to one span must not break spans that wrap a line."""
+    rule = FormattingRule({"type": rule_type, "text": text})
+
+    passed, message = rule.run(content)
+
+    assert passed, f"{label}: {message}"
+
+
+def test_is_bold_detects_span_with_nested_markup_between_words() -> None:
+    """The markup-tolerance path (and its fallback) still resolves nested tags."""
+    rule = FormattingRule({"type": "is_bold", "text": "hello world"})
+
+    passed, message = rule.run("**hello <mark>world</mark>**")
+
+    assert passed
+    assert message == ""
+
+
+# ---------------------------------------------------------------------------
+# The fallback path must not flatten the document onto one line
+# ---------------------------------------------------------------------------
+
+
+def test_strip_other_formatting_preserves_line_structure() -> None:
+    """Newlines carry the heading/body distinction the detectors rely on."""
+    stripped = _strip_other_formatting("# Some Title\n\n<em>plain</em> body", "bold")
+
+    assert "\n" in stripped
+    assert stripped.splitlines()[0].strip() == "# Some Title"
+
+
+def test_strip_other_formatting_still_collapses_horizontal_whitespace() -> None:
+    stripped = _strip_other_formatting("a    b\tc", "bold")
+
+    assert stripped == "a b c"

--- a/tests/parse_bench/evaluation/metrics/parse/test_parse_table_cell_augmentation.py
+++ b/tests/parse_bench/evaluation/metrics/parse/test_parse_table_cell_augmentation.py
@@ -1,0 +1,117 @@
+"""Table cell text must be counted exactly once by the bag rules.
+
+``_augment_with_table_cell_text`` used to *append* extracted cell text to
+content that still contained the table, so every table word was counted at
+least twice (original + cell) and usually three times (original + cell +
+row join).  Colspan/rowspan cells were replicated once per covered grid
+position on top of that.  The occurrence-counting rules
+(``too_many_word_occurence``, ``unexpected_sentence``, ``bag_of_digit``)
+read those inflated counts directly.
+"""
+
+import re
+
+from parse_bench.evaluation.metrics.parse.rules_bag import (
+    TooManyWordOccurencePercentRule,
+    WordBagRule,
+)
+from parse_bench.evaluation.metrics.parse.rules_base import (
+    _augment_with_table_cell_text,
+    _extract_table_cell_texts,
+)
+from parse_bench.test_cases.parse_rule_schemas import ParseTooManyWordOccurrencePercentRule
+
+
+def _count(word: str, text: str) -> int:
+    return len(re.findall(rf"(?<!\w){re.escape(word)}(?!\w)", text, flags=re.IGNORECASE))
+
+
+HTML_DOC = """Intro of the doc.
+
+<table>
+<tr><td>Table of contents</td><td>Page of 5</td></tr>
+<tr><td>Chapter of one</td><td>12</td></tr>
+</table>
+
+Outro of the doc."""
+
+MARKDOWN_DOC = """Intro of the doc.
+
+| Name of item | Qty |
+| --- | --- |
+| Bolt of steel | 3 |
+
+Outro of the doc."""
+
+
+class TestAugmentedTextCountsCellsOnce:
+    def test_html_table_words_counted_once(self):
+        augmented = _augment_with_table_cell_text(HTML_DOC)
+        # 2 in prose + 3 in table cells
+        assert _count("of", augmented) == 5
+        assert _count("contents", augmented) == 1
+        assert _count("12", augmented) == 1
+
+    def test_markdown_table_words_counted_once(self):
+        augmented = _augment_with_table_cell_text(MARKDOWN_DOC)
+        # 2 in prose + 2 in table cells
+        assert _count("of", augmented) == 4
+        assert _count("Bolt", augmented) == 1
+        assert _count("Qty", augmented) == 1
+
+    def test_colspan_cell_counted_once(self):
+        md = (
+            '<table><tr><td colspan="3">Wide header of cells</td></tr>'
+            "<tr><td>a1</td><td>b1</td><td>c1</td></tr></table>"
+        )
+        augmented = _augment_with_table_cell_text(md)
+        assert _count("Wide", augmented) == 1
+        assert _count("of", augmented) == 1
+        assert _extract_table_cell_texts(md) == ["Wide header of cells", "a1", "b1", "c1"]
+
+    def test_rowspan_cell_counted_once(self):
+        md = '<table><tr><td rowspan="2">Spanning of rows</td><td>x1</td></tr><tr><td>y1</td></tr></table>'
+        augmented = _augment_with_table_cell_text(md)
+        assert _count("Spanning", augmented) == 1
+        assert _count("of", augmented) == 1
+
+    def test_nested_table_cell_counted_once(self):
+        md = "<table><tr><td>Outer of cell</td><td><table><tr><td>Inner of cell</td></tr></table></td></tr></table>"
+        augmented = _augment_with_table_cell_text(md)
+        assert _count("Outer", augmented) == 1
+        assert _count("Inner", augmented) == 1
+        assert _count("of", augmented) == 2
+
+    def test_word_in_both_prose_and_cell_counted_twice(self):
+        md = "Invoice total is due.\n\n<table><tr><td>Invoice</td><td>42</td></tr></table>"
+        augmented = _augment_with_table_cell_text(md)
+        assert _count("Invoice", augmented) == 2
+
+    def test_caption_text_survives_and_is_counted_once(self):
+        md = "<table><caption>Ozonesonde of note</caption><tr><td>a1</td></tr></table>"
+        augmented = _augment_with_table_cell_text(md)
+        assert _count("Ozonesonde", augmented) == 1
+        assert _count("of", augmented) == 1
+
+    def test_table_free_content_is_unchanged(self):
+        md = "Just prose of the doc.\n\nNo tables of any kind here."
+        assert _augment_with_table_cell_text(md) == md
+
+    def test_row_spanning_text_stays_contiguous_in_normalized_full_text(self):
+        """Cells of a row must remain adjacent so cross-cell sentences match."""
+        full_text = WordBagRule._normalize_full_word_text(HTML_DOC)
+        full_text = re.sub(r"\s+", " ", full_text)
+        assert "table of contents page of 5" in full_text.lower()
+
+
+class TestTooManyWordOccurenceNotInflatedByTables:
+    def test_table_word_does_not_exceed_its_allowed_count(self):
+        rule = TooManyWordOccurencePercentRule(
+            ParseTooManyWordOccurrencePercentRule(
+                type="too_many_word_occurence_percent",
+                bag_of_word={"of": 5, "contents": 1},
+            )
+        )
+        passed, explanation, score = rule.run(HTML_DOC)
+        assert passed, explanation
+        assert score == 1.0

--- a/tests/parse_bench/evaluation/metrics/parse/test_parse_text_order_rule_html.py
+++ b/tests/parse_bench/evaluation/metrics/parse/test_parse_text_order_rule_html.py
@@ -1,0 +1,113 @@
+"""TextOrderRule must match against HTML-stripped text.
+
+A parser may legitimately render a page as an HTML table where the ground truth
+is plain markdown.  Before the strip, every order rule on such a page scored 0
+regardless of content fidelity, which caps ``content_faithfulness`` at 0.667
+(order carries weight 0.5 of 1.5).
+
+These tests pin BOTH directions: correct reading order inside a table passes,
+and genuinely wrong reading order inside a table still fails.  Order rules must
+not become vacuous on table-bearing pages.
+"""
+
+from __future__ import annotations
+
+from parse_bench.evaluation.metrics.parse.test_rules import TextOrderRule
+
+# Ground-truth anchors are authored against plain markdown, so each one spans a
+# label and its page number — i.e. it crosses a `</td><td>` boundary once the
+# parser renders the page as a table.  That span is what markup blindness breaks.
+_TOC_RULE = {
+    "type": "order",
+    "before": "Introduction to the coverage of the plan 103",
+    "after": "Appendix listing the expedited review process 108",
+    "max_diffs": 2,
+}
+
+_INTRO_ROW = "<tr><td>Introduction to the coverage of the plan</td><td>103</td></tr>"
+_APPENDIX_ROW = "<tr><td>Appendix listing the expedited review process</td><td>108</td></tr>"
+
+
+def test_order_rule_passes_when_table_reading_order_is_correct() -> None:
+    """The same sentences, rendered as an HTML table, in the GT reading order."""
+    rule = TextOrderRule(_TOC_RULE)
+
+    passed, message = rule.run(f"<table>{_INTRO_ROW}{_APPENDIX_ROW}</table>")
+
+    assert passed, message
+    assert message == ""
+
+
+def test_order_rule_still_fails_when_table_reading_order_is_wrong() -> None:
+    """Genuinely inverted reading order inside a table must NOT pass.
+
+    This is the guard against making order rules vacuous on tables: stripping
+    markup may not turn a real ordering defect into a pass.  Both anchors are
+    findable here, so the failure is an ordering verdict, not a lookup miss.
+    """
+    rule = TextOrderRule(_TOC_RULE)
+
+    passed, message = rule.run(f"<table>{_APPENDIX_ROW}{_INTRO_ROW}</table>")
+
+    assert not passed
+    assert "appears before" in message
+
+
+def test_order_rule_does_not_weld_adjacent_table_cells() -> None:
+    """Tags become a separator, so adjacent cells stay separate tokens."""
+    rule = TextOrderRule(
+        {
+            "type": "order",
+            "before": "alpha beta",
+            "after": "gamma delta",
+            "max_diffs": 0,
+        }
+    )
+
+    passed, message = rule.run("<table><tr><td>alpha</td><td>beta</td><td>gamma</td><td>delta</td></tr></table>")
+
+    assert passed, message
+
+
+def test_order_rule_preserves_plain_markdown_pass() -> None:
+    """Plain-markdown documents keep their existing behaviour."""
+    rule = TextOrderRule(_TOC_RULE)
+
+    passed, message = rule.run(
+        "# Handbook\n\n"
+        "Introduction to the coverage of the plan .......... 103\n\n"
+        "Appendix listing the expedited review process ...... 108\n"
+    )
+
+    assert passed, message
+
+
+def test_order_rule_preserves_plain_markdown_failure() -> None:
+    """Plain-markdown documents with inverted order still fail."""
+    rule = TextOrderRule(_TOC_RULE)
+
+    passed, _ = rule.run(
+        "# Handbook\n\n"
+        "Appendix listing the expedited review process ...... 108\n\n"
+        "Introduction to the coverage of the plan .......... 103\n"
+    )
+
+    assert not passed
+
+
+def test_order_rule_strips_tags_symmetrically_in_rule_text() -> None:
+    """A GT anchor that itself carries markup normalizes the same way."""
+    rule = TextOrderRule(
+        {
+            "type": "order",
+            "before": "<td>Introduction to the coverage of the plan</td>",
+            "after": "Appendix listing the expedited review process",
+            "max_diffs": 2,
+        }
+    )
+
+    passed, message = rule.run(
+        "Introduction to the coverage of the plan\n\nAppendix listing the expedited review process\n"
+    )
+
+    assert passed, message

--- a/tests/parse_bench/evaluation/metrics/parse/test_parse_text_presence_rule.py
+++ b/tests/parse_bench/evaluation/metrics/parse/test_parse_text_presence_rule.py
@@ -1,0 +1,1759 @@
+from __future__ import annotations
+
+import pytest
+
+from parse_bench.evaluation.metrics.parse.test_rules import (
+    BagOfDigitPercentRule,
+    FormattingRule,
+    LatexRule,
+    MarkColorRule,
+    MissingSentencePercentRule,
+    MissingSentenceRule,
+    MissingSpecificSentenceRule,
+    MissingSpecificWordRule,
+    MissingWordPercentRule,
+    MissingWordRule,
+    NotLatexRule,
+    TextOrderRule,
+    TextPresenceRule,
+    TitleHierarchyPercentRule,
+    TitleLevelRule,
+    TooManySentenceOccurencePercentRule,
+    TooManySentenceOccurenceRule,
+    TooManyWordOccurencePercentRule,
+    TooManyWordOccurenceRule,
+    UnexpectedSentencePercentRule,
+    UnexpectedSentenceRule,
+    UnexpectedWordPercentRule,
+    UnexpectedWordRule,
+)
+
+
+def test_present_rule_default_behavior_with_count_omitted() -> None:
+    rule = TextPresenceRule({"type": "present", "text": "hello", "max_diffs": 0})
+
+    passed, message = rule.run("prefix hello suffix")
+    assert passed
+    assert message == ""
+
+
+def test_present_rule_keeps_default_behavior_with_count_zero() -> None:
+    rule = TextPresenceRule({"type": "present", "text": "hello", "count": 0, "max_diffs": 0})
+
+    passed, message = rule.run("hello hello hello")
+
+    assert passed
+    assert message == ""
+
+
+def test_present_rule_with_exact_count_passes() -> None:
+    rule = TextPresenceRule({"type": "present", "text": "hello", "count": 2, "max_diffs": 0})
+
+    passed, message = rule.run("hello world\nhello again")
+
+    assert passed
+    assert message == ""
+
+
+def test_present_rule_normalizes_unicode_double_quotes() -> None:
+    rule = TextPresenceRule({"type": "present", "text": 'he said "hello"', "max_diffs": 0})
+
+    passed, message = rule.run("He said “hello” in the report.")
+
+    assert passed
+    assert message == ""
+
+
+def test_present_rule_normalizes_unicode_single_quotes_with_keep_formatting() -> None:
+    rule = TextPresenceRule(
+        {
+            "type": "present",
+            "text": "it's correct",
+            "keep_formatting_text_normalisation": True,
+            "max_diffs": 0,
+        }
+    )
+
+    passed, message = rule.run("It’s correct")
+
+    assert passed
+    assert message == ""
+
+
+def test_order_rule_matches_latex_formula_simplified() -> None:
+    """LaTeX formulas are simplified to numbers/operators/variables, not replaced with 'LATEX'."""
+    rule = TextOrderRule(
+        {
+            "type": "order",
+            "before": "Variance of a population is",
+            "after": "where sigma is standard deviation",
+            "max_diffs": 2,
+        }
+    )
+
+    passed, message = rule.run("Variance of a population is $\\sigma^2$. where sigma is standard deviation")
+
+    assert passed
+    assert message == ""
+
+
+def test_is_latex_rule_passes_on_inline_dollar_formula() -> None:
+    rule = LatexRule(
+        {
+            "type": "is_latex",
+            "formula": r"\frac{a}{b}",
+        }
+    )
+
+    passed, message = rule.run(r"The ratio is $\frac{a}{b}$ in this line.")
+
+    assert passed
+    assert message == ""
+
+
+def test_is_latex_rule_passes_on_block_formula_with_delimiters_in_query() -> None:
+    rule = LatexRule(
+        {
+            "type": "is_latex",
+            "formula": r"$$E = mc^2$$",
+        }
+    )
+
+    passed, message = rule.run(
+        """
+Some intro text.
+$$
+E = mc^2
+$$
+"""
+    )
+
+    assert passed
+    assert message == ""
+
+
+def test_is_latex_rule_fails_when_formula_not_present() -> None:
+    rule = LatexRule(
+        {
+            "type": "is_latex",
+            "formula": r"\int_0^1 x\,dx",
+        }
+    )
+
+    passed, message = rule.run(r"Only $a+b$ is present here.")
+
+    assert not passed
+    assert "not found" in message.lower()
+
+
+def test_is_latex_rule_uses_raw_md_content_not_normalized_content() -> None:
+    rule = LatexRule(
+        {
+            "type": "is_latex",
+            "formula": r"\frac{a}{b}",
+        }
+    )
+
+    passed, message = rule.run(
+        r"Value is $\frac{a}{b}$.",
+        normalized_content="LATEX",
+    )
+
+    assert passed
+    assert message == ""
+
+
+def test_is_latex_rule_surfaces_placeholder_preprocessing_hint() -> None:
+    rule = LatexRule(
+        {
+            "type": "is_latex",
+            "formula": r"\frac{a}{b}",
+        }
+    )
+
+    passed, message = rule.run("This output was preprocessed as LATEX token only.")
+
+    assert not passed
+    assert "placeholder" in message.lower()
+
+
+def test_is_latex_rule_ignores_presentation_only_differences() -> None:
+    rule = LatexRule(
+        {
+            "type": "is_latex",
+            "formula": r"(\frac{a}{b}) = c",
+        }
+    )
+
+    passed, message = rule.run(r"$$\left(\dfrac{a}{b}\right) \ = c \tag{7}$$")
+
+    assert passed, message
+
+
+def test_is_latex_rule_ignores_equivalent_comparison_and_text_commands() -> None:
+    rule = LatexRule(
+        {
+            "type": "is_latex",
+            "formula": r"x \le 4, s.t. y \ge 1",
+        }
+    )
+
+    passed, message = rule.run(r"$x \leq 4, \text{s.t.} y \geq 1$")
+
+    assert passed, message
+
+
+def test_is_latex_rule_allows_raw_inequality_characters_inside_math() -> None:
+    rule = LatexRule(
+        {
+            "type": "is_latex",
+            "formula": r"\Delta = x < 0.93",
+        }
+    )
+
+    passed, message = rule.run(r"First $|x| < 1$, then $\Delta = x < 0.93$, and finally $y > 0$.")
+
+    assert passed, message
+
+
+def test_is_latex_rule_does_not_pair_currency_across_html() -> None:
+    rule = LatexRule({"type": "is_latex", "formula": "10 million in revenue"})
+
+    passed, _ = rule.run("<td>$10 million</td><td>$20 million</td>")
+
+    assert not passed
+
+
+def test_is_latex_rule_does_not_pair_currency_prose_on_one_line() -> None:
+    rule = LatexRule({"type": "is_latex", "formula": "10 million and"})
+
+    passed, _ = rule.run("Revenue rose from $10 million and expenses reached $20 million.")
+
+    assert not passed
+
+
+def test_is_not_latex_rule_passes_for_plain_formula_like_text() -> None:
+    rule = NotLatexRule({"type": "is_not_latex", "text": "N = 806"})
+
+    passed, message = rule.run("Phase II/III total N = 806 participants.")
+
+    assert passed
+    assert message == ""
+
+
+def test_is_not_latex_rule_fails_for_target_inside_latex() -> None:
+    rule = NotLatexRule({"type": "is_not_latex", "text": "$400 billion"})
+
+    passed, message = rule.run("Expected investment is $400 billion$ next year.")
+
+    assert not passed
+    assert "ordinary text" in message
+
+
+def test_is_not_latex_rule_is_paired_with_presence_for_missing_text() -> None:
+    rule = NotLatexRule({"type": "is_not_latex", "text": "$400 billion"})
+
+    passed, message = rule.run("The amount was omitted.")
+
+    assert passed
+    assert message == ""
+
+
+def test_is_title_passes_for_markdown_heading_without_level() -> None:
+    rule = TitleLevelRule(
+        {
+            "type": "is_title",
+            "text": "Executive Summary",
+        }
+    )
+
+    passed, message = rule.run("## Executive Summary")
+
+    assert passed
+    assert message == ""
+
+
+def test_is_title_passes_for_bold_text_without_heading() -> None:
+    rule = TitleLevelRule(
+        {
+            "type": "is_title",
+            "text": "Executive Summary",
+        }
+    )
+
+    passed, message = rule.run("**Executive Summary**")
+
+    assert passed
+    assert message == ""
+
+
+def test_is_title_ignores_level_for_heading_matching() -> None:
+    rule = TitleLevelRule(
+        {
+            "type": "is_title",
+            "text": "Executive Summary",
+            "level": 1,
+        }
+    )
+
+    passed_other_heading, _ = rule.run("## Executive Summary")
+    passed_bold, _ = rule.run("<b>Executive Summary</b>")
+
+    assert passed_other_heading
+    assert passed_bold
+
+
+def test_is_title_fails_for_inline_bold_not_standalone_line() -> None:
+    rule = TitleLevelRule(
+        {
+            "type": "is_title",
+            "text": "Executive Summary",
+        }
+    )
+
+    passed, message = rule.run("This paragraph has **Executive Summary** inline.")
+
+    assert not passed
+    assert "title" in message.lower()
+
+
+def test_is_title_fails_for_bold_prefix_with_trailing_text() -> None:
+    rule = TitleLevelRule(
+        {
+            "type": "is_title",
+            "text": "Executive Summary",
+        }
+    )
+
+    passed, _ = rule.run("**Executive Summary** details")
+
+    assert not passed
+
+
+def test_is_bold_rule_accepts_markdown_heading_text() -> None:
+    rule = FormattingRule(
+        {
+            "type": "is_bold",
+            "text": "Executive Summary",
+        }
+    )
+
+    passed, message = rule.run("# Executive Summary")
+
+    assert passed
+    assert message == ""
+
+
+def test_is_not_bold_rule_fails_for_markdown_heading_text() -> None:
+    rule = FormattingRule(
+        {
+            "type": "is_not_bold",
+            "text": "Executive Summary",
+        }
+    )
+
+    passed, message = rule.run("## Executive Summary")
+
+    assert not passed
+    assert "unexpectedly had" in message
+
+
+def test_is_title_passes_when_html_heading_is_entity_escaped() -> None:
+    rule = TitleLevelRule(
+        {
+            "type": "is_title",
+            "text": "Executive Summary",
+            "level": 2,
+        }
+    )
+
+    passed, message = rule.run("&lt;h2&gt;Executive Summary&lt;/h2&gt;")
+
+    assert passed
+    assert message == ""
+
+
+def test_is_title_passes_when_markdown_markers_are_escaped() -> None:
+    rule = TitleLevelRule(
+        {
+            "type": "is_title",
+            "text": "Executive Summary",
+        }
+    )
+
+    passed_heading, message_heading = rule.run(r"\# Executive Summary")
+    passed_bold, message_bold = rule.run(r"\*\*Executive Summary\*\*")
+
+    assert passed_heading
+    assert message_heading == ""
+    assert passed_bold
+    assert message_bold == ""
+
+
+@pytest.mark.parametrize("product_split", ["**Product Split**", "<strong>Product Split</strong>"])
+def test_title_hierarchy_percent_passes_on_valid_nested_structure(product_split: str) -> None:
+    rule = TitleHierarchyPercentRule(
+        {
+            "type": "title_hierarchy_percent",
+            "title_hierarchy": {
+                "Executive Summary": {
+                    "Revenue Breakdown": ["Regional Split", "Product Split"],
+                    "Outlook": {},
+                }
+            },
+        }
+    )
+
+    content = f"""
+# Executive Summary
+## Revenue Breakdown
+### Regional Split
+{product_split}
+## Outlook
+"""
+
+    passed, message, score = rule.run(content)
+
+    assert passed
+    assert message == ""
+    assert score == 1.0
+
+
+def test_title_hierarchy_percent_penalizes_bad_order_or_depth() -> None:
+    rule = TitleHierarchyPercentRule(
+        {
+            "type": "title_hierarchy_percent",
+            "title_hierarchy": {
+                "Executive Summary": {
+                    "Revenue Breakdown": ["Regional Split", "Product Split"],
+                }
+            },
+        }
+    )
+
+    content = """
+**Product Split**
+## Revenue Breakdown
+# Executive Summary
+"""
+
+    passed, message, score = rule.run(content)
+
+    assert not passed
+    assert 0.0 <= score < 1.0
+    assert "score=" in message
+
+
+def test_present_rule_with_exact_count_fails_when_mismatch() -> None:
+    rule = TextPresenceRule({"type": "present", "text": "hello", "count": 2, "max_diffs": 0})
+
+    passed, message = rule.run("hello once")
+
+    assert not passed
+    assert "exactly 2 time(s), but found 1" in message
+
+
+def test_present_rule_rejects_negative_count() -> None:
+    with pytest.raises(ValueError, match="Count field cannot be negative"):
+        TextPresenceRule({"type": "present", "text": "hello", "count": -1})
+
+
+def test_present_rule_rejects_non_integer_count() -> None:
+    with pytest.raises(ValueError, match="integer"):
+        TextPresenceRule({"type": "present", "text": "hello", "count": 1.5})
+
+
+def test_unexpected_sentence_rule_passes_when_only_whitelisted_sentences_exist() -> None:
+    rule = UnexpectedSentenceRule(
+        {
+            "type": "unexpected_sentence",
+            "bag_of_sentence": {
+                "sentence one": 1,
+                "another sentence": 1,
+            },
+        }
+    )
+
+    passed, message = rule.run("Sentence one. another sentence")
+
+    assert passed
+    assert message == ""
+
+
+def test_unexpected_sentence_rule_fails_on_unknown_sentence() -> None:
+    rule = UnexpectedSentenceRule(
+        {
+            "type": "unexpected_sentence",
+            "bag_of_sentence": {
+                "allowed sentence": 1,
+            },
+        }
+    )
+
+    passed, message = rule.run("Allowed sentence\nCompletely new sentence")
+
+    assert not passed
+    assert "completely new sentence" in message
+
+
+def test_sentence_rules_merge_short_fragments_with_next() -> None:
+    """Short fragments (< 7 chars) are merged with the next chunk instead of
+    being silently dropped.  Here "ok" and "tiny" merge with subsequent text."""
+    rule = UnexpectedSentenceRule(
+        {
+            "type": "unexpected_sentence",
+            "bag_of_sentence": {
+                "allowed sentence": 1,
+                "ok tiny short": 1,
+            },
+        }
+    )
+
+    # "ok", "tiny", and "short" are merged into one sentence instead of dropped.
+    passed, message = rule.run("Allowed sentence. ok. tiny\nshort")
+
+    assert passed
+    assert message == ""
+
+
+def test_sentence_rules_strip_markdown_markers_before_matching() -> None:
+    rule = UnexpectedSentenceRule(
+        {
+            "type": "unexpected_sentence",
+            "bag_of_sentence": {
+                "article": 1,
+                "section": 1,
+            },
+        }
+    )
+
+    passed, message = rule.run("# article\n## section")
+
+    assert passed
+    assert message == ""
+
+
+def test_sentence_rules_strip_html_tags_before_matching() -> None:
+    rule = UnexpectedSentenceRule(
+        {
+            "type": "unexpected_sentence",
+            "bag_of_sentence": {
+                "article section": 1,
+            },
+        }
+    )
+
+    passed, message = rule.run("<h1>article section</h1>")
+
+    assert passed
+    assert message == ""
+
+
+def test_sentence_rules_normalize_encoded_html_tags_and_lt_entity() -> None:
+    rule = UnexpectedSentenceRule(
+        {
+            "type": "unexpected_sentence",
+            "bag_of_sentence": {
+                "&lt;h1&gt;value &lt; threshold&lt;/h1&gt;": 1,
+            },
+        }
+    )
+
+    passed, message = rule.run("&lt;div&gt;value &lt; threshold&lt;/div&gt;")
+
+    assert passed
+    assert message == ""
+
+
+def test_sentence_rules_remove_multi_dot_runs_in_bag_and_content() -> None:
+    rule = UnexpectedSentenceRule(
+        {
+            "type": "unexpected_sentence",
+            "bag_of_sentence": {
+                "net income .. adjusted . . basis": 1,
+            },
+        }
+    )
+
+    passed, message = rule.run("net income adjusted basis")
+
+    assert passed
+    assert message == ""
+
+
+def test_too_many_sentence_occurence_rule_fails_on_over_limit() -> None:
+    rule = TooManySentenceOccurenceRule(
+        {
+            "type": "too_many_sentence_occurence",
+            "bag_of_sentence": {
+                "sentence one": 1,
+            },
+        }
+    )
+
+    passed, message = rule.run("sentence one. sentence one")
+
+    assert not passed
+    assert "sentence one" in message
+
+
+def test_missing_sentence_rule_fails_on_under_limit() -> None:
+    rule = MissingSentenceRule(
+        {
+            "type": "missing_sentence",
+            "bag_of_sentence": {
+                "required sentence": 2,
+            },
+        }
+    )
+
+    passed, message = rule.run("required sentence")
+
+    assert not passed
+    assert "required sentence" in message
+
+
+def test_missing_sentence_rule_matches_sentence_in_markdown_table_cell() -> None:
+    rule = MissingSentenceRule(
+        {
+            "type": "missing_sentence",
+            "bag_of_sentence": {
+                "required sentence": 1,
+            },
+        }
+    )
+
+    passed, message = rule.run("| header |\n|---|\n| required sentence |")
+
+    assert passed
+    assert message == ""
+
+
+def test_missing_sentence_rule_splits_multiple_sentences_from_one_table_cell() -> None:
+    rule = MissingSentenceRule(
+        {
+            "type": "missing_sentence",
+            "bag_of_sentence": {
+                "first sentence": 1,
+                "second sentence": 1,
+            },
+        }
+    )
+
+    md = "<table><tr><td>First sentence. Second sentence.</td></tr></table>"
+    passed, message = rule.run(md)
+
+    assert passed
+    assert message == ""
+
+
+def test_unexpected_sentence_percent_rule_returns_partial_score() -> None:
+    rule = UnexpectedSentencePercentRule(
+        {
+            "type": "unexpected_sentence_percent",
+            "bag_of_sentence": {
+                "allowed sentence": 1,
+            },
+        }
+    )
+
+    passed, message, score = rule.run("Allowed sentence. Completely new sentence")
+
+    assert not passed
+    assert 0.0 < score < 1.0
+    assert "score=" in message
+
+
+def test_too_many_sentence_occurence_percent_rule_returns_zero_when_all_over_limit() -> None:
+    rule = TooManySentenceOccurencePercentRule(
+        {
+            "type": "too_many_sentence_occurence_percent",
+            "bag_of_sentence": {
+                "sentence one": 0,
+            },
+        }
+    )
+
+    passed, message, score = rule.run("sentence one. sentence one")
+
+    assert not passed
+    assert score == 0.0
+    assert "score=" in message
+
+
+def test_missing_sentence_percent_rule_returns_partial_score() -> None:
+    rule = MissingSentencePercentRule(
+        {
+            "type": "missing_sentence_percent",
+            "bag_of_sentence": {
+                "required sentence": 2,
+                "other sentence": 1,
+            },
+        }
+    )
+
+    passed, message, score = rule.run("required sentence")
+
+    assert not passed
+    assert score == pytest.approx(1 / 3)
+    assert "score=" in message
+
+
+def test_sentence_percent_rules_treat_quoted_and_unquoted_sentence_as_same() -> None:
+    md = '"ACM SIGPLAN Notices."\n"ACM SIGPLAN Notices."'
+    bag = {"acm sigplan notices": 2}
+
+    missing_rule = MissingSentencePercentRule(
+        {
+            "type": "missing_sentence_percent",
+            "bag_of_sentence": bag,
+        }
+    )
+    unexpected_rule = UnexpectedSentencePercentRule(
+        {
+            "type": "unexpected_sentence_percent",
+            "bag_of_sentence": bag,
+        }
+    )
+
+    missing_passed, missing_message, missing_score = missing_rule.run(md)
+    unexpected_passed, unexpected_message, unexpected_score = unexpected_rule.run(md)
+
+    assert missing_passed
+    assert missing_message == ""
+    assert missing_score == pytest.approx(1.0)
+
+    assert unexpected_passed
+    assert unexpected_message == ""
+    assert unexpected_score == pytest.approx(1.0)
+
+
+def test_missing_sentence_rule_handles_decimal_section_heading() -> None:
+    rule = MissingSentenceRule(
+        {
+            "type": "missing_sentence",
+            "bag_of_sentence": {
+                "10.1 General 296": 1,
+                "PDF 32000-1:2008": 1,
+            },
+        }
+    )
+
+    section_line = f"10.1 General {'.' * 145} 296"
+    passed, message = rule.run(
+        f"""
+        {section_line}
+        PDF 32000-1:2008
+        """
+    )
+
+    assert passed
+    assert message == ""
+
+
+def test_missing_sentence_rule_splits_on_question_and_exclamation_marks() -> None:
+    rule = MissingSentenceRule(
+        {
+            "type": "missing_sentence",
+            "bag_of_sentence": {
+                "are you ready": 1,
+                "lets go": 1,
+            },
+        }
+    )
+
+    passed, message = rule.run("Are you ready? Lets go!")
+
+    assert passed
+    assert message == ""
+
+
+def test_missing_sentence_rule_splits_on_cjk_ideographic_full_stop() -> None:
+    rule = MissingSentenceRule(
+        {
+            "type": "missing_sentence",
+            "bag_of_sentence": {
+                "这是第一句话": 1,
+                "这是第二句话": 1,
+            },
+        }
+    )
+
+    passed, message = rule.run("这是第一句话。这是第二句话")
+
+    assert passed
+    assert message == ""
+
+
+def test_missing_sentence_rule_splits_on_cjk_ideographic_comma() -> None:
+    rule = MissingSentenceRule(
+        {
+            "type": "missing_sentence",
+            "bag_of_sentence": {
+                "这是第一部分": 1,
+                "这是第二部分": 1,
+            },
+        }
+    )
+
+    passed, message = rule.run("这是第一部分、这是第二部分")
+
+    assert passed
+    assert message == ""
+
+
+def test_missing_sentence_rule_splits_on_fullwidth_comma() -> None:
+    rule = MissingSentenceRule(
+        {
+            "type": "missing_sentence",
+            "bag_of_sentence": {
+                "这是第一部分": 1,
+                "这是第二部分": 1,
+            },
+        }
+    )
+
+    passed, message = rule.run("这是第一部分，这是第二部分")
+
+    assert passed
+    assert message == ""
+
+
+def test_missing_sentence_rule_splits_on_fullwidth_exclamation_and_question() -> None:
+    rule = MissingSentenceRule(
+        {
+            "type": "missing_sentence",
+            "bag_of_sentence": {
+                "你好世界": 1,
+                "你准备好了吗": 1,
+            },
+        }
+    )
+
+    passed, message = rule.run("你好世界！你准备好了吗？")
+
+    assert passed
+    assert message == ""
+
+
+def test_missing_sentence_rule_splits_on_horizontal_ellipsis() -> None:
+    rule = MissingSentenceRule(
+        {
+            "type": "missing_sentence",
+            "bag_of_sentence": {
+                "first part here": 1,
+                "second part here": 1,
+            },
+        }
+    )
+
+    passed, message = rule.run("first part here…second part here")
+
+    assert passed
+    assert message == ""
+
+
+def test_missing_sentence_rule_splits_on_fullwidth_semicolon() -> None:
+    rule = MissingSentenceRule(
+        {
+            "type": "missing_sentence",
+            "bag_of_sentence": {
+                "这是第一部分": 1,
+                "这是第二部分": 1,
+            },
+        }
+    )
+
+    passed, message = rule.run("这是第一部分；这是第二部分")
+
+    assert passed
+    assert message == ""
+
+
+def test_missing_specific_sentence_rule_matches_sentence_in_table_cell() -> None:
+    rule = MissingSpecificSentenceRule(
+        {
+            "type": "missing_specific_sentence",
+            "sentence": "required sentence",
+        }
+    )
+
+    passed, message = rule.run("| header |\n|---|\n| required sentence |")
+
+    assert passed
+    assert message == ""
+
+
+def test_missing_specific_sentence_rule_matches_sentence_split_across_table_cells() -> None:
+    """Sentence text split across multiple cells in the same row should still match."""
+    rule = MissingSpecificSentenceRule(
+        {
+            "type": "missing_specific_sentence",
+            "sentence": "hello world foo bar",
+        }
+    )
+
+    md = "| col1 | col2 |\n|---|---|\n| hello world | foo bar |"
+    passed, message = rule.run(md)
+
+    assert passed
+    assert message == ""
+
+
+def test_sentence_bag_rules_reject_invalid_bag_definition() -> None:
+    with pytest.raises(ValueError, match="non-empty dictionary"):
+        UnexpectedSentenceRule({"type": "unexpected_sentence", "bag_of_sentence": {}})
+
+    with pytest.raises(ValueError, match="integer"):
+        TooManySentenceOccurenceRule(
+            {
+                "type": "too_many_sentence_occurence",
+                "bag_of_sentence": {"sentence": 1.2},
+            }
+        )
+
+    with pytest.raises(ValueError, match="cannot be negative"):
+        MissingSentenceRule(
+            {
+                "type": "missing_sentence",
+                "bag_of_sentence": {"sentence": -1},
+            }
+        )
+
+
+def test_sentence_bag_rule_skips_invalid_noise_entries_in_bag() -> None:
+    rule = UnexpectedSentenceRule(
+        {
+            "type": "unexpected_sentence",
+            "bag_of_sentence": {
+                "..": 2,
+                ". . .": 3,
+                "allowed sentence": 1,
+            },
+        }
+    )
+
+    passed, message = rule.run("allowed sentence")
+
+    assert passed
+    assert message == ""
+
+
+def test_sentence_bag_rule_executes_with_empty_normalized_bag() -> None:
+    rule = UnexpectedSentenceRule(
+        {
+            "type": "unexpected_sentence",
+            "bag_of_sentence": {
+                "..": 1,
+                ". .": 1,
+                "tiny": 1,
+            },
+        }
+    )
+
+    passed, message = rule.run("this sentence would normally be unexpected")
+
+    assert not passed
+    assert "this sentence would normally be unexpected" in message
+
+
+def test_unexpected_word_rule_fails_on_unknown_word() -> None:
+    rule = UnexpectedWordRule(
+        {
+            "type": "unexpected_word",
+            "bag_of_word": {
+                "allowed": 5,
+                "word": 5,
+            },
+        }
+    )
+
+    passed, message = rule.run("Allowed word and surprise")
+
+    assert not passed
+    assert "surprise" in message
+
+
+def test_unexpected_sentence_rule_reports_all_unexpected_sentences() -> None:
+    rule = UnexpectedSentenceRule(
+        {
+            "type": "unexpected_sentence",
+            "bag_of_sentence": {
+                "allowed sentence": 1,
+            },
+        }
+    )
+
+    passed, message = rule.run("Allowed sentence. Extra sentence one. Extra sentence two")
+
+    assert not passed
+    assert "extra sentence one" in message
+    assert "extra sentence two" in message
+
+
+def test_unexpected_word_rule_reports_all_unexpected_words() -> None:
+    rule = UnexpectedWordRule(
+        {
+            "type": "unexpected_word",
+            "bag_of_word": {
+                "allowed": 5,
+                "words": 5,
+            },
+        }
+    )
+
+    passed, message = rule.run("allowed words surprise mystery")
+
+    assert not passed
+    assert "surprise" in message
+    assert "mystery" in message
+
+
+def test_too_many_word_occurence_rule_fails_on_over_limit() -> None:
+    rule = TooManyWordOccurenceRule(
+        {
+            "type": "too_many_word_occurence",
+            "bag_of_word": {
+                "total": 1,
+            },
+        }
+    )
+
+    passed, message = rule.run("total total")
+
+    assert not passed
+    assert "total" in message
+
+
+def test_word_rules_ignore_words_shorter_than_two_characters() -> None:
+    rule = UnexpectedWordRule(
+        {
+            "type": "unexpected_word",
+            "bag_of_word": {
+                "allowed": 5,
+                "words": 5,
+                "ok": 5,
+                "big": 5,
+            },
+        }
+    )
+
+    # Single-char words like "a" and "I" are ignored because they are shorter than 2 chars.
+    # "ok" (2 chars) and "big" (3 chars) now pass the MIN_WORD_LENGTH=2 filter.
+    passed, message = rule.run("allowed words ok big a I")
+
+    assert passed
+    assert message == ""
+
+
+def test_word_rule_skips_invalid_markdown_noise_in_bag() -> None:
+    rule = UnexpectedWordRule(
+        {
+            "type": "unexpected_word",
+            "bag_of_word": {
+                "##": 3,
+                "allowed": 1,
+            },
+        }
+    )
+
+    passed, message = rule.run("allowed")
+
+    assert passed
+    assert message == ""
+
+
+def test_word_rules_strip_html_tags_in_bag_and_content() -> None:
+    rule = UnexpectedWordRule(
+        {
+            "type": "unexpected_word",
+            "bag_of_word": {
+                "<b>allowed</b>": 1,
+            },
+        }
+    )
+
+    passed, message = rule.run("<span>allowed</span>")
+
+    assert passed
+    assert message == ""
+
+
+def test_word_rules_strip_encoded_html_tags_in_bag_and_content() -> None:
+    rule = UnexpectedWordRule(
+        {
+            "type": "unexpected_word",
+            "bag_of_word": {
+                "&lt;b&gt;allowed&lt;/b&gt;": 1,
+            },
+        }
+    )
+
+    passed, message = rule.run("&lt;span&gt;allowed&lt;/span&gt;")
+
+    assert passed
+    assert message == ""
+
+
+def test_missing_word_rule_fails_on_under_limit() -> None:
+    rule = MissingWordRule(
+        {
+            "type": "missing_word",
+            "bag_of_word": {
+                "required": 2,
+            },
+        }
+    )
+
+    passed, message = rule.run("required")
+
+    assert not passed
+    assert "required" in message
+
+
+def test_missing_word_rule_matches_word_in_markdown_table_cell() -> None:
+    rule = MissingWordRule(
+        {
+            "type": "missing_word",
+            "bag_of_word": {
+                "required": 1,
+            },
+        }
+    )
+
+    passed, message = rule.run("| item |\n|---|\n| required |")
+
+    assert passed
+    assert message == ""
+
+
+def test_missing_specific_word_rule_matches_word_in_table_cell() -> None:
+    rule = MissingSpecificWordRule(
+        {
+            "type": "missing_specific_word",
+            "word": "required",
+        }
+    )
+
+    passed, message = rule.run("<table><tr><td>required</td></tr></table>")
+
+    assert passed
+    assert message == ""
+
+
+def test_missing_specific_word_rule_keeps_words_around_currency_amounts() -> None:
+    md = (
+        "In 2023, our net income was $15.00 billion, representing a favorable change of $2.44 "
+        "billion. This included a one-time non-cash tax benefit of $5.93 billion for the release "
+        "of valuation allowance on certain deferred tax assets. "
+        "Our cash flows provided by operating activities in 2023 and 2022 were $13.26 billion and "
+        "$14.72 billion, respectively."
+    )
+
+    for word in ["assets", "activities", "2022", "2023"]:
+        rule = MissingSpecificWordRule(
+            {
+                "type": "missing_specific_word",
+                "word": word,
+            }
+        )
+
+        passed, message = rule.run(md)
+
+        assert passed
+        assert message == ""
+
+
+def test_missing_specific_word_rule_still_fails_for_absent_word() -> None:
+    md = "valuation allowance on certain deferred tax assets"
+    rule = MissingSpecificWordRule(
+        {
+            "type": "missing_specific_word",
+            "word": "allowances",
+        }
+    )
+
+    passed, message = rule.run(md)
+
+    assert not passed
+    assert "allowances" in message
+
+
+def test_missing_specific_word_rule_handles_apostrophe_word() -> None:
+    """Words with apostrophes like d'équipage should not raise during init."""
+    rule = MissingSpecificWordRule(
+        {
+            "type": "missing_specific_word",
+            "word": "d'équipage",
+            "page": 1,
+        }
+    )
+    assert rule.normalized_word == "equipage"
+
+    passed, _ = rule.run("Les membres d'équipage sont présents.")
+    assert passed
+
+    passed, msg = rule.run("Some unrelated content.")
+    assert not passed
+    assert "equipage" in msg
+
+
+def test_missing_specific_word_rule_handles_contraction() -> None:
+    """Contractions like can't should pick the longest valid fragment ('can') with MIN_WORD_LENGTH=2."""
+    rule = MissingSpecificWordRule(
+        {
+            "type": "missing_specific_word",
+            "word": "can't",
+            "page": 1,
+        }
+    )
+    assert rule.normalized_word == "can"
+
+    passed, _ = rule.run("You can't do that.")
+    assert passed
+
+    passed, msg = rule.run("Some unrelated content.")
+    assert not passed
+    assert "can" in msg
+
+
+def test_unexpected_word_percent_rule_returns_partial_score() -> None:
+    rule = UnexpectedWordPercentRule(
+        {
+            "type": "unexpected_word_percent",
+            "bag_of_word": {
+                "allowed": 5,
+                "words": 5,
+            },
+        }
+    )
+
+    passed, message, score = rule.run("allowed words surprise mystery")
+
+    assert not passed
+    assert 0.0 < score < 1.0
+    assert "score=" in message
+
+
+def test_too_many_word_occurence_percent_rule_returns_zero_when_all_over_limit() -> None:
+    rule = TooManyWordOccurencePercentRule(
+        {
+            "type": "too_many_word_occurence_percent",
+            "bag_of_word": {
+                "total": 0,
+            },
+        }
+    )
+
+    passed, message, score = rule.run("total total")
+
+    assert not passed
+    assert score == 0.0
+    assert "score=" in message
+
+
+def test_missing_word_percent_rule_returns_partial_score() -> None:
+    rule = MissingWordPercentRule(
+        {
+            "type": "missing_word_percent",
+            "bag_of_word": {
+                "required": 2,
+                "other": 1,
+            },
+        }
+    )
+
+    passed, message, score = rule.run("required")
+
+    assert not passed
+    assert score == pytest.approx(1 / 3)
+    assert "score=" in message
+
+
+def test_word_bag_rules_reject_invalid_bag_definition() -> None:
+    with pytest.raises(ValueError, match="non-empty dictionary"):
+        UnexpectedWordRule({"type": "unexpected_word", "bag_of_word": {}})
+
+    with pytest.raises(ValueError, match="integer"):
+        TooManyWordOccurenceRule(
+            {
+                "type": "too_many_word_occurence",
+                "bag_of_word": {"word": 1.2},
+            }
+        )
+
+    with pytest.raises(ValueError, match="cannot be negative"):
+        MissingWordRule(
+            {
+                "type": "missing_word",
+                "bag_of_word": {"word": -1},
+            }
+        )
+
+
+# ---- substring fallback tests ----
+
+
+def test_missing_sentence_rule_finds_sentence_via_substring_fallback() -> None:
+    """A sentence split across line boundaries by the parser should still be found
+    via substring matching in the normalized full text."""
+    rule = MissingSentenceRule(
+        {
+            "type": "missing_sentence",
+            "bag_of_sentence": {
+                "the quick brown fox jumps over the lazy dog": 1,
+            },
+        }
+    )
+    # The sentence split by "." so bag extraction splits it differently,
+    # but substring matching in normalized full text should still find it.
+    md = "The quick brown fox jumps\nover the lazy dog"
+    passed, message = rule.run(md)
+
+    assert passed, f"Expected pass via substring fallback, got: {message}"
+
+
+def test_missing_sentence_rule_still_fails_when_truly_missing() -> None:
+    """Substring fallback should not produce false positives."""
+    rule = MissingSentenceRule(
+        {
+            "type": "missing_sentence",
+            "bag_of_sentence": {
+                "this sentence is not in the content": 1,
+            },
+        }
+    )
+    passed, message = rule.run("Completely unrelated content here instead")
+
+    assert not passed
+
+
+def test_too_many_sentence_rule_uses_substring_count() -> None:
+    """Substring fallback should detect repeated occurrences even when
+    bag extraction splits them differently."""
+    rule = TooManySentenceOccurenceRule(
+        {
+            "type": "too_many_sentence_occurence",
+            "bag_of_sentence": {
+                "repeated sentence here": 1,
+            },
+        }
+    )
+    # Two occurrences separated by newline — bag splitting may merge or split differently
+    md = "Repeated sentence here\nsome filler text\nRepeated sentence here"
+    passed, message = rule.run(md)
+
+    assert not passed, "Expected failure for over-limit, got pass"
+
+
+def test_unexpected_sentence_rule_accepts_substring_of_bag_entry() -> None:
+    """An actual sentence fragment that is a substring of a bag entry should not
+    be flagged as unexpected (handles boundary misalignment)."""
+    rule = UnexpectedSentenceRule(
+        {
+            "type": "unexpected_sentence",
+            "bag_of_sentence": {
+                "the quick brown fox jumps over the lazy dog": 1,
+            },
+        }
+    )
+    # "quick brown fox jumps over the lazy dog" is a sub-piece of the bag entry
+    md = "Quick brown fox jumps over the lazy dog"
+    passed, message = rule.run(md)
+
+    assert passed, f"Expected pass for substring of bag entry, got: {message}"
+
+
+def test_missing_word_rule_finds_word_via_substring_fallback() -> None:
+    """Word-boundary substring matching should find words that tokenization may miss."""
+    rule = MissingWordRule(
+        {
+            "type": "missing_word",
+            "bag_of_word": {
+                "revenue": 2,
+            },
+        }
+    )
+    # Content has "revenue" twice but in contexts that might tokenize differently
+    md = "Total revenue was high. The revenue grew."
+    passed, message = rule.run(md)
+
+    assert passed, f"Expected pass, got: {message}"
+
+
+def test_missing_word_percent_rule_uses_substring_fallback() -> None:
+    """MissingWordPercentRule should use substring fallback for higher accuracy."""
+    rule = MissingWordPercentRule(
+        {
+            "type": "missing_word_percent",
+            "bag_of_word": {
+                "revenue": 1,
+                "expenses": 1,
+            },
+        }
+    )
+    md = "Total revenue and total expenses"
+    passed, message, score = rule.run(md)
+
+    assert passed
+    assert score == 1.0
+
+
+def test_too_many_word_rule_uses_substring_count() -> None:
+    """TooManyWordOccurenceRule should detect over-limit via substring matching."""
+    rule = TooManyWordOccurenceRule(
+        {
+            "type": "too_many_word_occurence",
+            "bag_of_word": {
+                "revenue": 1,
+            },
+        }
+    )
+    md = "Revenue from sales. Total revenue. Net revenue."
+    passed, message = rule.run(md)
+
+    assert not passed, "Expected failure for over-limit, got pass"
+
+
+# ---- bag_of_digit_percent rule tests ----
+
+
+def test_bag_of_digit_percent_rule_perfect_match() -> None:
+    """All expected digits are present with correct counts → score 1.0."""
+    rule = BagOfDigitPercentRule(
+        {
+            "type": "bag_of_digit_percent",
+            "bag_of_digit": {"1": 2, "5": 1, "0": 1},
+        }
+    )
+
+    passed, message, score = rule.run("Revenue was 150 and cost was 11")
+
+    assert passed
+    assert score == 1.0
+
+
+def test_bag_of_digit_percent_rule_partial_match() -> None:
+    """Some digits are missing → score between 0 and 1."""
+    rule = BagOfDigitPercentRule(
+        {
+            "type": "bag_of_digit_percent",
+            "bag_of_digit": {"1": 3, "5": 2, "0": 1},
+        }
+    )
+
+    # Content has: 1 appears 2x, 5 appears 1x, 0 appears 1x → matched=4 / expected=6
+    passed, message, score = rule.run("15 and 10")
+
+    assert not passed
+    assert 0.0 < score < 1.0
+    assert "score=" in message
+
+
+def test_bag_of_digit_percent_rule_no_digits_in_content() -> None:
+    """No digits in content → score 0.0."""
+    rule = BagOfDigitPercentRule(
+        {
+            "type": "bag_of_digit_percent",
+            "bag_of_digit": {"3": 2, "7": 1},
+        }
+    )
+
+    passed, message, score = rule.run("No digits here at all")
+
+    assert not passed
+    assert score == 0.0
+
+
+def test_bag_of_digit_percent_rule_ignores_html_attributes() -> None:
+    """Digits in HTML tag attributes (e.g. colspan='2') must NOT be counted."""
+    rule = BagOfDigitPercentRule(
+        {
+            "type": "bag_of_digit_percent",
+            "bag_of_digit": {"2": 1},
+        }
+    )
+
+    # The only "2" is inside an HTML attribute — should NOT match
+    passed, _, score = rule.run('<td colspan="2">text</td>')
+
+    assert not passed
+    assert score == 0.0
+
+
+def test_bag_of_digit_percent_rule_counts_digits_in_table_cell_text() -> None:
+    """Digits inside table cell text content should be counted."""
+    rule = BagOfDigitPercentRule(
+        {
+            "type": "bag_of_digit_percent",
+            "bag_of_digit": {"4": 1, "2": 1},
+        }
+    )
+
+    md = '<table><tr><td colspan="3">42</td></tr></table>'
+    passed, _, score = rule.run(md)
+
+    assert passed
+    assert score == 1.0
+
+
+def test_bag_of_digit_percent_rule_counts_digits_in_markdown_table() -> None:
+    """Digits in markdown pipe tables should be counted."""
+    rule = BagOfDigitPercentRule(
+        {
+            "type": "bag_of_digit_percent",
+            "bag_of_digit": {"9": 1, "8": 1},
+        }
+    )
+
+    md = "| Col A | Col B |\n|-------|-------|\n| 9 | 8 |"
+    passed, _, score = rule.run(md)
+
+    assert passed
+    assert score == 1.0
+
+
+def test_bag_of_digit_percent_rule_rejects_non_digit_keys() -> None:
+    """Keys must be single digit characters (0-9)."""
+    with pytest.raises(ValueError, match="single digit"):
+        BagOfDigitPercentRule(
+            {
+                "type": "bag_of_digit_percent",
+                "bag_of_digit": {"abc": 1},
+            }
+        )
+
+
+def test_bag_of_digit_percent_rule_rejects_empty_bag() -> None:
+    """Empty bag_of_digit is rejected."""
+    with pytest.raises(ValueError, match="non-empty dictionary"):
+        BagOfDigitPercentRule(
+            {
+                "type": "bag_of_digit_percent",
+                "bag_of_digit": {},
+            }
+        )
+
+
+def test_bag_of_digit_percent_rule_rejects_negative_count() -> None:
+    """Negative counts are rejected."""
+    with pytest.raises(ValueError, match="cannot be negative"):
+        BagOfDigitPercentRule(
+            {
+                "type": "bag_of_digit_percent",
+                "bag_of_digit": {"1": -1},
+            }
+        )
+
+
+def test_bag_of_digit_percent_rule_complex_html_table() -> None:
+    """Digits in cell content are counted, digits in HTML attrs are not."""
+    rule = BagOfDigitPercentRule(
+        {
+            "type": "bag_of_digit_percent",
+            "bag_of_digit": {"1": 2, "0": 2, "5": 1},
+        }
+    )
+
+    md = '<table><tr><td rowspan="2" colspan="3">100</td><td>15</td></tr></table>'
+
+    passed, _, score = rule.run(md)
+
+    assert passed
+    assert score == 1.0
+
+
+# ---- New tests for bugfixes ----
+
+
+def test_fuzzy_match_threshold_floor_for_short_query() -> None:
+    """Short queries should have a threshold floor of 0.7 to avoid matching everything."""
+    # "hi" with max_diffs=1 would give threshold=0.5 without floor — too permissive
+    rule = TextPresenceRule({"type": "present", "text": "hi", "max_diffs": 1})
+    # "zz" should NOT match "hi" even with fuzzy matching
+    passed, _ = rule.run("zz completely different text")
+    assert not passed
+
+
+def test_latex_simplification_distinguishes_different_formulas() -> None:
+    """Different LaTeX formulas should produce different simplified tokens."""
+    from parse_bench.evaluation.metrics.parse.rules_base import _strip_and_replace_latex
+
+    result = _strip_and_replace_latex(r"$\frac{a}{b}$ and $x^2 + y^2$")
+    # Should contain distinguishable simplified forms, not just "LATEX" twice
+    assert "LATEX" not in result or result.count("LATEX") == 0
+    assert "ab" in result.lower() or "a" in result  # frac{a}{b} → contains a and b
+    assert "x2" in result or "x" in result  # x^2 → contains x and 2
+
+
+def test_sentence_substring_word_boundary_avoids_false_positives() -> None:
+    """Short sentence substring matching should use word boundaries."""
+    from parse_bench.evaluation.metrics.parse.rules_bag import SentenceBagRule
+
+    # "the cat" should not match inside "other category"
+    count = SentenceBagRule._count_sentence_in_full_text("the cat", "other category is here")
+    assert count == 0
+
+    # But should match when actually present
+    count = SentenceBagRule._count_sentence_in_full_text("the cat", "the cat is here")
+    assert count == 1
+
+
+def test_word_rules_handle_cjk_characters() -> None:
+    """CJK characters stay grouped as multi-char tokens (matching JS annotation tool)."""
+    # Multi-char CJK bag entries should match as substring in content
+    rule = MissingWordRule(
+        {
+            "type": "missing_word",
+            "bag_of_word": {
+                "\u4f60\u597d": 1,  # 你好
+                "\u4e16\u754c": 1,  # 世界
+            },
+        }
+    )
+
+    passed, message = rule.run("你好世界")
+
+    assert passed
+    assert message == ""
+
+
+def test_word_rules_handle_short_words_with_new_min_length() -> None:
+    """Words with 2-3 characters should now be recognized (MIN_WORD_LENGTH=2)."""
+    rule = MissingWordRule(
+        {
+            "type": "missing_word",
+            "bag_of_word": {
+                "ok": 1,
+                "the": 1,
+            },
+        }
+    )
+
+    passed, message = rule.run("This is ok and the end")
+
+    assert passed
+    assert message == ""
+
+
+def test_repetition_detection_catches_late_repetition() -> None:
+    """Repetition detection should catch repetitive content anywhere in the document."""
+    from parse_bench.evaluation.metrics.parse.rules_text import BaselineRule
+
+    rule = BaselineRule({"type": "baseline"})
+
+    # Normal start, then repetitive content filling the document
+    content = "Normal start here. " + "x" * 5000
+    passed, message = rule.run(content)
+
+    assert not passed
+    assert "repetitive" in message.lower()
+
+
+def test_formatting_rule_tolerates_mark_tags_between_words() -> None:
+    """Markup tolerance should handle <mark>, <sup>, <em> etc. between words."""
+    rule = FormattingRule(
+        {
+            "type": "is_bold",
+            "text": "hello world",
+        }
+    )
+
+    # Words separated by a <mark> tag should still match
+    passed, message = rule.run("**hello <mark>world</mark>**")
+
+    assert passed
+    assert message == ""
+
+
+# ---------------------------------------------------------------------------
+# MarkColorRule tests
+# ---------------------------------------------------------------------------
+
+
+def test_mark_color_rule_passes_with_style_attribute() -> None:
+    rule = MarkColorRule({"type": "mark_color", "text": "important", "color": "yellow"})
+
+    passed, message = rule.run('Some text <mark style="background-color: yellow">important</mark> here.')
+    assert passed
+    assert message == ""
+
+
+def test_is_mark_rule_accepts_color_attributes_without_weakening_color_check() -> None:
+    semantic_rule = FormattingRule({"type": "is_mark", "text": "important"})
+    color_rule = MarkColorRule({"type": "mark_color", "text": "important", "color": "yellow"})
+    markdown = '<mark style="background-color: yellow">important</mark>'
+
+    assert semantic_rule.run(markdown)[0]
+    assert color_rule.run(markdown)[0]
+
+
+def test_mark_color_rule_passes_with_background_attribute() -> None:
+    rule = MarkColorRule({"type": "mark_color", "text": "important", "color": "yellow"})
+
+    passed, message = rule.run('Some text <mark background="yellow">important</mark> here.')
+    assert passed
+    assert message == ""
+
+
+def test_mark_color_rule_passes_with_backgroundcolor_attribute() -> None:
+    rule = MarkColorRule({"type": "mark_color", "text": "important", "color": "yellow"})
+
+    passed, message = rule.run('Some text <mark backgroundColor="yellow">important</mark> here.')
+    assert passed
+    assert message == ""
+
+
+def test_mark_color_rule_fails_when_wrong_color() -> None:
+    rule = MarkColorRule({"type": "mark_color", "text": "important", "color": "yellow"})
+
+    passed, message = rule.run('Some text <mark style="background-color: red">important</mark> here.')
+    assert not passed
+    assert "yellow" in message
+
+
+def test_mark_color_rule_fails_when_no_mark_tag() -> None:
+    rule = MarkColorRule({"type": "mark_color", "text": "important", "color": "yellow"})
+
+    passed, message = rule.run("Some text important here.")
+    assert not passed
+
+
+def test_mark_color_rule_fails_when_mark_has_no_attributes() -> None:
+    rule = MarkColorRule({"type": "mark_color", "text": "important", "color": "yellow"})
+
+    passed, message = rule.run("Some text <mark>important</mark> here.")
+    assert not passed
+
+
+def test_mark_color_rule_case_insensitive_color() -> None:
+    rule = MarkColorRule({"type": "mark_color", "text": "note", "color": "yellow"})
+
+    passed, message = rule.run('Text <mark style="background-color: Yellow">note</mark>.')
+    assert passed
+    assert message == ""
+
+
+def test_mark_color_rule_hex_color() -> None:
+    rule = MarkColorRule({"type": "mark_color", "text": "highlighted", "color": "#ff0"})
+
+    passed, message = rule.run('Text <mark style="background-color: #ff0">highlighted</mark>.')
+    assert passed
+    assert message == ""
+
+
+def test_mark_color_rule_text_not_in_mark() -> None:
+    """Text exists but not inside the colored mark tag."""
+    rule = MarkColorRule({"type": "mark_color", "text": "other", "color": "yellow"})
+
+    passed, message = rule.run('Before other <mark style="background-color: yellow">important</mark> after.')
+    assert not passed
+
+
+def test_mark_color_rule_with_nested_formatting() -> None:
+    """Text inside mark tag has nested bold formatting."""
+    rule = MarkColorRule({"type": "mark_color", "text": "hello world", "color": "green"})
+
+    passed, message = rule.run('<mark style="background-color: green">**hello** world</mark>')
+    assert passed
+    assert message == ""

--- a/tests/parse_bench/evaluation/metrics/parse/test_relaxed_normalize_cell_text.py
+++ b/tests/parse_bench/evaluation/metrics/parse/test_relaxed_normalize_cell_text.py
@@ -1,0 +1,98 @@
+"""Tests for relaxed_normalize_cell_text() — the relaxed-only cell-text folds
+(LI-8223 items 2 & 3): tag-strip separator injection and homoglyph/equivalence
+canonicalization.
+
+These folds run ONLY on the relaxed metric path (via ``normalize_for_relaxed``)
+and compose with the strict ``normalize_cell_text`` that runs on top.
+"""
+
+from __future__ import annotations
+
+from parse_bench.evaluation.metrics.parse.utils import (
+    normalize_cell_text,
+    relaxed_normalize_cell_text,
+)
+
+
+class TestTagStripSeparatorInjection:
+    """Block/line tags become separators so list items don't concatenate."""
+
+    def test_ul_li_list_does_not_fuse(self) -> None:
+        # Without separator injection get_text-style stripping would fuse to "AB".
+        assert relaxed_normalize_cell_text("<ul><li>A</li><li>B</li></ul>") == "• A • B"
+
+    def test_ul_li_matches_literal_bullets(self) -> None:
+        # Motivating case Low-Back-Guideline (1)_page2: a <ul><li> prediction and
+        # a literal ■-bulleted GT cell must converge to the same shape.
+        pred = relaxed_normalize_cell_text("<ul><li>A</li><li>B</li></ul>")
+        gt = relaxed_normalize_cell_text("■ A<br>■ B")
+        assert pred == gt == "• A • B"
+
+    def test_br_becomes_space(self) -> None:
+        assert relaxed_normalize_cell_text("line1<br>line2") == "line1 line2"
+
+    def test_paragraph_tags_become_space(self) -> None:
+        assert relaxed_normalize_cell_text("<p>one</p><p>two</p>") == "one two"
+
+    def test_ordered_list(self) -> None:
+        assert relaxed_normalize_cell_text("<ol><li>A</li><li>B</li></ol>") == "• A • B"
+
+    def test_plain_text_unchanged(self) -> None:
+        assert relaxed_normalize_cell_text("plain value") == "plain value"
+
+
+class TestHomoglyphFolding:
+    """Visually-identical codepoints fold to a canonical form."""
+
+    def test_micro_sign_to_greek_mu(self) -> None:
+        # µ U+00B5 MICRO SIGN vs μ U+03BC GREEK SMALL LETTER MU
+        assert relaxed_normalize_cell_text("5 µm") == relaxed_normalize_cell_text("5 μm") == "5 μm"
+
+    def test_non_breaking_hyphen(self) -> None:
+        assert relaxed_normalize_cell_text("A‑B") == "A-B"
+
+    def test_figure_dash(self) -> None:
+        assert relaxed_normalize_cell_text("A‒B") == "A-B"
+
+    def test_en_dash(self) -> None:
+        assert relaxed_normalize_cell_text("A–B") == "A-B"
+
+    def test_nbsp_to_space(self) -> None:
+        assert relaxed_normalize_cell_text("A B") == "A B"
+
+    def test_square_bullets_fold_to_canonical(self) -> None:
+        # Only the SQUARE bullets fold at the relaxed layer (strict already folds
+        # circle bullets in mixed-content cells).
+        canonical = relaxed_normalize_cell_text("■ item")
+        for bullet in ("▪", "•"):
+            assert relaxed_normalize_cell_text(f"{bullet} item") == canonical == "• item"
+
+    def test_circle_markers_not_folded_boolean_distinction_preserved(self) -> None:
+        # Whole-cell ● (yes) vs ○ (no) is a REAL content distinction: the strict
+        # boolean-marker pass must still see them unchanged after relaxed runs.
+        # (Folding them to • would make checked-vs-unchecked score as a match,
+        # since • is itself a truthy marker glyph.)
+        for glyph in ("●", "○", "◦"):
+            assert relaxed_normalize_cell_text(glyph) == glyph
+        from parse_bench.evaluation.metrics.parse.utils import normalize_cell_text
+
+        assert normalize_cell_text(relaxed_normalize_cell_text("●")) != normalize_cell_text(
+            relaxed_normalize_cell_text("○")
+        )
+
+
+class TestComposesWithStrict:
+    """The relaxed fold runs before the strict normalize_cell_text; the
+    composition is stable (running strict on top is a no-op on the fold's
+    output for these cases)."""
+
+    def test_bullet_survives_strict(self) -> None:
+        folded = relaxed_normalize_cell_text("■ A<br>■ B")
+        assert normalize_cell_text(folded) == "• A • B"
+
+    def test_idempotent(self) -> None:
+        once = relaxed_normalize_cell_text("<ul><li>A</li><li>B</li></ul>")
+        assert relaxed_normalize_cell_text(once) == once
+
+    def test_empty_string(self) -> None:
+        assert relaxed_normalize_cell_text("") == ""

--- a/tests/parse_bench/evaluation/metrics/parse/test_rule_metric_budget_and_bag_images.py
+++ b/tests/parse_bench/evaluation/metrics/parse/test_rule_metric_budget_and_bag_images.py
@@ -1,0 +1,84 @@
+"""Focused regressions for ported fixes that had no dedicated internal test.
+
+- ``rules_bag``: markdown image alt text is stripped from BOTH the word-bag and
+  the sentence-bag extraction paths.
+- ``rule_based_metric``: ``normalize_text`` runs under the per-rule timeout and
+  the aggregate per-document budget skips (scores 0) the remaining rules.
+- ``utils.strip_dot_leaders``: the trailing dot-leader strip is linear, so a
+  degenerate OCR page of dots cannot stall a worker.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from parse_bench.evaluation.metrics.parse import rule_based_metric
+from parse_bench.evaluation.metrics.parse.rule_based_metric import RuleBasedMetric, _RuleTimeoutError
+from parse_bench.evaluation.metrics.parse.rules_bag import SentenceBagRule, WordBagRule
+from parse_bench.evaluation.metrics.parse.utils import normalize_cell_text, strip_dot_leaders
+
+_IMG_MD = "Real prose sentence here. ![spurious alt caption](figure.png) Another sentence."
+
+
+def test_word_bag_strips_markdown_image_alt_text() -> None:
+    words = WordBagRule._extract_normalized_words_static(_IMG_MD)
+    assert "real" in words
+    assert "spurious" not in words
+    assert "caption" not in words
+
+
+def test_sentence_bag_strips_markdown_image_alt_text() -> None:
+    sentences = SentenceBagRule._extract_normalized_sentences_static(_IMG_MD)
+    joined = " ".join(sentences)
+    assert "real prose sentence here" in joined
+    assert "spurious" not in joined
+
+
+def _present_rules(n: int) -> list[dict]:
+    return [{"type": "present", "text": f"word{i}"} for i in range(n)]
+
+
+def test_document_rule_budget_skips_remaining_rules(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A vanishingly small budget is exhausted after the first rule; the rest are
+    # skipped with a score of 0 and an explanation, never evaluated.
+    monkeypatch.setenv("BENCH_DOC_RULE_BUDGET_SECONDS", "1e-9")
+    result = RuleBasedMetric().compute(expected=_present_rules(3), actual="word0 word1 word2")
+    meta = result.metadata
+    assert meta["total"] == 3
+    assert len(meta["rule_results"]) == 3
+    assert meta["skipped_over_budget"] >= 1
+    skipped = [r for r in meta["rule_results"] if r["explanation"].startswith("Skipped: document rule budget")]
+    assert len(skipped) == meta["skipped_over_budget"]
+    assert all(r["score"] == 0.0 and r["passed"] is False for r in skipped)
+
+
+def test_document_rule_budget_disabled_when_non_positive(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BENCH_DOC_RULE_BUDGET_SECONDS", "0")
+    result = RuleBasedMetric().compute(expected=_present_rules(3), actual="word0 word1 word2")
+    assert result.value == 1.0
+    assert result.metadata["skipped_over_budget"] == 0
+
+
+def test_normalize_timeout_skips_whole_document(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom(_: str) -> str:
+        raise _RuleTimeoutError()
+
+    monkeypatch.setattr(rule_based_metric, "normalize_text", _boom)
+    result = RuleBasedMetric().compute(expected=_present_rules(2), actual="word0 word1")
+    assert result.value == 0.0
+    meta = result.metadata
+    assert meta["total"] == 2
+    assert meta["skipped_over_budget"] == 2
+    assert "normalization exceeded" in meta["note"]
+    assert len(meta["rule_results"]) == 2
+    assert all(r["score"] == 0.0 for r in meta["rule_results"])
+
+
+def test_trailing_dot_leader_strip_is_linear() -> None:
+    page = "Item " + "." * 130_000
+    start = time.monotonic()
+    assert strip_dot_leaders(page).rstrip(". ") == "Item"
+    normalize_cell_text(page)
+    assert time.monotonic() - start < 2.0

--- a/tests/parse_bench/evaluation/metrics/parse/test_table_caption_title_band.py
+++ b/tests/parse_bench/evaluation/metrics/parse/test_table_caption_title_band.py
@@ -1,0 +1,89 @@
+"""Tests for ``<caption>`` / title-band equivalence in GriTS.
+
+``<caption>`` is the element HTML provides for a table's title, and a
+prediction that uses it is doing the right thing. Ground truth spells the same
+title three other ways: as a full-width header band (a single ``colspan`` cell
+across row 0), as body text above the table, or not at all.
+
+Only the header band cost anything. The caption is not a ``<td>``/``<th>``, so
+it never enters either grid; against GT body text or no title at all the two
+grids already matched. Against a GT band, the band was an unmatched extra GT
+row and GriTS charged the prediction for it.
+
+The band is now dropped when the other side's caption says the same thing,
+checked in both directions and gated on text equality under the ordinary cell
+normalization. A band that says something the caption does not is left alone
+and still scores, so this cannot silently forgive a lost title row.
+"""
+
+from __future__ import annotations
+
+from parse_bench.evaluation.metrics.parse.grits_metric import GriTSMetric
+from parse_bench.evaluation.metrics.parse.table_extraction import extract_table_pairs
+
+_BODY = "<tbody><tr><td>Cash</td><td>10</td></tr><tr><td>Debt</td><td>5</td></tr></tbody>"
+_HEADER = "<tr><th>Item</th><th>2025</th></tr>"
+
+GT_BAND = f'<table><thead><tr><th colspan="2">Balance Sheet</th></tr>{_HEADER}</thead>{_BODY}</table>'
+GT_BODY_TEXT = f"Balance Sheet\n\n<table><thead>{_HEADER}</thead>{_BODY}</table>"
+GT_NO_TITLE = f"<table><thead>{_HEADER}</thead>{_BODY}</table>"
+PRED_CAPTION = f"<table><caption>Balance Sheet</caption><thead>{_HEADER}</thead>{_BODY}</table>"
+
+
+def _grits(expected: str, actual: str) -> float:
+    exp, act, _ = extract_table_pairs(expected, actual)
+    values = GriTSMetric().compute(exp, act)
+    return float(next(v.value for v in values if v.metric_name == "grits_con"))
+
+
+class TestCaptionIsNotPenalized:
+    def test_against_a_ground_truth_header_band(self) -> None:
+        assert _grits(GT_BAND, PRED_CAPTION) == 1.0
+
+    def test_against_ground_truth_body_text(self) -> None:
+        assert _grits(GT_BODY_TEXT, PRED_CAPTION) == 1.0
+
+    def test_against_a_ground_truth_with_no_title(self) -> None:
+        assert _grits(GT_NO_TITLE, PRED_CAPTION) == 1.0
+
+    def test_symmetric_when_the_ground_truth_carries_the_caption(self) -> None:
+        assert _grits(PRED_CAPTION, GT_BAND) == 1.0
+
+
+class TestUnchangedCases:
+    def test_identical_banded_tables(self) -> None:
+        assert _grits(GT_BAND, GT_BAND) == 1.0
+
+    def test_identical_captioned_tables(self) -> None:
+        assert _grits(PRED_CAPTION, PRED_CAPTION) == 1.0
+
+    def test_a_prediction_that_simply_loses_the_band_still_pays(self) -> None:
+        # No caption anywhere: the missing band is a real content loss.
+        assert _grits(GT_BAND, GT_NO_TITLE) < 1.0
+
+
+class TestTheGuardHolds:
+    def test_a_different_caption_does_not_erase_the_band(self) -> None:
+        # The caption names another table; the GT band is real content the
+        # prediction did not reproduce, and must still be charged.
+        pred = PRED_CAPTION.replace("<caption>Balance Sheet</caption>", "<caption>Income Statement</caption>")
+        assert _grits(GT_BAND, pred) < 1.0
+
+    def test_cell_errors_are_still_scored_under_the_equivalence(self) -> None:
+        pred = PRED_CAPTION.replace("<td>10</td>", "<td>99</td>")
+        assert _grits(GT_BAND, pred) < 1.0
+
+    def test_a_non_uniform_first_row_is_not_a_band(self) -> None:
+        # Row 0 is a genuine two-cell header row, not a colspan title, so the
+        # caption must not delete it even though its first cell matches.
+        gt = f"<table><thead><tr><th>Balance Sheet</th><th>2025</th></tr>{_HEADER}</thead>{_BODY}</table>"
+        assert _grits(gt, PRED_CAPTION) < 1.0
+
+
+def test_caption_survives_the_title_stripping_stage() -> None:
+    """The equivalence needs the caption to reach the metric."""
+    from parse_bench.evaluation.metrics.parse.table_title_stripping import strip_title_rows
+
+    _exp, act, _counts = extract_table_pairs(GT_BAND, PRED_CAPTION)
+    stripped = strip_title_rows(act[0])
+    assert stripped.table_data.caption == "Balance Sheet"

--- a/tests/parse_bench/evaluation/metrics/parse/test_table_cell_inline_marker_separator.py
+++ b/tests/parse_bench/evaluation/metrics/parse/test_table_cell_inline_marker_separator.py
@@ -1,0 +1,81 @@
+"""A run of abutting inline markers inside a table CELL separates; a lone one joins.
+
+This is the cell-text counterpart of ``test_normalize_text_inline_tag_separator``.
+Once ``_augment_with_table_cell_text`` REPLACES a table with its cell text, that
+text no longer carries its markup into ``normalize_text``, so the marker-run rule
+there cannot reach it.  ``BeautifulSoup.get_text()`` concatenates text nodes with
+no separator, so a byte-faithful ``<u>105</u><s>103</s>`` extracted as the welded
+``105103`` and every word/sentence rule reported both page numbers as missing.
+
+The asymmetry must match ``normalize_text`` exactly: two abutting markers are the
+boundary between two separately-styled tokens and separate; ONE marker between two
+content characters is an intra-token style change and must still join.
+"""
+
+import pytest
+
+from parse_bench.evaluation.metrics.parse.rules_base import (
+    _augment_with_table_cell_text,
+    _extract_table_cell_texts,
+)
+from parse_bench.evaluation.metrics.parse.table_parsing import parse_html_tables
+from parse_bench.evaluation.metrics.parse.utils import normalize_text
+
+
+def _cells(html: str) -> list[list[str]]:
+    return [list(row) for table in parse_html_tables(html) for row in table.data]
+
+
+def test_two_abutting_markers_in_a_cell_separate():
+    """The witness weld: `<u>105</u><s>103</s>` is two page numbers, not one."""
+    html = "<table><tr><td>Appeals</td><td><u>105</u><s>103</s></td></tr></table>"
+    assert _cells(html) == [["Appeals", "105 103"]]
+
+
+def test_a_lone_marker_in_a_cell_still_joins():
+    """One marker inside a token is a style change, not a boundary."""
+    html = "<table><tr><td>Shizuok<mark>a</mark> University</td></tr></table>"
+    assert _cells(html) == [["Shizuoka University"]]
+
+
+@pytest.mark.parametrize(
+    ("cell_html", "expected"),
+    [
+        ("<b><u>103</u><s>101</s></b>", "103 101"),
+        ("<u>103</u><s>101</s><i>99</i>", "103 101 99"),
+        ("<u>103</u> <s>101</s>", "103 101"),
+        ("<del>old</del><ins>new</ins>", "old new"),
+        ("<span>a</span><span>b</span>", "a b"),
+        ("plain text", "plain text"),
+        ("<u>whole cell</u>", "whole cell"),
+    ],
+)
+def test_marker_shapes_in_cells(cell_html: str, expected: str):
+    assert _cells(f"<table><tr><td>{cell_html}</td></tr></table>") == [[expected]]
+
+
+def test_intra_word_marker_run_is_the_documented_edge():
+    """A run WITHIN a word still separates - same as normalize_text does."""
+    html = "<table><tr><td>ab<u>c</u><s>d</s>ef</td></tr></table>"
+    assert _cells(html) == [["abc def"]]
+
+
+def test_augmented_text_carries_the_separated_cell():
+    """End to end: the weld does not survive into the augmented document text."""
+    md = "<table><tr><td>Appeals</td><td><u>105</u><s>103</s></td></tr></table>"
+    augmented = _augment_with_table_cell_text(md)
+    assert "105 103" in augmented
+    assert "105103" not in augmented
+
+
+def test_normalized_augmented_text_matches_the_ground_truth_spelling():
+    """The GT annotates this page as `~~105~~ 103`; both sides must agree."""
+    md = "<table><tr><td><u>105</u><s>103</s></td></tr></table>"
+    assert normalize_text(_augment_with_table_cell_text(md)).endswith("105 103")
+    assert normalize_text("~~105~~ 103") == "105 103"
+
+
+def test_a_table_without_markers_is_untouched():
+    """Guard: cells with no inline markers extract exactly as before."""
+    md = "<table><tr><td>Definitions</td><td>103</td></tr></table>"
+    assert _extract_table_cell_texts(md) == ["Definitions", "103"]

--- a/tests/parse_bench/evaluation/metrics/parse/test_table_dot_leaders.py
+++ b/tests/parse_bench/evaluation/metrics/parse/test_table_dot_leaders.py
@@ -1,0 +1,1119 @@
+"""Tests for dot-leader stripping in the two table-cell normalizers.
+
+A dot leader is the row of periods a typesetter runs between a label and its
+value so the eye can track across the column::
+
+    1995 . . . . . . . . . . . . . . . . . . .    57.4%    37.6%
+
+The dot count is a function of column width, not of content — the same label
+reaches the evaluator as ``Total assets`` from one document and
+``Total assets . . . . . . .`` from another, and neither spelling is more
+correct than the other.
+
+``_normalize_trm_cell_text`` already stripped both the contiguous
+(``.....``) and the spaced (``. . . . .``) form, but ``normalize_cell_text``
+— the normalizer GriTS, TEDS and header accuracy use — stripped only a
+*trailing contiguous* run. A prediction that reproduces a spaced leader
+faithfully therefore scored a full cell miss under GriTS while scoring a
+clean match under TRM. Both now call the same ``strip_dot_leaders`` helper,
+so the two metrics cannot drift apart on the question again.
+
+The run definition requires a *second* period reachable across blanks alone.
+That is what keeps real content intact: in a decimal (``1.5``), a dotted
+abbreviation (``U.S.``), a European thousands separator (``1.234.567``) and a
+version string (``3.14.1``) the periods are separated by non-blank characters,
+so none of them is a leader.
+
+
+The acceptance property: indifference to leader decoration
+==========================================================
+
+The grader must not be able to tell whether a leader was drawn, or how its
+dots were spaced. Formally, for a label ``L`` and any leader decoration ``d``::
+
+    normalize(L + d) == normalize(L)
+
+This has to hold with the decoration on *either* side, because which side
+carries it is not fixed: human-annotated ground truth usually omits leaders
+while a faithful prediction reproduces them, but ground-truth corpora
+transcribed from the page carry them too.
+
+How much a residual difference costs depends on the metric, and the two
+families differ sharply:
+
+* **Fuzzy** — GriTS-Con scores cells with ``_lcs_similarity``
+  (``2·|LCS| / (|s1| + |s2|)``, ``grits_metric.py:102``) and TEDS with a
+  normalized Levenshtein distance (``teds_metric.py:120``). A one-character
+  residual costs a fraction of one cell, and that fraction grows as the cell
+  gets shorter — 0.06 on ``"Acme Inc."`` but 0.33 on ``"3."``.
+* **Exact** — table record match compares cells with ``cell_score``
+  (``table_record_match_metric.py``) and header accuracy's
+  ``header_content_bag`` / ``header_data_alignment`` / ``header_perfect``
+  submetrics (``header_accuracy_metric.py``). There a one-character residual
+  would cost the **entire cell**.
+
+Because the exact-match family exists, "the residual is small" is not an
+available defence, and these tests assert the property rather than a
+similarity floor.
+
+
+Two layers: normalization, then leader-insensitive comparison
+=============================================================
+
+One family of cells cannot satisfy the property by normalization alone: a
+label whose own last character is a period, so that a single period sits
+between the label and the run and belongs, by shape alone, to either.
+``"Acme Inc. ...."`` normalizes to ``"Acme Inc"`` while an undecorated
+``"Acme Inc."`` keeps its period.
+
+Three candidate resolutions were weighed:
+
+1. **Keep the label's period during normalization.** Rejected.
+   ``"Acme Inc....."`` is one undifferentiated glyph run and nothing marks how
+   many dots belonged to ``Inc.``; ``"Employed. . . ."`` has precisely the
+   same shape. Keeping the period therefore forces the *spaced* and
+   *contiguous* spellings of one leader to normalize differently, which is the
+   exact artefact this module exists to remove and which was measured at 0.046
+   grits_trm_composite of false regression on a single page.
+
+2. **Drop every cell-final period on both sides during normalization.** This
+   is an exact closure, and it was prototyped. Rejected anyway, because
+   ``normalize_cell_text`` is shared, and
+   ``table_normalization_relaxed._EMPTY_TEMPLATES`` documents a deliberate
+   dependency on the opposite convention — ``"ft."`` / ``"in."`` are unit
+   residue precisely *because* of the period, and its comment states that the
+   trailing-period strip "is intentionally NOT applied" since bare ``"ft"`` /
+   ``"in"`` would sweep up legitimate English columns. Mutating every
+   period-terminated table cell also reaches far past "repeated dots", the
+   property actually under repair, and feeds the mutated text downstream.
+
+3. **Decide it at comparison time.** Adopted. ``cells_match_leader_insensitive``
+   (``utils.py``) asks of a *pair* whether their difference is confined to a
+   trailing dot/period tail — each side gives up its own tail, so the period's
+   owner never has to be decided. It rewrites no cell and feeds nothing
+   downstream, so the "intentionally NOT applied" comment in the relaxed
+   normalizer still governs the mutation pipeline unchanged; this layer sits
+   beside it, not against it. Only the tail is discounted, which is what keeps
+   ``"3.1.4"`` off ``"3.14"`` and ``"192.168.1.1"`` off ``"192.168.1"``.
+
+So a *normalization* boundary remains — ``strip_dot_leaders("Acme Inc. ....")``
+is still ``"Acme Inc"`` while ``"Acme Inc."`` keeps its period — but it costs
+nothing on the exact-match metrics. ``TestTheNormalizationBoundary`` pins the
+text, and ``TestComparisonLevelLeaderIndifference`` pins that the metrics no
+longer see it. The boundary's two shapes:
+
+* a final token that ends in a period and contains no other one (``"Inc."``,
+  ``"Jr."``, ``"No."``, ``"ft."``) — absorbed under every leader spelling;
+* a *multi-period* abbreviation with the leader written contiguously
+  (``"U.S....."`` -> ``"U.S"``). A blank between them is evidence that the
+  period is the label's, and where that evidence exists it is used:
+  ``"U.S. ....."`` and ``"E.O. ....."`` keep their period.
+
+The GriTS / TEDS residual is unchanged and still real
+=====================================================
+
+Those metrics score cells with a similarity function, not equality, and are
+deliberately *not* routed through the comparison layer: a fuzzy score is
+already tolerant of a one-character tail, and blending an equality override
+into it would make its numbers non-comparable with published GriTS. The
+measured residual is pinned below at ~0.06 (``"Acme Inc."``) to ~0.33
+(``"3."``) of one cell.
+
+Numeric labels are exempt, and that is a fix in this change
+==========================================================
+
+A number has the same *shape* as an abbreviation — ``"3.14."`` and ``"E.O."``
+are both a period-containing token ending in a period — but not the same
+ambiguity, because a number never legitimately ends in a period. Before this
+change the shape rule was applied to both, so ``"3.14. . . ."`` normalized to
+``"3.14."``: a period present in neither the content nor the leader, and one
+that the merely spaced spelling ``"3.14 . . . ."`` did not produce. Numeric
+labels now resolve the adjacent period to the leader
+(``_ATTACHED_NUMERIC_DOT_LEADER_RE``), which restores full indifference for
+every numeric cell — see ``TestNumericCells``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from parse_bench.evaluation.metrics.parse.grits_metric import _lcs_similarity
+from parse_bench.evaluation.metrics.parse.header_accuracy_metric import (
+    HeaderCell,
+    _header_content_bag_score,
+    _header_data_alignment_score,
+    _header_perfect_score,
+    _normalize_header_text,
+)
+from parse_bench.evaluation.metrics.parse.table_record_match_metric import (
+    _normalize_trm_cell_text,
+    align_columns,
+    cell_score,
+)
+from parse_bench.evaluation.metrics.parse.utils import (
+    cells_match_leader_insensitive,
+    leader_insensitive_core,
+    normalize_cell_text,
+    strip_dot_leaders,
+)
+
+#: Every way one leader run has been observed spelled. Reused by the
+#: indifference sweeps below, with the decoration appended to a label.
+DECORATIONS = [
+    "",  # undecorated — the usual ground-truth spelling
+    "..",
+    "....",
+    "...........",
+    " ..",
+    " ....",
+    ". . . .",
+    " . . . .",
+    ".  .  .",
+    ".. ..",
+    "…",
+    " …",
+]
+
+
+def trm_cell_match(gt: str, pred: str) -> float:
+    """Score one cell pair the way table record match does.
+
+    TRM normalizes with ``normalize_text`` + ``_normalize_trm_cell_text`` and
+    then compares for **equality**, so this returns 1.0 or 0.0 and nothing in
+    between. It is the strictest consumer of ``strip_dot_leaders`` and the
+    reason the tests below assert equality rather than a similarity floor.
+    """
+    return cell_score(
+        _normalize_trm_cell_text(normalize_cell_text(gt)),
+        _normalize_trm_cell_text(normalize_cell_text(pred)),
+    )
+
+
+def _header_cells(texts: list[str]) -> list[HeaderCell]:
+    """One row of header cells, normalized the way the metric normalizes them."""
+    return [HeaderCell(_normalize_header_text(t), 0, i, 1, 1) for i, t in enumerate(texts)]
+
+
+def header_content_bag(gt_texts: list[str], pred_texts: list[str]) -> float:
+    """Score one header row pair the way ``header_content_bag`` does."""
+    return _header_content_bag_score(_header_cells(gt_texts), _header_cells(pred_texts))
+
+
+def header_data_alignment(gt_texts: list[str], pred_texts: list[str]) -> float:
+    """Score one header row pair the way ``header_data_alignment`` does.
+
+    The grid mapping is the identity here — the point under test is the text
+    comparison at the mapped position, not the alignment search.
+    """
+    lookup = {(0, i): _normalize_header_text(t) for i, t in enumerate(pred_texts)}
+    return _header_data_alignment_score(
+        _header_cells(gt_texts),
+        lookup,
+        {0: 0},
+        {i: i for i in range(len(pred_texts))},
+    )
+
+
+def header_perfect(gt_texts: list[str], pred_texts: list[str]) -> float:
+    """Score one header row pair the way ``header_perfect`` does."""
+    return _header_perfect_score(_header_cells(gt_texts), _header_cells(pred_texts))
+
+
+class TestSpacedLeadersAreStripped:
+    """The form that only TRM used to handle."""
+
+    @pytest.mark.parametrize(
+        "cell",
+        [
+            "Total assets . . . . . . .",
+            "Total assets .  .  .  .",
+            "Total assets ..",
+            "Total assets.......",
+        ],
+    )
+    def test_grits_normalizer_matches_the_bare_label(self, cell: str) -> None:
+        assert normalize_cell_text(cell) == normalize_cell_text("Total assets")
+
+    @pytest.mark.parametrize(
+        "cell",
+        [
+            "Total assets . . . . . . .",
+            "Total assets.......",
+        ],
+    )
+    def test_trm_normalizer_matches_the_bare_label(self, cell: str) -> None:
+        assert _normalize_trm_cell_text(cell) == _normalize_trm_cell_text("Total assets")
+
+    def test_the_motivating_cell(self) -> None:
+        # Verbatim from the prediction for a market-performance table: the
+        # year label carries the leader that the page prints.
+        cell = "1995 . . . . . . . . . . . . . . . . . . . . . . . . . . . . . ."
+        assert normalize_cell_text(cell) == "1995"
+
+    def test_the_two_normalizers_agree(self) -> None:
+        # The bug was a disagreement, not a missing feature. Pin the agreement.
+        cell = "Total assets . . . . . . ."
+        assert strip_dot_leaders(cell).strip() == "Total assets"
+        assert normalize_cell_text(cell).lower() == _normalize_trm_cell_text(normalize_cell_text(cell)).lower()
+
+
+class TestIndifferenceToLeaderDecoration:
+    """The acceptance property, swept over every spelling and both sides.
+
+    A label whose last character is a period is excluded here and handled by
+    ``TestTheKnownBoundary`` instead — see the module docstring.
+    """
+
+    LABELS = [
+        "Total assets",
+        "Employed",
+        "1995",
+        "Cash and equivalents",
+        "PHS Act",
+        "FD&C Act",
+        "Net income (loss)",
+        # Numeric cells hold across every spelling as of this change.
+        "3.14",
+        "1,234.56",
+        "$1,234.56",
+        "192.168.1.1",
+    ]
+
+    @pytest.mark.parametrize("label", LABELS)
+    def test_every_decoration_reduces_to_one_text(self, label: str) -> None:
+        """normalize(label + d) is the same text for every decoration d."""
+        results = {normalize_cell_text(label + d) for d in DECORATIONS}
+        assert len(results) == 1, f"{label!r} normalized {len(results)} ways: {sorted(results)}"
+
+    @pytest.mark.parametrize("label", LABELS)
+    @pytest.mark.parametrize("decoration", DECORATIONS)
+    def test_decoration_on_the_prediction_side(self, label: str, decoration: str) -> None:
+        """GT plain, prediction decorated — the usual human-annotation case."""
+        assert trm_cell_match(label, label + decoration) == 1.0
+
+    @pytest.mark.parametrize("label", LABELS)
+    @pytest.mark.parametrize("decoration", DECORATIONS)
+    def test_decoration_on_the_ground_truth_side(self, label: str, decoration: str) -> None:
+        """GT decorated, prediction plain — GT corpora carry leaders too."""
+        assert trm_cell_match(label + decoration, label) == 1.0
+
+    @pytest.mark.parametrize("label", LABELS)
+    def test_two_different_decorations_agree(self, label: str) -> None:
+        """Both sides decorated, differently — the paired-replay case."""
+        assert trm_cell_match(label + " ....", label + ". . . .") == 1.0
+
+
+class TestTheNormalizationBoundary:
+    """A label ending in a period does not normalize to the same *text* as its
+    decorated form — but the exact-match metrics no longer see the difference.
+
+    Pinned deliberately, so the trade-off recorded in the module docstring is
+    visible in the suite rather than folklore. What the metrics score is
+    pinned in ``TestComparisonLevelLeaderIndifference``.
+    """
+
+    #: (label whose final token is period-free but ends in a period, decorated form)
+    BOUNDARY_PAIRS = [
+        ("Acme Inc.", "Acme Inc. ...."),
+        ("Acme Inc.", "Acme Inc....."),
+        ("Jr.", "Jr. .."),
+        ("No.", "No. ..."),
+        ("3.", "3. ...."),
+        ("ft.", "ft. ...."),
+    ]
+
+    @pytest.mark.parametrize(("plain", "decorated"), BOUNDARY_PAIRS)
+    def test_the_decorated_form_loses_the_label_period(self, plain: str, decorated: str) -> None:
+        assert normalize_cell_text(plain) == plain
+        assert normalize_cell_text(decorated) == plain.rstrip(".")
+
+    @pytest.mark.parametrize(("plain", "decorated"), BOUNDARY_PAIRS)
+    def test_the_exact_match_metrics_no_longer_pay_for_it(self, plain: str, decorated: str) -> None:
+        """The two texts differ, yet TRM scores them a full match.
+
+        This is the whole point of the comparison layer: the residual is
+        confined to a trailing period, which ``cells_match_leader_insensitive``
+        discounts on both sides at once.
+        """
+        assert normalize_cell_text(plain) != normalize_cell_text(decorated)
+        assert trm_cell_match(plain, decorated) == 1.0
+        assert trm_cell_match(decorated, plain) == 1.0
+
+    @pytest.mark.parametrize(
+        ("plain", "decorated", "expected_similarity"),
+        [
+            # The fuzzy metrics pay only the missing character, and the shorter
+            # the cell the larger that fraction is.
+            ("Acme Inc.", "Acme Inc. ....", 2 * 8 / (9 + 8)),  # ~0.941
+            ("Jr.", "Jr. ..", 2 * 2 / (3 + 2)),  # 0.800
+            ("3.", "3. ....", 2 * 1 / (2 + 1)),  # ~0.667
+        ],
+    )
+    def test_the_fuzzy_metrics_pay_only_the_character(
+        self, plain: str, decorated: str, expected_similarity: float
+    ) -> None:
+        """GriTS-Con cost, quantified — it scales inversely with cell length.
+
+        Unchanged by the comparison layer, which the fuzzy metrics do not use.
+        """
+        similarity = _lcs_similarity(normalize_cell_text(plain), normalize_cell_text(decorated))
+        assert similarity == pytest.approx(expected_similarity)
+        assert similarity < 1.0
+
+    @pytest.mark.parametrize(
+        ("plain", "decorated"),
+        [
+            # A blank between the abbreviation and the run is evidence that the
+            # period is the label's, and the rules use it: the attached rule's
+            # label token is ``[^\s.…]+`` and cannot span the abbreviation's own
+            # periods, so only the blank-introduced run is stripped.
+            ("E.O.", "E.O. ....."),
+            ("U.S.A.", "U.S.A. ..."),
+            ("Ph.D.", "Ph.D. ...."),
+            ("U.S.", "U.S. . . . ."),
+        ],
+    )
+    def test_a_spaced_leader_leaves_a_multi_period_abbreviation_intact(self, plain: str, decorated: str) -> None:
+        assert normalize_cell_text(decorated) == plain
+        assert trm_cell_match(plain, decorated) == 1.0
+
+    @pytest.mark.parametrize(
+        ("plain", "decorated"),
+        [
+            # Written contiguously there is no such evidence — the run and the
+            # abbreviation's period are one glyph run — so the period goes.
+            ("E.O.", "E.O....."),
+            ("U.S.A.", "U.S.A...."),
+            ("U.S.", "U.S...."),
+            ("Ph.D.", "Ph.D.. . . ."),
+        ],
+    )
+    def test_a_contiguous_leader_absorbs_the_abbreviation_period(self, plain: str, decorated: str) -> None:
+        # The normalized *text* loses the period ...
+        assert normalize_cell_text(decorated) == plain.rstrip(".")
+        # ... and the comparison layer makes that free on the exact metrics.
+        assert trm_cell_match(plain, decorated) == 1.0
+        assert trm_cell_match(decorated, plain) == 1.0
+
+
+class TestComparisonLevelLeaderIndifference:
+    """The exact-match metrics ignore a trailing dot/period tail.
+
+    ``cells_match_leader_insensitive`` is asked of a *pair*, so both sides give
+    up their own tail and nobody has to decide whether a period closed an
+    abbreviation or opened a leader. It rewrites no cell — every normalizer in
+    this file still produces exactly the text pinned elsewhere in the module.
+    """
+
+    #: The shapes the normalizer cannot reconcile, which this layer must.
+    RESIDUAL_PAIRS = [
+        ("Acme Inc.", "Acme Inc. ...."),
+        ("Acme Inc.", "Acme Inc....."),
+        ("Jr.", "Jr. .."),
+        ("No.", "No. ..."),
+        ("ft.", "ft. ...."),
+        ("3.", "3. ...."),
+        ("E.O.", "E.O....."),
+        ("U.S.", "U.S...."),
+        ("U.S.A.", "U.S.A...."),
+        ("Ph.D.", "Ph.D.. . . ."),
+    ]
+
+    @pytest.mark.parametrize(("plain", "decorated"), RESIDUAL_PAIRS)
+    def test_trm_scores_a_full_match(self, plain: str, decorated: str) -> None:
+        assert trm_cell_match(plain, decorated) == 1.0
+        assert trm_cell_match(decorated, plain) == 1.0
+
+    @pytest.mark.parametrize(("plain", "decorated"), RESIDUAL_PAIRS)
+    def test_header_content_bag_scores_a_full_match(self, plain: str, decorated: str) -> None:
+        assert header_content_bag([plain], [decorated]) == 1.0
+        assert header_content_bag([decorated], [plain]) == 1.0
+
+    @pytest.mark.parametrize(("plain", "decorated"), RESIDUAL_PAIRS)
+    def test_header_data_alignment_scores_a_full_match(self, plain: str, decorated: str) -> None:
+        assert header_data_alignment([plain], [decorated]) == 1.0
+        assert header_data_alignment([decorated], [plain]) == 1.0
+
+    @pytest.mark.parametrize(("plain", "decorated"), RESIDUAL_PAIRS)
+    def test_header_perfect_scores_a_full_match(self, plain: str, decorated: str) -> None:
+        # The fourth exact-match submetric. Held to the same rule so the
+        # header family cannot disagree with itself about one cell.
+        assert header_perfect([plain], [decorated]) == 1.0
+        assert header_perfect([decorated], [plain]) == 1.0
+
+    @pytest.mark.parametrize(("plain", "decorated"), RESIDUAL_PAIRS)
+    def test_the_normalized_texts_really_do_still_differ(self, plain: str, decorated: str) -> None:
+        """Guards against the layer being tested against a no-op.
+
+        If a later change closed the gap in the normalizer instead, these
+        assertions fail and the tests above stop proving anything.
+        """
+        assert normalize_cell_text(plain) != normalize_cell_text(decorated)
+
+    def test_it_is_a_comparison_and_not_a_mutation(self) -> None:
+        # No normalizer output moved. The relaxed metric's dependency on a
+        # cell-final period ("ft." / "in." as unit residue) is untouched.
+        assert normalize_cell_text("ft.") == "ft."
+        assert _normalize_trm_cell_text("ft.") == "ft."
+        assert strip_dot_leaders("Acme Inc. ....").strip() == "Acme Inc"
+
+
+class TestTheCoreOnlyReachesTheTail:
+    """``leader_insensitive_core`` is a right-strip and nothing more."""
+
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
+            ("Acme Inc.", "Acme Inc"),
+            ("Acme Inc", "Acme Inc"),
+            ("3.", "3"),
+            ("3.14", "3.14"),
+            ("3.1.4", "3.1.4"),
+            ("192.168.1.1", "192.168.1.1"),
+            ("192.168.1", "192.168.1"),
+            ("$1,234.56.", "$1,234.56"),
+            ("$1,234.56", "$1,234.56"),
+            # Interior periods are never in reach — the pattern is anchored
+            # at the end of the string.
+            ("Note 4. Income taxes", "Note 4. Income taxes"),
+            ("e.g. deferred taxes", "e.g. deferred taxes"),
+            ("A..B", "A..B"),
+            # A run with digits after it is content, not a tail.
+            ("...5", "...5"),
+            ("Introduction ..... 3", "Introduction ..... 3"),
+            # Whole-cell dots have no core at all.
+            (".", ""),
+            ("...", ""),
+            ("…", ""),
+            ("", ""),
+        ],
+    )
+    def test_core(self, text: str, expected: str) -> None:
+        assert leader_insensitive_core(text) == expected
+
+
+class TestNumericEdgeCasesUnderComparison:
+    """The cases that make "just drop the dots" wrong.
+
+    Discounting the *tail* is safe; discounting dots anywhere is not. These
+    pin the difference.
+    """
+
+    @pytest.mark.parametrize(
+        ("gt", "pred"),
+        [
+            ("3.14", "3.14..."),
+            ("3.14", "3.14."),
+            ("3.1.4", "3.1.4......"),
+            ("3.", "3"),
+            ("$1,234.56", "$1,234.56."),
+            ("1.5", "1.5."),
+            ("2.0.1", "2.0.1…"),
+        ],
+    )
+    def test_a_trailing_tail_is_free(self, gt: str, pred: str) -> None:
+        assert trm_cell_match(gt, pred) == 1.0
+        assert trm_cell_match(pred, gt) == 1.0
+        assert header_content_bag([gt], [pred]) == 1.0
+        assert header_content_bag([pred], [gt]) == 1.0
+
+    @pytest.mark.parametrize(
+        ("left", "right"),
+        [
+            # The user-named trap: a version string must never collapse onto
+            # the decimal that shares its digits.
+            ("3.1.4......", "3.14"),
+            ("3.1.4", "3.14"),
+            ("3.1.4.", "3.14."),
+            # An interior period is content on both sides.
+            ("192.168.1.1", "192.168.1"),
+            ("192.168.1.1.", "192.168.1."),
+            ("1.234.567", "1.234.56"),
+            # Different values behind identical decoration.
+            ("3.14 ...", "3.15 ..."),
+            ("1,234.56 ..", "1,234.57 .."),
+            ("Introduction ..... 3", "Introduction ..... 4"),
+        ],
+    )
+    def test_distinct_numbers_stay_distinct(self, left: str, right: str) -> None:
+        assert trm_cell_match(left, right) == 0.0
+        assert trm_cell_match(right, left) == 0.0
+        assert header_content_bag([left], [right]) == 0.0
+
+
+class TestDotsOnlyCellsUnderComparison:
+    """A cell with no core cannot borrow one from the other side.
+
+    The pinned normalization decision is that a dots-only cell (``"..."``,
+    ``"…"``) becomes the empty string, and that a lone ``"."`` is not a run and
+    survives. The comparison layer keeps faith with both: two dots-only cells
+    still compare equal *because they are both empty*, and a cell whose core is
+    empty is never matched against a label through the fallback.
+    """
+
+    @pytest.mark.parametrize("cell", ["...", "…", "..", "  ..  "])
+    def test_two_dots_only_cells_still_match(self, cell: str) -> None:
+        assert normalize_cell_text(cell) == ""
+        assert trm_cell_match(cell, "...") == 1.0
+
+    @pytest.mark.parametrize("other", ["Total assets", "3", "Acme Inc.", "Jr.", "."])
+    def test_a_dots_only_cell_matches_nothing_with_content(self, other: str) -> None:
+        assert trm_cell_match("...", other) == 0.0
+        assert trm_cell_match(other, "...") == 0.0
+
+    @pytest.mark.parametrize("sentinel", ["-", "", "n/a", "nan"])
+    def test_a_dots_only_cell_does_match_a_missing_value_marker(self, sentinel: str) -> None:
+        """Not this layer's doing, and pinned so it is not mistaken for it.
+
+        ``"..."`` normalizes to ``""``, and ``cell_score`` treats an empty cell
+        and a missing-value sentinel (``"-"``, ``"n/a"``, ...) as equal in its
+        own first branch, before any equality check. That predates the
+        comparison layer and is unchanged by it.
+        """
+        assert normalize_cell_text("...") == ""
+        assert trm_cell_match("...", sentinel) == 1.0
+
+    def test_a_lone_period_keeps_its_pinned_behavior(self) -> None:
+        # ``"."`` normalizes to ``"."`` (not a run) while ``"..."`` normalizes
+        # to ``""``. Both cores are empty, so the fallback declines and the
+        # two stay unequal — exactly as before this layer existed.
+        assert normalize_cell_text(".") == "."
+        assert trm_cell_match(".", "...") == 0.0
+        assert trm_cell_match(".", "") == 0.0
+        assert cells_match_leader_insensitive(".", "") is False
+        # Against itself it matches on plain equality, not on the fallback.
+        assert trm_cell_match(".", ".") == 1.0
+
+    def test_the_fallback_never_manufactures_a_match_from_nothing(self) -> None:
+        assert cells_match_leader_insensitive("...", "Total") is False
+        assert cells_match_leader_insensitive("", "Total") is False
+        assert cells_match_leader_insensitive(".", "Total") is False
+
+
+class TestColumnKeyingAgreesWithCellScoring:
+    """Row pairing and column keying use the same equivalence as ``cell_score``.
+
+    TRM has no separate record key: rows are paired by a Hungarian assignment
+    over ``_record_similarity``, which is a sum of ``cell_score`` — so fixing
+    ``cell_score`` fixes row pairing by construction, and there is nothing else
+    to extend there. Columns *are* keyed, by header text, but through a fuzzy
+    ratio rather than equality. That ratio is length-relative and a short key
+    pair such as ``"No."`` / ``"No"`` scores 0.80, below the 0.9 match
+    threshold, so without the same equivalence the column would go unmatched
+    and every cell under it would score 0 — the metric would pair a row on
+    cells it then refused to score. ``_align_columns_header_core`` therefore
+    consults ``cells_match_leader_insensitive`` too.
+    """
+
+    @pytest.mark.parametrize(
+        ("gt_key", "pred_key"),
+        [
+            ("No.", "No. ..."),
+            ("Jr.", "Jr. .."),
+            ("Item", "Item ...."),
+            ("Acme Inc.", "Acme Inc. ...."),
+            ("ft.", "ft. ...."),
+        ],
+    )
+    def test_a_decorated_key_still_matches_its_column(self, gt_key: str, pred_key: str) -> None:
+        gt_keys = [normalize_cell_text(gt_key), "Amount"]
+        pred_keys = [normalize_cell_text(pred_key), "Amount"]
+        mapping, _ = align_columns(gt_keys, pred_keys)
+        assert mapping.get(gt_keys[0]) == pred_keys[0]
+        # And with the decoration on the other side.
+        mapping_rev, _ = align_columns(pred_keys, gt_keys)
+        assert mapping_rev.get(pred_keys[0]) == gt_keys[0]
+
+    def test_distinct_keys_are_still_distinct(self) -> None:
+        mapping, _ = align_columns(["Employed", "Amount"], ["Unemployed", "Amount"])
+        assert "Employed" not in mapping
+
+    def test_an_empty_key_pair_is_left_to_the_fuzzy_path(self) -> None:
+        """The fallback is skipped when both keys are empty.
+
+        Two empty keys already pair on ``fuzz.ratio("", "") == 100``, so the
+        outcome below is the pre-existing one. The point of the ``not
+        gk_empty`` guard is that the fallback must not be what decides it —
+        ``cells_match_leader_insensitive("", "")`` is trivially true, and
+        routing empty keys through it would silently pin a perfect similarity
+        for a case the fuzzy path owns.
+        """
+        mapping, _ = align_columns(["", "Amount"], ["", "Amount"])
+        assert mapping == {"": "", "Amount": "Amount"}
+        # An empty key against a real one is still refused, as before.
+        mapping_mixed, _ = align_columns(["", "Amount"], ["Item", "Amount"])
+        assert "" not in mapping_mixed
+
+
+class TestLeadersInsideACell:
+    """A leader between a label and a value in one cell, not only at the end."""
+
+    def test_label_value_pair_in_one_cell(self) -> None:
+        assert normalize_cell_text("Total assets . . . . . 5,061") == "Total assets 5,061"
+
+    def test_a_run_wedged_between_word_characters_survives(self) -> None:
+        # No whitespace on either side, so this is punctuation rather than
+        # typography. Pinned by ``test_normalize_cell_text`` as ``A..B`` and
+        # kept here at cell scale.
+        assert normalize_cell_text("Total assets.....5,061") == "Total assets.....5,061"
+
+
+class TestTableOfContentsRows:
+    """Leader followed by trailing content — the TOC shape.
+
+    The run rules end at ``(?=\\s|$)``, so a leader that is followed by a
+    space and then a page number is stripped where it stands and the number
+    survives. A run with no blank on either side is punctuation and is left
+    alone, which is why ``"Introduction...3"`` is untouched.
+    """
+
+    @pytest.mark.parametrize(
+        ("cell", "expected"),
+        [
+            ("Introduction ..... 3", "Introduction 3"),
+            ("Employed. . . . 12", "Employed 12"),
+            ("Total assets . . . . . 5,061", "Total assets 5,061"),
+            ("Introduction ...3", "Introduction 3"),
+            ("Introduction... 3", "Introduction 3"),
+            # No blank on either side of the run — punctuation, not typography.
+            ("Introduction...3", "Introduction...3"),
+        ],
+    )
+    def test_toc_row_normalization(self, cell: str, expected: str) -> None:
+        assert normalize_cell_text(cell) == expected
+
+    @pytest.mark.parametrize(
+        ("gt", "pred"),
+        [
+            ("Introduction 3", "Introduction ..... 3"),
+            ("Employed 12", "Employed. . . . 12"),
+            ("Total assets 5,061", "Total assets . . . . . 5,061"),
+        ],
+    )
+    def test_a_toc_row_is_indifferent_on_both_sides(self, gt: str, pred: str) -> None:
+        assert trm_cell_match(gt, pred) == 1.0
+        assert trm_cell_match(pred, gt) == 1.0
+
+    def test_the_page_number_is_still_content(self) -> None:
+        # Stripping the leader must not make two different pages compare equal.
+        assert normalize_cell_text("Introduction ..... 3") != normalize_cell_text("Introduction ..... 4")
+
+
+class TestMultipleRunsAndPositions:
+    """More than one run per cell, and runs at the start of a cell."""
+
+    @pytest.mark.parametrize(
+        ("cell", "expected"),
+        [
+            ("A .. B .. C", "A B C"),
+            ("Chapter 1 ... 7 ... 8", "Chapter 1 7 8"),
+            ("a. . . b. . . c", "a b c"),
+        ],
+    )
+    def test_every_run_in_the_cell_is_stripped(self, cell: str, expected: str) -> None:
+        assert normalize_cell_text(cell) == expected
+
+    @pytest.mark.parametrize(
+        ("cell", "expected"),
+        [
+            (".... Total", "Total"),
+            ("... Total", "Total"),
+            ("…Total", "Total"),
+            (".. ..Total", "Total"),
+            # A single leading period is not a run, so it is left alone.
+            (".Total", ".Total"),
+        ],
+    )
+    def test_a_leading_leader_is_stripped(self, cell: str, expected: str) -> None:
+        assert normalize_cell_text(cell) == expected
+
+
+class TestWhitespaceInsideASpacedRun:
+    """The blanks separating a run's dots may be any non-newline whitespace.
+
+    The run pattern separates dots with ``[^\\S\\n]*``, so a transcriber that
+    emits NBSP, a tab, a thin space or a figure space between the dots — all
+    of which occur when a PDF's inter-glyph gaps are reconstructed — produces
+    the same normalized text as one that emits plain spaces.
+    """
+
+    SPELLINGS = [
+        "Employed. . . .",
+        "Employed.\xa0.\xa0.\xa0.",  # NBSP
+        "Employed.\t.\t.",  # tab
+        "Employed.  .  .",  # thin space
+        "Employed. . .",  # figure space
+        "Employed\xa0. . . .",  # NBSP before the run
+        "Employed.  .  .",  # doubled plain spaces
+    ]
+
+    @pytest.mark.parametrize("cell", SPELLINGS)
+    def test_every_blank_kind_reduces_to_the_bare_label(self, cell: str) -> None:
+        assert normalize_cell_text(cell) == "Employed"
+
+    @pytest.mark.parametrize("cell", SPELLINGS)
+    def test_indifferent_against_the_plain_label(self, cell: str) -> None:
+        assert trm_cell_match("Employed", cell) == 1.0
+        assert trm_cell_match(cell, "Employed") == 1.0
+
+    def test_a_newline_does_not_join_a_run(self) -> None:
+        # ``[^\S\n]`` excludes newlines deliberately: two dots on separate
+        # lines are two cells' worth of content, not one leader.
+        assert normalize_cell_text("foo ....\nbar ....") == "foo bar"
+
+
+class TestDotOnlyCells:
+    """A cell that is nothing but dots — ditto / missing-value marks.
+
+    A run needs two dots, so ``".."``, ``"..."`` and ``"…"`` are complete runs
+    and the cell empties; a lone ``"."`` is not a run and survives. Emptying is
+    safe for grading precisely because it happens on both sides: a ditto mark
+    in ground truth and the same mark in a prediction still compare equal. It
+    does mean a ditto cell and a genuinely blank cell become
+    indistinguishable, which is recorded here as a decision, not an accident.
+    """
+
+    @pytest.mark.parametrize("cell", ["..", "...", "....", "…", " ... ", "…...", "  ..  "])
+    def test_a_dot_only_cell_empties(self, cell: str) -> None:
+        assert normalize_cell_text(cell) == ""
+
+    def test_a_lone_period_is_not_a_run(self) -> None:
+        assert normalize_cell_text(".") == "."
+
+    @pytest.mark.parametrize("cell", ["...", "…", ".."])
+    def test_a_ditto_cell_matches_the_same_ditto_on_the_other_side(self, cell: str) -> None:
+        # Indifference still holds: both sides normalize identically.
+        assert trm_cell_match(cell, cell) == 1.0
+
+    def test_a_ditto_cell_becomes_indistinguishable_from_a_blank(self) -> None:
+        # The accepted cost of the rule above. Pinned so it stays a decision.
+        assert normalize_cell_text("...") == normalize_cell_text("")
+
+
+class TestRealContentSurvives:
+    """Periods that are content, not typography."""
+
+    @pytest.mark.parametrize(
+        "cell",
+        [
+            "1.5",
+            "1.234.567",
+            "3.14.1",
+            "U.S.",
+            "U.S. Treasury",
+            "Acme Inc.",
+            "e.g. deferred taxes",
+            "Note 4. Income taxes",
+        ],
+    )
+    def test_cell_is_unchanged(self, cell: str) -> None:
+        assert normalize_cell_text(cell) == cell
+
+    @pytest.mark.parametrize(
+        ("cell", "expected"),
+        [
+            # An abbreviation period that *introduces* a leader keeps its own
+            # period: a spaced run may not begin mid-token, so only the
+            # contiguous tail is a leader. Verbatim from an acronym glossary.
+            ("E.O. .....................", "E.O."),
+            ("PHS Act ..................", "PHS Act"),
+            ("FD&C Act .................", "FD&C Act"),
+        ],
+    )
+    def test_an_abbreviation_before_a_leader_keeps_its_period(self, cell: str, expected: str) -> None:
+        assert normalize_cell_text(cell) == expected
+
+    def test_a_sentence_ending_period_survives(self) -> None:
+        assert normalize_cell_text("Amounts are in millions.") == "Amounts are in millions."
+
+    def test_an_ellipsis_in_prose_is_treated_as_a_leader(self) -> None:
+        # Known and accepted: an ellipsis is indistinguishable from a short
+        # leader by shape alone, and this is already the shipped TRM behavior.
+        # Recorded here so the trade-off is a decision and not a surprise.
+        assert normalize_cell_text("continued ... see note 4") == "continued see note 4"
+
+
+class TestNumericCells:
+    """Numbers keep every period that carries value.
+
+    A leader needs a second dot reachable across blanks alone, so a decimal
+    point, a version separator and a European thousands separator are all
+    immune — their neighbours are digits, not blanks.
+    """
+
+    @pytest.mark.parametrize(
+        "cell",
+        [
+            "3.14",
+            "2.0.1",
+            "1.5",
+            "0.046",
+            "192.168.1.1",
+            "1,234.56",
+            "$1,234.56",
+            "1.234.567",
+            "(1,234.56)",
+            "-3.14",
+            "3.14%",
+        ],
+    )
+    def test_numeric_cell_is_unchanged(self, cell: str) -> None:
+        assert normalize_cell_text(cell) == cell
+
+    @pytest.mark.parametrize(
+        ("plain", "decorated"),
+        [
+            ("$1,234.56", "$1,234.56 ...."),
+            ("3.14", "3.14 ..."),
+            ("192.168.1.1", "192.168.1.1 .."),
+            ("2.0.1", "2.0.1…"),
+        ],
+    )
+    def test_a_decorated_number_matches_the_plain_number(self, plain: str, decorated: str) -> None:
+        assert normalize_cell_text(decorated) == plain
+        assert trm_cell_match(plain, decorated) == 1.0
+        assert trm_cell_match(decorated, plain) == 1.0
+
+    @pytest.mark.parametrize(
+        ("plain", "decorated"),
+        [
+            # The leader's first dot is glued to the number and the rest is
+            # spaced. The number already contains a period, so the period-free
+            # attached rule cannot fire and the glued dot used to survive as a
+            # spurious trailing period ("3.14." — in neither content nor
+            # leader). ``_ATTACHED_NUMERIC_DOT_LEADER_RE`` now resolves it to
+            # the leader, because a number never ends in a period.
+            ("3.14", "3.14. . . ."),
+            ("1,234.56", "1,234.56. . . ."),
+            ("$1,234.56", "$1,234.56. . . ."),
+            ("192.168.1.1", "192.168.1.1. . . ."),
+            ("2.0.1", "2.0.1. . . ."),
+            ("0.046", "0.046. . ."),
+            ("v1.2.3", "v1.2.3. . . ."),
+        ],
+    )
+    def test_a_glued_first_dot_does_not_leave_a_spurious_period(self, plain: str, decorated: str) -> None:
+        assert normalize_cell_text(decorated) == plain
+        assert trm_cell_match(plain, decorated) == 1.0
+        assert trm_cell_match(decorated, plain) == 1.0
+
+    def test_the_numeric_rule_does_not_reach_a_period_that_ends_a_clause(self) -> None:
+        # It only fires when actual dots follow, so a number that merely ends a
+        # sentence or introduces a caption keeps its period.
+        assert normalize_cell_text("Note 4. Income taxes") == "Note 4. Income taxes"
+        assert normalize_cell_text("Rev. 2.0") == "Rev. 2.0"
+        assert normalize_cell_text("3.") == "3."
+
+    def test_a_bare_ordinal_is_the_boundary_case(self) -> None:
+        # "3." is a label whose final token is period-free but ends in a
+        # period, so it sits inside the accepted boundary above, not here.
+        assert normalize_cell_text("3.") == "3."
+        assert normalize_cell_text("3. ....") == "3"
+
+    def test_stripping_never_merges_two_different_numbers(self) -> None:
+        assert normalize_cell_text("3.14 ...") != normalize_cell_text("3.15 ...")
+        assert normalize_cell_text("1,234.56 ..") != normalize_cell_text("1,234.57 ..")
+
+
+class TestSpacingStyleIsNotContent:
+    """The leader's *spacing* must not move a metric.
+
+    A dot leader is one glyph run on the page; whether a transcriber renders
+    it ``....``, ``. . . .``, ``.. ..`` or ``…`` is a decision about the
+    transcription, never about the document. Every spelling therefore has to
+    reduce to the same text.
+
+    This was a live source of false regression signal: on one benchmark page
+    two arms of a paired replay transcribed the same stub column as
+    ``Employed............`` and ``Employed. . . . . . . .``. The spaced
+    spelling kept a stray period (``Employed.``) because a spaced run was only
+    recognised when a blank introduced it, so an identical reading of an
+    identical glyph run cost 0.046 grits_trm_composite.
+    """
+
+    #: Every way the same leader run has been observed in the wild.
+    SPELLINGS = [
+        "Employed............",
+        "Employed. . . . . . . .",
+        "Employed . . . . . . . .",
+        "Employed ...........",
+        "Employed.. ..",
+        "Employed…",
+        "Employed …",
+    ]
+
+    @pytest.mark.parametrize("cell", SPELLINGS)
+    def test_every_spelling_reduces_to_the_bare_label(self, cell: str) -> None:
+        assert normalize_cell_text(cell) == "Employed"
+
+    @pytest.mark.parametrize("cell", SPELLINGS)
+    def test_the_two_normalizers_still_agree(self, cell: str) -> None:
+        # GriTS and TRM must not drift apart on any spelling.
+        assert _normalize_trm_cell_text(normalize_cell_text(cell)) == "Employed"
+
+    def test_the_motivating_pair_scores_identical(self) -> None:
+        # The exact two cells from the replay bench, which used to differ.
+        assert normalize_cell_text("Employed............") == normalize_cell_text("Employed. . . . . . . .")
+
+
+class TestEllipsisIsALeader:
+    """U+2026 is one glyph standing for three periods."""
+
+    def test_ellipsis_equals_three_dots(self) -> None:
+        assert normalize_cell_text("Total assets…") == normalize_cell_text("Total assets...")
+
+    def test_spaced_ellipsis_equals_three_dots(self) -> None:
+        assert normalize_cell_text("Total assets …") == normalize_cell_text("Total assets ...")
+
+    def test_ellipsis_between_word_characters_survives(self) -> None:
+        # Same rule as ``A..B``: no blank on either side makes it punctuation.
+        assert normalize_cell_text("1…5") == "1…5"
+
+    def test_a_mixed_ellipsis_and_period_run_is_one_leader(self) -> None:
+        assert normalize_cell_text("Total assets …...") == "Total assets"
+        assert normalize_cell_text("Total assets ...…") == "Total assets"
+
+
+class TestLeaderStrippingIsNotTextEquivalence:
+    """Stripping a leader must not make different labels compare equal."""
+
+    @pytest.mark.parametrize(
+        ("left", "right"),
+        [
+            ("Employed....", "Unemployed...."),
+            ("Employed....", "Employer...."),
+            ("Employed. . . .", "Employed elsewhere . . . ."),
+            ("Total assets . . . 5,061", "Total assets . . . 5,062"),
+        ],
+    )
+    def test_distinct_labels_stay_distinct(self, left: str, right: str) -> None:
+        assert normalize_cell_text(left) != normalize_cell_text(right)
+
+
+class TestVersionsAndDecimalsSurviveTheAttachedRule:
+    """The label-attached rule must not reach into dotted content."""
+
+    @pytest.mark.parametrize(
+        "cell",
+        [
+            "v1.2.3",
+            "1.2.3",
+            "Python 3.14.1",
+            "1.5",
+            "0.046",
+            "Rev. 2.0",
+            "192.168.1.1",
+        ],
+    )
+    def test_cell_is_unchanged(self, cell: str) -> None:
+        assert normalize_cell_text(cell) == cell
+
+
+class TestIdempotence:
+    """Normalizing twice must equal normalizing once.
+
+    ``strip_dot_leaders`` may run on text another pass already touched — the
+    relaxed metric path composes folds — so a rule that keeps finding new runs
+    in its own output would make a cell's score depend on how many times it
+    was normalized.
+    """
+
+    CASES = [
+        # Labels crossed with every decoration.
+        *[
+            label + decoration
+            for label in ("Total assets", "Employed", "Acme Inc.", "U.S.A.", "E.O.", "Jr.", "No.", "3.", "ft.")
+            for decoration in DECORATIONS
+        ],
+        # Every other shape pinned in this file.
+        "...",
+        "…",
+        "..",
+        ".",
+        ".... Total",
+        ".Total",
+        "Introduction ..... 3",
+        "Employed. . . . 12",
+        "A .. B .. C",
+        "Chapter 1 ... 7 ... 8",
+        "3.14",
+        "2.0.1",
+        "$1,234.56",
+        "192.168.1.1",
+        "Total assets.....5,061",
+        "1…5",
+        "Amounts are in millions.",
+        "continued ... see note 4",
+        "Employed.\xa0.\xa0.",
+        "foo ....\nbar ....",
+        "",
+    ]
+
+    @pytest.mark.parametrize("cell", CASES)
+    def test_strip_dot_leaders_is_idempotent(self, cell: str) -> None:
+        once = strip_dot_leaders(cell)
+        assert strip_dot_leaders(once) == once
+
+    #: ``"No."`` is excluded from the two cell normalizers below and pinned on
+    #: its own — it is the single shape where a second pass is not a no-op.
+    IDEMPOTENT_CASES = [c for c in CASES if not c.lower().startswith("no.")]
+
+    @pytest.mark.parametrize("cell", IDEMPOTENT_CASES)
+    def test_trm_cell_normalizer_is_idempotent(self, cell: str) -> None:
+        once = _normalize_trm_cell_text(cell)
+        assert _normalize_trm_cell_text(once) == once
+
+    @pytest.mark.parametrize("cell", IDEMPOTENT_CASES)
+    def test_normalize_cell_text_is_idempotent(self, cell: str) -> None:
+        once = normalize_cell_text(cell)
+        assert normalize_cell_text(once) == once
+
+    @pytest.mark.parametrize("cell", ["No. ...", "No. . . . .", "No.…", "No....."])
+    def test_a_decorated_boolean_token_is_the_one_non_idempotent_shape(self, cell: str) -> None:
+        """``"No. ..."`` -> ``"No"`` -> ``"no"``, because ``no`` is a boolean marker.
+
+        ``_normalize_table_boolean_marker`` runs *before* leader stripping and
+        must stay there — it has to see ``○`` / ``●`` before
+        ``_normalize_unicode_symbols`` folds them onto one bullet, or a
+        checked box and an unchecked box become the same cell. Leader
+        stripping can therefore expose a bare ``No`` that only a second pass
+        would fold. Harmless in production, where each side is normalized
+        exactly once, and pinned here so the ordering constraint is visible.
+
+        ``strip_dot_leaders`` itself stays idempotent on these — the extra
+        pass comes from the boolean fold sitting upstream of it, which is why
+        the sweep above covers the helper without an exclusion list.
+        """
+        assert strip_dot_leaders(strip_dot_leaders(cell)) == strip_dot_leaders(cell)
+        once = normalize_cell_text(cell)
+        assert once == "No"
+        assert normalize_cell_text(once) == "no"
+
+
+class TestSymmetry:
+    """Ground truth and prediction go through the same function.
+
+    ``normalize_cell_text`` is applied to the ground-truth grid at
+    ``grits_metric.py:861`` and to the prediction grid at
+    ``grits_metric.py:865``; TEDS normalizes both trees at
+    ``teds_metric.py:120-121``; TRM routes both tables through
+    ``normalize_table`` -> ``_normalize_trm_table_text`` ->
+    ``strip_dot_leaders`` (``table_record_match_metric.py:105``). There is no
+    path that normalizes one side and not the other.
+    """
+
+    def test_leader_on_either_side_normalizes_alike(self) -> None:
+        gt = "Cash and equivalents"
+        pred = "Cash and equivalents . . . . . . . . . ."
+        assert normalize_cell_text(gt) == normalize_cell_text(pred)
+        # And with the sides swapped — GT corpora carry leaders too.
+        assert normalize_cell_text(pred) == normalize_cell_text(gt)
+
+    @pytest.mark.parametrize("decoration", DECORATIONS)
+    def test_both_normalizers_are_indifferent_in_both_directions(self, decoration: str) -> None:
+        label = "Cash and equivalents"
+        decorated = label + decoration
+        assert normalize_cell_text(label) == normalize_cell_text(decorated)
+        assert _normalize_trm_cell_text(label) == _normalize_trm_cell_text(decorated)
+        assert trm_cell_match(label, decorated) == 1.0
+        assert trm_cell_match(decorated, label) == 1.0

--- a/tests/parse_bench/evaluation/metrics/parse/test_table_extraction.py
+++ b/tests/parse_bench/evaluation/metrics/parse/test_table_extraction.py
@@ -1,0 +1,119 @@
+"""Tests for the shared table extraction stage."""
+
+from __future__ import annotations
+
+import pickle
+
+import pytest
+
+from parse_bench.evaluation.metrics.parse.table_extraction import (
+    ExtractedTable,
+    GroundTruthTableParseError,
+    extract_html_tables,
+    extract_table_pairs,
+)
+
+ONE_TABLE = """
+<table><tr><th>A</th><th>B</th></tr><tr><td>1</td><td>2</td></tr></table>
+"""
+
+TWO_TABLES = """
+<table><tr><th>A</th></tr><tr><td>1</td></tr></table>
+some text
+<table><tr><th>B</th></tr><tr><td>2</td></tr></table>
+"""
+
+# A "<table" appears but no closing </table> AND no parseable content -
+# extract_html_tables grabs it via fallback, parse_html_tables returns []
+MALFORMED = "<table>oops"
+
+
+def test_single_table_each_side() -> None:
+    expected, actual, counts = extract_table_pairs(ONE_TABLE, ONE_TABLE)
+    assert len(expected) == 1
+    assert len(actual) == 1
+    assert counts.expected == 1
+    assert counts.actual == 1
+    assert counts.unparseable_pred == 0
+    assert isinstance(expected[0], ExtractedTable)
+    assert "<table" in expected[0].raw_html.lower()
+    assert expected[0].table_data.data.shape == (2, 2)
+
+
+def test_multi_table() -> None:
+    expected, actual, counts = extract_table_pairs(TWO_TABLES, TWO_TABLES)
+    assert len(expected) == 2
+    assert len(actual) == 2
+    assert counts.expected == 2
+    assert counts.actual == 2
+
+
+def test_extract_html_tables_preserves_indices_after_expanding_lowercase_chars() -> None:
+    md = "GARANTİ BBVA\n\n<table><thead><tr><td>A</td></tr></thead></table>"
+
+    tables = extract_html_tables(md)
+
+    assert tables == ["<table><thead><tr><td>A</td></tr></thead></table>"]
+    expected, actual, counts = extract_table_pairs(md, md)
+    assert len(expected) == 1
+    assert len(actual) == 1
+    assert counts.expected == 1
+    assert counts.actual == 1
+
+
+def test_extract_html_tables_matches_tags_case_insensitively() -> None:
+    md = "<TABLE><TR><TD>A</TD></TR></TABLE>"
+
+    assert extract_html_tables(md) == [md]
+
+
+def test_no_tables() -> None:
+    expected, actual, counts = extract_table_pairs("no tables here", "also nothing")
+    assert expected == []
+    assert actual == []
+    assert counts.expected == 0
+    assert counts.actual == 0
+    assert counts.unparseable_pred == 0
+
+
+def test_mismatched_counts() -> None:
+    expected, actual, counts = extract_table_pairs(TWO_TABLES, ONE_TABLE)
+    assert counts.expected == 2
+    assert counts.actual == 1
+
+
+def test_pred_unparseable_dropped() -> None:
+    # one good table + one malformed in actual
+    actual_md = ONE_TABLE + "\n" + MALFORMED
+    expected, actual, counts = extract_table_pairs(ONE_TABLE, actual_md)
+    assert counts.expected == 1
+    # The malformed slice may or may not be picked up by extract_html_tables;
+    # if it is, parse_html_tables drops it, increasing unparseable_pred.
+    # Either way, len(actual) + counts.unparseable_pred should equal the
+    # number of slices extract_html_tables produced for actual_md.
+    assert counts.unparseable_pred >= 0
+    assert counts.actual == len(actual)
+
+
+def test_gt_unparseable_raises() -> None:
+    gt_md = ONE_TABLE + "\n" + MALFORMED
+    # Only raises if extract_html_tables actually produced a slice that
+    # parse_html_tables can't parse. Build a deliberate failing fixture:
+    # a "<table" with no closing tag triggers extract_html_tables's
+    # fallback path that grabs from <table to end-of-string.
+    bad = "before <table foo bar baz"
+    with pytest.raises(GroundTruthTableParseError) as exc_info:
+        extract_table_pairs(bad, ONE_TABLE, doc_id="doc-xyz")
+    assert "doc-xyz" in str(exc_info.value)
+    # Use gt_md to silence unused-variable warning
+    _ = gt_md
+
+
+def test_pickle_roundtrip() -> None:
+    """ExtractedTable must pickle for the parallel-path subprocess in P4."""
+    expected, _, _ = extract_table_pairs(ONE_TABLE, ONE_TABLE)
+    et = expected[0]
+    blob = pickle.dumps(et)
+    restored = pickle.loads(blob)
+    assert restored.raw_html == et.raw_html
+    assert restored.table_data.data.shape == et.table_data.data.shape

--- a/tests/parse_bench/evaluation/metrics/parse/test_table_marker_cells_rule.py
+++ b/tests/parse_bench/evaluation/metrics/parse/test_table_marker_cells_rule.py
@@ -1,0 +1,188 @@
+from parse_bench.evaluation.metrics.parse.rules_base import create_test_rule
+from parse_bench.evaluation.metrics.parse.rules_table import TableMarkerCellsRule
+
+
+def _run(markdown: str, **overrides: object) -> tuple[bool, str]:
+    rule = create_test_rule({"type": "table_marker_cells", **overrides})
+    assert isinstance(rule, TableMarkerCellsRule)
+    return rule.run(markdown)
+
+
+def test_repeated_ocr_glyphs_pass_across_rows_and_columns() -> None:
+    markdown = """
+<table>
+  <tr><th>Skill</th><th>A</th><th>B</th></tr>
+  <tr><td>Finance</td><td>Ө</td><td></td></tr>
+  <tr><td>Operations</td><td></td><td>Ө</td></tr>
+</table>
+"""
+
+    assert _run(markdown, min_distinct_columns=2) == (True, "")
+
+
+def test_known_markers_pass_in_one_status_column() -> None:
+    markdown = """
+| Goal | Status |
+| --- | --- |
+| First | ✓ |
+| Second | ✓ |
+"""
+
+    assert _run(markdown) == (True, "")
+
+
+def test_html_images_inside_table_cells_pass() -> None:
+    markdown = """
+<table>
+  <tr><th>Goal</th><th>Status</th></tr>
+  <tr><td>First</td><td><img src="first.png" alt="green"></td></tr>
+  <tr><td>Second</td><td><p><img src="second.png"></p></td></tr>
+</table>
+"""
+
+    assert _run(markdown) == (True, "")
+
+
+def test_html_images_with_labels_still_count_as_icon_cells() -> None:
+    markdown = """
+<table>
+  <tr><th>Crop</th><th>Product</th></tr>
+  <tr><td><img src="corn.png"> Corn</td><td>A</td></tr>
+  <tr><td><img src="soy.png"> Soybeans</td><td>B</td></tr>
+</table>
+"""
+
+    assert _run(markdown) == (True, "")
+
+
+def test_semantic_marker_labels_pass() -> None:
+    markdown = """
+| Skill | Alice | Bob |
+| --- | --- | --- |
+| Finance | Orange Square | Grey Square |
+| Operations | Grey Square | Orange Square |
+"""
+
+    assert _run(markdown, min_distinct_columns=2) == (True, "")
+
+
+def test_bracketed_icon_labels_pass_with_surrounding_text() -> None:
+    markdown = """
+| Crop | Product |
+| --- | --- |
+| [icon: Corn] Corn | A |
+| [icon: Soybeans] Soybeans | B |
+"""
+
+    assert _run(markdown) == (True, "")
+
+
+def test_leading_symbol_with_value_passes() -> None:
+    markdown = """
+| Company | Change |
+| --- | --- |
+| First | ▲ 512.40 |
+| Second | ▲ 125.00 |
+"""
+
+    assert _run(markdown) == (True, "")
+
+
+def test_word_alias_embedded_in_prose_does_not_pass() -> None:
+    markdown = """
+| Goal | Comment |
+| --- | --- |
+| First | selected for review |
+| Second | selected by committee |
+"""
+
+    assert _run(markdown)[0] is False
+
+
+def test_missing_value_dashes_are_not_markers_by_default() -> None:
+    markdown = """
+| Metric | 2024 | 2025 |
+| --- | --- | --- |
+| Revenue | - | 10 |
+| Profit | - | 2 |
+"""
+
+    assert _run(markdown)[0] is False
+
+
+def test_markers_in_one_column_fail_when_two_are_required() -> None:
+    markdown = """
+| Goal | Status |
+| --- | --- |
+| First | ✓ |
+| Second | ✓ |
+"""
+
+    passed, message = _run(markdown, min_distinct_columns=2)
+    assert passed is False
+    assert "only 1 table column(s)" in message
+
+    rule = create_test_rule({"type": "table_marker_cells", "min_distinct_columns": 2})
+    rule.run(markdown)
+    assert rule.result_details["tables_inspected"] == 1
+    assert rule.result_details["best_table"]["marker_cells"] == 2
+    assert rule.result_details["best_table"]["recognized_tokens"] == {"✓": 2}
+    assert "at least 2 are required" in rule.result_details["diagnosis"]
+
+
+def test_repeated_ascii_abbreviation_is_not_a_marker() -> None:
+    markdown = """
+| Metric | 2024 |
+| --- | --- |
+| Revenue | M |
+| Profit | M |
+"""
+
+    assert _run(markdown)[0] is False
+
+
+def test_custom_marker_alias_passes() -> None:
+    markdown = """
+| Goal | Status |
+| --- | --- |
+| First | done-icon |
+| Second | done-icon |
+"""
+
+    assert _run(markdown, marker_aliases=["done-icon"])[0] is True
+
+
+def test_custom_marker_alias_lists_pass() -> None:
+    markdown = """
+| Impact | Low | High |
+| --- | --- | --- |
+| Very high | | H, D, E |
+| High | | B, C |
+| Medium | F | I |
+"""
+
+    assert _run(markdown, marker_aliases=list("abcdefghi"))[0] is True
+
+
+def test_bracket_wrapped_aliases_pass() -> None:
+    markdown = """
+| Skill | Alice | Bob |
+| --- | --- | --- |
+| Finance | [yes] | |
+| Operations | | [yes] |
+"""
+
+    assert _run(markdown, min_distinct_columns=2)[0] is True
+
+
+def test_marker_text_outside_a_table_fails() -> None:
+    rule = create_test_rule({"type": "table_marker_cells"})
+    assert rule.run("First ✓\n\nSecond ✓") == (
+        False,
+        "No tables found; icon-valued cells could not be evaluated",
+    )
+    assert rule.result_details == {
+        "requirement": ">=2 marker cells across >=2 rows and >=1 columns",
+        "tables_inspected": 0,
+        "diagnosis": "The parser emitted no recognizable Markdown or HTML table.",
+    }

--- a/tests/parse_bench/evaluation/metrics/parse/test_table_pairing.py
+++ b/tests/parse_bench/evaluation/metrics/parse/test_table_pairing.py
@@ -1,0 +1,81 @@
+"""Unit tests for the shared page-aware table assignment helper."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from parse_bench.evaluation.metrics.parse.table_pairing import (
+    assign_tables,
+    page_blocking_active,
+)
+
+
+def _pairs(row_ind: list[int], col_ind: list[int]) -> set[tuple[int, int]]:
+    return set(zip(row_ind, col_ind, strict=True))
+
+
+# --- page_blocking_active --------------------------------------------------
+
+
+def test_page_blocking_active_requires_both_lists_and_lengths():
+    assert page_blocking_active([1, 2], [1, 2], 2, 2) is True
+    assert page_blocking_active(None, [1, 2], 2, 2) is False
+    assert page_blocking_active([1, 2], None, 2, 2) is False
+    assert page_blocking_active([1], [1, 2], 2, 2) is False  # exp length != n_expected
+    assert page_blocking_active([1, 2], [1], 2, 2) is False  # act length != n_actual
+
+
+# --- assign_tables: global (no pages) --------------------------------------
+
+
+def test_global_assignment_matches_linear_sum_assignment():
+    # cost = -score; the optimal global assignment pairs the diagonal.
+    cost = np.array([[-1.0, 0.0], [0.0, -1.0]])
+    row_ind, col_ind = assign_tables(cost)
+    assert _pairs(row_ind, col_ind) == {(0, 0), (1, 1)}
+
+
+def test_global_assignment_picks_cross_pairs_when_cheaper():
+    # Best global match is the anti-diagonal — proves no page constraint applies.
+    cost = np.array([[0.0, -1.0], [-1.0, 0.0]])
+    row_ind, col_ind = assign_tables(cost)
+    assert _pairs(row_ind, col_ind) == {(0, 1), (1, 0)}
+
+
+# --- assign_tables: per-page -----------------------------------------------
+
+
+def test_per_page_forbids_cross_page_even_when_cheaper():
+    # Anti-diagonal is globally cheapest, but pages force the diagonal.
+    cost = np.array([[0.0, -1.0], [-1.0, 0.0]])
+    row_ind, col_ind = assign_tables(cost, expected_pages=[1, 2], actual_pages=[1, 2])
+    assert _pairs(row_ind, col_ind) == {(0, 0), (1, 1)}
+
+
+def test_per_page_gt_without_prediction_is_unmatched():
+    # GT page 2 has no prediction -> that GT row is left unmatched.
+    cost = np.array([[-1.0], [-1.0]])  # 2 GT x 1 pred
+    row_ind, col_ind = assign_tables(cost, expected_pages=[1, 2], actual_pages=[1])
+    assert _pairs(row_ind, col_ind) == {(0, 0)}
+    assert 1 not in row_ind
+
+
+def test_per_page_pred_only_page_is_ignored():
+    # Pred on page 3 has no GT -> not force-matched.
+    cost = np.array([[-1.0, -1.0]])  # 1 GT x 2 pred
+    row_ind, col_ind = assign_tables(cost, expected_pages=[1], actual_pages=[1, 3])
+    assert _pairs(row_ind, col_ind) == {(0, 0)}
+
+
+def test_per_page_multiple_tables_same_page():
+    # Two GT and two pred all on page 1 -> behaves like a global 2x2 solve.
+    cost = np.array([[-1.0, 0.0], [0.0, -1.0]])
+    row_ind, col_ind = assign_tables(cost, expected_pages=[1, 1], actual_pages=[1, 1])
+    assert _pairs(row_ind, col_ind) == {(0, 0), (1, 1)}
+
+
+def test_length_mismatch_falls_back_to_global():
+    cost = np.array([[0.0, -1.0], [-1.0, 0.0]])
+    # expected_pages too short -> page blocking disabled -> global anti-diagonal.
+    row_ind, col_ind = assign_tables(cost, expected_pages=[1], actual_pages=[1, 2])
+    assert _pairs(row_ind, col_ind) == {(0, 1), (1, 0)}

--- a/tests/parse_bench/evaluation/metrics/parse/test_table_record_match_metric.py
+++ b/tests/parse_bench/evaluation/metrics/parse/test_table_record_match_metric.py
@@ -1,0 +1,2844 @@
+"""Tests for table_record_match metric."""
+
+import pytest
+
+from parse_bench.evaluation.metrics.parse.table_extraction import (
+    extract_html_tables,
+)
+from parse_bench.evaluation.metrics.parse.table_parsing import (
+    parse_html_tables,
+)
+from parse_bench.evaluation.metrics.parse.table_record_match_metric import (
+    HeaderInfo,
+    TableRecordMatchMetric,
+    _align_columns_header_core,
+    _demote_pred_headers,
+    _is_all_empty_record,
+    _normalize_sub_sup_for_table,
+    _normalize_trm_cell_text,
+    _resolve_header_row_values,
+    _try_recover_pred_header,
+    _try_section_header_promotion,
+    align_columns,
+    build_record_details,
+    build_records,
+    cell_score,
+    extract_header_info,
+    match_records,
+    normalize_table,
+    table_to_records,
+)
+from parse_bench.evaluation.metrics.parse.table_splitting import (
+    _detect_period_candidates,
+    enumerate_split_options,
+)
+from parse_bench.evaluation.metrics.parse.table_splitting import (
+    build_sub_table as _build_sub_table,
+)
+from parse_bench.evaluation.metrics.parse.utils import _normalize_table_boolean_marker, normalize_text
+
+
+def _norm(s: str) -> str:
+    """Pre-normalize a string the same way normalize_table does per cell."""
+    return _normalize_trm_cell_text(normalize_text(_normalize_table_boolean_marker(s)))
+
+
+def _html(table_body: str) -> str:
+    """Wrap table rows in a full HTML table."""
+    return f"<table>{table_body}</table>"
+
+
+def _simple_table(headers: list[str], rows: list[list[str]]) -> str:
+    """Build a simple HTML table from headers and row data."""
+    hdr = "<tr>" + "".join(f"<th>{h}</th>" for h in headers) + "</tr>"
+    body = ""
+    for row in rows:
+        body += "<tr>" + "".join(f"<td>{c}</td>" for c in row) + "</tr>"
+    return _html(f"<thead>{hdr}</thead><tbody>{body}</tbody>")
+
+
+@pytest.fixture
+def metric() -> TableRecordMatchMetric:
+    return TableRecordMatchMetric()
+
+
+# ---- 1. Identical tables → 1.0 ----
+def test_identical_tables(metric: TableRecordMatchMetric) -> None:
+    table = _simple_table(["Name", "Age"], [["Alice", "30"], ["Bob", "25"]])
+    result = metric.compute(expected=table, actual=table)
+    assert len(result) == 2
+    assert result[0].value == pytest.approx(1.0)
+    # Perfect match rate
+    assert result[1].metric_name == "table_record_match_perfect"
+    assert result[1].value == pytest.approx(1.0)
+
+
+# ---- 2. Row-shuffled → 1.0 ----
+def test_row_shuffled(metric: TableRecordMatchMetric) -> None:
+    gt = _simple_table(["Name", "Age"], [["Alice", "30"], ["Bob", "25"], ["Carol", "35"]])
+    pred = _simple_table(["Name", "Age"], [["Carol", "35"], ["Alice", "30"], ["Bob", "25"]])
+    result = metric.compute(expected=gt, actual=pred)
+    assert result[0].value == pytest.approx(1.0)
+
+
+# ---- 3. Column-shuffled → 1.0 ----
+def test_column_shuffled(metric: TableRecordMatchMetric) -> None:
+    gt = _simple_table(["Name", "Age"], [["Alice", "30"], ["Bob", "25"]])
+    pred = _simple_table(["Age", "Name"], [["30", "Alice"], ["25", "Bob"]])
+    result = metric.compute(expected=gt, actual=pred)
+    assert result[0].value == pytest.approx(1.0)
+
+
+# ---- 4. Row + column shuffled → 1.0 ----
+def test_row_and_column_shuffled(metric: TableRecordMatchMetric) -> None:
+    gt = _simple_table(
+        ["Name", "Age", "City"],
+        [
+            ["Alice", "30", "NYC"],
+            ["Bob", "25", "LA"],
+        ],
+    )
+    pred = _simple_table(
+        ["City", "Name", "Age"],
+        [
+            ["LA", "Bob", "25"],
+            ["NYC", "Alice", "30"],
+        ],
+    )
+    result = metric.compute(expected=gt, actual=pred)
+    assert result[0].value == pytest.approx(1.0)
+
+
+# ---- 5. Missing row → proportional penalty ----
+def test_missing_row(metric: TableRecordMatchMetric) -> None:
+    gt = _simple_table(["Name", "Age"], [["Alice", "30"], ["Bob", "25"], ["Carol", "35"]])
+    pred = _simple_table(["Name", "Age"], [["Alice", "30"], ["Bob", "25"]])
+    result = metric.compute(expected=gt, actual=pred)
+    # 2 of 3 rows match → ~0.67
+    assert 0.55 <= result[0].value <= 0.75
+
+
+# ---- 6. Extra row → proportional penalty ----
+def test_extra_row(metric: TableRecordMatchMetric) -> None:
+    gt = _simple_table(["Name", "Age"], [["Alice", "30"], ["Bob", "25"]])
+    pred = _simple_table(["Name", "Age"], [["Alice", "30"], ["Bob", "25"], ["Carol", "35"]])
+    result = metric.compute(expected=gt, actual=pred)
+    # 2 matched / max(2, 3) = 0.67
+    assert 0.55 <= result[0].value <= 0.75
+
+
+# ---- 7. Wrong cell value → strict penalty ----
+def test_wrong_cell_strict(metric: TableRecordMatchMetric) -> None:
+    gt = _simple_table(["Name", "Age"], [["Alice", "30"], ["Bob", "25"]])
+    pred = _simple_table(["Name", "Age"], [["Alice", "31"], ["Bob", "25"]])
+    result = metric.compute(expected=gt, actual=pred)
+    # One cell wrong out of 4 total → 3/4 cells correct in matched row → 0.75 avg per row
+    # Row 1: 1 of 2 cells match → 0.5. Row 2: 2 of 2 → 1.0. Avg = 0.75
+    assert result[0].value == pytest.approx(0.75)
+
+
+# ---- 8. Headerless tables → content-based alignment ----
+def test_headerless_tables(metric: TableRecordMatchMetric) -> None:
+    gt = _html("<tr><td>Alice</td><td>30</td></tr><tr><td>Bob</td><td>25</td></tr>")
+    pred = _html("<tr><td>Alice</td><td>30</td></tr><tr><td>Bob</td><td>25</td></tr>")
+    result = metric.compute(expected=gt, actual=pred)
+    assert result[0].value == pytest.approx(1.0)
+
+
+# ---- 9. Dual-axis headers (row + column) → matched via Hungarian ----
+def test_dual_axis_headers(metric: TableRecordMatchMetric) -> None:
+    gt = _html(
+        "<thead><tr><th></th><th>Q1</th><th>Q2</th></tr></thead>"
+        "<tbody>"
+        "<tr><th>Revenue</th><td>100</td><td>200</td></tr>"
+        "<tr><th>Cost</th><td>50</td><td>80</td></tr>"
+        "</tbody>"
+    )
+    # Rows swapped
+    pred = _html(
+        "<thead><tr><th></th><th>Q1</th><th>Q2</th></tr></thead>"
+        "<tbody>"
+        "<tr><th>Cost</th><td>50</td><td>80</td></tr>"
+        "<tr><th>Revenue</th><td>100</td><td>200</td></tr>"
+        "</tbody>"
+    )
+    result = metric.compute(expected=gt, actual=pred)
+    assert result[0].value == pytest.approx(1.0)
+
+
+# ---- 10. Multi-level headers → keys flatten with space separator ----
+def test_multi_level_headers(metric: TableRecordMatchMetric) -> None:
+    gt = _html(
+        "<thead>"
+        '<tr><th colspan="2">Sales</th></tr>'
+        "<tr><th>Q1</th><th>Q2</th></tr>"
+        "</thead>"
+        "<tbody>"
+        "<tr><td>100</td><td>200</td></tr>"
+        "</tbody>"
+    )
+    pred = _html(
+        "<thead>"
+        '<tr><th colspan="2">Sales</th></tr>'
+        "<tr><th>Q1</th><th>Q2</th></tr>"
+        "</thead>"
+        "<tbody>"
+        "<tr><td>100</td><td>200</td></tr>"
+        "</tbody>"
+    )
+    result = metric.compute(expected=gt, actual=pred)
+    assert result[0].value == pytest.approx(1.0)
+
+    # Verify that the spanning "Sales" title row is excluded from keys,
+    # leaving just the column-discriminating "Q1", "Q2"
+    tables = parse_html_tables(gt)
+    keys, records, _ = table_to_records(tables[0])
+    assert keys == ["Q1", "Q2"], f"Expected title row excluded, got: {keys}"
+
+
+# ---- 11. Section headers → now regular data rows (no special treatment) ----
+def test_section_headers(metric: TableRecordMatchMetric) -> None:
+    gt = _html(
+        "<thead><tr><th>Item</th><th>Value</th></tr></thead>"
+        "<tbody>"
+        "<tr><td>A</td><td>10</td></tr>"
+        '<tr><th colspan="2">Section B</th></tr>'
+        "<tr><td>B1</td><td>20</td></tr>"
+        "</tbody>"
+    )
+    pred = _html(
+        "<thead><tr><th>Item</th><th>Value</th></tr></thead>"
+        "<tbody>"
+        "<tr><td>A</td><td>10</td></tr>"
+        '<tr><th colspan="2">Section B</th></tr>'
+        "<tr><td>B1</td><td>20</td></tr>"
+        "</tbody>"
+    )
+    result = metric.compute(expected=gt, actual=pred)
+    assert result[0].value == pytest.approx(1.0)
+
+    # Section rows are now regular records (no _section field)
+    tables = parse_html_tables(gt)
+    keys, records, _ = table_to_records(tables[0])
+    assert len(records) == 3  # A, Section B, B1
+    assert all("_section" not in r for r in records)
+
+
+# ---- 12. Empty table → 0.0 ----
+def test_empty_table(metric: TableRecordMatchMetric) -> None:
+    gt = _simple_table(["A", "B"], [["x", "y"]])
+    pred = _html("<thead><tr><th>A</th><th>B</th></tr></thead><tbody></tbody>")
+    result = metric.compute(expected=gt, actual=pred)
+    assert result[0].value == pytest.approx(0.0)
+
+
+# ---- 13. Tables with numeric values → strict matching ----
+def test_numeric_strict(metric: TableRecordMatchMetric) -> None:
+    gt = _simple_table(["Metric", "Value"], [["Revenue", "1000000"]])
+    pred = _simple_table(["Metric", "Value"], [["Revenue", "1000001"]])
+    result = metric.compute(expected=gt, actual=pred)
+    # "1000000" != "1000001" → 1 of 2 cells wrong → score = 0.5
+    assert result[0].value == pytest.approx(0.5)
+
+
+# ---- 14. Multiple tables per document → scores averaged ----
+def test_multiple_tables_averaged(metric: TableRecordMatchMetric) -> None:
+    t1_gt = _simple_table(["A"], [["1"]])
+    t2_gt = _simple_table(["B"], [["2"]])
+    t1_pred = _simple_table(["A"], [["1"]])  # Perfect match
+    t2_pred = _simple_table(["B"], [["999"]])  # Bad match
+
+    expected = t1_gt + t2_gt
+    actual = t1_pred + t2_pred
+    result = metric.compute(expected=expected, actual=actual)
+    # Average of ~1.0 and a low score
+    assert 0.2 < result[0].value < 0.9
+
+
+# ---- 15. Mismatched table counts → unmatched GT tables score 0.0 ----
+def test_mismatched_table_counts(metric: TableRecordMatchMetric) -> None:
+    t1 = _simple_table(["A"], [["1"]])
+    t2 = _simple_table(["B"], [["2"]])
+    t3 = _simple_table(["C"], [["3"]])
+
+    expected = t1 + t2 + t3  # 3 GT tables
+    actual = t1 + t2  # 2 predicted tables
+
+    result = metric.compute(expected=expected, actual=actual)
+    # Two tables score ~1.0 each, third scores 0.0 → avg ~0.67
+    assert 0.55 <= result[0].value <= 0.75
+    assert result[0].metadata["n_gt_tables"] == 3
+    assert result[0].metadata["n_pred_tables"] == 2
+
+
+# ---- 15b. Extra predicted tables → no penalty ----
+def test_extra_predicted_tables_no_penalty(metric: TableRecordMatchMetric) -> None:
+    t1 = _simple_table(["A"], [["1"]])
+    t2 = _simple_table(["B"], [["2"]])
+    t3 = _simple_table(["C"], [["3"]])
+
+    expected = t1 + t2  # 2 GT tables
+    actual = t1 + t2 + t3  # 3 predicted tables (1 extra)
+
+    result = metric.compute(expected=expected, actual=actual)
+    # Both GT tables matched perfectly, extra pred table ignored → 1.0
+    assert result[0].value == pytest.approx(1.0)
+    assert result[0].metadata["n_gt_tables"] == 2
+    assert result[0].metadata["n_pred_tables"] == 3
+
+
+# ---- 16. Duplicate column headers → disambiguated with _0, _1 suffixes ----
+def test_duplicate_column_headers(metric: TableRecordMatchMetric) -> None:
+    gt = _html("<thead><tr><th>Value</th><th>Value</th></tr></thead><tbody><tr><td>A</td><td>B</td></tr></tbody>")
+    tables = parse_html_tables(gt)
+    keys, records, _ = table_to_records(tables[0])
+    assert len(keys) == 2
+    assert keys[0] != keys[1], f"Keys should be disambiguated, got: {keys}"
+    assert "Value" in keys[0] and "Value" in keys[1]
+
+
+# ---- 17. No tables in actual → 0.0 ----
+def test_no_tables_in_actual(metric: TableRecordMatchMetric) -> None:
+    gt = _simple_table(["A", "B"], [["1", "2"]])
+    result = metric.compute(expected=gt, actual="No tables here")
+    assert len(result) == 2
+    assert result[0].value == 0.0
+    assert result[0].metadata["tables_predicted"] is False
+    assert result[1].metric_name == "table_record_match_perfect"
+    assert result[1].value == 0.0
+
+
+# ---- Additional: cell_score unit tests ----
+def test_cell_score_exact_match() -> None:
+    assert cell_score("hello", "hello") == 1.0
+
+
+def test_cell_score_empty_both() -> None:
+    assert cell_score("", "") == 1.0
+    assert cell_score("nan", "NaN") == 1.0
+
+
+def test_cell_score_one_empty() -> None:
+    assert cell_score("hello", "") == 0.0
+    assert cell_score("", "hello") == 0.0
+
+
+def test_cell_score_numeric_strict() -> None:
+    assert cell_score("100", "101") == 0.0
+    assert cell_score("100", "100") == 1.0
+
+
+def test_cell_score_text_strict() -> None:
+    assert cell_score("Revenue", "Revnue") == 0.0
+    assert cell_score("Revenue", "Revenue") == 1.0
+
+
+# ---- No GT tables → empty list ----
+def test_no_gt_tables(metric: TableRecordMatchMetric) -> None:
+    result = metric.compute(expected="No tables", actual=_simple_table(["A"], [["1"]]))
+    assert result == []
+
+
+# ===========================================================================
+# Bug-fix regression tests (Notion triage doc fixes)
+# ===========================================================================
+
+
+# ---- Fix 1: <br> tag boundaries preserve spaces in parse_html_tables ----
+
+
+class TestBrTagSpacePreservation:
+    """Fix 1: parse_html_tables must not merge words across <br> boundaries.
+
+    Before the fix, `cell.get_text(strip=True)` would concatenate text nodes
+    without separators, so `<td>Name and<br>location</td>` became
+    "Name andlocation" instead of "Name and location".
+    """
+
+    def test_br_preserves_space_between_words(self) -> None:
+        """<br> between words should produce a space, not merge them."""
+        html = _html("<thead><tr><th>Col</th></tr></thead><tbody><tr><td>Name and<br>location</td></tr></tbody>")
+        tables = parse_html_tables(html)
+        cell_value = tables[0].data[1][0]  # first data row, first col
+        assert "and location" in cell_value or "and\nlocation" in cell_value
+        assert "andlocation" not in cell_value
+
+    def test_br_in_header_preserves_space(self) -> None:
+        """<br> inside header cells should also preserve word boundaries."""
+        html = _html("<thead><tr><th>Earned Car<br>Years</th></tr></thead><tbody><tr><td>100</td></tr></tbody>")
+        tables = parse_html_tables(html)
+        header_value = tables[0].data[0][0]  # header row
+        assert "Car Years" in header_value or "Car\nYears" in header_value
+        assert "CarYears" not in header_value
+
+    def test_br_does_not_affect_cells_without_br(self) -> None:
+        """Normal cells without <br> should be unaffected by the fix."""
+        html = _html("<thead><tr><th>A</th></tr></thead><tbody><tr><td>hello world</td></tr></tbody>")
+        tables = parse_html_tables(html)
+        assert tables[0].data[1][0] == "hello world"
+
+    def test_multiple_br_tags(self) -> None:
+        """Multiple <br> tags should each produce a space."""
+        html = _html("<thead><tr><th>Col</th></tr></thead><tbody><tr><td>A<br>B<br>C</td></tr></tbody>")
+        tables = parse_html_tables(html)
+        value = tables[0].data[1][0]
+        # Should have spaces (or newlines) between A, B, C — never merged
+        assert "AB" not in value
+        assert "BC" not in value
+
+    def test_end_to_end_br_does_not_penalize_score(self, metric: TableRecordMatchMetric) -> None:
+        """A GT with <br> and a prediction without should still match."""
+        gt = _html("<thead><tr><th>Category</th></tr></thead><tbody><tr><td>Contracts,<br>Employment</td></tr></tbody>")
+        pred = _html("<thead><tr><th>Category</th></tr></thead><tbody><tr><td>Contracts, Employment</td></tr></tbody>")
+        result = metric.compute(expected=gt, actual=pred)
+        assert result[0].value == pytest.approx(1.0)
+
+
+# ---- Fix 2: Whitespace around currency/punctuation in cell_score ----
+
+
+class TestCellTextNormalization:
+    """Fix 2: cell_score must treat "$ 5,061" and "$5,061" as equal.
+
+    _normalize_trm_cell_text() runs inside cell_score only (not shared
+    normalize_text). It handles whitespace around $/%/parens and
+    thousands-separator commas in numeric contexts.
+    """
+
+    # -- whitespace around punctuation --
+
+    def test_dollar_space(self) -> None:
+        """Space after $ should be ignored: '$ 5,061' == '$5,061'."""
+        assert cell_score(_norm("$ 5,061"), _norm("$5,061")) == 1.0
+
+    def test_dollar_multiple_spaces(self) -> None:
+        """Multiple spaces after $ should also be collapsed."""
+        assert cell_score(_norm("$  315"), _norm("$315")) == 1.0
+
+    def test_percent_space(self) -> None:
+        """Space before % should be ignored: '50 %' == '50%'."""
+        assert cell_score(_norm("50 %"), _norm("50%")) == 1.0
+
+    def test_open_paren_space(self) -> None:
+        """Space before ( should be ignored: 'word (n)' == 'word(n)'."""
+        assert cell_score(_norm("word (n)"), _norm("word(n)")) == 1.0
+
+    def test_close_paren_space(self) -> None:
+        """Space before ) should be ignored: '(n )' == '(n)'."""
+        assert cell_score(_norm("(n )"), _norm("(n)")) == 1.0
+
+    def test_combined_currency_and_paren(self) -> None:
+        """Combined patterns: '$ (5,061)' == '$(5,061)'."""
+        assert cell_score(_norm("$ (5,061)"), _norm("$(5,061)")) == 1.0
+
+    # -- thousands-separator comma removal --
+
+    def test_dollar_with_comma(self) -> None:
+        """'$5,061' == '$5061' — comma is a thousands separator."""
+        assert cell_score(_norm("$5,061"), _norm("$5061")) == 1.0
+
+    def test_plain_number_with_comma(self) -> None:
+        """'1,000' == '1000' — plain numeric value."""
+        assert cell_score(_norm("1,000"), _norm("1000")) == 1.0
+
+    def test_large_number_multiple_commas(self) -> None:
+        """'1,000,000' == '1000000' — multiple thousands separators."""
+        assert cell_score(_norm("1,000,000"), _norm("1000000")) == 1.0
+
+    def test_percentage_with_comma(self) -> None:
+        """'1,234%' == '1234%' — percentage with comma."""
+        assert cell_score(_norm("1,234%"), _norm("1234%")) == 1.0
+
+    def test_negative_number_with_comma(self) -> None:
+        """'-1,500' == '-1500'."""
+        assert cell_score(_norm("-1,500"), _norm("-1500")) == 1.0
+
+    def test_parenthetical_negative_with_comma(self) -> None:
+        """'(1,500)' == '(1500)' — accounting-style negatives."""
+        assert cell_score(_norm("(1,500)"), _norm("(1500)")) == 1.0
+
+    def test_comma_in_text_preserved(self) -> None:
+        """'Smith, John' must NOT match 'Smith John' — not a number."""
+        assert cell_score(_norm("Smith, John"), _norm("Smith John")) == 0.0
+
+    def test_comma_between_words_preserved(self) -> None:
+        """'Revenue, net' must NOT match 'Revenue net'."""
+        assert cell_score(_norm("Revenue, net"), _norm("Revenue net")) == 0.0
+
+    def test_genuine_difference_still_fails(self) -> None:
+        """Actual value differences must still score 0.0."""
+        assert cell_score(_norm("$5,061"), _norm("$5,062")) == 0.0
+
+    # -- helper function direct tests --
+
+    def test_normalize_trm_cell_text_whitespace(self) -> None:
+        """Direct test of whitespace rules."""
+        assert _normalize_trm_cell_text("$ 315") == "$315"
+        assert _normalize_trm_cell_text("50 %") == "50%"
+        assert _normalize_trm_cell_text("word (n)") == "word(n)"
+        assert _normalize_trm_cell_text("(n )") == "(n)"
+
+    def test_normalize_trm_cell_text_commas(self) -> None:
+        """Direct test of comma removal rules."""
+        assert _normalize_trm_cell_text("$5,061") == "$5061"
+        assert _normalize_trm_cell_text("1,000,000") == "1000000"
+        assert _normalize_trm_cell_text("smith, john") == "smith, john"
+
+    def test_normalize_trm_cell_text_registered_symbol(self) -> None:
+        """Whitespace before ® is stripped: 'Apple ® Inc' → 'Apple® Inc'."""
+        assert _normalize_trm_cell_text("Apple ® Inc") == "Apple® Inc"
+        assert _normalize_trm_cell_text("Acme  ®") == "Acme®"
+        # No space before → unchanged
+        assert _normalize_trm_cell_text("Apple® Inc") == "Apple® Inc"
+
+    def test_normalize_trm_cell_text_boolean_markers(self) -> None:
+        """Visual boolean markers match bracketed textual booleans."""
+        assert _norm("✓") == _norm("[yes]") == "yes"
+        assert _norm("✔") == _norm("yes") == "yes"
+        assert _norm("X") == _norm("[yes]") == "yes"
+        assert _norm("x") == _norm("[yes]") == "yes"
+        assert _norm("●") == _norm("[yes]") == "yes"
+        assert _norm("✗") == _norm("[no]") == "no"
+        assert _norm("✘") == _norm("no") == "no"
+        assert _norm("○") == _norm("[no]") == "no"
+
+    # -- end-to-end table test --
+
+    def test_end_to_end_dollar_space_and_comma_table(self, metric: TableRecordMatchMetric) -> None:
+        """Full table where GT has '$ 1,200' and pred has '$1200'."""
+        gt = _simple_table(["Item", "Cost"], [["Widget", "$ 315"], ["Gadget", "$ 1,200"]])
+        pred = _simple_table(["Item", "Cost"], [["Widget", "$315"], ["Gadget", "$1200"]])
+        result = metric.compute(expected=gt, actual=pred)
+        assert result[0].value == pytest.approx(1.0)
+
+    def test_end_to_end_teds_boolean_glyph_table(self, metric: TableRecordMatchMetric) -> None:
+        """Check/cross glyphs should match [yes]/[no] in boolean matrix cells."""
+        gt = _html(
+            """
+<tr><th>Dataset</th><th>TD</th><th>TSR</th><th>TR</th><th># tables</th></tr>
+<tr><td>Marmot [6]</td><td>✓</td><td>✗</td><td>✗</td><td>958</td></tr>
+<tr><td>ICDAR2013 [2]</td><td>✓</td><td>✓</td><td>✓</td><td>156</td></tr>
+<tr><td>SciTSR³</td><td>✗</td><td>✓</td><td>✓</td><td>15k</td></tr>
+"""
+        )
+        pred = _html(
+            """
+<thead><tr><th>Dataset</th><th>TD</th><th>TSR</th><th>TR</th><th># tables</th></tr></thead>
+<tbody>
+<tr><td>Marmot [6]</td><td>[yes]</td><td>[no]</td><td>[no]</td><td>958</td></tr>
+<tr><td>ICDAR2013 [2]</td><td>[yes]</td><td>[yes]</td><td>[yes]</td><td>156</td></tr>
+<tr><td>SciTSR<sup>3</sup></td><td>[no]</td><td>[yes]</td><td>[yes]</td><td>15k</td></tr>
+</tbody>
+"""
+        )
+
+        result = metric.compute(expected=gt, actual=pred)
+
+        assert result[0].value == pytest.approx(1.0)
+
+    def test_end_to_end_hospital_dot_table(self, metric: TableRecordMatchMetric) -> None:
+        """Filled dot availability markers should match [yes] cells."""
+        gt = _html(
+            """
+<tr><th>Hospital</th><th>County</th><th>Trio HMO</th><th>Local Access+ / SaveNet</th><th>Flag</th></tr>
+<tr><td>Alameda Hospital</td><td>Alameda</td><td>●</td><td>●</td><td>X</td></tr>
+<tr><td>Eden Medical Center</td><td>Alameda</td><td>●</td><td></td><td></td></tr>
+"""
+        )
+        pred = _html(
+            """
+<thead>
+<tr><th>Hospital</th><th>County</th><th>Trio HMO</th><th>Local Access+ /<br>SaveNet</th><th>Flag</th></tr>
+</thead>
+<tbody>
+<tr><td>Alameda Hospital</td><td>Alameda</td><td>[yes]</td><td>[yes]</td><td>[yes]</td></tr>
+<tr><td>Eden Medical Center</td><td>Alameda</td><td>[yes]</td><td></td><td></td></tr>
+</tbody>
+"""
+        )
+
+        result = metric.compute(expected=gt, actual=pred)
+
+        assert result[0].value == pytest.approx(1.0)
+
+
+# ---- Fix 3: Superscript digit stripping in normalize_text ----
+
+
+class TestSuperscriptDigitStripping:
+    """Fix 3: Unicode superscript digits (¹²³ etc.) should be stripped.
+
+    These codepoints (U+00B9, U+00B2, U+00B3, U+2070, U+2074–U+2079) are
+    typically footnote markers. NFD decomposition does NOT decompose them.
+    We strip them (not convert to regular digits) to avoid changing values
+    like "84.1¹" → "84.11". This is consistent with <sup> tag removal.
+    """
+
+    def test_superscript_one_stripped(self) -> None:
+        """U+00B9 (¹) should be stripped."""
+        assert normalize_text("84.1\u00b9") == normalize_text("84.1")
+
+    def test_superscript_two_stripped(self) -> None:
+        """U+00B2 (²) should be stripped."""
+        assert normalize_text("100\u00b2") == normalize_text("100")
+
+    def test_superscript_three_stripped(self) -> None:
+        """U+00B3 (³) should be stripped."""
+        assert normalize_text("value\u00b3") == normalize_text("value")
+
+    def test_superscript_higher_digits_stripped(self) -> None:
+        """U+2074–U+2079 (⁴⁵⁶⁷⁸⁹) should be stripped."""
+        for cp in ["\u2074", "\u2075", "\u2076", "\u2077", "\u2078", "\u2079"]:
+            assert normalize_text(f"test{cp}") == normalize_text("test"), f"Superscript {cp!r} was not stripped"
+
+    def test_superscript_zero_stripped(self) -> None:
+        """U+2070 (⁰) should be stripped."""
+        assert normalize_text("x\u2070") == normalize_text("x")
+
+    def test_multiple_superscripts_stripped(self) -> None:
+        """Multiple consecutive superscript digits should all be stripped."""
+        assert normalize_text("note\u00b9\u00b2") == normalize_text("note")
+
+    def test_superscript_not_converted_to_digit(self) -> None:
+        """Stripping must NOT convert ¹ to 1 (would change numeric values)."""
+        result = normalize_text("84.1\u00b9")
+        assert "84.11" not in result
+        assert "84.1" in result
+
+    def test_cell_score_with_superscript(self) -> None:
+        """cell_score should match values that differ only by superscript."""
+        assert cell_score(_norm("84.1\u00b9"), _norm("84.1")) == 1.0
+        assert cell_score(_norm("Total\u00b2"), _norm("Total")) == 1.0
+
+    def test_regular_digits_unaffected(self) -> None:
+        """Regular digits 0-9 must NOT be stripped."""
+        assert "123" in normalize_text("123")
+        assert normalize_text("84.1") == normalize_text("84.1")
+
+    def test_html_sup_vs_unicode_superscript_header_match(self) -> None:
+        """<sup>1</sup> in header must normalize the same as unicode ¹.
+
+        When one table uses <th>Name<sup>1</sup></th> and the other uses
+        <th>Name¹</th>, both should produce the same header text so that
+        column alignment succeeds.
+        """
+        gt_html = (
+            "<table><thead><tr>"
+            "<th>Number</th><th>Name<sup>1</sup></th><th>Description</th>"
+            "</tr></thead><tbody>"
+            "<tr><td>1</td><td>Beet</td><td>Leafy</td></tr>"
+            "</tbody></table>"
+        )
+        pred_html = (
+            "<table><thead><tr>"
+            "<th>Number</th><th>Name\u00b9</th><th>Description</th>"
+            "</tr></thead><tbody>"
+            "<tr><td>1</td><td>Beet</td><td>Leafy</td></tr>"
+            "</tbody></table>"
+        )
+        gt_tables = parse_html_tables(gt_html)
+        pred_tables = parse_html_tables(pred_html)
+        assert len(gt_tables) == 1 and len(pred_tables) == 1
+        gt_keys, gt_records, _ = table_to_records(normalize_table(gt_tables[0]))
+        pred_keys, pred_records, _ = table_to_records(normalize_table(pred_tables[0]))
+        # Headers should match — both should normalize "Name" the same way
+        assert gt_keys == pred_keys
+        # Records should therefore match perfectly
+        assert gt_records == pred_records
+
+
+# ===========================================================================
+# Phase 1: Nested table extraction and parsing
+# ===========================================================================
+
+
+class TestNestedTableExtraction:
+    """Phase 1: Nested tables should not break extraction or parsing."""
+
+    def test_extract_html_tables_nested(self) -> None:
+        """Nested table inside a cell should not truncate the outer table."""
+        html = (
+            "<table><tr><td>A</td><td>"
+            "<table><tr><td>Nested</td></tr></table>"
+            "</td></tr><tr><td>B</td><td>C</td></tr></table>"
+        )
+        tables = extract_html_tables(html)
+        assert len(tables) == 1  # One top-level table, not two
+        assert "B" in tables[0]  # Second row NOT truncated
+
+    def test_extract_html_tables_nested_preserves_outer(self) -> None:
+        """Outer table should contain the full HTML including nested table."""
+        html = (
+            "<table><tr><td>Row1</td></tr>"
+            "<tr><td><table><tr><td>Inner</td></tr></table></td></tr>"
+            "<tr><td>Row3</td></tr></table>"
+        )
+        tables = extract_html_tables(html)
+        assert len(tables) == 1
+        assert "Row3" in tables[0]
+
+    def test_extract_multiple_top_level_with_nested(self) -> None:
+        """Multiple top-level tables, one with a nested table."""
+        html = "<table><tr><td>T1</td></tr></table><table><tr><td><table><tr><td>N</td></tr></table></td></tr></table>"
+        tables = extract_html_tables(html)
+        assert len(tables) == 2
+
+    def test_extract_does_not_match_table_prefix(self) -> None:
+        """<tabledata> or similar tags should not be matched as <table>."""
+        html = "<tabledata>foo</tabledata><table><tr><td>Real</td></tr></table>"
+        tables = extract_html_tables(html)
+        assert len(tables) == 1
+        assert "Real" in tables[0]
+
+    def test_parse_html_tables_nested_no_row_leak(self) -> None:
+        """Nested table rows must not appear in the outer table's grid."""
+        html = (
+            "<table>"
+            "<tr><td>Cell A</td><td>"
+            "<table><tr><td>Nested1</td></tr><tr><td>Nested2</td></tr></table>"
+            "</td></tr>"
+            "<tr><td>Cell B</td><td>Cell C</td></tr>"
+            "</table>"
+        )
+        tables = parse_html_tables(html)
+        # Should be 1 top-level table (nested table becomes cell text)
+        assert len(tables) == 1
+        assert tables[0].data.shape == (2, 2)  # 2 rows, 2 cols
+        assert tables[0].data[0, 0] == "Cell A"
+        assert tables[0].data[1, 0] == "Cell B"
+
+    def test_nested_table_becomes_cell_text(self) -> None:
+        """Nested table content should appear as text in the containing cell."""
+        html = "<table><tr><td>X</td><td><table><tr><td>A</td></tr><tr><td>B</td></tr></table></td></tr></table>"
+        tables = parse_html_tables(html)
+        assert len(tables) == 1
+        # The cell with the nested table should contain flattened text
+        cell_val = tables[0].data[0, 1]
+        assert "A" in cell_val
+        assert "B" in cell_val
+
+    def test_end_to_end_nested_table_scores(self, metric: TableRecordMatchMetric) -> None:
+        """A table with nested content should still score well against flat equivalent."""
+        gt = _simple_table(["Name", "Details"], [["Alice", "Note A Note B"], ["Bob", "Note C"]])
+        pred = (
+            "<table><thead><tr><th>Name</th><th>Details</th></tr></thead>"
+            "<tbody>"
+            "<tr><td>Alice</td><td>"
+            "<table><tr><td>Note A</td></tr><tr><td>Note B</td></tr></table>"
+            "</td></tr>"
+            "<tr><td>Bob</td><td>Note C</td></tr>"
+            "</tbody></table>"
+        )
+        result = metric.compute(expected=gt, actual=pred)
+        # Should not crash; should find 1 table on each side
+        assert len(result) == 2
+        assert result[0].metadata["n_pred_tables"] == 1
+
+
+# ===========================================================================
+# Phase 2: <td> title row detection
+# ===========================================================================
+
+
+class TestTdTitleRows:
+    """Phase 2: <td> title rows should be excluded like <th> title rows."""
+
+    def test_td_title_row_excluded_from_records(self) -> None:
+        """A <td> row spanning full width with uniform text is a title, not data."""
+        html = _html(
+            '<tr><td colspan="2">Table Title</td></tr>'
+            "<thead><tr><th>A</th><th>B</th></tr></thead>"
+            "<tbody><tr><td>1</td><td>2</td></tr></tbody>"
+        )
+        tables = parse_html_tables(html)
+        keys, records, _ = table_to_records(tables[0])
+        # Title row should not appear as a record
+        assert len(records) == 1
+        assert records[0] != {"A": "Table Title", "B": "Table Title"}
+
+    def test_td_title_row_not_in_keys(self) -> None:
+        """<td> title row text should not appear in column keys."""
+        html = _html(
+            '<tr><td colspan="2">Sales Data</td></tr>'
+            "<thead><tr><th>Q1</th><th>Q2</th></tr></thead>"
+            "<tbody><tr><td>100</td><td>200</td></tr></tbody>"
+        )
+        tables = parse_html_tables(html)
+        keys, records, _ = table_to_records(tables[0])
+        assert keys == ["Q1", "Q2"]
+
+    def test_td_title_matches_th_title(self, metric: TableRecordMatchMetric) -> None:
+        """GT with <th> title and pred with <td> title should score 1.0."""
+        gt = _html(
+            "<thead>"
+            '<tr><th colspan="2">Title</th></tr>'
+            "<tr><th>A</th><th>B</th></tr>"
+            "</thead>"
+            "<tbody><tr><td>1</td><td>2</td></tr></tbody>"
+        )
+        pred = _html(
+            '<tr><td colspan="2">Title</td></tr>'
+            "<thead><tr><th>A</th><th>B</th></tr></thead>"
+            "<tbody><tr><td>1</td><td>2</td></tr></tbody>"
+        )
+        result = metric.compute(expected=gt, actual=pred)
+        assert result[0].value == pytest.approx(1.0)
+
+    def test_td_title_vs_no_title(self, metric: TableRecordMatchMetric) -> None:
+        """Pred with <td> title row vs GT without title should still score 1.0."""
+        gt = _simple_table(["A", "B"], [["1", "2"]])
+        pred = _html(
+            '<tr><td colspan="2">Some Title</td></tr>'
+            "<thead><tr><th>A</th><th>B</th></tr></thead>"
+            "<tbody><tr><td>1</td><td>2</td></tr></tbody>"
+        )
+        result = metric.compute(expected=gt, actual=pred)
+        assert result[0].value == pytest.approx(1.0)
+
+    def test_multiple_td_title_rows(self) -> None:
+        """Multiple consecutive <td> title rows should all be excluded."""
+        html = _html(
+            '<tr><td colspan="2">Title Line 1</td></tr>'
+            '<tr><td colspan="2">Title Line 2</td></tr>'
+            "<thead><tr><th>X</th><th>Y</th></tr></thead>"
+            "<tbody><tr><td>a</td><td>b</td></tr></tbody>"
+        )
+        tables = parse_html_tables(html)
+        keys, records, _ = table_to_records(tables[0])
+        assert len(records) == 1
+        assert keys == ["X", "Y"]
+
+    def test_non_uniform_td_row_is_not_title(self) -> None:
+        """A <td> row with different values in each column is data, not a title."""
+        html = _html(
+            "<tr><td>Cat A</td><td>Cat B</td></tr>"
+            "<thead><tr><th>X</th><th>Y</th></tr></thead>"
+            "<tbody><tr><td>1</td><td>2</td></tr></tbody>"
+        )
+        tables = parse_html_tables(html)
+        keys, records, _ = table_to_records(tables[0])
+        # "Cat A" / "Cat B" is a data row, not a title — it must appear in records
+        cat_values = [r for r in records if "Cat A" in r.values() or "Cat B" in r.values()]
+        assert len(cat_values) > 0, "Non-uniform <td> row should be data, not a title"
+
+    def test_headerless_table_uniform_row_not_title(self) -> None:
+        """In a fully headerless table where ALL rows are uniform, none are titles.
+
+        If every row has uniform text across columns, the entire table
+        is just data — we can't strip all rows as titles.
+        """
+        html = _html("<tr><td>Yes</td><td>Yes</td></tr><tr><td>No</td><td>No</td></tr>")
+        tables = parse_html_tables(html)
+        keys, records, _ = table_to_records(tables[0])
+        assert len(records) == 2  # Both rows are data, not titles
+
+    def test_headerless_table_with_td_title(self) -> None:
+        """A headerless table with a <td colspan> title row followed by data rows.
+
+        The title row should be stripped even without any <th> cells.
+        """
+        html = _html(
+            '<tr><td colspan="2">Report Title</td></tr>'
+            "<tr><td>Alice</td><td>30</td></tr>"
+            "<tr><td>Bob</td><td>25</td></tr>"
+        )
+        tables = parse_html_tables(html)
+        keys, records, _ = table_to_records(tables[0])
+        assert len(records) == 2  # Title row excluded, 2 data rows remain
+        # Title text should not appear in records
+        for r in records:
+            assert "Report Title" not in r.values()
+
+    def test_single_column_td_row_not_title(self) -> None:
+        """In a 1-column table, a leading <td> row must NOT be treated as a title.
+
+        "Uniform text across all columns" is trivially true for 1 column,
+        so the n_cols > 1 guard must prevent false positives.
+        """
+        html = _html("<tr><td>Row 1</td></tr><tr><td>Row 2</td></tr>")
+        tables = parse_html_tables(html)
+        keys, records, _ = table_to_records(tables[0])
+        assert len(records) == 2  # Both rows are data, not titles
+
+
+# ===========================================================================
+# Phase 3: Section header removal
+# ===========================================================================
+
+
+class TestSectionHeaderRemoval:
+    """Phase 3: Section headers are regular data rows — no special treatment."""
+
+    def test_th_section_row_becomes_record(self) -> None:
+        """A mid-table <th> row should be emitted as a regular record."""
+        html = _html(
+            "<thead><tr><th>Item</th><th>Value</th></tr></thead>"
+            "<tbody>"
+            "<tr><td>A</td><td>10</td></tr>"
+            '<tr><th colspan="2">Section B</th></tr>'
+            "<tr><td>B1</td><td>20</td></tr>"
+            "</tbody>"
+        )
+        tables = parse_html_tables(html)
+        keys, records, _ = table_to_records(tables[0])
+        # 3 records: A/10, Section B/Section B, B1/20
+        assert len(records) == 3
+
+    def test_th_vs_td_section_row_match(self, metric: TableRecordMatchMetric) -> None:
+        """GT with <th> section row and pred with <td> equivalent should score 1.0."""
+        gt = _html(
+            "<thead><tr><th>Item</th><th>Value</th></tr></thead>"
+            "<tbody>"
+            "<tr><td>A</td><td>10</td></tr>"
+            '<tr><th colspan="2">Section B</th></tr>'
+            "<tr><td>B1</td><td>20</td></tr>"
+            "</tbody>"
+        )
+        pred = _html(
+            "<thead><tr><th>Item</th><th>Value</th></tr></thead>"
+            "<tbody>"
+            "<tr><td>A</td><td>10</td></tr>"
+            '<tr><td colspan="2">Section B</td></tr>'
+            "<tr><td>B1</td><td>20</td></tr>"
+            "</tbody>"
+        )
+        result = metric.compute(expected=gt, actual=pred)
+        assert result[0].value == pytest.approx(1.0)
+
+    def test_no_section_field_in_records(self) -> None:
+        """Records must not contain _section metadata field."""
+        html = _html(
+            "<thead><tr><th>A</th><th>B</th></tr></thead>"
+            "<tbody>"
+            "<tr><td>1</td><td>2</td></tr>"
+            '<tr><th colspan="2">Section</th></tr>'
+            "<tr><td>3</td><td>4</td></tr>"
+            "</tbody>"
+        )
+        tables = parse_html_tables(html)
+        keys, records, _ = table_to_records(tables[0])
+        for r in records:
+            assert "_section" not in r
+
+    def test_section_header_both_sides(self, metric: TableRecordMatchMetric) -> None:
+        """Both sides with same section headers should score 1.0."""
+        table = _html(
+            "<thead><tr><th>Item</th><th>Value</th></tr></thead>"
+            "<tbody>"
+            "<tr><td>A</td><td>10</td></tr>"
+            '<tr><th colspan="2">Group</th></tr>'
+            "<tr><td>B</td><td>20</td></tr>"
+            "</tbody>"
+        )
+        result = TableRecordMatchMetric().compute(expected=table, actual=table)
+        assert result[0].value == pytest.approx(1.0)
+
+    def test_missing_section_row_penalizes_proportionally(self, metric: TableRecordMatchMetric) -> None:
+        """If GT has a section row and pred omits it, penalty is proportional (1 missing row)."""
+        gt = _html(
+            "<thead><tr><th>Item</th><th>Value</th></tr></thead>"
+            "<tbody>"
+            "<tr><td>A</td><td>10</td></tr>"
+            '<tr><th colspan="2">Section B</th></tr>'
+            "<tr><td>B1</td><td>20</td></tr>"
+            "</tbody>"
+        )
+        pred = _html(
+            "<thead><tr><th>Item</th><th>Value</th></tr></thead>"
+            "<tbody>"
+            "<tr><td>A</td><td>10</td></tr>"
+            "<tr><td>B1</td><td>20</td></tr>"
+            "</tbody>"
+        )
+        result = metric.compute(expected=gt, actual=pred)
+        # 2 of 3 GT records matched → ~0.67, not 1.0 (section row is now a real record)
+        assert 0.55 <= result[0].value <= 0.75
+
+
+# ===========================================================================
+# Combined integration test (all three normalizations)
+# ===========================================================================
+
+
+class TestCombinedNormalizations:
+    """All three normalizations together in realistic scenarios."""
+
+    def test_combined_nested_td_title_and_section(self, metric: TableRecordMatchMetric) -> None:
+        """All three normalizations in one table: nested table + <td> title + <th> section."""
+        gt = _html(
+            "<thead><tr><th>Item</th><th>Value</th></tr></thead>"
+            "<tbody>"
+            "<tr><td>A</td><td>10</td></tr>"
+            "<tr><td>B</td><td>20</td></tr>"
+            "</tbody>"
+        )
+        pred = (
+            "<table>"
+            '<tr><td colspan="2">Report Title</td></tr>'
+            "<thead><tr><th>Item</th><th>Value</th></tr></thead>"
+            "<tbody>"
+            "<tr><td>A</td><td>10</td></tr>"
+            '<tr><th colspan="2">Section X</th></tr>'
+            "<tr><td>B</td><td>"
+            "<table><tr><td>20</td></tr></table>"
+            "</td></tr>"
+            "</tbody>"
+            "</table>"
+        )
+        result = metric.compute(expected=gt, actual=pred)
+        # Should find 1 table on each side (nested table is cell text, not a separate table)
+        assert result[0].metadata["n_gt_tables"] == 1
+        assert result[0].metadata["n_pred_tables"] == 1
+        # <td> title row excluded, section row is a record, nested table content is cell text
+        # GT has 2 data records; pred has 3 (A, Section X, B) — section row is extra
+        # Score should reflect 2 matched out of 3, not crash or score 0
+        assert result[0].value > 0.5
+
+
+# ===========================================================================
+# Row-key removal tests
+# ===========================================================================
+
+
+class TestNoRowKey:
+    """Records should not contain _row_key metadata."""
+
+    def test_dual_axis_no_row_key(self) -> None:
+        """Dual-axis table records should NOT have _row_key field."""
+        html = _html(
+            "<thead><tr><th></th><th>Q1</th><th>Q2</th></tr></thead>"
+            "<tbody>"
+            "<tr><th>Revenue</th><td>100</td><td>200</td></tr>"
+            "</tbody>"
+        )
+        tables = parse_html_tables(html)
+        keys, records, _ = table_to_records(tables[0])
+        for r in records:
+            assert "_row_key" not in r
+
+    def test_dual_axis_row_header_in_data(self) -> None:
+        """Row header <th> values should appear as regular data columns."""
+        html = _html(
+            "<thead><tr><th></th><th>Q1</th><th>Q2</th></tr></thead>"
+            "<tbody>"
+            "<tr><th>Revenue</th><td>100</td><td>200</td></tr>"
+            "<tr><th>Cost</th><td>50</td><td>80</td></tr>"
+            "</tbody>"
+        )
+        tables = parse_html_tables(html)
+        keys, records, _ = table_to_records(tables[0])
+        # All columns should be in keys (including the row-header column)
+        assert len(keys) == 3
+        # Revenue/Cost should appear as values in records
+        all_values = [v for r in records for v in r.values()]
+        assert "Revenue" in all_values
+        assert "Cost" in all_values
+
+
+# ===========================================================================
+# Partial-span title detection tests
+# ===========================================================================
+
+
+class TestPartialSpanTitle:
+    """Title detection for headers that span most but not all columns."""
+
+    def test_title_with_empty_corner(self) -> None:
+        """A spanning header missing the leftmost corner cell is still a title."""
+        html = _html(
+            "<thead>"
+            '<tr><th></th><th colspan="2">Sales</th></tr>'
+            "<tr><th>Region</th><th>Q1</th><th>Q2</th></tr>"
+            "</thead>"
+            "<tbody><tr><td>East</td><td>100</td><td>200</td></tr></tbody>"
+        )
+        tables = parse_html_tables(html)
+        keys, records, _ = table_to_records(tables[0])
+        # "Sales" should be excluded as a title — it spans all columns
+        # that Q1/Q2 span but misses the empty corner
+        assert "Sales" not in " ".join(keys)
+        assert "Q1" in keys or any("Q1" in k for k in keys)
+
+    def test_title_below_leaf_headers(self) -> None:
+        """A spanning header BELOW the leaf column headers is still a title."""
+        html = _html(
+            "<thead>"
+            "<tr><th>Q1</th><th>Q2</th></tr>"
+            '<tr><th colspan="2">Sales</th></tr>'
+            "</thead>"
+            "<tbody><tr><td>100</td><td>200</td></tr></tbody>"
+        )
+        tables = parse_html_tables(html)
+        keys, records, _ = table_to_records(tables[0])
+        # "Sales" spans all columns as a redundant leaf → title, excluded
+        assert keys == ["Q1", "Q2"]
+
+    def test_title_below_with_empty_corner(self) -> None:
+        """Spanning header below leaf headers, with an empty corner cell."""
+        html = _html(
+            "<thead>"
+            "<tr><th>Region</th><th>Q1</th><th>Q2</th></tr>"
+            '<tr><th></th><th colspan="2">Sales</th></tr>'
+            "</thead>"
+            "<tbody><tr><td>East</td><td>100</td><td>200</td></tr></tbody>"
+        )
+        tables = parse_html_tables(html)
+        keys, records, _ = table_to_records(tables[0])
+        # "Sales" covers all columns that have headers above (Q1, Q2)
+        # minus the edge (Region) → title, excluded
+        assert "Sales" not in " ".join(keys)
+        assert "Region" in keys
+
+    def test_title_below_vs_above_match(self, metric: TableRecordMatchMetric) -> None:
+        """GT and pred both with title below (trailing) should score 1.0."""
+        gt = _html(
+            "<thead>"
+            "<tr><th>Q1</th><th>Q2</th></tr>"
+            '<tr><th colspan="2">Sales</th></tr>'
+            "</thead>"
+            "<tbody><tr><td>100</td><td>200</td></tr></tbody>"
+        )
+        pred = _html(
+            "<thead>"
+            "<tr><th>Q1</th><th>Q2</th></tr>"
+            '<tr><th colspan="2">Sales</th></tr>'
+            "</thead>"
+            "<tbody><tr><td>100</td><td>200</td></tr></tbody>"
+        )
+        result = metric.compute(expected=gt, actual=pred)
+        assert result[0].value == pytest.approx(1.0)
+
+    def test_group_header_not_title(self) -> None:
+        """A header that spans only SOME data columns is a group header, not a title."""
+        html = _html(
+            "<thead>"
+            '<tr><th colspan="2">Group A</th><th>Other</th></tr>'
+            "<tr><th>X</th><th>Y</th><th>Z</th></tr>"
+            "</thead>"
+            "<tbody><tr><td>1</td><td>2</td><td>3</td></tr></tbody>"
+        )
+        tables = parse_html_tables(html)
+        keys, records, _ = table_to_records(tables[0])
+        # "Group A" spans only 2 of 3 data columns — NOT a title
+        assert any("Group A" in k for k in keys)
+
+    def test_trailing_th_title_becomes_data_record(self) -> None:
+        """A <th> title row at the END of a multi-row header block becomes a data record."""
+        html = _html(
+            "<tr><th>Disorder</th><th>Medical History</th><th>Physical Exam</th></tr>"
+            '<tr><th colspan="3">SPINAL DISORDERS</th></tr>'
+            "<tr><td>Fracture</td><td>Major trauma</td><td>Percussion</td></tr>"
+        )
+        tables = parse_html_tables(html)
+        keys, records, _ = table_to_records(tables[0])
+        # Keys should come from the real header row only
+        assert keys == ["Disorder", "Medical History", "Physical Exam"]
+        # SPINAL DISORDERS should be emitted as a data record
+        assert len(records) == 2
+        assert records[0] == {
+            "Disorder": "SPINAL DISORDERS",
+            "Medical History": "SPINAL DISORDERS",
+            "Physical Exam": "SPINAL DISORDERS",
+        }
+        assert records[1] == {
+            "Disorder": "Fracture",
+            "Medical History": "Major trauma",
+            "Physical Exam": "Percussion",
+        }
+
+    def test_trailing_th_title_matches_td_equivalent(self) -> None:
+        """<th> title at end of header block should produce same records as <td> equivalent."""
+        th_html = _html(
+            '<tr><th>A</th><th>B</th></tr><tr><th colspan="2">Section</th></tr><tr><td>1</td><td>2</td></tr>'
+        )
+        td_html = _html(
+            '<tr><th>A</th><th>B</th></tr><tr><td colspan="2">Section</td></tr><tr><td>1</td><td>2</td></tr>'
+        )
+        th_tables = parse_html_tables(th_html)
+        td_tables = parse_html_tables(td_html)
+        th_keys, th_records, _ = table_to_records(th_tables[0])
+        td_keys, td_records, _ = table_to_records(td_tables[0])
+        assert th_keys == td_keys
+        assert th_records == td_records
+
+    def test_leading_th_title_still_skipped(self) -> None:
+        """A <th> title row at the START of a multi-row header block stays skipped."""
+        html = _html(
+            "<thead>"
+            '<tr><th colspan="2">Title</th></tr>'
+            "<tr><th>A</th><th>B</th></tr>"
+            "</thead>"
+            "<tbody><tr><td>1</td><td>2</td></tr></tbody>"
+        )
+        tables = parse_html_tables(html)
+        keys, records, _ = table_to_records(tables[0])
+        assert keys == ["A", "B"]
+        # Leading title row should NOT become a data record
+        assert len(records) == 1
+        assert records[0] == {"A": "1", "B": "2"}
+
+    def test_two_th_title_rows_at_top_no_double_emit(self) -> None:
+        """Two consecutive single-value <th> rows at the top.
+
+        Locks in the expected behavior for this shape:
+          1. Strip the top <th> row as the table title.
+          2. After stripping, only one header row remains, so the
+             section-header carve-out (which fires only inside a
+             multi-row header block) does NOT engage.
+          3. The remaining <th> row stays as the column header and is
+             not also emitted as data — exactly two data records (A, B).
+        """
+        from parse_bench.evaluation.metrics.parse.table_extraction import (
+            ExtractedTable,
+        )
+        from parse_bench.evaluation.metrics.parse.table_record_match_metric import (
+            extract_header_info_from_hints,
+        )
+        from parse_bench.evaluation.metrics.parse.table_title_stripping import (
+            strip_title_rows,
+        )
+
+        html = _html(
+            "<tbody>"
+            '<tr><th colspan="2">NAFOCG Tier Codes:</th></tr>'
+            '<tr><th colspan="2">NAFOCG Tie/AF_OCG Ratio</th></tr>'
+            "<tr><td>A</td><td>&lt; 1</td></tr>"
+            "<tr><td>B</td><td>= 1</td></tr>"
+            "</tbody>"
+        )
+        tables = parse_html_tables(html)
+        et = strip_title_rows(ExtractedTable(raw_html="", table_data=tables[0]))
+        header = extract_header_info_from_hints(et.table_data, et.header_hints)
+        records = build_records(et.table_data, header)
+
+        # Top title stripped — recorded in stripped_titles, not in column keys
+        assert any("nafocg tier codes" in t.lower() for t in header.stripped_titles)
+        assert not any("Tier Codes" in k for k in header.keys)
+
+        # Exactly two data records (A and B) — the remaining <th> row is
+        # the column header, not a section header, and must not be
+        # double-classified as data.
+        assert len(records) == 2
+        data_values = [tuple(r.values()) for r in records]
+        assert ("A", "< 1") in data_values
+        assert ("B", "= 1") in data_values
+        # Section-header text must not also appear as a data record
+        assert not any(any("Tie/AF_OCG Ratio" in str(v) for v in r.values()) for r in records)
+
+    def test_two_th_title_rows_e2e_no_extra_prediction(self, metric: TableRecordMatchMetric) -> None:
+        """End-to-end regression for the BRWS-134565917 bug.
+
+        Pred has two consecutive single-value <th> rows at the top
+        (title + section header). GT contains the same content but with
+        plain <td> cells (no <th> markup), so it parses with synthetic
+        column keys and the section-header text as the first data row.
+
+        Pre-fix: the pred-side header detector kept the title <th> row as
+        a header AND re-emitted the second <th> row as data via the
+        trailing-th-title carve-out, producing a spurious extra predicted
+        record (no GT match) that dragged TRM below ~0.65.
+
+        Post-fix: pred's title row is stripped, the remaining <th> row is
+        the column header, and there is no spurious extra record.
+        """
+        pred = _html(
+            "<tbody>"
+            '<tr><th colspan="2">NAFOCG Tier Codes:</th></tr>'
+            '<tr><th colspan="2">NAFOCG Tie/AF_OCG Ratio</th></tr>'
+            "<tr><td>A</td><td>&lt; 1</td></tr>"
+            "<tr><td>B</td><td>= 1</td></tr>"
+            "</tbody>"
+        )
+        gt = _html(
+            "<tbody>"
+            "<tr><td>NAFOCG Tier Codes:</td><td>NAFOCG Tie/AF_OCG Ratio</td></tr>"
+            "<tr><td>A</td><td>&lt; 1</td></tr>"
+            "<tr><td>B</td><td>= 1</td></tr>"
+            "</tbody>"
+        )
+        result = metric.compute(expected=gt, actual=pred)
+        # Pre-fix this scored ~0.625 (spurious Pred#1 extra prediction).
+        # Post-fix it scores ~0.833 — the extra prediction is gone.
+        assert result[0].metric_name == "table_record_match"
+        assert result[0].value > 0.75
+
+    def test_leading_all_empty_row_stripped(self, metric: TableRecordMatchMetric) -> None:
+        """Leading all-empty rows are physically removed by the strip stage.
+
+        Before this fix, a leading ``<tr><td></td><td></td></tr>`` caused
+        ``find_col_header_rows`` to break at row 0 (not a ``<th>`` row),
+        losing the real ``<th>`` header block behind it. Column keys fell
+        back to synthetic ``col_0`` / ``col_1``, and comparing against a
+        GT with real headers dropped TRM to 0.0.
+        """
+        from parse_bench.evaluation.metrics.parse.table_extraction import (
+            ExtractedTable,
+        )
+        from parse_bench.evaluation.metrics.parse.table_title_stripping import (
+            strip_title_rows,
+        )
+
+        html_with_empty = _html(
+            "<tbody>"
+            "<tr><td></td><td></td></tr>"
+            "<tr><th>A</th><th>B</th></tr>"
+            "<tr><td>1</td><td>2</td></tr>"
+            "<tr><td>3</td><td>4</td></tr>"
+            "</tbody>"
+        )
+        tables = parse_html_tables(html_with_empty)
+        et = strip_title_rows(ExtractedTable(raw_html="", table_data=tables[0]))
+        # Leading empty row is gone: 1 header + 2 data = 3 rows.
+        assert et.table_data.data.shape[0] == 3
+        assert et.header_hints is not None
+        # Real header row is preserved (row index 0 in the trimmed table).
+        assert et.header_hints.col_header_rows == frozenset({0})
+
+        # End-to-end: GT clean, pred with a leading empty row → perfect.
+        gt = _html("<tr><th>A</th><th>B</th></tr><tr><td>1</td><td>2</td></tr><tr><td>3</td><td>4</td></tr>")
+        result = metric.compute(expected=gt, actual=html_with_empty)
+        assert result[0].value == pytest.approx(1.0)
+
+    def test_stripped_titles_not_double_normalized(self) -> None:
+        """Regression: stripped_titles must be passed through verbatim from hints.
+
+        ``strip_title_rows`` already collects ``stripped_titles`` from a
+        normalized copy of the table, so the strings stored in
+        ``HeaderHints.stripped_titles`` are single-normalized. Re-applying
+        the per-cell normalization chain in ``extract_header_info_from_hints``
+        would double-normalize them — and ``_normalize_trm_cell_text``'s
+        comma-stripping rule is not idempotent (``"1,2,3" → "12,3" → "123"``),
+        so a doubly-normalized title would fail to prefix-match the
+        single-normalized column keys it is compared against.
+        """
+        from parse_bench.evaluation.metrics.parse.table_record_match_metric import (
+            extract_header_info_from_hints,
+        )
+        from parse_bench.evaluation.metrics.parse.table_title_stripping import (
+            HeaderHints,
+        )
+
+        # Build a minimal trimmed table; the contents of the table aren't
+        # what's under test — only the title round-trip.
+        tables = parse_html_tables(_html("<tr><td>x</td><td>y</td></tr>"))
+        hints = HeaderHints(
+            col_header_rows=frozenset(),
+            th_title_rows=frozenset(),
+            stripped_titles=frozenset({"foo 12,3"}),  # already single-normalized
+        )
+        header = extract_header_info_from_hints(tables[0], hints)
+        # Must be preserved verbatim — NOT double-normalized to "foo 123".
+        assert header.stripped_titles == {"foo 12,3"}
+
+
+# ===========================================================================
+# Multi-level key separator tests
+# ===========================================================================
+
+
+class TestKeySpaceSeparator:
+    """Multi-level headers use space separator, matching concatenated forms."""
+
+    def test_space_separator_key_format(self) -> None:
+        """Keys from multi-level headers should use space, not ' > '."""
+        html = _html(
+            "<thead>"
+            '<tr><th colspan="2">Group A</th><th>Other</th></tr>'
+            "<tr><th>X</th><th>Y</th><th>Z</th></tr>"
+            "</thead>"
+            "<tbody><tr><td>1</td><td>2</td><td>3</td></tr></tbody>"
+        )
+        tables = parse_html_tables(html)
+        keys, records, _ = table_to_records(tables[0])
+        # Should be "Group A X", "Group A Y", "Z" — not "Group A > X"
+        assert " > " not in " | ".join(keys)
+        assert "Group A X" in keys
+        assert "Group A Y" in keys
+
+    def test_concatenated_vs_multilevel_match(self, metric: TableRecordMatchMetric) -> None:
+        """'July €000s' in one cell should match 'July' + '€000s' in two header rows."""
+        gt = _html(
+            "<thead>"
+            '<tr><th colspan="2">Period</th><th>Other</th></tr>'
+            "<tr><th>July</th><th>Aug</th><th>Total</th></tr>"
+            "</thead>"
+            "<tbody><tr><td>100</td><td>200</td><td>300</td></tr></tbody>"
+        )
+        # Pred has the same structure — keys should match via space join
+        pred = _html(
+            "<thead>"
+            '<tr><th colspan="2">Period</th><th>Other</th></tr>'
+            "<tr><th>July</th><th>Aug</th><th>Total</th></tr>"
+            "</thead>"
+            "<tbody><tr><td>100</td><td>200</td><td>300</td></tr></tbody>"
+        )
+        result = metric.compute(expected=gt, actual=pred)
+        assert result[0].value == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# Record details diagnostics
+# ---------------------------------------------------------------------------
+
+
+class TestRecordDetails:
+    """Tests for build_record_details and its integration into compute()."""
+
+    def test_build_record_details_matched_pair(self) -> None:
+        """Matched records produce per-cell expected/actual/score entries."""
+        gt_records = [{"Name": "Alice", "Age": "30"}]
+        pred_records = [{"Name": "Alice", "Age": "30"}]
+        col_mapping = {"Name": "Name", "Age": "Age"}
+        matches = [(0, 0, 1.0)]
+
+        details = build_record_details(gt_records, pred_records, col_mapping, matches)
+
+        assert len(details) == 1
+        d = details[0]
+        assert d["type"] == "matched"
+        assert d["gt_index"] == 0
+        assert d["pred_index"] == 0
+        assert d["score"] == pytest.approx(1.0)
+        assert len(d["cells"]) == 2
+        for cell in d["cells"]:
+            assert cell["expected"] == cell["actual"]
+            assert cell["score"] == pytest.approx(1.0)
+
+    def test_build_record_details_wrong_cell(self) -> None:
+        """A mismatched cell should score 0.0 while correct cells score 1.0."""
+        gt_records = [{"Name": "Alice", "Age": "30"}]
+        pred_records = [{"Name": "Alice", "Age": "99"}]
+        col_mapping = {"Name": "Name", "Age": "Age"}
+        matches = [(0, 0, 0.5)]
+
+        details = build_record_details(gt_records, pred_records, col_mapping, matches)
+
+        cells_by_col = {c["column"]: c for c in details[0]["cells"]}
+        assert cells_by_col["Name"]["score"] == pytest.approx(1.0)
+        assert cells_by_col["Age"]["expected"] == "30"
+        assert cells_by_col["Age"]["actual"] == "99"
+        assert cells_by_col["Age"]["score"] == pytest.approx(0.0)
+
+    def test_build_record_details_unmatched_gt(self) -> None:
+        """GT records with no pred match appear as unmatched_gt."""
+        gt_records = [{"X": "1"}, {"X": "2"}]
+        pred_records = [{"X": "1"}]
+        col_mapping = {"X": "X"}
+        matches = [(0, 0, 1.0)]
+
+        details = build_record_details(gt_records, pred_records, col_mapping, matches)
+
+        unmatched = [d for d in details if d["type"] == "unmatched_gt"]
+        assert len(unmatched) == 1
+        assert unmatched[0]["gt_index"] == 1
+        assert unmatched[0]["pred_index"] is None
+        assert unmatched[0]["score"] == 0.0
+
+    def test_build_record_details_unmatched_pred(self) -> None:
+        """Extra pred records appear as unmatched_pred."""
+        gt_records = [{"X": "1"}]
+        pred_records = [{"X": "1"}, {"X": "extra"}]
+        col_mapping = {"X": "X"}
+        matches = [(0, 0, 1.0)]
+
+        details = build_record_details(gt_records, pred_records, col_mapping, matches)
+
+        unmatched = [d for d in details if d["type"] == "unmatched_pred"]
+        assert len(unmatched) == 1
+        assert unmatched[0]["gt_index"] is None
+        assert unmatched[0]["pred_index"] == 1
+
+    def test_build_record_details_zero_columns(self) -> None:
+        """Cells in zero_columns should report score 0.0, not the raw cell_score."""
+        gt_records = [{"Name": "Alice", "Age": "30"}]
+        pred_records = [{"Name": "Alice", "Age": "30"}]
+        col_mapping = {"Name": "Name", "Age": "Age"}
+        matches = [(0, 0, 0.5)]  # pair_score reflects the zero-column penalty
+
+        details = build_record_details(
+            gt_records,
+            pred_records,
+            col_mapping,
+            matches,
+            zero_columns={"Age"},
+        )
+
+        cells_by_col = {c["column"]: c for c in details[0]["cells"]}
+        # Name is not penalized — values match so score should be 1.0
+        assert cells_by_col["Name"]["score"] == pytest.approx(1.0)
+        # Age is in zero_columns — detail score must be 0.0 even though values match
+        assert cells_by_col["Age"]["score"] == pytest.approx(0.0)
+
+    def test_record_details_in_compute_output(self, metric: TableRecordMatchMetric) -> None:
+        """record_details should appear in per_table_details from compute()."""
+        gt = _simple_table(["Name", "Age"], [["Alice", "30"], ["Bob", "25"]])
+        pred = _simple_table(["Name", "Age"], [["Alice", "30"], ["Bob", "99"]])
+        result = metric.compute(expected=gt, actual=pred)
+
+        per_table = result[0].metadata["per_table_details"]
+        assert len(per_table) == 1
+        assert "record_details" in per_table[0]
+        record_details = per_table[0]["record_details"]
+        assert len(record_details) == 2  # two matched records
+        for rd in record_details:
+            assert rd["type"] == "matched"
+            assert "cells" in rd
+            assert len(rd["cells"]) == 2  # Name and Age columns
+
+
+# ---- Incomplete table (no closing </table>) should still score > 0 ----
+def test_incomplete_predicted_table_scores_nonzero(metric: TableRecordMatchMetric) -> None:
+    """A predicted table missing </table> should still be scored, not silently dropped."""
+    expected = _simple_table(["Name", "Age"], [["Alice", "30"], ["Bob", "25"]])
+    # Identical content but missing closing tag
+    actual = (
+        "<table><thead><tr><th>Name</th><th>Age</th></tr></thead>"
+        "<tbody><tr><td>Alice</td><td>30</td></tr>"
+        "<tr><td>Bob</td><td>25</td></tr></tbody>"
+    )
+    result = metric.compute(expected=expected, actual=actual)
+    assert len(result) >= 1
+    assert result[0].value > 0.0
+
+
+# ---------------------------------------------------------------------------
+# Unmatched column penalty
+# ---------------------------------------------------------------------------
+
+
+class TestBidirectionalUnmatchedColumnPenalty:
+    """Unmatched GT columns must penalize the score, not be silently ignored."""
+
+    def test_record_similarity_penalizes_unmatched_columns(self) -> None:
+        """_record_similarity (via match_records) must score 0 for unmatched GT columns."""
+        gt_keys = ["Name", "Age", "City"]
+        pred_keys = ["Name"]  # only 1 of 3 columns
+
+        gt_records = [{"Name": "Alice", "Age": "30", "City": "NYC"}]
+        pred_records = [{"Name": "Alice"}]
+
+        col_mapping, _ = align_columns(gt_keys, pred_keys)
+        # Only "Name" should map
+        assert len(col_mapping) == 1
+
+        _, score = match_records(gt_records, pred_records, col_mapping, gt_keys=gt_keys)
+        # With 1/3 columns matched and that cell correct: ~0.33, NOT 1.0
+        assert score < 0.5
+        assert score == pytest.approx(1.0 / 3.0)
+
+    def test_multilevel_header_title_stripping_aligns(self, metric: TableRecordMatchMetric) -> None:
+        """Multi-level GT headers vs flat pred headers should align via title fallback.
+
+        GT has hierarchical keys like 'Group A', 'Group B', 'Group C' because
+        'Group' is kept as part of the multi-level header.  Pred strips 'Group'
+        as a title row, producing keys 'A', 'B', 'C'.  The prefix-stripping
+        fallback should detect that 'Group' was a stripped title in pred, use
+        it to strip the prefix from GT keys, and align all columns.
+        """
+        gt = _html(
+            "<tbody>"
+            '<tr><th rowspan="2">Q</th><th colspan="3">Group</th></tr>'
+            "<tr><th>A</th><th>B</th><th>C</th></tr>"
+            "<tr><td>Q1</td><td>1</td><td>2</td><td>3</td></tr>"
+            "<tr><td>Q2</td><td>4</td><td>5</td><td>6</td></tr>"
+            "</tbody>"
+        )
+        # Pred: title row makes "Group" a title, so keys become just "A","B","C"
+        pred = _html(
+            "<tbody>"
+            '<tr><th colspan="4">Group</th></tr>'
+            "<tr><th>Q</th><th>A</th><th>B</th><th>C</th></tr>"
+            "<tr><td>Q1</td><td>1</td><td>2</td><td>3</td></tr>"
+            "<tr><td>Q2</td><td>4</td><td>5</td><td>6</td></tr>"
+            "</tbody>"
+        )
+        result = metric.compute(expected=gt, actual=pred)
+        # Title-aware prefix stripping should align all columns → 1.0
+        assert result[0].value == pytest.approx(1.0)
+
+    def test_unmatched_columns_penalize_without_title(self, metric: TableRecordMatchMetric) -> None:
+        """When column mismatch is NOT due to title stripping, penalty still applies."""
+        gt = _simple_table(
+            ["Name", "Age", "City"],
+            [["Alice", "30", "NYC"], ["Bob", "25", "LA"]],
+        )
+        pred = _simple_table(
+            ["Name", "X", "Y"],
+            [["Alice", "30", "NYC"], ["Bob", "25", "LA"]],
+        )
+        result = metric.compute(expected=gt, actual=pred)
+        # "Name" matches, but "Age"↔"X" and "City"↔"Y" are below threshold
+        # so only 1/3 columns map → score < 1.0
+        assert result[0].value < 1.0
+
+    def test_extra_pred_columns_penalize(self, metric: TableRecordMatchMetric) -> None:
+        """Extra pred columns that don't map to GT should penalize the score."""
+        gt = _simple_table(["Name", "Age"], [["Alice", "30"], ["Bob", "25"]])
+        pred = _simple_table(
+            ["Name", "Age", "Extra1", "Extra2"],
+            [["Alice", "30", "x", "y"], ["Bob", "25", "a", "b"]],
+        )
+        result = metric.compute(expected=gt, actual=pred)
+        # 2 of 4 columns match → record score ~0.5, not 1.0
+        assert result[0].value < 1.0
+        assert result[0].value == pytest.approx(0.5)
+
+    def test_partial_column_match_gives_credit(self, metric: TableRecordMatchMetric) -> None:
+        """Matched columns should still contribute to the score."""
+        gt = _simple_table(
+            ["Name", "Age", "City", "Country"],
+            [["Alice", "30", "NYC", "US"]],
+        )
+        # Pred matches 2 of 4 GT columns
+        pred = _simple_table(
+            ["Name", "City"],
+            [["Alice", "NYC"]],
+        )
+        result = metric.compute(expected=gt, actual=pred)
+        # 2/4 columns matched with correct values → 0.5
+        assert result[0].value == pytest.approx(0.5)
+
+    def test_all_columns_matched_still_scores_perfectly(self, metric: TableRecordMatchMetric) -> None:
+        """When all columns align, score should still be 1.0 (no false penalty)."""
+        table = _simple_table(
+            ["Name", "Age", "City"],
+            [["Alice", "30", "NYC"], ["Bob", "25", "LA"]],
+        )
+        result = metric.compute(expected=table, actual=table)
+        assert result[0].value == pytest.approx(1.0)
+
+
+# ===========================================================================
+# Phase 1 v2: Header normalization & strict threshold
+# ===========================================================================
+
+
+class TestHeaderNormalization:
+    """Phase 1 v2: col_headers are normalized; threshold is 0.9."""
+
+    def test_header_whitespace_accent_normalized(self, metric: TableRecordMatchMetric) -> None:
+        """Headers with whitespace/accent differences should match after normalization."""
+        gt = _simple_table(["Résumé", "Naïve"], [["a", "b"]])
+        pred = _simple_table(["Resume", "Naive"], [["a", "b"]])
+        result = metric.compute(expected=gt, actual=pred)
+        assert result[0].value == pytest.approx(1.0)
+
+    def test_threshold_rejects_fuzzy_below_90(self, metric: TableRecordMatchMetric) -> None:
+        """Column headers below 0.9 similarity should not match."""
+        gt = _simple_table(["Revenue", "Cost"], [["100", "50"]])
+        pred = _simple_table(["Rev", "Cst"], [["100", "50"]])
+        result = metric.compute(expected=gt, actual=pred)
+        # "Revenue" vs "Rev" is ~55% similarity, should NOT match
+        assert result[0].value < 1.0
+
+    def test_empty_header_vs_nonempty_no_match(self) -> None:
+        """Empty header vs non-empty header should produce 0.0 similarity."""
+        mapping, _ = _align_columns_header_core(
+            ["Name", "Age"],
+            ["Name", "col_1"],
+            pred_synthetic=frozenset({"col_1"}),
+        )
+        # "Age" (real) vs "col_1" (synthetic) should not match
+        assert "Age" not in mapping or mapping.get("Age") != "col_1"
+
+
+# ===========================================================================
+# Phase 2 v2: Header block & title refinements
+# ===========================================================================
+
+
+class TestFlatBottomHeader:
+    """Phase 2 v2: Flat-bottom header enforcement."""
+
+    def test_bottom_row_non_th_excluded(self) -> None:
+        """Bottom header row with non-<th> cells should be excluded from header block."""
+        # Row 0 is all <th>, row 1 has mix of <th> and <td>
+        html = _html("<thead><tr><th>A</th><th>B</th></tr></thead><tbody><tr><td>1</td><td>2</td></tr></tbody>")
+        tables = parse_html_tables(html)
+        keys, records, _ = table_to_records(tables[0])
+        # Normal case: header row kept
+        assert keys == ["A", "B"]
+        assert len(records) == 1
+
+    def test_single_spanning_header_not_stripped_as_title(self) -> None:
+        """A single spanning header row should NOT be stripped as title."""
+        html = _html(
+            '<thead><tr><th colspan="2">Category</th></tr></thead><tbody><tr><td>A</td><td>B</td></tr></tbody>'
+        )
+        tables = parse_html_tables(html)
+        header = extract_header_info(tables[0])
+        # Should NOT be stripped — it's the only header row
+        assert header.col_header_rows, "Single header row should not be stripped"
+        assert not header.th_title_rows, "Only header row should not be detected as title"
+
+    def test_mixed_th_td_bottom_row_excluded(self) -> None:
+        """Bottom header row with <td> at a column that has <th> in an earlier row is excluded.
+
+        Row 0: <th>A</th> <td>B</td>  — mixed, but first <th> row so included
+        Row 1: <td>X</td> <th>Y</th>  — col 0 is <td>, even though col 0 had <th> at row 0
+
+        Row 1 is excluded because (1, 0) is not a <th>-originated cell.
+        """
+        html = _html("<tr><th>A</th><td>B</td></tr><tr><td>X</td><th>Y</th></tr><tr><td>1</td><td>2</td></tr>")
+        tables = parse_html_tables(html)
+        header = extract_header_info(tables[0])
+        # Row 1 has a <td> at col 0 — it should NOT be in the header block
+        assert 1 not in header.col_header_rows
+        # Row 0 may or may not be a header (it has mixed <th>/<td>),
+        # but row 1's <td>X must not sneak in as a header cell
+        assert "X" not in " ".join(header.keys)
+
+    def test_colspan_th_row_kept_as_header(self) -> None:
+        """A row where <th colspan> covers all columns should stay in the header block.
+
+        Row 0: <th colspan="3">Group</th>  — expands to 3 grid cells, all from <th>
+        Row 1: <th>A</th><th>B</th><th>C</th>  — all <th>
+
+        The grid has non-empty values at all 3 columns of row 0, but they
+        all originate from the same <th> element.  The partial-<th> guard
+        must not reject this row.
+        """
+        html = _html(
+            "<thead>"
+            '<tr><th colspan="3">Group</th></tr>'
+            "<tr><th>A</th><th>B</th><th>C</th></tr>"
+            "</thead>"
+            "<tbody><tr><td>1</td><td>2</td><td>3</td></tr></tbody>"
+        )
+        tables = parse_html_tables(html)
+        header = extract_header_info(tables[0])
+        assert 0 in header.col_header_rows, "colspan'd <th> row should be in header block"
+        assert 1 in header.col_header_rows, "leaf <th> row should be in header block"
+
+    def test_partial_th_row_with_empty_td_is_a_section_row(self) -> None:
+        """A partial-<th> row in a table with a <th> row-header column is data.
+
+        Row 0: <th></th><th>Q1</th><th>Q2</th>  — all <th>, header
+        Row 1: <th>Revenue</th><td></td><td></td>  — <td> cells are empty
+        Row 2: <th>Cost</th><td>50</td><td>80</td>  — a data row
+
+        Row 2 proves column 0 carries <th> *row* headers, so row 1's <th> is
+        a row header too and its empty <td> cells make it a section label, not
+        another level of column header. This is the balance-sheet shape — a
+        prediction spelling row labels as <th> used to fold "Revenue" into the
+        label column's key and unmatch that column against a ground truth that
+        spells the same rows with <td>.
+        """
+        html = _html(
+            "<thead><tr><th></th><th>Q1</th><th>Q2</th></tr></thead>"
+            "<tbody>"
+            "<tr><th>Revenue</th><td></td><td></td></tr>"
+            "<tr><th>Cost</th><td>50</td><td>80</td></tr>"
+            "</tbody>"
+        )
+        tables = parse_html_tables(html)
+        header = extract_header_info(tables[0])
+        assert header.col_header_rows == {0}, "Section row must not extend the header block"
+        assert "Revenue" not in header.keys
+
+    def test_partial_th_row_with_empty_td_section_row_nonempty_corner(self) -> None:
+        """Same as above but row 0 has a non-empty corner cell instead of empty.
+
+        Row 0: <th>Q0</th><th>Q1</th><th>Q2</th>  — all <th>, header
+        Row 1: <th>Revenue</th><td></td><td></td>  — a section label
+
+        The keys stay the row-0 header; "Revenue" does not join "Q0".
+        """
+        html = _html(
+            "<thead><tr><th>Q0</th><th>Q1</th><th>Q2</th></tr></thead>"
+            "<tbody>"
+            "<tr><th>Revenue</th><td></td><td></td></tr>"
+            "<tr><th>Cost</th><td>50</td><td>80</td></tr>"
+            "</tbody>"
+        )
+        tables = parse_html_tables(html)
+        header = extract_header_info(tables[0])
+        assert header.col_header_rows == {0}, "Section row must not extend the header block"
+        assert header.keys == ["Q0", "Q1", "Q2"]
+
+    def test_dual_axis_data_row_excluded_from_headers(self) -> None:
+        """A dual-axis row (<th> row header + <td> data) must NOT be in the header block.
+
+        Row 0: <th></th><th>Q1</th><th>Q2</th>  — all <th>, header
+        Row 1: <th>Revenue</th><td>100</td><td>200</td>  — <th> is row label, <td> is data
+
+        Row 1 has non-empty <td> cells that are NOT from <th> elements,
+        so it's a data row despite containing a <th>.
+        """
+        html = _html(
+            "<thead><tr><th></th><th>Q1</th><th>Q2</th></tr></thead>"
+            "<tbody>"
+            "<tr><th>Revenue</th><td>100</td><td>200</td></tr>"
+            "</tbody>"
+        )
+        tables = parse_html_tables(html)
+        header = extract_header_info(tables[0])
+        assert 0 in header.col_header_rows, "Full-<th> row should be header"
+        assert 1 not in header.col_header_rows, "Dual-axis data row should NOT be header"
+
+
+class TestSectionHeaderPromotion:
+    """Phase 2 v2: Section header promotion try-both logic."""
+
+    def test_section_header_promoted_when_improves_alignment(self, metric: TableRecordMatchMetric) -> None:
+        """Section header below main header should be promoted when it improves alignment."""
+        # GT has the section value as part of header (2-level)
+        gt = _html(
+            "<thead>"
+            "<tr><th>Item</th><th>Value</th></tr>"
+            "</thead>"
+            "<tbody>"
+            '<tr><td colspan="2">Group A</td></tr>'
+            "<tr><td>X</td><td>10</td></tr>"
+            "</tbody>"
+        )
+        # Same structure — both sides have identical data
+        pred = _html(
+            "<thead>"
+            "<tr><th>Item</th><th>Value</th></tr>"
+            "</thead>"
+            "<tbody>"
+            '<tr><td colspan="2">Group A</td></tr>'
+            "<tr><td>X</td><td>10</td></tr>"
+            "</tbody>"
+        )
+        result = metric.compute(expected=gt, actual=pred)
+        assert result[0].value == pytest.approx(1.0)
+
+
+# ===========================================================================
+# Phase 3 v2: Header recovery & demotion
+# ===========================================================================
+
+
+class TestHeaderRecovery:
+    """Phase 3 v2: Recover pred headers from first data row."""
+
+    def test_pred_without_th_first_row_matches_gt(self, metric: TableRecordMatchMetric) -> None:
+        """Pred without <th> tags but first row matches GT headers → recovered."""
+        gt = _simple_table(["Name", "Age"], [["Alice", "30"], ["Bob", "25"]])
+        pred = _html(
+            "<tr><td>Name</td><td>Age</td></tr><tr><td>Alice</td><td>30</td></tr><tr><td>Bob</td><td>25</td></tr>"
+        )
+        result = metric.compute(expected=gt, actual=pred)
+        assert result[0].value == pytest.approx(1.0)
+
+    def test_pred_without_headers_no_match_no_recovery(self, metric: TableRecordMatchMetric) -> None:
+        """Pred without headers, first row doesn't match GT → no recovery."""
+        gt = _simple_table(["Name", "Age"], [["Alice", "30"]])
+        pred = _html("<tr><td>Foo</td><td>Bar</td></tr><tr><td>Alice</td><td>30</td></tr>")
+        result = metric.compute(expected=gt, actual=pred)
+        # No recovery — columns don't align, score should be low
+        assert result[0].value < 1.0
+
+
+class TestHeaderDemotion:
+    """Phase 3 v2: Demote pred headers when GT has no headers."""
+
+    def test_gt_no_headers_pred_with_headers_demoted(self, metric: TableRecordMatchMetric) -> None:
+        """Pred with <th> tags but GT has no headers → pred headers demoted to data."""
+        gt = _html("<tr><td>Alice</td><td>30</td></tr><tr><td>Bob</td><td>25</td></tr>")
+        pred = _simple_table(["Name", "Age"], [["Alice", "30"], ["Bob", "25"]])
+        result = metric.compute(expected=gt, actual=pred)
+        # After demotion, pred has 3 rows (header demoted to data) vs 2 GT rows
+        # Score should reflect mismatch but not crash
+        assert result[0].value < 1.0
+
+    def test_gt_no_headers_pred_with_td_title_and_headers_demoted(self, metric: TableRecordMatchMetric) -> None:
+        """Pred with <td> title + <th> headers, GT has no headers → title stripped, header demoted.
+
+        GT: 3 data rows (no headers, no titles)
+        Pred: 1 <td> title row + 1 <th> header row + 3 data rows
+
+        The upstream strip stage physically removes the <td> title row,
+        so it never reaches the demotion stage. The <th> header row is
+        then demoted to data because GT has no real headers. Net: pred
+        has 4 data rows (demoted header + 3 originally-data rows).
+        """
+        gt = _html(
+            "<tr><td>Alice</td><td>30</td></tr><tr><td>Bob</td><td>25</td></tr><tr><td>Carol</td><td>35</td></tr>"
+        )
+        pred = _html(
+            '<tr><td colspan="2">People</td></tr>'
+            "<thead><tr><th>Name</th><th>Age</th></tr></thead>"
+            "<tbody>"
+            "<tr><td>Alice</td><td>30</td></tr>"
+            "<tr><td>Bob</td><td>25</td></tr>"
+            "<tr><td>Carol</td><td>35</td></tr>"
+            "</tbody>"
+        )
+        result = metric.compute(expected=gt, actual=pred)
+        # Title stripped + <th> row demoted: 1 demoted header + 3 data = 4 records.
+        n_pred = result[0].metadata["per_table_details"][0].get("n_pred_records", 0)
+        assert n_pred == 4, f"Expected 4 pred records after strip+demote, got {n_pred}"
+
+    def test_gt_no_headers_pred_no_headers_positional(self, metric: TableRecordMatchMetric) -> None:
+        """Both without headers → positional alignment via synthetic keys."""
+        gt = _html("<tr><td>Alice</td><td>30</td></tr><tr><td>Bob</td><td>25</td></tr>")
+        pred = _html("<tr><td>Alice</td><td>30</td></tr><tr><td>Bob</td><td>25</td></tr>")
+        result = metric.compute(expected=gt, actual=pred)
+        assert result[0].value == pytest.approx(1.0)
+
+
+# ===========================================================================
+# Phase 4 v2: Empty header penalty, hard zero gate, no content alignment
+# ===========================================================================
+
+
+class TestEmptyHeaderPenalty:
+    """Phase 4 v2: Empty pred header for real GT header → column scores 0."""
+
+    def test_empty_pred_header_zeros_column(self, metric: TableRecordMatchMetric) -> None:
+        """GT column with real header matched to empty pred header → entire column scores 0."""
+        gt = _simple_table(["Name", "Age"], [["Alice", "30"]])
+        # Pred has same data but empty header for second column
+        pred = _html("<thead><tr><th>Name</th><th></th></tr></thead><tbody><tr><td>Alice</td><td>30</td></tr></tbody>")
+        result = metric.compute(expected=gt, actual=pred)
+        # Union denominator: "Name" matches (1.0), GT "Age" unmatched, pred ""
+        # unmatched → union size = 3, score = 1/3.
+        assert result[0].value == pytest.approx(1 / 3)
+
+    def test_no_column_matches_returns_zero(self, metric: TableRecordMatchMetric) -> None:
+        """No column matches → score exactly 0.0."""
+        gt = _simple_table(["Alpha", "Beta"], [["1", "2"]])
+        pred = _simple_table(["Gamma", "Delta"], [["1", "2"]])
+        result = metric.compute(expected=gt, actual=pred)
+        assert result[0].value == pytest.approx(0.0)
+
+    def test_headerless_vs_headerless_positional(self, metric: TableRecordMatchMetric) -> None:
+        """Headerless-vs-headerless tables align positionally via synthetic keys."""
+        gt = _html("<tr><td>A</td><td>B</td></tr><tr><td>C</td><td>D</td></tr>")
+        pred = _html("<tr><td>A</td><td>B</td></tr><tr><td>C</td><td>D</td></tr>")
+        result = metric.compute(expected=gt, actual=pred)
+        assert result[0].value == pytest.approx(1.0)
+
+    def test_all_columns_zeroed_scores_zero(self, metric: TableRecordMatchMetric) -> None:
+        """When ALL GT columns have real headers but ALL pred headers are empty, score is 0."""
+        gt = _simple_table(["Name", "Age"], [["Alice", "30"]])
+        pred = _html("<thead><tr><th></th><th></th></tr></thead><tbody><tr><td>Alice</td><td>30</td></tr></tbody>")
+        result = metric.compute(expected=gt, actual=pred)
+        assert result[0].value == pytest.approx(0.0)
+
+    def test_no_column_matches_detail_has_reason(self, metric: TableRecordMatchMetric) -> None:
+        """Hard gate returns detail dict with 'reason': 'no column matches'."""
+        gt = _simple_table(["Alpha", "Beta"], [["1", "2"]])
+        pred = _simple_table(["Gamma", "Delta"], [["1", "2"]])
+        result = metric.compute(expected=gt, actual=pred)
+        detail = result[0].metadata["per_table_details"][0]
+        assert detail["reason"] == "no column matches"
+
+    def test_no_column_matches_appears_in_detail_strings(self, metric: TableRecordMatchMetric) -> None:
+        """Hard gate (no column matches) should show reason, columns, and record count."""
+        gt = _simple_table(["Alpha", "Beta"], [["1", "2"]])
+        pred = _simple_table(["Gamma", "Delta"], [["1", "2"]])
+        result = metric.compute(expected=gt, actual=pred)
+        details = result[0].details or []
+        matching = [line for line in details if "no column matches" in line]
+        assert matching
+        assert "alpha" in matching[0].lower()
+        assert "beta" in matching[0].lower()
+        assert "1 record" in matching[0]
+
+    def test_unmatched_table_appears_in_detail_strings(self, metric: TableRecordMatchMetric) -> None:
+        """A GT table with no pred pairing should show columns and record count."""
+        t1 = _simple_table(["A"], [["1"]])
+        t2 = _simple_table(["B"], [["2"]])
+        t3 = _simple_table(["C"], [["3"]])
+        result = metric.compute(expected=t1 + t2 + t3, actual=t1 + t2)
+        details = result[0].details or []
+        matching = [line for line in details if "unmatched" in line]
+        assert matching
+        # Should include the GT table's column name and record count
+        assert "1 record" in matching[0]
+
+
+# ===========================================================================
+# Non-happy-path unit tests for helpers
+# ===========================================================================
+
+
+class TestSectionHeaderPromotionEdgeCases:
+    """Edge cases for _try_section_header_promotion."""
+
+    def test_no_header_rows_returns_none(self) -> None:
+        """No header rows → None (nothing to promote below)."""
+        header = HeaderInfo(
+            keys=["col_0", "col_1"],
+            synthetic_keys=frozenset({"col_0", "col_1"}),
+            col_header_rows=set(),
+            th_title_rows=set(),
+            td_title_rows=set(),
+            stripped_titles=set(),
+        )
+        html = _html("<tr><td>A</td><td>B</td></tr>")
+        table = parse_html_tables(html)[0]
+        assert _try_section_header_promotion(table, header) is None
+
+    def test_header_block_is_last_row_returns_none(self) -> None:
+        """Header block is the last row → no candidate row below."""
+        html = _html("<thead><tr><th>A</th><th>B</th></tr></thead>")
+        table = parse_html_tables(html)[0]
+        header = extract_header_info(table)
+        assert _try_section_header_promotion(table, header) is None
+
+    def test_candidate_row_not_section_like_returns_none(self) -> None:
+        """Candidate row has multiple distinct values → not a section header."""
+        html = _html(
+            "<thead><tr><th>A</th><th>B</th></tr></thead>"
+            "<tbody>"
+            "<tr><td>X</td><td>Y</td></tr>"
+            "<tr><td>1</td><td>2</td></tr>"
+            "</tbody>"
+        )
+        table = parse_html_tables(html)[0]
+        header = extract_header_info(table)
+        assert _try_section_header_promotion(table, header) is None
+
+
+class TestHeaderRecoveryEdgeCases:
+    """Edge cases for _try_recover_pred_header."""
+
+    def test_gt_all_synthetic_no_recovery(self) -> None:
+        """GT has all synthetic keys → no recovery attempted."""
+        gt_header = HeaderInfo(
+            keys=["col_0", "col_1"],
+            synthetic_keys=frozenset({"col_0", "col_1"}),
+            col_header_rows=set(),
+            th_title_rows=set(),
+            td_title_rows=set(),
+            stripped_titles=set(),
+        )
+        pred_header = HeaderInfo(
+            keys=["col_0", "col_1"],
+            synthetic_keys=frozenset({"col_0", "col_1"}),
+            col_header_rows=set(),
+            th_title_rows=set(),
+            td_title_rows=set(),
+            stripped_titles=set(),
+        )
+        html = _html("<tr><td>Name</td><td>Age</td></tr>")
+        pred_table = parse_html_tables(html)[0]
+        assert _try_recover_pred_header(gt_header, pred_table, pred_header) is None
+
+    def test_pred_already_has_real_headers_no_recovery(self) -> None:
+        """Pred already has real headers → no recovery attempted."""
+        gt_header = HeaderInfo(
+            keys=["Name", "Age"],
+            synthetic_keys=frozenset(),
+            col_header_rows={0},
+            th_title_rows=set(),
+            td_title_rows=set(),
+            stripped_titles=set(),
+        )
+        pred_header = HeaderInfo(
+            keys=["Name", "Age"],
+            synthetic_keys=frozenset(),
+            col_header_rows={0},
+            th_title_rows=set(),
+            td_title_rows=set(),
+            stripped_titles=set(),
+        )
+        html = _simple_table(["Name", "Age"], [["Alice", "30"]])
+        pred_table = parse_html_tables(html)[0]
+        assert _try_recover_pred_header(gt_header, pred_table, pred_header) is None
+
+    def test_pred_no_data_rows_no_recovery(self) -> None:
+        """Pred has no data rows → no recovery (nothing to promote)."""
+        gt_header = HeaderInfo(
+            keys=["Name", "Age"],
+            synthetic_keys=frozenset(),
+            col_header_rows={0},
+            th_title_rows=set(),
+            td_title_rows=set(),
+            stripped_titles=set(),
+        )
+        html = _html("<thead><tr><th>X</th><th>Y</th></tr></thead>")
+        pred_table = parse_html_tables(html)[0]
+        pred_header = extract_header_info(pred_table)
+        # All rows are header rows — no data rows to recover from
+        assert _try_recover_pred_header(gt_header, pred_table, pred_header) is None
+
+
+class TestHeaderDemotionEdgeCases:
+    """Edge cases for _demote_pred_headers."""
+
+    def test_gt_has_real_headers_no_demotion(self) -> None:
+        """GT has real headers → no demotion needed."""
+        gt_header = HeaderInfo(
+            keys=["Name", "Age"],
+            synthetic_keys=frozenset(),
+            col_header_rows={0},
+            th_title_rows=set(),
+            td_title_rows=set(),
+            stripped_titles=set(),
+        )
+        pred_header = HeaderInfo(
+            keys=["Name", "Age"],
+            synthetic_keys=frozenset(),
+            col_header_rows={0},
+            th_title_rows=set(),
+            td_title_rows=set(),
+            stripped_titles=set(),
+        )
+        html = _simple_table(["Name", "Age"], [["Alice", "30"]])
+        pred_table = parse_html_tables(html)[0]
+        result = _demote_pred_headers(gt_header, pred_table, pred_header)
+        assert result is pred_header  # Unchanged
+
+    def test_pred_all_synthetic_no_demotion(self) -> None:
+        """Pred already has all synthetic keys → nothing to demote."""
+        gt_header = HeaderInfo(
+            keys=["col_0", "col_1"],
+            synthetic_keys=frozenset({"col_0", "col_1"}),
+            col_header_rows=set(),
+            th_title_rows=set(),
+            td_title_rows=set(),
+            stripped_titles=set(),
+        )
+        pred_header = HeaderInfo(
+            keys=["col_0", "col_1"],
+            synthetic_keys=frozenset({"col_0", "col_1"}),
+            col_header_rows=set(),
+            th_title_rows=set(),
+            td_title_rows=set(),
+            stripped_titles=set(),
+        )
+        html = _html("<tr><td>A</td><td>B</td></tr>")
+        pred_table = parse_html_tables(html)[0]
+        result = _demote_pred_headers(gt_header, pred_table, pred_header)
+        assert result is pred_header  # Unchanged
+
+
+class TestAlignColumnsHeaderCoreEdgeCases:
+    """Edge cases for _align_columns_header_core empty-vs-nonempty guard."""
+
+    def test_synthetic_gt_vs_real_pred_no_match(self) -> None:
+        """Synthetic GT key vs real pred key → 0 similarity (no match)."""
+        mapping, _ = _align_columns_header_core(["col_0"], ["Name"], gt_synthetic=frozenset({"col_0"}))
+        assert not mapping
+
+    def test_synthetic_pred_vs_real_gt_no_match(self) -> None:
+        """Real GT key vs synthetic pred key → 0 similarity (no match)."""
+        mapping, _ = _align_columns_header_core(["Name"], ["col_0"], pred_synthetic=frozenset({"col_0"}))
+        assert not mapping
+
+    def test_both_real_headers_match(self) -> None:
+        """Both sides have real (non-synthetic) headers → normal fuzzy match."""
+        mapping, score = _align_columns_header_core(["Name", "Age"], ["Name", "Age"])
+        assert len(mapping) == 2
+        assert mapping == {"Name": "Name", "Age": "Age"}
+        assert score == pytest.approx(1.0)
+
+    def test_dash_separator_in_collapsed_hierarchy_matches(self) -> None:
+        """'A B' (GT, joined parent/child) matches 'A - B' (pred uses dash join)."""
+        mapping, score = _align_columns_header_core(["Group A B"], ["Group A - B"])
+        assert mapping == {"Group A B": "Group A - B"}
+        assert score >= 0.9
+
+    def test_short_dash_separator_in_collapsed_hierarchy_matches(self) -> None:
+        """Short keys: 'A B' vs 'A - B'. Without dash normalization fuzz=75%."""
+        mapping, score = _align_columns_header_core(["A B"], ["A - B"])
+        assert mapping == {"A B": "A - B"}
+        assert score >= 0.9
+
+    def test_en_dash_and_em_dash_separator_matches(self) -> None:
+        """En-dash and em-dash variants are also accepted as join separators."""
+        mapping_en, _ = _align_columns_header_core(["Group A B"], ["Group A \u2013 B"])
+        assert mapping_en == {"Group A B": "Group A \u2013 B"}
+        mapping_em, _ = _align_columns_header_core(["Group A B"], ["Group A \u2014 B"])
+        assert mapping_em == {"Group A B": "Group A \u2014 B"}
+
+    def test_dash_in_data_value_not_collapsed(self) -> None:
+        """Header normalization doesn't break unrelated dashes (sanity check)."""
+        # Pre-fix sanity: completely different keys still don't match.
+        mapping, _ = _align_columns_header_core(["Range"], ["Date"])
+        assert not mapping
+
+    def test_both_synthetic_keys_match(self) -> None:
+        """Both sides synthetic → positional alignment via matching key names.
+
+        When both sides are synthetic, both gk_empty and pk_empty are True,
+        so the empty-vs-nonempty guard doesn't fire. fuzz.ratio("col_0",
+        "col_0") gives 1.0, producing a positional match. This is intended:
+        headerless tables should align by column position, not by content.
+        """
+        syn = frozenset({"col_0", "col_1"})
+        mapping, score = _align_columns_header_core(
+            ["col_0", "col_1"], ["col_0", "col_1"], gt_synthetic=syn, pred_synthetic=syn
+        )
+        assert len(mapping) == 2
+        assert score == pytest.approx(1.0)
+
+    def test_real_key_named_col_not_treated_as_synthetic(self) -> None:
+        """A real header literally named 'col_0' should NOT be treated as synthetic.
+
+        This is the key reason for using a set rather than string-prefix matching.
+        """
+        mapping, score = _align_columns_header_core(
+            ["col_0"],
+            ["col_0"],
+            gt_synthetic=frozenset(),  # NOT synthetic despite the name
+            pred_synthetic=frozenset(),
+        )
+        assert len(mapping) == 1
+        assert score == pytest.approx(1.0)
+
+    def test_pred_synthetic_col_0_vs_gt_real_col_0_no_match(self) -> None:
+        """Pred has synthetic 'col_0', GT has real header named 'col_0' → no match.
+
+        The strings are identical, but the synthetic-vs-real asymmetry should
+        block the match.  With string-prefix matching this would incorrectly
+        match (both start with 'col_').
+        """
+        mapping, _ = _align_columns_header_core(
+            ["col_0"],
+            ["col_0"],
+            gt_synthetic=frozenset(),  # real
+            pred_synthetic=frozenset({"col_0"}),  # synthetic
+        )
+        assert not mapping
+
+    def test_gt_synthetic_col_0_vs_pred_real_col_0_no_match(self) -> None:
+        """Mirror: GT synthetic 'col_0' vs pred real 'col_0' → no match."""
+        mapping, _ = _align_columns_header_core(
+            ["col_0"],
+            ["col_0"],
+            gt_synthetic=frozenset({"col_0"}),  # synthetic
+            pred_synthetic=frozenset(),  # real
+        )
+        assert not mapping
+
+    def test_mixed_real_and_synthetic_partial_match(self) -> None:
+        """Mix of real and synthetic keys — only real-to-real pairs should match."""
+        mapping, _ = _align_columns_header_core(
+            ["Name", "col_1"],
+            ["Name", "col_1"],
+            gt_synthetic=frozenset({"col_1"}),
+            pred_synthetic=frozenset({"col_1"}),
+        )
+        assert mapping == {"Name": "Name", "col_1": "col_1"}
+
+    def test_mixed_real_synthetic_cross_no_match(self) -> None:
+        """Real key on one side, synthetic on the other — even with same name, no match."""
+        mapping, _ = _align_columns_header_core(
+            ["Name", "col_1"],
+            ["Name", "col_1"],
+            gt_synthetic=frozenset(),  # both real on GT side
+            pred_synthetic=frozenset({"col_1"}),  # col_1 synthetic on pred side
+        )
+        # "Name" ↔ "Name" matches (both real)
+        # "col_1" GT (real) vs "col_1" pred (synthetic) → blocked
+        assert len(mapping) == 1
+        assert "Name" in mapping
+
+
+class TestTitleStripGuardEdgeCases:
+    """Edge cases for _detect_th_title_rows: at most one title stripped from top."""
+
+    def test_two_title_rows_both_spanning_strips_only_top(self) -> None:
+        """Two header rows that are both spanning titles → only topmost stripped."""
+        html = _html(
+            "<thead>"
+            '<tr><th colspan="2">Title A</th></tr>'
+            '<tr><th colspan="2">Title B</th></tr>'
+            "</thead>"
+            "<tbody><tr><td>1</td><td>2</td></tr></tbody>"
+        )
+        tables = parse_html_tables(html)
+        header = extract_header_info(tables[0])
+        # Only the topmost title row is stripped; row 1 remains as a header
+        assert header.th_title_rows == {0}
+        assert 1 in header.col_header_rows
+
+    def test_three_deep_titles_one_real_header_strips_top_only(self) -> None:
+        """Three header rows: two spanning titles + one real → only topmost title stripped.
+
+        Row 0: <th colspan="3">Title A</th>  — spanning title (stripped)
+        Row 1: <th colspan="3">Title B</th>  — spanning title (kept — max 1 strip)
+        Row 2: <th>X</th><th>Y</th><th>Z</th>  — real leaf header
+
+        Only row 0 is stripped. Row 1's "Title B" becomes part of keys.
+        """
+        html = _html(
+            "<thead>"
+            '<tr><th colspan="3">Title A</th></tr>'
+            '<tr><th colspan="3">Title B</th></tr>'
+            "<tr><th>X</th><th>Y</th><th>Z</th></tr>"
+            "</thead>"
+            "<tbody><tr><td>1</td><td>2</td><td>3</td></tr></tbody>"
+        )
+        tables = parse_html_tables(html)
+        header = extract_header_info(tables[0])
+        assert header.th_title_rows == {0}
+        assert header.col_header_rows == {0, 1, 2}
+        # Row 1 "Title B" is now part of keys (joined with row 2 leaf headers)
+        assert any("Title B" in k for k in header.keys) or any("title b" in k.lower() for k in header.keys)
+
+
+class TestBottomOfBlockTitleStrip:
+    """Title rows at the bottom of the header block should be stripped."""
+
+    def test_bottom_units_subheader_stripped(self) -> None:
+        """A spanning <th> units row at the bottom of the header block is stripped.
+
+        This reproduces a real-world pattern (e.g. AMZN 10-K tables) where GT
+        has a <td colspan> units row (not a header) but pred has it as <th colspan>
+        (a header).  Without stripping, the units text pollutes every column key
+        and column alignment fails completely.
+
+        GT structure:
+          Row 0: <th rowspan="2"></th><th colspan="5">Year Ended December 31,</th>  — title
+          Row 1: <th>2005</th>...<th>2001</th>  — real leaf header
+          Row 2: <td colspan="5">(in millions)</td>  — data row (units)
+
+        Pred structure (same content, but units row is <th>):
+          Row 0: <th colspan="6">Year Ended December 31,</th>  — title
+          Row 1: <th></th><th>2005</th>...<th>2001</th>  — real leaf header
+          Row 2: <th colspan="6">(in millions)</th>  — title at bottom of block
+        """
+        gt_html = _html(
+            "<thead>"
+            '<tr><th rowspan="2"></th><th colspan="5">Year Ended December 31,</th></tr>'
+            "<tr><th>2005</th><th>2004</th><th>2003</th><th>2002</th><th>2001</th></tr>"
+            "</thead>"
+            "<tbody>"
+            '<tr><td></td><td colspan="5">(in millions)</td></tr>'
+            "<tr><td>Net sales</td><td>$8,490</td><td>$6,921</td><td>$5,264</td><td>$3,933</td><td>$3,122</td></tr>"
+            "</tbody>"
+        )
+        pred_html = _html(
+            "<thead>"
+            '<tr><th colspan="6">Year Ended December 31,</th></tr>'
+            "<tr><th> </th><th>2005</th><th>2004</th><th>2003</th><th>2002</th><th>2001</th></tr>"
+            '<tr><th colspan="6">(in millions)</th></tr>'
+            "</thead>"
+            "<tbody>"
+            "<tr><td>Net sales</td><td>$8,490</td><td>$6,921</td><td>$5,264</td><td>$3,933</td><td>$3,122</td></tr>"
+            "</tbody>"
+        )
+
+        # Pred should strip both top title (row 0) and bottom title (row 2)
+        pred_tables = parse_html_tables(pred_html)
+        pred_header = extract_header_info(normalize_table(pred_tables[0]))
+        assert 0 in pred_header.th_title_rows, "top title row should be stripped"
+        assert 2 in pred_header.th_title_rows, "bottom units title row should be stripped"
+
+        # Column alignment should succeed
+        gt_tables = parse_html_tables(gt_html)
+        gt_header = extract_header_info(normalize_table(gt_tables[0]))
+        col_mapping, score = align_columns(
+            gt_header.keys,
+            pred_header.keys,
+            gt_synthetic=gt_header.synthetic_keys,
+            pred_synthetic=pred_header.synthetic_keys,
+        )
+        # All 6 columns should align
+        assert len(col_mapping) == 6
+        assert score > 0.9
+
+        # End-to-end: metric should score > 0
+        metric = TableRecordMatchMetric()
+        results = metric.compute(gt_html, pred_html)
+        assert results[0].value > 0.9
+
+
+class TestMidTableSectionHeaderAsData:
+    """Mid-table section header rows are data, not headers."""
+
+    def test_mid_table_th_section_is_data_row(self) -> None:
+        """A <th> row in the middle of the table body is a data record, not a header."""
+        html = _html(
+            "<thead><tr><th>Item</th><th>Value</th></tr></thead>"
+            "<tbody>"
+            "<tr><td>A</td><td>10</td></tr>"
+            '<tr><th colspan="2">Section X</th></tr>'
+            "<tr><td>B</td><td>20</td></tr>"
+            "</tbody>"
+        )
+        tables = parse_html_tables(html)
+        header = extract_header_info(tables[0])
+        # The section row (row 2 in grid) should NOT be in col_header_rows
+        assert header.col_header_rows == {0}
+        # It should appear as a data record
+        records = build_records(tables[0], header)
+        section_records = [r for r in records if "Section X" in r.values()]
+        assert len(section_records) == 1
+
+
+# ===========================================================================
+# Phase 5: Side-by-Side Table Splitting Tests
+# ===========================================================================
+
+
+class TestResolveHeaderRowValues:
+    """Tests for _resolve_header_row_values helper."""
+
+    def test_single_header_row(self) -> None:
+        html = _html(
+            "<tr><th>A</th><th>B</th><th>A</th><th>B</th></tr><tr><td>1</td><td>2</td><td>3</td><td>4</td></tr>"
+        )
+        tables = parse_html_tables(html)
+        table = normalize_table(tables[0])
+        header = extract_header_info(table)
+        row_values = _resolve_header_row_values(table, header)
+        assert len(row_values) == 1
+        assert row_values[0] == [_norm("A"), _norm("B"), _norm("A"), _norm("B")]
+
+    def test_multi_level_header(self) -> None:
+        html = _html(
+            '<tr><th colspan="2">Group 1</th><th colspan="2">Group 2</th></tr>'
+            "<tr><th>X</th><th>Y</th><th>X</th><th>Y</th></tr>"
+            "<tr><td>1</td><td>2</td><td>3</td><td>4</td></tr>"
+        )
+        tables = parse_html_tables(html)
+        table = normalize_table(tables[0])
+        header = extract_header_info(table)
+        row_values = _resolve_header_row_values(table, header)
+        assert len(row_values) == 2
+        # Row 0: colspan spans, so both cols get "Group 1" / "Group 2"
+        assert row_values[0] == [_norm("Group 1"), _norm("Group 1"), _norm("Group 2"), _norm("Group 2")]
+        assert row_values[1] == [_norm("X"), _norm("Y"), _norm("X"), _norm("Y")]
+
+
+class TestDetectRepeatingHeaderPeriod:
+    """Tests for _detect_period_candidates."""
+
+    def test_simple_repeating_2col_pattern(self) -> None:
+        """4 columns with headers [A, B, A, B] → period 2."""
+        html = _html(
+            "<tr><th>A</th><th>B</th><th>A</th><th>B</th></tr><tr><td>1</td><td>2</td><td>3</td><td>4</td></tr>"
+        )
+        tables = parse_html_tables(html)
+        table = normalize_table(tables[0])
+        header = extract_header_info(table)
+        assert _detect_period_candidates(table, header) == [(2, 1)]
+
+    def test_repeating_3col_pattern(self) -> None:
+        """6 columns with headers [A, B, C, A, B, C] → period 3."""
+        html = _html(
+            "<tr><th>A</th><th>B</th><th>C</th><th>A</th><th>B</th><th>C</th></tr>"
+            "<tr><td>1</td><td>2</td><td>3</td><td>4</td><td>5</td><td>6</td></tr>"
+        )
+        tables = parse_html_tables(html)
+        table = normalize_table(tables[0])
+        header = extract_header_info(table)
+        assert _detect_period_candidates(table, header) == [(3, 1)]
+
+    def test_returns_all_valid_periods(self) -> None:
+        """12 columns repeating every 2 — exposes periods 2, 4, 6 (no GT filter)."""
+        html = _html(
+            "<tr><th>A</th><th>B</th><th>A</th><th>B</th>"
+            "<th>A</th><th>B</th><th>A</th><th>B</th>"
+            "<th>A</th><th>B</th><th>A</th><th>B</th></tr>"
+            "<tr><td>1</td><td>2</td><td>3</td><td>4</td>"
+            "<td>5</td><td>6</td><td>7</td><td>8</td>"
+            "<td>9</td><td>10</td><td>11</td><td>12</td></tr>"
+        )
+        tables = parse_html_tables(html)
+        table = normalize_table(tables[0])
+        header = extract_header_info(table)
+        candidates = _detect_period_candidates(table, header)
+        periods = sorted(p for p, _ in candidates)
+        assert periods == [2, 4, 6]
+
+    def test_no_repeating_pattern_returns_empty(self) -> None:
+        html = _html(
+            "<tr><th>A</th><th>B</th><th>C</th><th>D</th></tr><tr><td>1</td><td>2</td><td>3</td><td>4</td></tr>"
+        )
+        tables = parse_html_tables(html)
+        table = normalize_table(tables[0])
+        header = extract_header_info(table)
+        assert _detect_period_candidates(table, header) == []
+
+    def test_varying_title_row_doesnt_block(self) -> None:
+        """Group/title row varies but leaf row repeats → period still detected."""
+        html = _html(
+            '<tr><th colspan="2">Title A</th><th colspan="2">Title B</th></tr>'
+            "<tr><th>X</th><th>Y</th><th>X</th><th>Y</th></tr>"
+            "<tr><td>1</td><td>2</td><td>3</td><td>4</td></tr>"
+        )
+        tables = parse_html_tables(html)
+        table = normalize_table(tables[0])
+        header = extract_header_info(table)
+        assert _detect_period_candidates(table, header) == [(2, 1)]
+
+    def test_no_header_rows_returns_empty(self) -> None:
+        html = _html(
+            "<tr><td>A</td><td>B</td><td>A</td><td>B</td></tr><tr><td>1</td><td>2</td><td>3</td><td>4</td></tr>"
+        )
+        tables = parse_html_tables(html)
+        table = normalize_table(tables[0])
+        header = extract_header_info(table)
+        assert _detect_period_candidates(table, header) == []
+
+    def test_single_column_returns_empty(self) -> None:
+        html = _html("<tr><th>A</th></tr><tr><td>1</td></tr>")
+        tables = parse_html_tables(html)
+        table = normalize_table(tables[0])
+        header = extract_header_info(table)
+        assert _detect_period_candidates(table, header) == []
+
+
+class TestBuildSubTable:
+    """Tests for _build_sub_table."""
+
+    def test_basic_column_split(self) -> None:
+        html = _html(
+            "<tr><th>A</th><th>B</th><th>C</th><th>D</th></tr><tr><td>1</td><td>2</td><td>3</td><td>4</td></tr>"
+        )
+        tables = parse_html_tables(html)
+        sub = _build_sub_table(tables[0], 0, 2)
+        assert sub.data.shape == (2, 2)
+        assert str(sub.data[1, 0]) == "1"
+        assert str(sub.data[1, 1]) == "2"
+
+    def test_header_cells_remapped(self) -> None:
+        html = _html(
+            "<tr><th>A</th><th>B</th><th>C</th><th>D</th></tr><tr><td>1</td><td>2</td><td>3</td><td>4</td></tr>"
+        )
+        tables = parse_html_tables(html)
+        sub = _build_sub_table(tables[0], 2, 4)
+        # Header cells should be remapped: (0,2) → (0,0), (0,3) → (0,1)
+        assert (0, 0) in sub.header_cells
+        assert (0, 1) in sub.header_cells
+
+    def test_col_headers_remapped(self) -> None:
+        html = _html(
+            "<tr><th>A</th><th>B</th><th>C</th><th>D</th></tr><tr><td>1</td><td>2</td><td>3</td><td>4</td></tr>"
+        )
+        tables = parse_html_tables(html)
+        sub = _build_sub_table(tables[0], 2, 4)
+        # col_headers keys should be 0, 1 (remapped from 2, 3)
+        assert 0 in sub.col_headers
+        assert 1 in sub.col_headers
+
+
+class TestEnumerateSplitOptions:
+    """Tests for enumerate_split_options."""
+
+    def test_includes_split_options(self) -> None:
+        """6-col table with period 2 headers → no-split + period-2 (3 segs)."""
+        html = _html(
+            "<tr><th>A</th><th>B</th><th>A</th><th>B</th><th>A</th><th>B</th></tr>"
+            "<tr><td>1</td><td>2</td><td>3</td><td>4</td><td>5</td><td>6</td></tr>"
+        )
+        tables = parse_html_tables(html)
+        table = normalize_table(tables[0])
+        options = enumerate_split_options(table)
+        # No-split sentinel + at least one real split
+        assert options[0].sub_tables is None
+        assert options[0].n_segments == 1
+        split_opts = [o for o in options if o.sub_tables is not None]
+        assert any(o.n_segments == 3 and o.period == 2 for o in split_opts)
+        for o in split_opts:
+            if o.period == 2:
+                assert o.sub_tables is not None
+                assert all(st.data.shape[1] == 2 for st in o.sub_tables)
+
+    def test_no_period_returns_only_no_split(self) -> None:
+        html = _html(
+            "<tr><th>A</th><th>B</th><th>C</th><th>D</th></tr><tr><td>1</td><td>2</td><td>3</td><td>4</td></tr>"
+        )
+        tables = parse_html_tables(html)
+        table = normalize_table(tables[0])
+        options = enumerate_split_options(table)
+        assert len(options) == 1
+        assert options[0].sub_tables is None
+
+
+# ===========================================================================
+# Empty Row Filtering
+# ===========================================================================
+
+
+class TestEmptyRowFiltering:
+    """Tests for filtering all-empty records from build_records()."""
+
+    def test_is_all_empty_record_true(self) -> None:
+        assert _is_all_empty_record({"a": "", "b": "", "c": ""})
+        assert _is_all_empty_record({"a": "  ", "b": " "})
+
+    def test_is_all_empty_record_false(self) -> None:
+        assert not _is_all_empty_record({"a": "x", "b": ""})
+        assert not _is_all_empty_record({"a": "-", "b": ""})
+        assert not _is_all_empty_record({"a": "n/a", "b": ""})
+
+    def test_empty_rows_filtered_from_records(self) -> None:
+        """All-empty rows are excluded from build_records() output."""
+        html = _html(
+            "<tr><th>A</th><th>B</th></tr>"
+            "<tr><td>1</td><td>2</td></tr>"
+            "<tr><td></td><td></td></tr>"
+            "<tr><td>3</td><td>4</td></tr>"
+        )
+        tables = parse_html_tables(html)
+        table = normalize_table(tables[0])
+        header = extract_header_info(table)
+        records = build_records(table, header)
+        assert len(records) == 2
+        assert records[0]["a"] == "1"
+        assert records[1]["a"] == "3"
+
+    def test_sentinel_rows_not_filtered(self) -> None:
+        """Rows with sentinel values like '-' or 'n/a' are NOT filtered."""
+        html = _html("<tr><th>A</th><th>B</th></tr><tr><td>-</td><td>n/a</td></tr>")
+        tables = parse_html_tables(html)
+        table = normalize_table(tables[0])
+        header = extract_header_info(table)
+        records = build_records(table, header)
+        assert len(records) == 1
+
+    def test_empty_rows_dont_penalize_score(self, metric: TableRecordMatchMetric) -> None:
+        """GT with trailing empty rows and pred without should still score 1.0."""
+        gt = _html(
+            "<tr><th>Name</th><th>Age</th></tr>"
+            "<tr><td>Alice</td><td>30</td></tr>"
+            "<tr><td></td><td></td></tr>"
+            "<tr><td></td><td></td></tr>"
+        )
+        pred = _simple_table(["Name", "Age"], [["Alice", "30"]])
+        result = metric.compute(expected=gt, actual=pred)
+        assert result[0].value == pytest.approx(1.0)
+
+    def test_empty_rows_in_pred_dont_penalize(self, metric: TableRecordMatchMetric) -> None:
+        """Pred with trailing empty rows should still score 1.0."""
+        gt = _simple_table(["Name", "Age"], [["Alice", "30"]])
+        pred = _html("<tr><th>Name</th><th>Age</th></tr><tr><td>Alice</td><td>30</td></tr><tr><td></td><td></td></tr>")
+        result = metric.compute(expected=gt, actual=pred)
+        assert result[0].value == pytest.approx(1.0)
+
+    @pytest.fixture
+    def metric(self) -> TableRecordMatchMetric:
+        return TableRecordMatchMetric()
+
+
+# ===========================================================================
+# Subscript/Superscript Preservation
+# ===========================================================================
+
+
+class TestSubSupPreservation:
+    """Tests for preserving subscript/superscript content in table normalization."""
+
+    def test_normalize_sub_sup_html_tags(self) -> None:
+        assert _normalize_sub_sup_for_table("H<sub>2</sub>O") == "H2O"
+        assert _normalize_sub_sup_for_table("x<sup>2</sup>") == "x2"
+        assert _normalize_sub_sup_for_table("10<sup>-3</sup>") == "10-3"
+
+    def test_normalize_sub_sup_preserves_non_digit_content(self) -> None:
+        """Non-digit content in sup/sub tags is preserved (e.g. ordinals)."""
+        assert _normalize_sub_sup_for_table("1<sup>st</sup>") == "1st"
+        assert _normalize_sub_sup_for_table("2<sup>nd</sup>") == "2nd"
+
+    def test_normalize_sub_sup_unicode_digits(self) -> None:
+        assert _normalize_sub_sup_for_table("H₂O") == "H2O"
+        assert _normalize_sub_sup_for_table("CO₂") == "CO2"
+        assert _normalize_sub_sup_for_table("x²") == "x2"
+        assert _normalize_sub_sup_for_table("10⁻³") == "10-3"
+
+    def test_normalize_sub_sup_unicode_letters(self) -> None:
+        assert _normalize_sub_sup_for_table("aⁿ") == "an"
+        assert _normalize_sub_sup_for_table("xᵢ") == "xi"
+
+    def test_normalize_sub_sup_no_tags(self) -> None:
+        """Plain text without sub/sup passes through unchanged."""
+        assert _normalize_sub_sup_for_table("hello world") == "hello world"
+        assert _normalize_sub_sup_for_table("123") == "123"
+
+    def test_end_to_end_unicode_sub_matches_html_sub(self, metric: TableRecordMatchMetric) -> None:
+        """GT with Unicode subscript and pred with HTML <sub> should score 1.0."""
+        gt = _simple_table(["Formula"], [["H₂O"], ["CO₂"]])
+        pred = _simple_table(["Formula"], [["H<sub>2</sub>O"], ["CO<sub>2</sub>"]])
+        result = metric.compute(expected=gt, actual=pred)
+        assert result[0].value == pytest.approx(1.0)
+
+    def test_end_to_end_unicode_superscript_symmetric(self, metric: TableRecordMatchMetric) -> None:
+        """Both sides with identical Unicode superscripts score 1.0."""
+        gt = _simple_table(["Value"], [["x²"], ["10⁻³"]])
+        pred = _simple_table(["Value"], [["x²"], ["10⁻³"]])
+        result = metric.compute(expected=gt, actual=pred)
+        assert result[0].value == pytest.approx(1.0)
+
+    def test_end_to_end_plain_text_matches_unicode_sup(self, metric: TableRecordMatchMetric) -> None:
+        """Plain ASCII text matches Unicode superscript after normalization."""
+        gt = _simple_table(["Value"], [["x2"], ["a3"]])
+        pred = _simple_table(["Value"], [["x²"], ["a³"]])
+        result = metric.compute(expected=gt, actual=pred)
+        assert result[0].value == pytest.approx(1.0)
+
+    def test_end_to_end_unicode_subscript_symmetric(self, metric: TableRecordMatchMetric) -> None:
+        """Both sides with identical Unicode subscripts score 1.0."""
+        gt = _simple_table(["Value"], [["H₂O"], ["CO₂"]])
+        pred = _simple_table(["Value"], [["H₂O"], ["CO₂"]])
+        result = metric.compute(expected=gt, actual=pred)
+        assert result[0].value == pytest.approx(1.0)
+
+    def test_end_to_end_plain_text_matches_unicode_sub(self, metric: TableRecordMatchMetric) -> None:
+        """Plain ASCII text matches Unicode subscript after normalization."""
+        gt = _simple_table(["Value"], [["H2O"], ["CO2"]])
+        pred = _simple_table(["Value"], [["H₂O"], ["CO₂"]])
+        result = metric.compute(expected=gt, actual=pred)
+        assert result[0].value == pytest.approx(1.0)
+
+    @pytest.fixture
+    def metric(self) -> TableRecordMatchMetric:
+        return TableRecordMatchMetric()
+
+
+class TestUnmatchedColumnPenaltyUnionDenominator:
+    """Both unmatched GT columns and extra pred columns must penalize the score.
+
+    With the union-size denominator, _record_similarity divides matched
+    cell scores by ``n_matched + (n_gt - n_matched) + (n_pred - n_matched)``.
+    A perfectly-matched single column shared between GT and pred should
+    therefore drop below 1.0 whenever either side carries extra columns.
+    """
+
+    def test_extra_pred_column_penalizes(self) -> None:
+        gt = _simple_table(["Name"], [["Alice"]])
+        pred = _simple_table(["Name", "Age"], [["Alice", "30"]])
+        metric = TableRecordMatchMetric()
+        result = metric.compute(expected=gt, actual=pred)
+        # 1 matched + 0 extra GT + 1 extra pred = 2 → 1/2
+        assert result[0].value == pytest.approx(0.5)
+
+    def test_extra_gt_column_penalizes(self) -> None:
+        gt = _simple_table(["Name", "Age"], [["Alice", "30"]])
+        pred = _simple_table(["Name"], [["Alice"]])
+        metric = TableRecordMatchMetric()
+        result = metric.compute(expected=gt, actual=pred)
+        # 1 matched + 1 unmatched GT + 0 extra pred = 2 → 1/2
+        assert result[0].value == pytest.approx(0.5)
+
+    def test_extra_columns_on_both_sides_penalize(self) -> None:
+        gt = _simple_table(["Name", "Age"], [["Alice", "30"]])
+        pred = _simple_table(["Name", "City"], [["Alice", "NYC"]])
+        metric = TableRecordMatchMetric()
+        result = metric.compute(expected=gt, actual=pred)
+        # 1 matched ("Name") + 1 unmatched GT ("Age") + 1 extra pred ("City")
+        # = 3 → 1/3
+        assert result[0].value == pytest.approx(1 / 3)
+
+
+class TestEmptyColumnDropping:
+    """normalize_table drops columns that are entirely empty.
+
+    A column counts as "entirely empty" only when every data cell AND
+    every header entry is the literal empty string after normalization.
+    Sentinel values like "-" or "n/a" count as real content and do not
+    qualify a column for removal.
+    """
+
+    def test_empty_gt_column_dropped(self) -> None:
+        gt = _html("<thead><tr><th>Name</th><th></th></tr></thead><tbody><tr><td>Alice</td><td></td></tr></tbody>")
+        pred = _simple_table(["Name"], [["Alice"]])
+        metric = TableRecordMatchMetric()
+        result = metric.compute(expected=gt, actual=pred)
+        assert result[0].value == pytest.approx(1.0)
+
+    def test_empty_pred_column_dropped(self) -> None:
+        gt = _simple_table(["Name"], [["Alice"]])
+        pred = _html("<thead><tr><th>Name</th><th></th></tr></thead><tbody><tr><td>Alice</td><td></td></tr></tbody>")
+        metric = TableRecordMatchMetric()
+        result = metric.compute(expected=gt, actual=pred)
+        assert result[0].value == pytest.approx(1.0)
+
+    def test_column_with_header_not_dropped(self) -> None:
+        """Header text present but all data cells empty → column kept."""
+        gt = _html("<thead><tr><th>Name</th><th>Age</th></tr></thead><tbody><tr><td>Alice</td><td></td></tr></tbody>")
+        pred = _html("<thead><tr><th>Name</th><th>Age</th></tr></thead><tbody><tr><td>Alice</td><td></td></tr></tbody>")
+        metric = TableRecordMatchMetric()
+        result = metric.compute(expected=gt, actual=pred)
+        assert result[0].value == pytest.approx(1.0)
+
+    def test_column_with_data_empty_header_not_dropped(self) -> None:
+        """Data cells present but header empty → column kept."""
+        gt = _html("<thead><tr><th>Name</th><th></th></tr></thead><tbody><tr><td>Alice</td><td>extra</td></tr></tbody>")
+        pred = _html(
+            "<thead><tr><th>Name</th><th></th></tr></thead><tbody><tr><td>Alice</td><td>extra</td></tr></tbody>"
+        )
+        metric = TableRecordMatchMetric()
+        result = metric.compute(expected=gt, actual=pred)
+        assert result[0].value == pytest.approx(1.0)
+
+    def test_column_of_only_dash_sentinels_not_dropped(self) -> None:
+        """A column whose data is only ``-``/``n/a`` sentinels must survive.
+
+        ``_normalize_trm_cell_text`` doesn't touch sentinels and
+        ``_col_is_empty`` only drops cells that normalize to the literal
+        empty string — so a column where every data cell is ``-`` must
+        still be present after ``normalize_table``. If a regression were
+        to extend the empty check to include sentinels, this would
+        silently erase real columns from the comparison.
+        """
+        html = _html(
+            "<thead><tr><th>Name</th><th>Status</th></tr></thead>"
+            "<tbody>"
+            "<tr><td>Alice</td><td>-</td></tr>"
+            "<tr><td>Bob</td><td>n/a</td></tr>"
+            "</tbody>"
+        )
+        tables = parse_html_tables(html)
+        table = normalize_table(tables[0])
+        # Both columns must survive
+        assert table.data.shape[1] == 2
+        header = extract_header_info(table)
+        assert "status" in header.keys  # normalized to lowercase
+
+    def test_row_headers_and_header_cells_remap_after_dropping_middle_column(self) -> None:
+        """Dropping an empty middle column must remap row_headers AND header_cells.
+
+        Build a 3-col table where column index 1 is entirely empty, with
+        a row-header ``<th>`` in col 0 and a header row in row 0. After
+        ``normalize_table`` drops col 1, the surviving ``header_cells``
+        and ``row_headers`` entries must reference the *new* column
+        indices (0 and 1), never the old index 2.
+        """
+        html = _html(
+            "<thead><tr><th>Metric</th><th></th><th>Value</th></tr></thead>"
+            "<tbody>"
+            "<tr><th>Revenue</th><td></td><td>100</td></tr>"
+            "<tr><th>Cost</th><td></td><td>50</td></tr>"
+            "</tbody>"
+        )
+        tables = parse_html_tables(html)
+        table = normalize_table(tables[0])
+        # Middle column should be dropped
+        assert table.data.shape[1] == 2
+        # Remaining columns' header_cells must be remapped to {0, 1}.
+        # (row 0 headers + each row-header <th> at col 0)
+        col_indices = {c for (_r, c) in table.header_cells}
+        assert col_indices <= {0, 1}, f"header_cells not remapped: {table.header_cells}"
+        # row_headers entries must also be remapped to col 0
+        for _row, entries in table.row_headers.items():
+            for c, _text in entries:
+                assert c in {0, 1}, f"row_headers col index not remapped: {c}"
+
+
+class TestFootnoteParenPreservation:
+    """Footnote markers like (1) inside <sup> must not lose their parens.
+
+    Regression: ``_sup_sub_to_unicode`` in table_parsing maps each char inside
+    <sup> through ``_ASCII_TO_SUPERSCRIPT.get(c, "")``, which silently drops
+    any non-digit (including parens). So ``<sup>(2)</sup>`` becomes ``²`` and
+    later normalizes to ``2``, gluing onto the preceding number. A bare-paren
+    prediction ``(2)`` survives normalization unchanged, so two semantically
+    equivalent representations score 0 against each other.
+    """
+
+    def test_sup_wrapped_paren_matches_bare_paren(self) -> None:
+        gt = (
+            "<table><tbody>"
+            "<tr><th>Owner</th><th>Shares</th></tr>"
+            "<tr><td>Vanguard</td><td>1,261,261,357<sup>(2)</sup></td></tr>"
+            "</tbody></table>"
+        )
+        pred = (
+            "<table><tbody>"
+            "<tr><th>Owner</th><th>Shares</th></tr>"
+            "<tr><td>Vanguard</td><td>1,261,261,357(2)</td></tr>"
+            "</tbody></table>"
+        )
+        metric = TableRecordMatchMetric()
+        result = metric.compute(expected=gt, actual=pred)
+        assert result[0].value == pytest.approx(1.0)

--- a/tests/parse_bench/evaluation/metrics/parse/test_table_row_header_th.py
+++ b/tests/parse_bench/evaluation/metrics/parse/test_table_row_header_th.py
@@ -1,0 +1,173 @@
+"""Tests for ``<th>`` row headers inside ``<tbody>``.
+
+Marking a row's label cell as ``<th>`` is valid HTML and semantically right —
+it is what a row header *is*::
+
+    <tr><th>Cash</th><td>1,777</td><td>555</td></tr>
+
+The header-block scanner used to read every such row as "this row is a header
+row", because it only stopped when a non-``<th>`` cell in the row had content.
+A balance sheet's section labels break exactly that test::
+
+    <tr><th>Assets</th><td></td><td></td></tr>
+    <tr><th>Current assets</th><td></td><td></td></tr>
+
+so those two rows joined the *column*-header block, their text was flattened
+into the label column's key (``"(In millions) Assets Current assets"``), and
+the column no longer aligned with a ground truth that spells the same table
+with ``<td>`` labels and the key ``"(In millions)"``. Every record then lost
+its label cell and scored 0.5 instead of 1.0.
+
+``find_row_header_cols`` names the columns that carry row headers — a column
+holding a ``<th>`` in a row that is unambiguously data — and a row whose only
+``<th>`` content sits in those columns no longer extends the header block.
+The rule is content-independent, so it applies identically to the ground truth
+and to the prediction.
+"""
+
+from __future__ import annotations
+
+from parse_bench.evaluation.metrics.parse.table_extraction import extract_table_pairs
+from parse_bench.evaluation.metrics.parse.table_parsing import parse_html_tables
+from parse_bench.evaluation.metrics.parse.table_record_match_metric import TableRecordMatchMetric
+from parse_bench.evaluation.metrics.parse.table_title_stripping import (
+    extract_header_info,
+    find_row_header_cols,
+)
+
+# The prediction shape: a <thead> column-header row, then section rows and data
+# rows whose label cell is a <th>.
+TH_ROW_HEADERS = (
+    "<table><thead><tr><th>(In millions)</th><th>2025</th><th>2024</th></tr></thead><tbody>"
+    "<tr><th>Assets</th><td></td><td></td></tr>"
+    "<tr><th>Current assets</th><td></td><td></td></tr>"
+    "<tr><th>Cash</th><td>1,777</td><td>555</td></tr>"
+    "<tr><th>Inventory</th><td>4,392</td><td>4,227</td></tr>"
+    "</tbody></table>"
+)
+
+# The ground-truth shape: the same table with <td> labels.
+TD_ROW_LABELS = (
+    "<table><thead><tr><th>(In millions)</th><th>2025</th><th>2024</th></tr></thead><tbody>"
+    "<tr><td>Assets</td><td></td><td></td></tr>"
+    "<tr><td>Current assets</td><td></td><td></td></tr>"
+    "<tr><td>Cash</td><td>1,777</td><td>555</td></tr>"
+    "<tr><td>Inventory</td><td>4,392</td><td>4,227</td></tr>"
+    "</tbody></table>"
+)
+
+
+def _header(html: str):  # noqa: ANN202 - local test helper
+    tables = parse_html_tables(html)
+    assert tables, "expected at least one parsed table"
+    return tables[0], extract_header_info(tables[0])
+
+
+def _trm(expected: str, actual: str) -> float:
+    values = TableRecordMatchMetric().compute(expected, actual)
+    score = next(v.value for v in values if v.metric_name == "table_record_match")
+    return float(score)
+
+
+class TestRowHeaderColumnDetection:
+    def test_label_column_is_recognized(self) -> None:
+        table, _ = _header(TH_ROW_HEADERS)
+        assert find_row_header_cols(table) == {0}
+
+    def test_a_table_without_body_th_has_no_row_header_column(self) -> None:
+        table, _ = _header(TD_ROW_LABELS)
+        assert find_row_header_cols(table) == set()
+
+
+class TestHeaderBlockStopsAtSectionRows:
+    def test_section_rows_do_not_join_the_header_block(self) -> None:
+        _table, header = _header(TH_ROW_HEADERS)
+        assert header.col_header_rows == {0}
+
+    def test_column_keys_stay_the_thead_row(self) -> None:
+        _table, header = _header(TH_ROW_HEADERS)
+        assert header.keys[0] == "(In millions)"
+
+    def test_the_td_spelling_is_unaffected(self) -> None:
+        _table, header = _header(TD_ROW_LABELS)
+        assert header.col_header_rows == {0}
+        assert header.keys[0] == "(In millions)"
+
+
+class TestScoringEquivalence:
+    def test_th_prediction_against_td_ground_truth(self) -> None:
+        assert _trm(TD_ROW_LABELS, TH_ROW_HEADERS) == 1.0
+
+    def test_td_prediction_against_th_ground_truth(self) -> None:
+        # Symmetric: the ground truth is the side using <th> row headers.
+        assert _trm(TH_ROW_HEADERS, TD_ROW_LABELS) == 1.0
+
+    def test_identical_sides_still_score_perfectly(self) -> None:
+        assert _trm(TD_ROW_LABELS, TD_ROW_LABELS) == 1.0
+        assert _trm(TH_ROW_HEADERS, TH_ROW_HEADERS) == 1.0
+
+    def test_a_real_cell_error_still_fails(self) -> None:
+        broken = TH_ROW_HEADERS.replace("<td>1,777</td>", "<td>9,999</td>")
+        assert _trm(TD_ROW_LABELS, broken) < 1.0
+
+
+class TestGenuineMultiLevelHeadersSurvive:
+    """A second header row that is really a column header must still count."""
+
+    MULTI_LEVEL = (
+        "<table><thead>"
+        '<tr><th rowspan="2">Year</th><th colspan="2">Annual Percentage Change</th></tr>'
+        "<tr><th>Berkshire</th><th>S&amp;P 500</th></tr>"
+        "</thead><tbody>"
+        "<tr><td>1995</td><td>57.4%</td><td>37.6%</td></tr>"
+        "<tr><td>1996</td><td>6.2</td><td>23.0</td></tr>"
+        "</tbody></table>"
+    )
+
+    def test_both_header_rows_are_kept(self) -> None:
+        _table, header = _header(self.MULTI_LEVEL)
+        assert header.col_header_rows == {0, 1}
+
+    def test_a_thead_row_is_never_read_as_a_section_label(self) -> None:
+        """Inside <thead> the document has said the row is a column header.
+
+        The shape is real: a wide permitted-uses matrix names its label column
+        in the last <thead> row, with every sibling cell an empty <td>, while
+        the body spells its row labels as <th>. Structurally that is identical
+        to a balance sheet's section row, and only the authored <thead> tells
+        them apart — so <thead> membership exempts the row.
+        """
+        html = (
+            "<table><thead>"
+            '<tr><th rowspan="2">TABLE 4-1</th><th colspan="2">Rural</th></tr>'
+            "<tr><th>RS-G</th><th>RR</th></tr>"
+            "<tr><th>Use Category</th><td></td><td></td></tr>"
+            "</thead><tbody>"
+            "<tr><th>Household Living</th><td>P</td><td>P</td></tr>"
+            "</tbody></table>"
+        )
+        table, header = _header(html)
+        assert find_row_header_cols(table) == {0}
+        assert header.col_header_rows == {0, 1, 2}, "<thead> rows stay in the header block"
+
+    def test_an_empty_corner_header_row_is_kept(self) -> None:
+        # <td></td> in the corner of an otherwise all-<th> header row: there is
+        # no row-header column here (no data row carries a <th>), so the row
+        # still joins the header block exactly as before.
+        html = (
+            "<table><tbody>"
+            "<tr><td></td><th>2025</th><th>2024</th></tr>"
+            "<tr><td>Cash</td><td>1,777</td><td>555</td></tr>"
+            "</tbody></table>"
+        )
+        table, header = _header(html)
+        assert find_row_header_cols(table) == set()
+        assert header.col_header_rows == {0}
+
+
+def test_tables_pair_and_score_through_the_shared_extraction_stage() -> None:
+    """The fix holds on the path the evaluator actually runs."""
+    expected, actual, counts = extract_table_pairs(TD_ROW_LABELS, TH_ROW_HEADERS)
+    assert counts.expected == 1
+    assert counts.actual == 1
+    assert expected[0].table_data.data.shape == actual[0].table_data.data.shape

--- a/tests/parse_bench/evaluation/metrics/parse/test_table_splitting.py
+++ b/tests/parse_bench/evaluation/metrics/parse/test_table_splitting.py
@@ -1,0 +1,276 @@
+"""Tests for the upstream ambiguous-merged-table splitter."""
+
+from __future__ import annotations
+
+from parse_bench.evaluation.metrics.parse.table_extraction import (
+    ExtractedTable,
+    extract_table_pairs,
+)
+from parse_bench.evaluation.metrics.parse.table_splitting import (
+    _SAFETY_CAP,
+    select_joint_split,
+    split_ambiguous_merged_pred,
+)
+
+
+def _doc_with_tables(tables_html: list[str]) -> str:
+    return "\n".join(tables_html)
+
+
+def _wrap(rows: str) -> str:
+    return f"<table>{rows}</table>"
+
+
+def test_no_split_when_actual_has_multiple_tables() -> None:
+    expected_md = _doc_with_tables(
+        [
+            _wrap("<tr><th>A</th><th>B</th></tr><tr><td>1</td><td>2</td></tr>"),
+            _wrap("<tr><th>A</th><th>B</th></tr><tr><td>3</td><td>4</td></tr>"),
+        ]
+    )
+    actual_md = expected_md
+    expected, actual, _ = extract_table_pairs(expected_md, actual_md)
+
+    result, did_split = split_ambiguous_merged_pred(expected, actual)
+    assert did_split is False
+    assert result is actual
+
+
+def test_no_split_when_expected_has_one_table() -> None:
+    md = _wrap("<tr><th>A</th><th>B</th></tr><tr><td>1</td><td>2</td></tr>")
+    expected, actual, _ = extract_table_pairs(md, md)
+
+    result, did_split = split_ambiguous_merged_pred(expected, actual)
+    assert did_split is False
+    assert result is actual
+
+
+def test_splits_periodic_merged_pred() -> None:
+    expected_md = _doc_with_tables(
+        [
+            _wrap("<tr><th>A</th><th>B</th></tr><tr><td>1</td><td>2</td></tr>"),
+            _wrap("<tr><th>A</th><th>B</th></tr><tr><td>3</td><td>4</td></tr>"),
+            _wrap("<tr><th>A</th><th>B</th></tr><tr><td>5</td><td>6</td></tr>"),
+        ]
+    )
+    actual_md = _wrap(
+        "<tr><th>A</th><th>B</th><th>A</th><th>B</th><th>A</th><th>B</th></tr>"
+        "<tr><td>1</td><td>2</td><td>3</td><td>4</td><td>5</td><td>6</td></tr>"
+    )
+    expected, actual, _ = extract_table_pairs(expected_md, actual_md)
+    assert len(expected) == 3
+    assert len(actual) == 1
+
+    result, did_split = split_ambiguous_merged_pred(expected, actual)
+    assert did_split is True
+    assert len(result) == 3
+    for et in result:
+        assert isinstance(et, ExtractedTable)
+        assert et.raw_html == ""
+        assert et.table_data.data.shape[1] == 2
+
+
+def _two_col_unit() -> str:
+    return "<tr><th>A</th><th>B</th></tr><tr><td>x</td><td>y</td></tr>"
+
+
+def _gt_n_two_col_tables(n: int) -> str:
+    return _doc_with_tables([_wrap(_two_col_unit()) for _ in range(n)])
+
+
+def _merged_period2(n_segments: int) -> str:
+    headers = "".join("<th>A</th><th>B</th>" for _ in range(n_segments))
+    cells = "".join("<td>x</td><td>y</td>" for _ in range(n_segments))
+    return _wrap(f"<tr>{headers}</tr><tr>{cells}</tr>")
+
+
+def _fixed_table() -> str:
+    return _wrap("<tr><th>X</th><th>Y</th><th>Z</th></tr><tr><td>1</td><td>2</td><td>3</td></tr>")
+
+
+def test_inexact_single_pred_split_applied_when_closer_than_baseline() -> None:
+    """Single merged pred (3 segs) vs 4 expected: dist 1 < baseline 3 → split."""
+    expected_md = _gt_n_two_col_tables(4)
+    actual_md = _merged_period2(3)
+    expected, actual, _ = extract_table_pairs(expected_md, actual_md)
+    assert len(expected) == 4 and len(actual) == 1
+
+    result, did_split = split_ambiguous_merged_pred(expected, actual)
+    assert did_split is True
+    assert len(result) == 3
+
+
+def test_multi_pred_single_splittable() -> None:
+    """One merged pred + one fixed pred → joint selector splits the merged one."""
+    expected_md = _gt_n_two_col_tables(3)
+    actual_md = _doc_with_tables([_merged_period2(2), _fixed_table()])
+    expected, actual, _ = extract_table_pairs(expected_md, actual_md)
+    assert len(expected) == 3 and len(actual) == 2
+
+    result, did_split = split_ambiguous_merged_pred(expected, actual)
+    assert did_split is True
+    assert len(result) == 3
+    # The fixed table should be preserved as-is (raw_html non-empty)
+    fixed_preserved = [et for et in result if et.raw_html != ""]
+    assert len(fixed_preserved) == 1
+
+
+def test_multi_pred_two_splittable_joint_optimum() -> None:
+    """Two splittable preds (each 2 segs) targeting 4 expected → both split."""
+    expected_md = _gt_n_two_col_tables(4)
+    actual_md = _doc_with_tables([_merged_period2(2), _merged_period2(2)])
+    expected, actual, _ = extract_table_pairs(expected_md, actual_md)
+    assert len(expected) == 4 and len(actual) == 2
+
+    result, did_split = split_ambiguous_merged_pred(expected, actual)
+    assert did_split is True
+    assert len(result) == 4
+    # Both got split → no original raw_html preserved
+    assert all(et.raw_html == "" for et in result)
+
+
+def test_strict_improvement_gate_no_op() -> None:
+    """Single splittable pred (2 segs) vs 2 expected: dist 1 vs baseline 1 → no-op."""
+    expected_md = _gt_n_two_col_tables(2)
+    actual_md = _merged_period2(2)
+    expected, actual, _ = extract_table_pairs(expected_md, actual_md)
+    # Trigger only fires when len(expected) > len(actual). Here that holds (2 > 1).
+    assert len(expected) == 2 and len(actual) == 1
+
+    # Actually len(actual)==1, baseline distance = |1-2|=1, split gives n_segments=2, dist=0.
+    # That's an improvement, so this should split. Adjust: use 3 expected to test gate.
+    expected_md = _gt_n_two_col_tables(3)
+    actual_md = _merged_period2(2)
+    expected, actual, _ = extract_table_pairs(expected_md, actual_md)
+    # baseline dist = |1-3|=2, split dist = |2-3|=1 → still improves. Use larger.
+    expected_md = _gt_n_two_col_tables(2)
+    actual_md = _doc_with_tables([_merged_period2(2), _fixed_table()])
+    expected, actual, _ = extract_table_pairs(expected_md, actual_md)
+    # Trigger requires len(expected) > len(actual). 2 > 2 is false → no-op trivially.
+    result, did_split = split_ambiguous_merged_pred(expected, actual)
+    assert did_split is False
+
+
+def test_safety_cap_no_op() -> None:
+    """Synthesize >256 variable Cartesian product → no-op."""
+    # Each merged_period2(2) yields 2 options (no-split + 1 split). 9 such tables → 2**9 = 512 > 256.
+    actual_md = _doc_with_tables([_merged_period2(2) for _ in range(9)])
+    expected_md = _gt_n_two_col_tables(18)
+    expected, actual, _ = extract_table_pairs(expected_md, actual_md)
+    chosen = select_joint_split(actual, len(expected))
+    assert chosen is None
+    result, did_split = split_ambiguous_merged_pred(expected, actual)
+    assert did_split is False
+    assert _SAFETY_CAP == 256
+
+
+def test_trigger_gate_when_expected_lte_actual() -> None:
+    """len(expected) <= len(actual) → no-op even with splittable preds."""
+    expected_md = _gt_n_two_col_tables(2)
+    actual_md = _doc_with_tables([_merged_period2(2), _merged_period2(2)])
+    expected, actual, _ = extract_table_pairs(expected_md, actual_md)
+    assert len(expected) == 2 and len(actual) == 2
+
+    result, did_split = split_ambiguous_merged_pred(expected, actual)
+    assert did_split is False
+    assert result is actual
+
+
+def test_raw_html_preserved_for_unchanged_tables() -> None:
+    """Partial split: untouched tables keep raw_html, sub-tables get ''."""
+    expected_md = _gt_n_two_col_tables(3)
+    actual_md = _doc_with_tables([_merged_period2(2), _fixed_table()])
+    expected, actual, _ = extract_table_pairs(expected_md, actual_md)
+    original_fixed_html = actual[1].raw_html
+    assert original_fixed_html != ""
+
+    result, did_split = split_ambiguous_merged_pred(expected, actual)
+    assert did_split is True
+    # Find the preserved fixed table
+    preserved = [et for et in result if et.raw_html != ""]
+    assert len(preserved) == 1
+    assert preserved[0].raw_html == original_fixed_html
+    # The other two are split sub-tables with empty raw_html
+    split_subs = [et for et in result if et.raw_html == ""]
+    assert len(split_subs) == 2
+
+
+def _merged_two_header_rows_period2() -> str:
+    """4 cols, two <th> rows that BOTH repeat with period 2 → n_repeating_rows=2."""
+    return _wrap(
+        "<tr><th>X</th><th>Y</th><th>X</th><th>Y</th></tr>"
+        "<tr><th>A</th><th>B</th><th>A</th><th>B</th></tr>"
+        "<tr><td>1</td><td>2</td><td>3</td><td>4</td></tr>"
+    )
+
+
+def _merged_period3() -> str:
+    """6 cols, one <th> row repeating with period 3 → n_segments=2, period=3."""
+    return _wrap(
+        "<tr><th>A</th><th>B</th><th>C</th><th>A</th><th>B</th><th>C</th></tr>"
+        "<tr><td>1</td><td>2</td><td>3</td><td>4</td><td>5</td><td>6</td></tr>"
+    )
+
+
+def test_tiebreak_more_repeating_rows_wins() -> None:
+    """Two splittable preds, equal segment-distance, one has more header evidence.
+
+    A = 4 cols, two repeating header rows (n_repeating_rows=2, period=2, segs=2).
+    B = 4 cols, one repeating header row  (n_repeating_rows=1, period=2, segs=2).
+    n_expected = 3.
+
+    Combos with distance 0 are (split-A, no-B)=3 and (no-A, split-B)=3.
+    Both have segment-distance 0. Tiebreak by Σn_repeating_rows: (split-A, no-B)
+    has rows=2 vs (no-A, split-B) has rows=1 → A is split, B is preserved.
+    """
+    expected_md = _gt_n_two_col_tables(3)
+    actual_md = _doc_with_tables([_merged_two_header_rows_period2(), _merged_period2(2)])
+    expected, actual, _ = extract_table_pairs(expected_md, actual_md)
+    assert len(expected) == 3 and len(actual) == 2
+    original_b_html = actual[1].raw_html
+    assert original_b_html != ""
+
+    result, did_split = split_ambiguous_merged_pred(expected, actual)
+    assert did_split is True
+    assert len(result) == 3
+    # B should be preserved (its raw_html survives); A's two sub-tables have raw_html="".
+    preserved = [et for et in result if et.raw_html != ""]
+    assert len(preserved) == 1
+    assert preserved[0].raw_html == original_b_html
+
+
+def test_tiebreak_larger_period_wins() -> None:
+    """Two splittable preds, tied on distance and on repeating-rows, differ on period.
+
+    A = 4 cols, period 2, n_segs=2, n_repeating_rows=1.
+    B = 6 cols, period 3, n_segs=2, n_repeating_rows=1.
+    n_expected = 3.
+
+    (split-A, no-B) and (no-A, split-B) both have distance 0 and Σrows=1.
+    Period tiebreak: Σperiod 2 vs 3 → larger wins → B is split, A preserved.
+    """
+    expected_md = _gt_n_two_col_tables(3)
+    actual_md = _doc_with_tables([_merged_period2(2), _merged_period3()])
+    expected, actual, _ = extract_table_pairs(expected_md, actual_md)
+    assert len(expected) == 3 and len(actual) == 2
+    original_a_html = actual[0].raw_html
+    assert original_a_html != ""
+
+    result, did_split = split_ambiguous_merged_pred(expected, actual)
+    assert did_split is True
+    assert len(result) == 3
+    preserved = [et for et in result if et.raw_html != ""]
+    assert len(preserved) == 1
+    assert preserved[0].raw_html == original_a_html
+
+
+def test_all_fixed_page_no_op() -> None:
+    """No pred table has any candidate periods → no-op."""
+    expected_md = _gt_n_two_col_tables(3)
+    actual_md = _doc_with_tables([_fixed_table(), _fixed_table()])
+    expected, actual, _ = extract_table_pairs(expected_md, actual_md)
+    assert len(expected) == 3 and len(actual) == 2
+
+    result, did_split = split_ambiguous_merged_pred(expected, actual)
+    assert did_split is False
+    assert result is actual

--- a/tests/parse_bench/evaluation/metrics/parse/test_table_tbody_provenance.py
+++ b/tests/parse_bench/evaluation/metrics/parse/test_table_tbody_provenance.py
@@ -1,0 +1,65 @@
+"""Regression tests for preserving explicit ``<tbody>`` row provenance."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from parse_bench.evaluation.metrics.parse.table_extraction import ExtractedTable
+from parse_bench.evaluation.metrics.parse.table_parsing import TableData, parse_html_tables
+from parse_bench.evaluation.metrics.parse.table_record_match_metric import normalize_table
+from parse_bench.evaluation.metrics.parse.table_splitting import build_sub_table
+from parse_bench.evaluation.metrics.parse.table_title_stripping import _remove_rows
+
+
+def _table(*, rows: list[list[str]], tbody_rows: set[int]) -> TableData:
+    return TableData(data=np.array(rows, dtype=object), tbody_rows=tbody_rows)
+
+
+def _extracted(td: TableData) -> ExtractedTable:
+    return ExtractedTable(raw_html="<table></table>", table_data=td)
+
+
+def test_normalize_table_preserves_tbody_rows() -> None:
+    td = _table(rows=[["H", ""], ["A", "1"]], tbody_rows={1})
+
+    assert normalize_table(td).tbody_rows == {1}
+
+
+def test_build_sub_table_filters_trimmed_tbody_rows() -> None:
+    td = _table(rows=[["H", "H2"], ["A", "1"], ["", ""]], tbody_rows={1, 2})
+
+    sub = build_sub_table(td, 0, 1)
+
+    assert sub.data.shape == (2, 1)
+    assert sub.tbody_rows == {1}
+
+
+def test_title_row_removal_remaps_tbody_rows() -> None:
+    td = _table(rows=[["Title"], ["H"], ["A"]], tbody_rows={2})
+
+    removed, old_to_new = _remove_rows(td, frozenset({0}))
+
+    assert old_to_new == {1: 0, 2: 1}
+    assert removed.tbody_rows == {1}
+
+
+def test_parser_marks_explicit_tbody_rows() -> None:
+    td = parse_html_tables("<table><tr><th>H</th></tr><tbody><tr><td>A</td></tr></tbody></table>")[0]
+
+    assert td.tbody_rows == {1}
+
+
+def test_parser_tracks_identical_tbody_rows_by_identity() -> None:
+    td = parse_html_tables(
+        "<table><tr><th>2022</th></tr><tbody><tr><th>2022</th></tr><tr><td>17</td></tr></tbody></table>"
+    )[0]
+
+    assert td.tbody_rows == {1, 2}
+
+
+def test_parser_marks_explicit_tfoot_rows() -> None:
+    td = parse_html_tables("<table><tfoot><tr><th>Footer</th></tr></tfoot><tbody><tr><td>A</td></tr></tbody></table>")[
+        0
+    ]
+
+    assert td.tfoot_rows == {0}

--- a/tests/parse_bench/evaluation/metrics/parse/test_table_title_stripping.py
+++ b/tests/parse_bench/evaluation/metrics/parse/test_table_title_stripping.py
@@ -1,0 +1,210 @@
+"""Tests for the upstream table-title-stripping stage.
+
+Focused on the ``max_top_title_rows`` cap semantics that the strip stage
+exposes to test cases. Detector-level edge cases are exercised by the
+broader TRM test suite.
+"""
+
+from __future__ import annotations
+
+from parse_bench.evaluation.metrics.parse.table_extraction import ExtractedTable
+from parse_bench.evaluation.metrics.parse.table_parsing import parse_html_tables
+from parse_bench.evaluation.metrics.parse.table_title_stripping import strip_title_rows
+
+
+def _wrap(html: str) -> ExtractedTable:
+    """Parse a single HTML table and wrap it in an ExtractedTable."""
+    tables = parse_html_tables(f"<table>{html}</table>")
+    assert tables, "expected at least one parsed table"
+    return ExtractedTable(raw_html=f"<table>{html}</table>", table_data=tables[0])
+
+
+def test_default_cap_strips_top_td_title_and_top_th_title() -> None:
+    """At default cap=1, both leading <td> title and one top <th> title are stripped."""
+    et = _wrap(
+        '<tr><td colspan="2">Report Title</td></tr>'
+        "<thead>"
+        '<tr><th colspan="2">(in millions)</th></tr>'
+        "<tr><th>Q1</th><th>Q2</th></tr>"
+        "</thead>"
+        "<tbody><tr><td>1</td><td>2</td></tr></tbody>"
+    )
+    out = strip_title_rows(et)
+    # Td title row + top th title row both removed
+    assert out.table_data.data.shape[0] == 2
+    hints = out.header_hints
+    assert hints is not None
+    # Stripped titles are stored normalized (lowercased)
+    assert "report title" in hints.stripped_titles
+    assert "(in millions)" in hints.stripped_titles
+
+
+def test_cap_zero_strips_nothing_from_top() -> None:
+    """``max_top_title_rows=0`` disables both top td and top th stripping.
+
+    The bottom-th title strip is independent and not affected here
+    because there is no bottom title in this fixture.
+    """
+    et = _wrap(
+        '<tr><td colspan="2">Report Title</td></tr>'
+        "<thead>"
+        '<tr><th colspan="2">(in millions)</th></tr>'
+        "<tr><th>Q1</th><th>Q2</th></tr>"
+        "</thead>"
+        "<tbody><tr><td>1</td><td>2</td></tr></tbody>"
+    )
+    out = strip_title_rows(et, max_top_title_rows=0)
+    # All four rows survive: td title + th title + th headers + data
+    assert out.table_data.data.shape[0] == 4
+    hints = out.header_hints
+    assert hints is not None
+    # Nothing was stripped, so no titles recorded
+    assert hints.stripped_titles == frozenset()
+
+
+def test_cap_two_strips_two_top_th_titles() -> None:
+    """``max_top_title_rows=2`` allows two stacked top <th> title rows to be stripped."""
+    et = _wrap(
+        "<thead>"
+        '<tr><th colspan="2">Annual Report</th></tr>'
+        '<tr><th colspan="2">(in millions)</th></tr>'
+        "<tr><th>Q1</th><th>Q2</th></tr>"
+        "</thead>"
+        "<tbody><tr><td>1</td><td>2</td></tr></tbody>"
+    )
+    out = strip_title_rows(et, max_top_title_rows=2)
+    # Both stacked title rows removed → 2 rows remain (real headers + data)
+    assert out.table_data.data.shape[0] == 2
+    hints = out.header_hints
+    assert hints is not None
+    assert "annual report" in hints.stripped_titles
+    assert "(in millions)" in hints.stripped_titles
+
+
+def test_cap_two_with_only_one_title_strips_one() -> None:
+    """A higher cap doesn't force extra stripping; only actual titles are removed."""
+    et = _wrap(
+        "<thead>"
+        '<tr><th colspan="2">Annual Report</th></tr>'
+        "<tr><th>Q1</th><th>Q2</th></tr>"
+        "</thead>"
+        "<tbody><tr><td>1</td><td>2</td></tr></tbody>"
+    )
+    out = strip_title_rows(et, max_top_title_rows=2)
+    assert out.table_data.data.shape[0] == 2  # one title removed, real header + data
+    hints = out.header_hints
+    assert hints is not None
+    assert "annual report" in hints.stripped_titles
+
+
+def test_rowspan2_title_strips_both_grid_rows_for_one_slot() -> None:
+    """A ``<th rowspan="2" colspan="2">`` title is one logical title.
+
+    With ``max_top_title_rows=1`` it must consume exactly 1 slot from
+    the cap AND strip both rowspan-expanded grid rows. Leaving the
+    second rowspan row in place would leave a phantom title cell in
+    the trimmed grid.
+    """
+    et = _wrap(
+        "<thead>"
+        '<tr><th rowspan="2" colspan="2">Big</th></tr>'
+        "<tr></tr>"
+        "<tr><th>X</th><th>Y</th></tr>"
+        "</thead>"
+        "<tbody><tr><td>1</td><td>2</td></tr></tbody>"
+    )
+    out = strip_title_rows(et, max_top_title_rows=1)
+    # Original 4 grid rows: 2 from rowspan title + 1 leaf header + 1 data.
+    # Both rowspan rows must be stripped → 2 rows remain.
+    assert out.table_data.data.shape[0] == 2
+    # And the surviving rows are the leaf header + the data row
+    surviving = [list(out.table_data.data[r]) for r in range(2)]
+    assert surviving == [["X", "Y"], ["1", "2"]]
+
+
+def test_two_stacked_th_titles_with_cap_one_strips_only_top() -> None:
+    """Two stacked single-rowspan ``<th>`` title rows with the same text.
+
+    Unlike the rowspan-2 case, each row originates from its own ``<th>``
+    element. With ``max_top_title_rows=1`` only the topmost is stripped;
+    the second stays in the trimmed grid because the cap is exhausted.
+    This is the contrast to the rowspan test above — same final
+    rendering of "Big" repeated twice on top of the header, but
+    different DOM source ⇒ different strip outcome.
+    """
+    et = _wrap(
+        "<thead>"
+        '<tr><th colspan="2">Big</th></tr>'
+        '<tr><th colspan="2">Big</th></tr>'
+        "<tr><th>X</th><th>Y</th></tr>"
+        "</thead>"
+        "<tbody><tr><td>1</td><td>2</td></tr></tbody>"
+    )
+    out = strip_title_rows(et, max_top_title_rows=1)
+    # 4 grid rows → 3: top "Big" stripped, second "Big" + leaf + data remain
+    assert out.table_data.data.shape[0] == 3
+    surviving = [list(out.table_data.data[r]) for r in range(3)]
+    assert surviving == [["Big", "Big"], ["X", "Y"], ["1", "2"]]
+
+
+def test_top_title_not_contiguous_with_top_is_not_stripped() -> None:
+    """Real <th> headers in row 0, span title in row 1, span title in row 2.
+
+    Title rows must be contiguous with the top OR bottom of the header
+    block to be stripped:
+
+    - Top-strip walks ``sorted(col_header_rows)`` from row 0 and
+      breaks on the first non-title row. Row 0 is real headers ⇒
+      top-strip takes nothing.
+    - Bottom-strip catches row 2 (it is the bottom of the header
+      block AND a title) and removes it from column keys.
+    - Row 1 sits between two non-strippable rows (real header above,
+      bottom-strip-target below). It is **not** strippable: it stays
+      in the grid AND in the column-key construction. Its text gets
+      concatenated into every column key.
+
+    This is the deliberate consequence of the contiguity rule. Docs
+    that hit this shape need ``max_top_title_rows`` set explicitly or
+    structural fixes upstream.
+    """
+    et = _wrap(
+        "<thead>"
+        "<tr><th>Mod Code</th><th>Buy Line</th></tr>"
+        '<tr><th colspan="2">##CASH ##ASBL</th></tr>'
+        '<tr><th colspan="2">MICHAEL BLOOMBERG FOR PRESIDENT</th></tr>'
+        "</thead>"
+        "<tbody><tr><td></td><td>1</td></tr></tbody>"
+    )
+    out = strip_title_rows(et, max_top_title_rows=1)
+    hints = out.header_hints
+    assert hints is not None
+    # Nothing physically removed → 4 rows survive (3 header + 1 data).
+    assert out.table_data.data.shape[0] == 4
+    assert hints.col_header_rows == frozenset({0, 1, 2})
+    # Only the bottom title is recorded for key-construction exclusion.
+    assert hints.th_title_rows == frozenset({2})
+    assert "michael bloomberg for president" in hints.stripped_titles
+    # Row 1 (##CASH ##ASBL) was NOT stripped — it must not appear in
+    # stripped_titles.
+    assert "##cash ##asbl" not in hints.stripped_titles
+
+
+def test_rowspan_title_does_not_double_consume_cap() -> None:
+    """A rowspan-2 title at top + one trailing leaf header still leaves the leaf intact.
+
+    Sanity check that consuming a rowspan title (which strips 2 grid rows
+    for 1 slot) doesn't accidentally also consume the next slot.
+    """
+    et = _wrap(
+        "<thead>"
+        '<tr><th rowspan="2" colspan="2">Big Title</th></tr>'
+        "<tr></tr>"
+        "<tr><th>Q1</th><th>Q2</th></tr>"
+        "</thead>"
+        "<tbody><tr><td>1</td><td>2</td></tr></tbody>"
+    )
+    out = strip_title_rows(et, max_top_title_rows=1)
+    # Both rowspan rows stripped (1 slot), leaf header + data remain.
+    assert out.table_data.data.shape[0] == 2
+    surviving = [list(out.table_data.data[r]) for r in range(2)]
+    assert surviving == [["Q1", "Q2"], ["1", "2"]]

--- a/tests/parse_bench/evaluation/metrics/parse/test_teds_metric.py
+++ b/tests/parse_bench/evaluation/metrics/parse/test_teds_metric.py
@@ -1,0 +1,441 @@
+"""Tests for the TEDS (Tree Edit Distance based Similarity) metric.
+
+Includes tests for:
+- Low-level TEDS.evaluate() with all three variants (content, struct, struct_bool)
+- High-level TEDSMetric.compute() with variant selection
+- Identical tables score 1.0 across all variants
+- Content changes affect content score but not struct scores
+- Empty-cell mismatches affect struct_bool but not struct
+- Structural differences (extra rows/cols, colspan) affect all variants
+- Edge cases: empty strings, no tables, malformed HTML
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "src"))
+
+from parse_bench.evaluation.metrics.parse.teds_metric import (
+    ALL_TEDS_VARIANTS,
+    TEDS,
+    TEDS_CONTENT,
+    TEDS_STRUCT,
+    TEDS_STRUCT_BOOL,
+    TEDSMetric,
+)
+
+# =============================================================================
+# Test tables
+# =============================================================================
+
+# Simple 2x2 table
+SIMPLE_2X2 = """<table>
+<tr><td>A</td><td>B</td></tr>
+<tr><td>C</td><td>D</td></tr>
+</table>"""
+
+# Same structure, completely different content
+SIMPLE_2X2_DIFF_CONTENT = """<table>
+<tr><td>X</td><td>Y</td></tr>
+<tr><td>Z</td><td>W</td></tr>
+</table>"""
+
+# Same structure, one cell empty
+SIMPLE_2X2_ONE_EMPTY = """<table>
+<tr><td>A</td><td>B</td></tr>
+<tr><td>C</td><td></td></tr>
+</table>"""
+
+# Same structure, all cells empty
+SIMPLE_2X2_ALL_EMPTY = """<table>
+<tr><td></td><td></td></tr>
+<tr><td></td><td></td></tr>
+</table>"""
+
+# 3x3 table (different dimensions)
+SIMPLE_3X3 = """<table>
+<tr><td>A</td><td>B</td><td>C</td></tr>
+<tr><td>D</td><td>E</td><td>F</td></tr>
+<tr><td>G</td><td>H</td><td>I</td></tr>
+</table>"""
+
+# Table with colspan
+TABLE_WITH_COLSPAN = """<table>
+<tr><td colspan="2">Header</td></tr>
+<tr><td>A</td><td>B</td></tr>
+</table>"""
+
+# Same content without colspan (different structure)
+TABLE_NO_COLSPAN = """<table>
+<tr><td>Header</td><td>Header</td></tr>
+<tr><td>A</td><td>B</td></tr>
+</table>"""
+
+# Table with headers (th tags)
+TABLE_WITH_HEADERS = """<table>
+<tr><th>Name</th><th>Value</th></tr>
+<tr><td>Alpha</td><td>100</td></tr>
+</table>"""
+
+# Same content using td instead of th
+TABLE_WITHOUT_HEADERS = """<table>
+<tr><td>Name</td><td>Value</td></tr>
+<tr><td>Alpha</td><td>100</td></tr>
+</table>"""
+
+# Table with extra row
+TABLE_3_ROWS = """<table>
+<tr><td>A</td><td>B</td></tr>
+<tr><td>C</td><td>D</td></tr>
+<tr><td>E</td><td>F</td></tr>
+</table>"""
+
+
+# =============================================================================
+# Tests for TEDS.evaluate() — low-level, all variants
+# =============================================================================
+
+
+class TestTEDSEvaluateIdentical:
+    """Identical tables should score 1.0 across all variants."""
+
+    def test_identical_simple(self):
+        teds = TEDS(variants=ALL_TEDS_VARIANTS)
+        scores, gt_n, pred_n = teds.evaluate(SIMPLE_2X2, SIMPLE_2X2)
+        assert scores[TEDS_CONTENT] == 1.0
+        assert scores[TEDS_STRUCT] == 1.0
+        assert scores[TEDS_STRUCT_BOOL] == 1.0
+        assert gt_n == pred_n
+
+    def test_identical_with_colspan(self):
+        teds = TEDS(variants=ALL_TEDS_VARIANTS)
+        scores, _, _ = teds.evaluate(TABLE_WITH_COLSPAN, TABLE_WITH_COLSPAN)
+        assert scores[TEDS_CONTENT] == 1.0
+        assert scores[TEDS_STRUCT] == 1.0
+        assert scores[TEDS_STRUCT_BOOL] == 1.0
+
+    def test_identical_all_empty(self):
+        teds = TEDS(variants=ALL_TEDS_VARIANTS)
+        scores, _, _ = teds.evaluate(SIMPLE_2X2_ALL_EMPTY, SIMPLE_2X2_ALL_EMPTY)
+        assert scores[TEDS_CONTENT] == 1.0
+        assert scores[TEDS_STRUCT] == 1.0
+        assert scores[TEDS_STRUCT_BOOL] == 1.0
+
+
+class TestTEDSEvaluateContentDifferences:
+    """Content differences should only affect TEDS content score."""
+
+    def test_different_content_same_structure(self):
+        """Completely different text: struct variants should still be 1.0."""
+        teds = TEDS(variants=ALL_TEDS_VARIANTS)
+        scores, _, _ = teds.evaluate(SIMPLE_2X2, SIMPLE_2X2_DIFF_CONTENT)
+        assert scores[TEDS_CONTENT] < 1.0
+        assert scores[TEDS_STRUCT] == 1.0
+        assert scores[TEDS_STRUCT_BOOL] == 1.0
+
+    def test_one_cell_empty_vs_filled(self):
+        """One cell empty in pred, filled in GT:
+        - content: penalized (Levenshtein)
+        - struct: not penalized (ignores content)
+        - struct_bool: penalized (empty vs non-empty mismatch)
+        """
+        teds = TEDS(variants=ALL_TEDS_VARIANTS)
+        scores, _, _ = teds.evaluate(SIMPLE_2X2, SIMPLE_2X2_ONE_EMPTY)
+        assert scores[TEDS_CONTENT] < 1.0
+        assert scores[TEDS_STRUCT] == 1.0
+        assert scores[TEDS_STRUCT_BOOL] < 1.0
+
+    def test_all_empty_vs_filled(self):
+        """All cells empty vs all filled:
+        - content: heavily penalized
+        - struct: still 1.0
+        - struct_bool: penalized (all mismatches)
+        """
+        teds = TEDS(variants=ALL_TEDS_VARIANTS)
+        scores, _, _ = teds.evaluate(SIMPLE_2X2, SIMPLE_2X2_ALL_EMPTY)
+        assert scores[TEDS_CONTENT] < 1.0
+        assert scores[TEDS_STRUCT] == 1.0
+        assert scores[TEDS_STRUCT_BOOL] < 1.0
+
+    def test_both_empty_tables(self):
+        """Both tables have empty cells — no content mismatch."""
+        teds = TEDS(variants=ALL_TEDS_VARIANTS)
+        scores, _, _ = teds.evaluate(SIMPLE_2X2_ALL_EMPTY, SIMPLE_2X2_ALL_EMPTY)
+        assert scores[TEDS_CONTENT] == 1.0
+        assert scores[TEDS_STRUCT] == 1.0
+        assert scores[TEDS_STRUCT_BOOL] == 1.0
+
+
+class TestTEDSEvaluateStructuralDifferences:
+    """Structural differences should penalize all variants."""
+
+    def test_different_dimensions(self):
+        """2x2 vs 3x3: different number of rows/cols penalizes all variants."""
+        teds = TEDS(variants=ALL_TEDS_VARIANTS)
+        scores, _, _ = teds.evaluate(SIMPLE_2X2, SIMPLE_3X3)
+        assert scores[TEDS_CONTENT] < 1.0
+        assert scores[TEDS_STRUCT] < 1.0
+        assert scores[TEDS_STRUCT_BOOL] < 1.0
+
+    def test_extra_row(self):
+        """2x2 vs 3x2: extra row penalizes all variants."""
+        teds = TEDS(variants=ALL_TEDS_VARIANTS)
+        scores, _, _ = teds.evaluate(SIMPLE_2X2, TABLE_3_ROWS)
+        assert scores[TEDS_CONTENT] < 1.0
+        assert scores[TEDS_STRUCT] < 1.0
+        assert scores[TEDS_STRUCT_BOOL] < 1.0
+
+    def test_colspan_mismatch(self):
+        """Table with colspan vs same content without — structural difference."""
+        teds = TEDS(variants=ALL_TEDS_VARIANTS)
+        scores, _, _ = teds.evaluate(TABLE_WITH_COLSPAN, TABLE_NO_COLSPAN)
+        assert scores[TEDS_CONTENT] < 1.0
+        assert scores[TEDS_STRUCT] < 1.0
+        assert scores[TEDS_STRUCT_BOOL] < 1.0
+
+    def test_th_vs_td(self):
+        """th tags vs td tags: tag mismatch penalizes all variants."""
+        teds = TEDS(variants=ALL_TEDS_VARIANTS)
+        scores, _, _ = teds.evaluate(TABLE_WITH_HEADERS, TABLE_WITHOUT_HEADERS)
+        assert scores[TEDS_CONTENT] < 1.0
+        assert scores[TEDS_STRUCT] < 1.0
+        assert scores[TEDS_STRUCT_BOOL] < 1.0
+
+
+class TestTEDSEvaluateScoreOrdering:
+    """Struct scores should be >= content scores when structure is the same."""
+
+    def test_struct_gte_content_for_content_diff(self):
+        """With only content differences, struct >= content."""
+        teds = TEDS(variants=ALL_TEDS_VARIANTS)
+        scores, _, _ = teds.evaluate(SIMPLE_2X2, SIMPLE_2X2_DIFF_CONTENT)
+        assert scores[TEDS_STRUCT] >= scores[TEDS_CONTENT]
+        assert scores[TEDS_STRUCT_BOOL] >= scores[TEDS_CONTENT]
+
+    def test_struct_bool_between_struct_and_content(self):
+        """With empty cell mismatch, struct_bool should be between struct and content."""
+        teds = TEDS(variants=ALL_TEDS_VARIANTS)
+        scores, _, _ = teds.evaluate(SIMPLE_2X2, SIMPLE_2X2_ONE_EMPTY)
+        assert scores[TEDS_STRUCT] >= scores[TEDS_STRUCT_BOOL]
+        assert scores[TEDS_STRUCT_BOOL] >= scores[TEDS_CONTENT]
+
+
+class TestTEDSEvaluateEdgeCases:
+    """Edge cases: empty inputs, no tables, malformed HTML."""
+
+    def test_empty_pred(self):
+        teds = TEDS(variants=ALL_TEDS_VARIANTS)
+        scores, gt_n, pred_n = teds.evaluate("", SIMPLE_2X2)
+        for v in ALL_TEDS_VARIANTS:
+            assert scores[v] == 0.0
+
+    def test_empty_true(self):
+        teds = TEDS(variants=ALL_TEDS_VARIANTS)
+        scores, _, _ = teds.evaluate(SIMPLE_2X2, "")
+        for v in ALL_TEDS_VARIANTS:
+            assert scores[v] == 0.0
+
+    def test_both_empty(self):
+        teds = TEDS(variants=ALL_TEDS_VARIANTS)
+        scores, _, _ = teds.evaluate("", "")
+        for v in ALL_TEDS_VARIANTS:
+            assert scores[v] == 0.0
+
+    def test_no_table_element(self):
+        teds = TEDS(variants=ALL_TEDS_VARIANTS)
+        scores, _, _ = teds.evaluate("<div>hello</div>", SIMPLE_2X2)
+        for v in ALL_TEDS_VARIANTS:
+            assert scores[v] == 0.0
+
+
+class TestTEDSVariantSelection:
+    """Verify that only requested variants are computed."""
+
+    def test_single_variant(self):
+        teds = TEDS(variants={TEDS_STRUCT})
+        scores, _, _ = teds.evaluate(SIMPLE_2X2, SIMPLE_2X2_DIFF_CONTENT)
+        assert TEDS_STRUCT in scores
+        assert TEDS_CONTENT not in scores
+        assert TEDS_STRUCT_BOOL not in scores
+
+    def test_two_variants(self):
+        teds = TEDS(variants={TEDS_CONTENT, TEDS_STRUCT_BOOL})
+        scores, _, _ = teds.evaluate(SIMPLE_2X2, SIMPLE_2X2)
+        assert TEDS_CONTENT in scores
+        assert TEDS_STRUCT_BOOL in scores
+        assert TEDS_STRUCT not in scores
+
+
+# =============================================================================
+# Tests for TEDSMetric.compute() — high-level, returns list[MetricValue]
+# =============================================================================
+
+
+class TestTEDSMetricDefaults:
+    """Default TEDSMetric should compute all variants."""
+
+    def test_default_returns_all_variants(self):
+        metric = TEDSMetric()
+        results = metric.compute(expected=SIMPLE_2X2, actual=SIMPLE_2X2)
+        names = {r.metric_name for r in results}
+        assert names == set(ALL_TEDS_VARIANTS)
+        for r in results:
+            assert r.value == 1.0
+
+    def test_content_only_variant(self):
+        metric = TEDSMetric(variants={TEDS_CONTENT})
+        results = metric.compute(expected=SIMPLE_2X2, actual=SIMPLE_2X2_DIFF_CONTENT)
+        assert len(results) == 1
+        assert results[0].metric_name == TEDS_CONTENT
+
+
+class TestTEDSMetricAllVariants:
+    """TEDSMetric with all variants."""
+
+    def test_all_variants_returns_three_metrics(self):
+        metric = TEDSMetric(variants=ALL_TEDS_VARIANTS)
+        results = metric.compute(expected=SIMPLE_2X2, actual=SIMPLE_2X2)
+        names = {r.metric_name for r in results}
+        assert names == set(ALL_TEDS_VARIANTS)
+        for r in results:
+            assert r.value == 1.0
+
+    def test_content_diff_scores(self):
+        """Different content: struct variants 1.0, content < 1.0."""
+        metric = TEDSMetric(variants=ALL_TEDS_VARIANTS)
+        results = metric.compute(expected=SIMPLE_2X2, actual=SIMPLE_2X2_DIFF_CONTENT)
+        by_name = {r.metric_name: r for r in results}
+        assert by_name[TEDS_CONTENT].value < 1.0
+        assert by_name[TEDS_STRUCT].value == 1.0
+        assert by_name[TEDS_STRUCT_BOOL].value == 1.0
+
+    def test_empty_cell_mismatch(self):
+        """One empty cell: struct still 1.0, struct_bool < 1.0."""
+        metric = TEDSMetric(variants=ALL_TEDS_VARIANTS)
+        results = metric.compute(expected=SIMPLE_2X2, actual=SIMPLE_2X2_ONE_EMPTY)
+        by_name = {r.metric_name: r for r in results}
+        assert by_name[TEDS_STRUCT].value == 1.0
+        assert by_name[TEDS_STRUCT_BOOL].value < 1.0
+        assert by_name[TEDS_CONTENT].value < 1.0
+
+
+class TestTEDSMetricMetadata:
+    """Verify metadata fields in returned MetricValues."""
+
+    def test_metadata_fields_present(self):
+        metric = TEDSMetric(variants={TEDS_CONTENT})
+        results = metric.compute(expected=SIMPLE_2X2, actual=SIMPLE_2X2)
+        r = results[0]
+        assert r.metadata["tables_predicted"] is True
+        assert r.metadata["tables_found_expected"] == 1
+        assert r.metadata["tables_found_actual"] == 1
+        assert r.metadata["tables_matched"] == 1
+        assert len(r.metadata["per_table_scores"]) == 1
+        assert len(r.metadata["per_table_details"]) == 1
+
+    def test_per_table_details_use_score_key(self):
+        metric = TEDSMetric(variants={TEDS_STRUCT})
+        results = metric.compute(expected=SIMPLE_2X2, actual=SIMPLE_2X2)
+        detail = results[0].metadata["per_table_details"][0]
+        assert "score" in detail
+        assert detail["score"] == 1.0
+        assert "gt_nodes" in detail
+        assert "pred_nodes" in detail
+
+    def test_no_tables_in_expected(self):
+        metric = TEDSMetric(variants=ALL_TEDS_VARIANTS)
+        results = metric.compute(expected="no tables here", actual=SIMPLE_2X2)
+        assert len(results) == 3
+        for r in results:
+            assert r.value == 0.0
+            assert "note" in r.metadata
+
+    def test_no_tables_in_actual(self):
+        metric = TEDSMetric(variants=ALL_TEDS_VARIANTS)
+        results = metric.compute(expected=SIMPLE_2X2, actual="no tables here")
+        assert len(results) == 3
+        for r in results:
+            assert r.value == 0.0
+            assert r.metadata["tables_matched"] == 0
+
+
+class TestTEDSMetricMultipleTables:
+    """Test Hungarian matching with multiple tables."""
+
+    def test_two_tables_in_expected(self):
+        two_tables = SIMPLE_2X2 + SIMPLE_3X3
+        metric = TEDSMetric(variants={TEDS_CONTENT})
+        results = metric.compute(expected=two_tables, actual=two_tables)
+        assert len(results) == 1
+        assert results[0].value == 1.0
+        assert results[0].metadata["tables_found_expected"] == 2
+        assert results[0].metadata["tables_found_actual"] == 2
+        assert results[0].metadata["tables_matched"] == 2
+
+    def test_fewer_actual_than_expected(self):
+        two_tables = SIMPLE_2X2 + SIMPLE_3X3
+        metric = TEDSMetric(variants={TEDS_CONTENT})
+        results = metric.compute(expected=two_tables, actual=SIMPLE_2X2)
+        assert len(results) == 1
+        # One table matched at 1.0, one unmatched at 0.0 → average 0.5
+        assert results[0].value == pytest.approx(0.5)
+
+
+# =============================================================================
+# Page-constrained matching (same-page table pairing)
+# =============================================================================
+
+
+def _matched(result):
+    """Set of (gt_idx, pred_idx) matched pairs from a TEDS MetricValue."""
+    return {
+        (d["gt_table_index"], d["pred_table_index"])
+        for d in result.metadata["per_table_details"]
+        if d.get("pred_table_index") is not None
+    }
+
+
+class TestTEDSPageBlocking:
+    def test_prefers_same_page_over_better_cross_page_match(self):
+        metric = TEDSMetric(variants={TEDS_CONTENT})
+        # GT: A@1, B@2.  Pred: B@1, A@2.  (A and B share structure, differ in content.)
+        expected = SIMPLE_2X2 + SIMPLE_2X2_DIFF_CONTENT
+        actual = SIMPLE_2X2_DIFF_CONTENT + SIMPLE_2X2
+
+        global_res = metric.compute(expected=expected, actual=actual)[0]
+        assert global_res.value == pytest.approx(1.0)
+        assert _matched(global_res) == {(0, 1), (1, 0)}
+
+        blocked = metric.compute(expected=expected, actual=actual, expected_pages=[1, 2], actual_pages=[1, 2])[0]
+        assert _matched(blocked) == {(0, 0), (1, 1)}
+        assert blocked.value < 1.0
+        for d in blocked.metadata["per_table_details"]:
+            if d.get("pred_table_index") is not None:
+                assert d["gt_page"] == d["pred_page"]
+
+    def test_unmatched_gt_page_scores_zero(self):
+        metric = TEDSMetric(variants={TEDS_CONTENT})
+        expected = SIMPLE_2X2 + SIMPLE_2X2_DIFF_CONTENT  # A@1, B@2
+        actual = SIMPLE_2X2  # only page 1
+        res = metric.compute(expected=expected, actual=actual, expected_pages=[1, 2], actual_pages=[1])[0]
+        assert _matched(res) == {(0, 0)}
+        assert res.value == pytest.approx(0.5)  # 1.0 matched + 0.0 unmatched page 2
+
+    def test_noop_when_all_one_page(self):
+        metric = TEDSMetric(variants={TEDS_CONTENT})
+        expected = SIMPLE_2X2 + SIMPLE_2X2_DIFF_CONTENT
+        actual = SIMPLE_2X2 + SIMPLE_2X2_DIFF_CONTENT
+        plain = metric.compute(expected=expected, actual=actual)[0]
+        paged = metric.compute(expected=expected, actual=actual, expected_pages=[1, 1], actual_pages=[1, 1])[0]
+        assert plain.value == paged.value
+        assert _matched(plain) == _matched(paged)
+
+    def test_length_mismatch_falls_back_to_global(self):
+        metric = TEDSMetric(variants={TEDS_CONTENT})
+        expected = SIMPLE_2X2 + SIMPLE_2X2_DIFF_CONTENT
+        actual = SIMPLE_2X2_DIFF_CONTENT + SIMPLE_2X2
+        res = metric.compute(expected=expected, actual=actual, expected_pages=[1], actual_pages=[1, 2])[0]
+        assert res.value == pytest.approx(1.0)
+        assert _matched(res) == {(0, 1), (1, 0)}

--- a/tests/parse_bench/evaluation/metrics/parse/test_text_color_rule.py
+++ b/tests/parse_bench/evaluation/metrics/parse/test_text_color_rule.py
@@ -1,0 +1,161 @@
+"""Behavior tests for the text_color rule (colored revision text)."""
+
+import pytest
+
+from parse_bench.evaluation.metrics.parse.rules_base import create_test_rule
+from parse_bench.evaluation.metrics.parse.rules_formatting import (
+    TextColorRule,
+    _rgb_to_hue_family,
+)
+
+
+def _rule(text: str, color: str) -> TextColorRule:
+    rule = create_test_rule({"type": "text_color", "text": text, "color": color})
+    assert isinstance(rule, TextColorRule)
+    return rule
+
+
+class TestHueFamily:
+    def test_pure_colors(self) -> None:
+        assert _rgb_to_hue_family(255, 0, 0) == "red"
+        assert _rgb_to_hue_family(0, 128, 0) == "green"
+        assert _rgb_to_hue_family(0, 0, 255) == "blue"
+
+    def test_light_red_is_red(self) -> None:
+        # LibreOffice track-changes salmon (#ffa6a6)
+        assert _rgb_to_hue_family(0xFF, 0xA6, 0xA6) == "red"
+
+    def test_amber_is_orange(self) -> None:
+        # LibreOffice track-changes amber (#c69200)
+        assert _rgb_to_hue_family(0xC6, 0x92, 0x00) == "orange"
+
+    def test_grayscale_has_no_family(self) -> None:
+        assert _rgb_to_hue_family(0, 0, 0) is None
+        assert _rgb_to_hue_family(120, 120, 120) is None
+        assert _rgb_to_hue_family(255, 255, 255) is None
+
+
+class TestTextColorRule:
+    def test_hex_span_matches_family(self) -> None:
+        rule = _rule("five (5) days in advance", "red")
+        ok, _ = rule.run('<span style="color:#ffa6a6">five (5) days in advance</span>')
+        assert ok
+
+    def test_named_font_color(self) -> None:
+        rule = _rule("five (5) days in advance", "red")
+        ok, _ = rule.run('<font color="red">five (5) days in advance</font>')
+        assert ok
+
+    def test_rgb_value(self) -> None:
+        rule = _rule("prior written agreement", "orange")
+        ok, _ = rule.run('<span style="color: rgb(198,146,0)">requires prior written agreement between</span>')
+        assert ok
+
+    def test_adjacent_family_accepted(self) -> None:
+        # amber may reasonably be called yellow or orange
+        rule = _rule("prior written agreement", "yellow")
+        ok, _ = rule.run('<span style="color:#c69200">prior written agreement</span>')
+        assert ok
+
+    def test_wrong_family_fails_with_found_families(self) -> None:
+        rule = _rule("five (5) days in advance", "red")
+        ok, msg = rule.run('<span style="color:blue">five (5) days in advance</span>')
+        assert not ok
+        assert "blue" in msg
+
+    def test_plain_strikeout_is_not_color(self) -> None:
+        rule = _rule("five (5) days in advance", "red")
+        ok, _ = rule.run("~~five (5) days in advance~~")
+        assert not ok
+
+    def test_unmarked_text_fails(self) -> None:
+        rule = _rule("five (5) days in advance", "red")
+        ok, msg = rule.run("must be notified five (5) days in advance")
+        assert not ok
+        assert "no colored markup" in msg
+
+    def test_nested_markup_inside_span_tolerated(self) -> None:
+        rule = _rule("five days in advance", "red")
+        ok, _ = rule.run('<span style="color:#ffa6a6">five ~~days~~ in advance</span>')
+        assert ok
+
+    def test_empty_text_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            create_test_rule({"type": "text_color", "text": " ", "color": "red"})
+
+    def test_empty_color_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            create_test_rule({"type": "text_color", "text": "hello world", "color": ""})
+
+
+class TestAbsentUnlessStrikeoutRule:
+    def _rule(self, text: str):
+        return create_test_rule({"type": "absent_unless_strikeout", "text": text})
+
+    def test_absent_passes(self) -> None:
+        ok, _ = self._rule("five (5) days in advance").run("The remaining agreement text.")
+        assert ok
+
+    def test_struck_tilde_passes(self) -> None:
+        ok, _ = self._rule("five (5) days in advance").run(
+            "~~must be notified at least five (5) days in advance~~ remains"
+        )
+        assert ok
+
+    def test_struck_html_passes(self) -> None:
+        ok, _ = self._rule("five (5) days in advance").run("<del>five (5) days in advance</del>")
+        assert ok
+
+    def test_line_through_style_passes(self) -> None:
+        ok, _ = self._rule("five (5) days in advance").run(
+            '<span style="text-decoration: line-through">five (5) days in advance</span>'
+        )
+        assert ok
+
+    def test_plain_occurrence_fails(self) -> None:
+        ok, msg = self._rule("five (5) days in advance").run("must be notified at least five (5) days in advance.")
+        assert not ok
+        assert "regular content" in msg
+
+    def test_plain_occurrence_outside_struck_region_fails(self) -> None:
+        ok, _ = self._rule("five (5) days in advance").run(
+            "~~other struck text~~ but five (5) days in advance stays plain"
+        )
+        assert not ok
+
+    def test_empty_text_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            create_test_rule({"type": "absent_unless_strikeout", "text": "  "})
+
+
+class TestPresentAsStrikeoutRule:
+    def _rule(self, text: str):
+        return create_test_rule({"type": "present_as_strikeout", "text": text})
+
+    def test_struck_passes(self) -> None:
+        ok, _ = self._rule("five (5) days in advance").run("~~notified at least five (5) days in advance~~")
+        assert ok
+
+    def test_struck_html_passes(self) -> None:
+        ok, _ = self._rule("five (5) days in advance").run("<del>five (5) days in advance</del>")
+        assert ok
+
+    def test_absent_fails(self) -> None:
+        ok, msg = self._rule("five (5) days in advance").run("Unrelated text.")
+        assert not ok
+        assert "dropped" in msg
+
+    def test_plain_fails(self) -> None:
+        ok, msg = self._rule("five (5) days in advance").run("five (5) days in advance stays plain")
+        assert not ok
+        assert "not marked as struck" in msg
+
+    def test_struck_copy_passes_even_with_plain_copy(self) -> None:
+        # The struck copy satisfies retention+marking; the plain leak is
+        # absent_unless_strikeout's job to punish.
+        ok, _ = self._rule("five (5) days").run("~~five (5) days~~ and five (5) days plain")
+        assert ok
+
+    def test_empty_text_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            create_test_rule({"type": "present_as_strikeout", "text": " "})

--- a/tests/parse_bench/evaluation/metrics/parse/test_text_similarity_metric.py
+++ b/tests/parse_bench/evaluation/metrics/parse/test_text_similarity_metric.py
@@ -1,0 +1,60 @@
+"""Tests for the parse ``text_similarity`` metric.
+
+Guards the scale of the reported value: autoevals ``Levenshtein`` already
+returns a normalized score in ``[0, 1]``, so a near-identical pair must land in
+the ~0.7 range (not ~0.007). A regression here previously divided that score by
+100, collapsing every value by two orders of magnitude.
+"""
+
+from autoevals.string import Levenshtein
+
+from parse_bench.evaluation.metrics.parse.text_similarity_metric import (
+    TextSimilarityMetric,
+)
+
+
+def test_autoevals_levenshtein_score_is_already_normalized() -> None:
+    """Document the autoevals contract this metric relies on: ``score`` is in
+    ``[0, 1]`` (1.0 identical, 0.0 fully disjoint) — NOT a 0-100 scale."""
+    lev = Levenshtein()
+    assert lev("hello world", "hello world").score == 1.0
+    assert lev("abcdefghij", "zzzzzzzzzz").score == 0.0
+    similar = lev("The quick brown fox", "The quick brown fox jumps").score
+    assert 0.6 <= similar <= 0.9
+
+
+def test_text_similarity_near_identical_pair_is_on_0_1_scale() -> None:
+    """A near-identical pair must score in the ~0.7 range on the correct 0-1
+    scale — not ~0.007, which is what the erroneous ``/100`` produced."""
+    metric = TextSimilarityMetric()
+    result = metric.compute(
+        expected="The quick brown fox",
+        actual="The quick brown fox jumps",
+    )
+    # The load-bearing assertion: the value is on the real 0-1 scale.
+    # This FAILS on the buggy ``result.score / 100.0`` (which yields ~0.0076).
+    assert result.value > 0.5
+    assert 0.6 <= result.value <= 0.9
+    # And it must equal the raw autoevals score (no rescaling applied).
+    assert result.value == result.metadata["levenshtein_score"]
+
+
+def test_text_similarity_identical_is_one() -> None:
+    """Identical strings score exactly 1.0."""
+    metric = TextSimilarityMetric()
+    result = metric.compute(expected="same text", actual="same text")
+    assert result.value == 1.0
+
+
+def test_text_similarity_both_empty_is_one() -> None:
+    """Two empty inputs are trivially identical."""
+    metric = TextSimilarityMetric()
+    result = metric.compute(expected="", actual="")
+    assert result.value == 1.0
+
+
+def test_text_similarity_one_empty_is_zero() -> None:
+    """One empty, one non-empty scores 0.0."""
+    metric = TextSimilarityMetric()
+    result = metric.compute(expected="", actual="non-empty")
+    assert result.value == 0.0

--- a/tests/parse_bench/evaluation/metrics/parse/test_title_hierarchy_inapplicable.py
+++ b/tests/parse_bench/evaluation/metrics/parse/test_title_hierarchy_inapplicable.py
@@ -1,0 +1,181 @@
+"""`title_hierarchy_percent` must be skipped, not scored 0.0, on inapplicable input.
+
+A ``title_hierarchy`` whose labels all normalize away (e.g. harvested from an
+ASCII banner: ``{"**": {}}``) carries no evaluable constraint. Scoring it 0.0
+zeroes ``rule_title_hierarchy_percent_pass_rate``, which drags
+``normalized_title_accuracy`` and then ``semantic_formatting`` to 0 on documents
+that parsed correctly. Such a rule is excluded from aggregation instead.
+
+A hierarchy that IS defined but is not satisfied by the output must still score
+low - only the undefined case is skipped.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from parse_bench.evaluation.metrics.parse.rule_based_metric import RuleBasedMetric
+from parse_bench.evaluation.metrics.parse.rules_base import RuleNotApplicable
+from parse_bench.evaluation.metrics.parse.test_rules import TitleHierarchyPercentRule
+
+# Content that genuinely satisfies the well-formed hierarchy used below.
+_GOOD_CONTENT = """
+# Executive Summary
+## Revenue Breakdown
+"""
+
+_WELL_FORMED_HIERARCHY = {"Executive Summary": {"Revenue Breakdown": {}}}
+
+
+def _rule(hierarchy: dict) -> TitleHierarchyPercentRule:
+    return TitleHierarchyPercentRule({"type": "title_hierarchy_percent", "title_hierarchy": hierarchy})
+
+
+# ---------------------------------------------------------------------------
+# The degenerate cases: no label survives normalization
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("hierarchy", "case"),
+    [
+        ({"**": {}}, "markdown bold banner"),
+        ({"~~": {}}, "strikethrough markers"),
+        ({"   ": {}}, "whitespace only"),
+        ({"": {}}, "empty string label"),
+        ({"**": {}, "~~": {}}, "several degenerate labels"),
+    ],
+)
+def test_degenerate_hierarchy_is_skipped(hierarchy: dict, case: str) -> None:
+    """No root label survives normalization -> the rule is inapplicable."""
+    with pytest.raises(RuleNotApplicable):
+        _rule(hierarchy).run("# Some Real Heading\n\nBody text.\n")
+
+
+def test_label_that_survives_normalization_is_not_degenerate() -> None:
+    """Guard on the boundary: ``***`` normalizes to ``*``, which IS a label.
+
+    Only labels that normalize to nothing make the rule inapplicable; a rule
+    with a weird-but-non-empty label stays a real, failable constraint.
+    """
+    passed, _, score = _rule({"***": {}}).run("# Some Real Heading\n")
+    assert not passed
+    assert score == 0.0
+
+
+def test_empty_hierarchy_is_skipped() -> None:
+    """An absent/empty hierarchy is undefined, not a failure."""
+    with pytest.raises(RuleNotApplicable):
+        _rule({}).run("# Some Real Heading\n")
+
+
+def test_degenerate_root_with_degenerate_children_is_skipped() -> None:
+    with pytest.raises(RuleNotApplicable):
+        _rule({"**": {"~~": {}}}).run("# A\n## B\n")
+
+
+# ---------------------------------------------------------------------------
+# Guards: defined hierarchies keep their existing behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_correct_hierarchy_still_scores_one() -> None:
+    passed, message, score = _rule(_WELL_FORMED_HIERARCHY).run(_GOOD_CONTENT)
+    assert passed
+    assert message == ""
+    assert score == 1.0
+
+
+def test_real_hierarchy_mismatch_still_scores_below_one() -> None:
+    """A defined hierarchy the output violates must still be penalised."""
+    content = """
+## Revenue Breakdown
+# Executive Summary
+"""
+    passed, _, score = _rule(_WELL_FORMED_HIERARCHY).run(content)
+    assert not passed
+    assert 0.0 <= score < 1.0
+
+
+def test_missing_titles_still_score_zero_not_skipped() -> None:
+    """Output with no titles at all is a real failure, not an inapplicable rule."""
+    passed, _, score = _rule(_WELL_FORMED_HIERARCHY).run("Just a paragraph, no headings.\n")
+    assert not passed
+    assert score == 0.0
+
+
+def test_partially_degenerate_hierarchy_is_still_evaluated() -> None:
+    """One surviving label is enough to make the rule applicable."""
+    hierarchy = {"**": {}, "Executive Summary": {}}
+    passed, message, score = _rule(hierarchy).run(_GOOD_CONTENT)
+    assert passed, message
+    assert score == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Aggregation: a skipped rule must leave no trace in the rollup
+# ---------------------------------------------------------------------------
+
+
+def _degenerate_rule_payload() -> dict:
+    return {"type": "title_hierarchy_percent", "title_hierarchy": {"**": {}}}
+
+
+def _is_title_payload() -> dict:
+    return {"type": "is_title", "text": "Executive Summary"}
+
+
+def test_skipped_rule_absent_from_rule_results() -> None:
+    metric = RuleBasedMetric()
+    result = metric.compute(
+        expected=[_is_title_payload(), _degenerate_rule_payload()],
+        actual=_GOOD_CONTENT,
+    )
+    types = [r.get("type") for r in result.metadata["rule_results"]]
+    assert "title_hierarchy_percent" not in types
+    assert types == ["is_title"]
+
+
+def test_skipped_rule_does_not_change_aggregate() -> None:
+    """Adding the degenerate rule to a document must not move any number."""
+    metric = RuleBasedMetric()
+    without = metric.compute(expected=[_is_title_payload()], actual=_GOOD_CONTENT)
+    with_degenerate = metric.compute(
+        expected=[_is_title_payload(), _degenerate_rule_payload()],
+        actual=_GOOD_CONTENT,
+    )
+
+    assert with_degenerate.value == without.value == 1.0
+    assert with_degenerate.metadata["total"] == without.metadata["total"] == 1
+    assert with_degenerate.metadata["passed"] == without.metadata["passed"] == 1
+
+
+def test_skipped_count_is_reported() -> None:
+    metric = RuleBasedMetric()
+    result = metric.compute(
+        expected=[_is_title_payload(), _degenerate_rule_payload()],
+        actual=_GOOD_CONTENT,
+    )
+    assert result.metadata["skipped_inapplicable"] == 1
+
+
+def test_document_with_only_inapplicable_rules_is_not_penalised() -> None:
+    """Nothing evaluable left -> same convention as a document with no rules."""
+    metric = RuleBasedMetric()
+    result = metric.compute(expected=[_degenerate_rule_payload()], actual=_GOOD_CONTENT)
+    assert result.value == 1.0
+    assert result.metadata["total"] == 0
+    assert result.metadata["rule_results"] == []
+
+
+def test_applicable_hierarchy_rule_still_aggregated() -> None:
+    """Guard: a defined hierarchy rule keeps contributing to the rollup."""
+    metric = RuleBasedMetric()
+    result = metric.compute(
+        expected=[{"type": "title_hierarchy_percent", "title_hierarchy": _WELL_FORMED_HIERARCHY}],
+        actual="Just a paragraph.\n",
+    )
+    types = [r.get("type") for r in result.metadata["rule_results"]]
+    assert types == ["title_hierarchy_percent"]
+    assert result.metadata["total"] == 1
+    assert result.value == 0.0

--- a/tests/parse_bench/test_cases/test_parse_rule_schemas.py
+++ b/tests/parse_bench/test_cases/test_parse_rule_schemas.py
@@ -1,0 +1,483 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+from pydantic import BaseModel
+
+from parse_bench.test_cases.loader import load_test_case
+from parse_bench.test_cases.parse_rule_schemas import (
+    ParseChartDataArrayLabelsRule,
+    ParsePresenceRule,
+    ParseRuleBase,
+    ParseTableRule,
+    coerce_parse_rule,
+    coerce_parse_rule_list,
+    get_rule_id,
+    get_rule_layout_bindings,
+    get_rule_layout_id,
+    get_rule_layout_ids,
+    get_rule_page,
+    get_rule_type,
+)
+from parse_bench.test_cases.schema import LayoutTestRule, ParseTestCase
+
+
+def test_coerce_parse_rule_accepts_unknown_fields_and_optional_id() -> None:
+    rule = coerce_parse_rule(
+        {
+            "type": "present",
+            "text": "hello",
+            "id": "rule-id-1",
+            "legacy_tag": "kept",
+        }
+    )
+
+    assert isinstance(rule, ParsePresenceRule)
+    # Direct attribute access
+    assert rule.id == "rule-id-1"
+    assert rule.type == "present"
+    assert rule.text == "hello"
+    # Extra fields accessible via get()
+    assert rule.get("legacy_tag") == "kept"
+    # get() still works for regular fields
+    assert rule.get("id") == "rule-id-1"
+
+
+def test_coerce_parse_rule_list_for_parse_test_case(tmp_path) -> None:
+    pdf_path = tmp_path / "sample.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4")
+    test_json = tmp_path / "sample.test.json"
+    test_json.write_text(
+        json.dumps(
+            {
+                "test_rules": [
+                    {"type": "present", "text": "hello"},
+                    {"type": "unexpected_word", "bag_of_word": {"sample": 1}},
+                ]
+            }
+        )
+    )
+
+    case = load_test_case(pdf_path, test_json)
+    assert isinstance(case, ParseTestCase)
+    assert case.test_rules is not None
+    assert all(not isinstance(rule, dict) and isinstance(rule, BaseModel) for rule in case.test_rules)
+
+    present_rule, word_rule = case.test_rules
+    assert present_rule.type == "present"
+    assert word_rule.type == "unexpected_word"
+
+
+def test_layout_test_rule_accepts_tags_and_round_trips_to_annotation() -> None:
+    rule = LayoutTestRule.model_validate(
+        {
+            "type": "layout",
+            "page": 2,
+            "bbox": [0.1, 0.2, 0.3, 0.4],
+            "canonical_class": "Text",
+            "tags": ["table_related", "Needs Review"],
+        }
+    )
+
+    assert rule.tags == ["table_related", "Needs Review"]
+
+    annotation = rule.to_layout_annotation()
+    assert annotation.page == 1
+    assert annotation.tags == ["table_related", "Needs Review"]
+
+
+def test_coerce_parse_rule_list_type_validation(tmp_path) -> None:
+    rules = coerce_parse_rule_list(
+        [
+            {"type": "present", "text": "hello"},
+            {"type": "unexpected_sentence", "bag_of_sentence": {"sample": 1}},
+        ]
+    )
+
+    assert len(rules) == 2
+    assert all(isinstance(rule, BaseModel) for rule in rules)
+
+
+def test_coerce_parse_rule_supports_word_percent_rules() -> None:
+    rules = coerce_parse_rule_list(
+        [
+            {"type": "unexpected_word_percent", "bag_of_word": {"sample": 1}},
+            {"type": "too_many_word_occurence_percent", "bag_of_word": {"sample": 1}},
+            {"type": "missing_word_percent", "bag_of_word": {"sample": 1}},
+        ]
+    )
+
+    assert [get_rule_type(rule) for rule in rules] == [
+        "unexpected_word_percent",
+        "too_many_word_occurence_percent",
+        "missing_word_percent",
+    ]
+
+
+def test_coerce_parse_rule_supports_sentence_percent_rules() -> None:
+    rules = coerce_parse_rule_list(
+        [
+            {"type": "unexpected_sentence_percent", "bag_of_sentence": {"sample sentence": 1}},
+            {
+                "type": "too_many_sentence_occurence_percent",
+                "bag_of_sentence": {"sample sentence": 1},
+            },
+            {"type": "missing_sentence_percent", "bag_of_sentence": {"sample sentence": 1}},
+        ]
+    )
+
+    assert [get_rule_type(rule) for rule in rules] == [
+        "unexpected_sentence_percent",
+        "too_many_sentence_occurence_percent",
+        "missing_sentence_percent",
+    ]
+
+
+def test_table_and_chart_rules_accept_nullable_fields() -> None:
+    rule = coerce_parse_rule(
+        {
+            "type": "table",
+            "cell": "A1",
+            "up": None,
+            "down": None,
+            "left": None,
+            "right": None,
+            "top_heading": None,
+            "left_heading": None,
+        }
+    )
+    assert isinstance(rule, ParseTableRule)
+
+
+def test_coerce_parse_rule_supports_is_title_without_level() -> None:
+    rule = coerce_parse_rule(
+        {
+            "type": "is_title",
+            "text": "Executive Summary",
+        }
+    )
+
+    assert get_rule_type(rule) == "is_title"
+    assert rule.get("level") is None
+
+
+def test_coerce_parse_rule_supports_title_hierarchy_percent() -> None:
+    rule = coerce_parse_rule(
+        {
+            "type": "title_hierarchy_percent",
+            "title_hierarchy": {"Executive Summary": {"Revenue Breakdown": ["Regional Split", "Product Split"]}},
+        }
+    )
+
+    assert get_rule_type(rule) == "title_hierarchy_percent"
+    assert isinstance(rule.get("title_hierarchy"), dict)
+
+
+def test_coerce_parse_rule_supports_heading_structure() -> None:
+    rule = coerce_parse_rule(
+        {
+            "type": "heading_structure",
+            "headings": [{"text": "Executive Summary", "level": 2}],
+        }
+    )
+
+    assert get_rule_type(rule) == "heading_structure"
+    assert rule.get("headings")[0].text == "Executive Summary"
+    assert rule.get("headings")[0].level == 2
+
+
+def test_heading_structure_requires_an_explicit_inventory() -> None:
+    with pytest.raises(ValueError, match="headings"):
+        coerce_parse_rule({"type": "heading_structure"})
+
+
+def test_coerce_parse_rule_supports_is_latex() -> None:
+    rule = coerce_parse_rule(
+        {
+            "type": "is_latex",
+            "formula": r"\frac{a}{b}",
+        }
+    )
+
+    assert get_rule_type(rule) == "is_latex"
+    assert rule.get("formula") == r"\frac{a}{b}"
+
+
+def test_coerce_parse_rule_supports_is_not_latex() -> None:
+    rule = coerce_parse_rule(
+        {
+            "type": "is_not_latex",
+            "text": "$400 billion",
+        }
+    )
+
+    assert get_rule_type(rule) == "is_not_latex"
+    assert rule.get("text") == "$400 billion"
+
+
+def test_coerce_parse_rule_supports_is_code_block() -> None:
+    rule = coerce_parse_rule(
+        {
+            "type": "is_code_block",
+            "language": "c",
+            "code": "jklnhj",
+        }
+    )
+
+    assert get_rule_type(rule) == "is_code_block"
+    assert rule.get("language") == "c"
+    assert rule.get("code") == "jklnhj"
+
+    chart_rule = coerce_parse_rule(
+        {
+            "type": "chart_data_point",
+            "labels": ["A", "B"],
+            "value": 310,
+            "relative_tolerance": 0.01,
+        }
+    )
+    assert chart_rule.value == 310
+    assert str(chart_rule.get("value")) == "310"
+
+
+def test_coerce_parse_rule_idempotent() -> None:
+    """Already-typed rules pass through coerce_parse_rule unchanged."""
+    rule = coerce_parse_rule({"type": "present", "text": "hello"})
+    assert isinstance(rule, ParsePresenceRule)
+
+    # Coercing again returns the same object
+    same_rule = coerce_parse_rule(rule)
+    assert same_rule is rule
+
+
+def test_direct_attribute_access_on_typed_rules() -> None:
+    """Direct attribute access works for all field types."""
+    rule = coerce_parse_rule(
+        {
+            "type": "present",
+            "text": "hello world",
+            "id": "test-1",
+            "page": 3,
+            "max_diffs": 2,
+            "tags": ["tag1", "tag2"],
+            "case_sensitive": False,
+            "first_n": 100,
+        }
+    )
+    assert isinstance(rule, ParsePresenceRule)
+    assert rule.type == "present"
+    assert rule.text == "hello world"
+    assert rule.id == "test-1"
+    assert rule.page == 3
+    assert rule.max_diffs == 2
+    assert rule.tags == ["tag1", "tag2"]
+    assert rule.case_sensitive is False
+    assert rule.first_n == 100
+    assert rule.last_n is None
+    assert rule.count is None
+
+
+def test_csv_path_alias_accessible_after_coercion() -> None:
+    """csv_path field (alias _csv_path) accessible by field name after coercion."""
+    rule = coerce_parse_rule(
+        {
+            "type": "chart_data_array_labels",
+            "data": [["A", "B"], [1, 2]],
+            "_csv_path": "/tmp/test.csv",
+        }
+    )
+    assert isinstance(rule, ParseChartDataArrayLabelsRule)
+    # Access by field name
+    assert rule.csv_path == "/tmp/test.csv"
+    # Access by alias via get()
+    assert rule.get("_csv_path") == "/tmp/test.csv"
+
+
+def test_tag_mutation_on_typed_models() -> None:
+    """Tags can be mutated directly on typed Pydantic models."""
+    rule = coerce_parse_rule({"type": "present", "text": "hello", "tags": ["a"]})
+    assert rule.tags == ["a"]
+
+    # Direct assignment works (Pydantic v2 non-frozen models)
+    rule.tags = ["a", "b", "c"]
+    assert rule.tags == ["a", "b", "c"]
+
+
+def test_helper_functions_use_direct_access() -> None:
+    """get_rule_type/id/page use direct attribute access on typed rules."""
+    rule = coerce_parse_rule({"type": "present", "text": "hello", "id": "r1", "page": 5})
+    assert get_rule_type(rule) == "present"
+    assert get_rule_id(rule) == "r1"
+    assert get_rule_page(rule) == 5
+
+    # Also works with None values
+    rule2 = coerce_parse_rule({"type": "absent", "text": "bye"})
+    assert get_rule_id(rule2) is None
+    assert get_rule_page(rule2) is None
+
+
+def test_get_returns_default_for_missing_keys() -> None:
+    """get() returns default for keys not in model fields or extra."""
+    rule = coerce_parse_rule({"type": "present", "text": "hello"})
+    assert rule.get("nonexistent") is None
+    assert rule.get("nonexistent", "fallback") == "fallback"
+
+
+def test_loader_produces_typed_rules(tmp_path) -> None:
+    """End-to-end: loader produces typed rules with tags merged."""
+    pdf_path = tmp_path / "sample.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4")
+    test_json = tmp_path / "sample.test.json"
+    test_json.write_text(
+        json.dumps(
+            {
+                "tags": ["doc-tag"],
+                "test_rules": [
+                    {"type": "present", "text": "hello", "tags": ["rule-tag"]},
+                    {"type": "absent", "text": "bye"},
+                ],
+            }
+        )
+    )
+
+    case = load_test_case(pdf_path, test_json)
+    assert isinstance(case, ParseTestCase)
+    assert case.test_rules is not None
+
+    # All rules are typed (not dicts)
+    for rule in case.test_rules:
+        assert isinstance(rule, ParseRuleBase)
+
+    # Tags are merged: doc-level tags propagated into rules
+    assert "doc-tag" in case.test_rules[0].tags
+    assert "rule-tag" in case.test_rules[0].tags
+    assert "doc-tag" in case.test_rules[1].tags
+    assert case.tags == ["doc-tag", "rule-tag"]
+
+
+def test_layout_grounding_normalizes_layout_id_to_layout_ids() -> None:
+    rule = coerce_parse_rule(
+        {
+            "type": "present",
+            "text": "hello",
+            "layout_id": "layout-1",
+        }
+    )
+    assert isinstance(rule, ParsePresenceRule)
+    assert rule.layout_id == "layout-1"
+    assert rule.layout_ids == ["layout-1"]
+    assert rule.layout_bindings == {}
+
+
+def test_layout_grounding_merges_layout_bindings_and_dedupes_layout_ids() -> None:
+    rule = coerce_parse_rule(
+        {
+            "type": "order",
+            "before": "a",
+            "after": "b",
+            "layout_id": "layout-a",
+            "layout_ids": ["layout-b", "layout-a"],
+            "layout_bindings": {
+                "before": "layout-a",
+                "after": "layout-c",
+            },
+        }
+    )
+    assert rule.layout_id == "layout-a"
+    assert rule.layout_ids == ["layout-a", "layout-b", "layout-c"]
+    assert rule.layout_bindings == {"before": "layout-a", "after": "layout-c"}
+
+
+def test_layout_grounding_sets_primary_id_from_layout_ids_when_missing() -> None:
+    rule = coerce_parse_rule(
+        {
+            "type": "present",
+            "text": "hello",
+            "layout_ids": ["layout-2", "layout-3"],
+        }
+    )
+    assert rule.layout_id == "layout-2"
+    assert rule.layout_ids == ["layout-2", "layout-3"]
+
+
+def test_layout_grounding_helper_accessors_for_typed_and_dict_rules() -> None:
+    typed_rule = coerce_parse_rule(
+        {
+            "type": "order",
+            "before": "a",
+            "after": "b",
+            "layout_bindings": {"before": "layout-1", "after": "layout-2"},
+        }
+    )
+    assert get_rule_layout_ids(typed_rule) == ["layout-1", "layout-2"]
+    assert get_rule_layout_id(typed_rule) == "layout-1"
+    assert get_rule_layout_bindings(typed_rule) == {"before": "layout-1", "after": "layout-2"}
+
+    dict_rule = {
+        "type": "present",
+        "text": "hello",
+        "layout_id": "layout-3",
+    }
+    assert get_rule_layout_ids(dict_rule) == ["layout-3"]
+    assert get_rule_layout_id(dict_rule) == "layout-3"
+    assert get_rule_layout_bindings(dict_rule) == {}
+
+
+def test_order_layout_bindings_reject_unknown_roles() -> None:
+    with pytest.raises(ValueError, match="only supports roles 'before' and 'after'"):
+        coerce_parse_rule(
+            {
+                "type": "order",
+                "before": "a",
+                "after": "b",
+                "layout_bindings": {
+                    "middle": "layout-1",
+                },
+            }
+        )
+
+
+def test_order_layout_bindings_reject_list_values() -> None:
+    with pytest.raises(ValueError, match="must be a single layout id string"):
+        coerce_parse_rule(
+            {
+                "type": "order",
+                "before": "a",
+                "after": "b",
+                "layout_bindings": {
+                    "before": ["layout-1", "layout-2"],
+                },
+            }
+        )
+
+
+def test_order_layout_id_is_canonicalized_to_before_binding_when_both_set() -> None:
+    rule = coerce_parse_rule(
+        {
+            "type": "order",
+            "before": "a",
+            "after": "b",
+            "layout_id": "layout-primary",
+            "layout_bindings": {
+                "before": "layout-other",
+                "after": "layout-secondary",
+            },
+        }
+    )
+    assert rule.layout_id == "layout-other"
+    assert rule.layout_ids == ["layout-other", "layout-primary", "layout-secondary"]
+
+
+def test_layout_test_rule_without_r_omits_key_on_dump() -> None:
+    rule = LayoutTestRule.model_validate(
+        {
+            "type": "layout",
+            "page": 1,
+            "bbox": [0.0, 0.0, 1.0, 1.0],
+            "canonical_class": "Text",
+        }
+    )
+
+    dumped = rule.model_dump(exclude_none=True)
+    assert "r" not in dumped


### PR DESCRIPTION
Introduces metric fixes: 
- text-similarity scale bug
- Unicode-aware normalization and dot-leader/marker/quote normalizers
- table-cell text substitution (was double-counting)
- per-page table pairing for GriTS/TEDS/TRM, 
- leader-insensitive TRM and header accuracy
- thead/tbody/tfoot/scope/colgroup/ caption-aware table parsing
- order-rule HTML stripping
- bag-rule image alt stripping
- degenerate-rule handling
- per-document rule budget
- delimiter-run emphasis matcher for formatting rules. 
- ParseTestCase accepts layout and extract-field rules and carries metadata; rule instances keep subclass fields across the worker round-trip.