### PR TITLE
6. Package parse-bench for PyPI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - run: uv sync --extra runners --extra fast --extra dev
+      - run: uv run ruff check src tests
+      - run: uv run ruff format --check src tests
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          python-version: ${{ matrix.python-version }}
+      - run: uv sync --extra runners --extra fast --extra dev
+      - run: uv run pytest -q
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv build
+      - name: Smoke-test the wheel in a clean environment
+        run: |
+          uv venv /tmp/smoke
+          uv pip install --python /tmp/smoke/bin/python dist/*.whl
+          /tmp/smoke/bin/parse-bench version
+          /tmp/smoke/bin/parse-bench pipelines > /dev/null
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,52 @@
+name: Publish to PyPI
+
+# Publishes when a version tag (v0.3.0, v1.0.0, ...) is pushed. The tag must
+# match `__version__` in src/parse_bench/__init__.py.
+#
+# Uses PyPI trusted publishing (OIDC): no API token is stored in GitHub.
+# One-time setup on pypi.org: project "parse-bench" -> Publishing -> add a
+# GitHub publisher with owner run-llama, repo ParseBench, workflow
+# publish.yml, environment pypi.
+
+on:
+  push:
+    tags: ["v*"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - name: Check tag matches package version
+        run: |
+          pkg_version=$(uv run --no-project python -c "import re,pathlib; print(re.search(r'__version__ = \"([^\"]+)\"', pathlib.Path('src/parse_bench/__init__.py').read_text()).group(1))")
+          tag_version="${GITHUB_REF_NAME#v}"
+          if [ "$pkg_version" != "$tag_version" ]; then
+            echo "Tag $GITHUB_REF_NAME does not match __version__ $pkg_version" >&2
+            exit 1
+          fi
+      - run: uv build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+          generate_release_notes: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to `parse-bench` are recorded here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project uses
+[Semantic Versioning](https://semver.org/).
+
+Scoring-relevant changes (anything that can move a leaderboard number) are
+called out explicitly so that results produced by different versions can be
+compared with care.
+
+## [0.3.0] - 2026-09-02
+
+### Added
+- `parse-bench` is now published to PyPI. Install with `pip install "parse-bench[runners]"`.
+- Per-provider extras (`llamaparse`, `openai`, `anthropic`, `google`, `azure`, `aws`,
+  `reducto`, `datalab`, `landingai`, `unstructured`, `chunkr`, `extend`, `docling`, `local`)
+  so a runner can be installed without every provider SDK. `runners` remains the union.
+- `parse-bench version` command.
+- CI (lint, tests, wheel smoke test) and a tag-driven PyPI publish workflow.
+
+### Changed
+- Dropped unused core dependencies `datasets` (which pulled in pyarrow, 123 MB) and `tqdm`; a base install is now ~280 MB instead of ~410 MB.
+- `markdown2` floor raised to 2.5.5: 2.5.4 renders `*`/`_` runs inside table cells differently, which changed 12 of 2078 LiteParse outputs between environments.
+- The package version is single-sourced from `parse_bench.__version__`.
+- `.env` discovery now walks up from the current directory instead of assuming a repo checkout.
+
+## [0.2.0] - 2026-09-01
+
+Last version distributed as a source checkout only. See the git history for details.

--- a/README.md
+++ b/README.md
@@ -44,14 +44,19 @@ _Top 10 by Overall score. For the full sortable, filterable leaderboard, see [pa
 **Prerequisites:** Create a `.env` file with the API key for the parsing tool you want to evaluate (see [Configuration](#configuration) for details).
 
 ```bash
-# Install
+# Install from PyPI (pick the extras for the providers you want to run)
+pip install "parse-bench[runners]"          # every provider SDK
+pip install "parse-bench[llamaparse]"       # or just one, e.g. llamaparse / openai / anthropic / google
+
+# Or, from a checkout of this repo
 uv sync --extra runners
 
 # Optional: add the `fast` extra for a JIT-accelerated TEDS table metric (numba).
 # Scores are identical to the default path — just faster on large tables.
-uv sync --extra runners --extra fast
+pip install "parse-bench[runners,fast]"
 
 # Quick test run (small dataset, 3 files per category — good for trying things out)
+# (drop the `uv run` prefix if you installed from PyPI)
 uv run parse-bench run llamaparse_agentic --test
 
 # Full benchmark run (replace llamaparse_agentic with any pipeline name, see "Available Pipelines" below)
@@ -63,7 +68,7 @@ uv run parse-bench serve llamaparse_agentic
 
 ## Available Pipelines
 
-A **pipeline** is a document parsing tool or configuration that you want to evaluate. There are 90+ pipelines available -- see [docs/pipelines.md](docs/pipelines.md) for the full list, or run `uv run parse-bench pipelines`.
+A **pipeline** is a document parsing tool or configuration that you want to evaluate. There are 180+ pipelines available -- see [docs/pipelines.md](docs/pipelines.md) for the full list, or run `uv run parse-bench pipelines`.
 
 <details>
 <summary><strong>Paper baselines (21 pipelines)</strong></summary>

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,65 @@
+# Releasing parse-bench
+
+Releases are cut from `main` and published to PyPI automatically by
+`.github/workflows/publish.yml` when a `v*` tag is pushed.
+
+## Versioning
+
+`parse-bench` follows semantic versioning with one benchmark-specific rule:
+
+- **Patch** (`0.3.x`): provider fixes, new pipelines, docs, tooling. Scores for
+  existing pipelines on the public dataset do not change.
+- **Minor** (`0.x.0`): anything that can change a score on the public dataset
+  (metric fixes, rule matching changes, aggregation changes) or a breaking CLI /
+  API change. Call these out under a "Scoring" heading in `CHANGELOG.md`.
+
+Evaluation outputs record the `parse-bench` version so leaderboard rows can be
+traced to the code that produced them.
+
+## Steps
+
+1. Update `CHANGELOG.md`: move items from `[Unreleased]` under a new
+   `## [X.Y.Z] - YYYY-MM-DD` heading.
+2. Bump `__version__` in `src/parse_bench/__init__.py` (the single source of truth;
+   `pyproject.toml` reads it at build time).
+3. Refresh the lockfile and run the checks:
+   ```bash
+   uv lock
+   uv sync --extra runners --extra fast --extra dev
+   uv run ruff check src tests && uv run ruff format --check src tests
+   uv run pytest -q
+   uv build
+   ```
+4. Open a PR with those changes and merge it.
+5. Tag and push:
+   ```bash
+   git tag vX.Y.Z && git push origin vX.Y.Z
+   ```
+   The publish workflow verifies that the tag matches `__version__`, builds the
+   sdist and wheel, publishes to PyPI via trusted publishing, and creates a GitHub
+   release with auto-generated notes.
+
+## One-time PyPI setup
+
+The publish workflow uses [trusted publishing](https://docs.pypi.org/trusted-publishers/),
+so no PyPI token is stored in GitHub.
+
+1. On pypi.org, create the `parse-bench` project (or use "Add a new pending publisher"
+   if the project does not exist yet).
+2. Under *Publishing*, add a GitHub publisher: owner `run-llama`, repository
+   `ParseBench`, workflow `publish.yml`, environment `pypi`.
+3. In the GitHub repository settings, create an environment named `pypi`. Optionally
+   require reviewers so a tag push cannot publish without approval.
+
+## Consuming the package from another project
+
+```bash
+uv add "parse-bench[runners]"          # or pip install "parse-bench[runners]"
+uv add "parse-bench[llamaparse]"       # just one provider
+```
+
+Pin an exact version in evaluation harnesses so scores are reproducible:
+
+```toml
+dependencies = ["parse-bench==0.3.0"]
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,27 @@
 [project]
 name = "parse-bench"
-version = "0.2.0"
-description = "Document parsing evaluation benchmark"
+dynamic = ["version"]
+description = "ParseBench: a benchmark and evaluation harness for document parsing systems on real-world enterprise documents"
 readme = "README.md"
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 requires-python = ">=3.12"
+authors = [
+    { name = "LlamaIndex" },
+]
+keywords = ["document-parsing", "ocr", "benchmark", "evaluation", "pdf", "markdown", "tables", "charts"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Text Processing",
+]
 dependencies = [
     "apted>=1.0.3",
     "beautifulsoup4>=4.12.0",
@@ -13,7 +31,7 @@ dependencies = [
     "huggingface-hub>=0.20.0",
     "lxml>=5.0.0",
     "markdown>=3.0",
-    "markdown2>=2.4.0",
+    "markdown2>=2.5.5",
     "numpy>=1.24.0",
     "pandas>=2.0.0",
     "pydantic>=2.0.0",
@@ -24,11 +42,9 @@ dependencies = [
     "rich>=13.7.0",
     "scikit-learn>=1.8.0",
     "scipy>=1.16.3",
-    "tqdm>=4.67.1",
     "unidecode>=1.3.0",
     "anls-star>=0.1.0",
     "autoevals>=0.0.20",
-    "datasets>=4.8.4",
 ]
 
 [project.optional-dependencies]
@@ -57,6 +73,21 @@ runners = [
     "unstructured-client>=0.26.0",
     "warp-ingest[ocr]>=2.0.1",
 ]
+# Per-provider extras for users who only need one runner. `runners` is the union.
+llamaparse = ["llama-cloud>=1.4.1", "httpx>=0.28.0"]
+openai = ["openai>=1.0.0", "pdf2image>=1.16.0", "pillow>=10.0.0", "pymupdf>=1.24.0"]
+anthropic = ["anthropic>=0.77.1", "pdf2image>=1.16.0", "pillow>=10.0.0", "pymupdf>=1.24.0"]
+google = ["google-genai>=1.0.0", "google-cloud-documentai>=2.20.0", "pdf2image>=1.16.0", "pillow>=10.0.0", "pymupdf>=1.24.0"]
+azure = ["azure-ai-documentintelligence>=1.0.0"]
+aws = ["boto3>=1.34.0", "amazon-textract-textractor>=1.7.0"]
+reducto = ["reductoai>=0.13.0"]
+datalab = ["datalab-python-sdk"]
+landingai = ["landingai-ade>=1.4.0"]
+unstructured = ["unstructured-client>=0.26.0"]
+chunkr = ["chunkr-ai>=0.0.43"]
+extend = ["extend-ai>=1.16.0"]
+docling = ["docling-core>=2.71.0", "httpx>=0.28.0"]
+local = ["pymupdf>=1.24.0", "pypdf>=6.4.0", "pytesseract>=0.3.10", "pdf2image>=1.16.0", "pillow>=10.0.0"]
 pymupdf4llm = [
     "pymupdf4llm==1.28.2",
     "rapidocr==3.9.2",
@@ -71,6 +102,14 @@ dev = [
     "numba>=0.59.0",
 ]
 
+[project.urls]
+Homepage = "https://parsebench.ai"
+Repository = "https://github.com/run-llama/ParseBench"
+Issues = "https://github.com/run-llama/ParseBench/issues"
+Dataset = "https://huggingface.co/datasets/llamaindex/ParseBench"
+Paper = "https://arxiv.org/abs/2604.08538"
+Changelog = "https://github.com/run-llama/ParseBench/blob/main/CHANGELOG.md"
+
 [project.scripts]
 parse-bench = "parse_bench.cli:main"
 
@@ -78,8 +117,24 @@ parse-bench = "parse_bench.cli:main"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.version]
+path = "src/parse_bench/__init__.py"
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/parse_bench"]
+
+[tool.hatch.build.targets.sdist]
+only-include = [
+    "src/parse_bench",
+    "tests",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md",
+]
+exclude = [
+    "**/__pycache__",
+    "**/.gitkeep",
+]
 
 [tool.uv]
 conflicts = [
@@ -104,7 +159,19 @@ select = [
     "UP", # pyupgrade
 ]
 
+[tool.ruff.format]
+# Vendored, contributor-maintained VLM providers: kept byte-for-byte as submitted.
+exclude = [
+    "src/parse_bench/inference/providers/parse/kdl_frontier_nano.py",
+    "src/parse_bench/inference/providers/parse/florin_parser_nano.py",
+    "src/parse_bench/inference/providers/parse/rakedoc_nano.py",
+]
+
 [tool.ruff.lint.per-file-ignores]
+# Vendored, contributor-maintained VLM providers (see [tool.ruff.format] above).
+"src/parse_bench/inference/providers/parse/kdl_frontier_nano.py" = ["ALL"]
+"src/parse_bench/inference/providers/parse/florin_parser_nano.py" = ["ALL"]
+"src/parse_bench/inference/providers/parse/rakedoc_nano.py" = ["ALL"]
 "src/parse_bench/analysis/detailed_report.py" = ["E501", "E402"]
 "src/parse_bench/analysis/comparison_report.py" = ["E501"]
 # Benchmark closures are invoked within the same loop iteration, so the

--- a/src/parse_bench/__init__.py
+++ b/src/parse_bench/__init__.py
@@ -1,3 +1,3 @@
 """Document parsing evaluation system for competitive benchmarking."""
 
-__version__ = "0.1.0"
+__version__ = "0.3.0"

--- a/src/parse_bench/cli.py
+++ b/src/parse_bench/cli.py
@@ -4,8 +4,9 @@ import sys
 from pathlib import Path
 
 import fire
-from dotenv import load_dotenv
+from dotenv import find_dotenv, load_dotenv
 
+from parse_bench import __version__
 from parse_bench.analysis.cli import AnalysisCLI
 from parse_bench.data.cli import DataCLI
 from parse_bench.evaluation.cli import EvaluationCLI
@@ -13,18 +14,13 @@ from parse_bench.inference.cli import InferenceCLI
 from parse_bench.pipeline.cli import PipelineCLI
 
 
-# Load .env file if it exists (look in current directory and project root)
+# Load .env file if it exists. Search the current directory and its parents so
+# the CLI works both from a repo checkout and as an installed package.
 def _load_env() -> None:
-    """Load environment variables from .env file."""
-    # Try current directory first, then project root
-    env_paths = [
-        Path.cwd() / ".env",
-        Path(__file__).parent.parent.parent / ".env",
-    ]
-    for env_path in env_paths:
-        if env_path.exists():
-            load_dotenv(env_path, override=False)  # Don't override existing env vars
-            break
+    """Load environment variables from the nearest .env file."""
+    env_path = find_dotenv(usecwd=True)
+    if env_path:
+        load_dotenv(env_path, override=False)  # Don't override existing env vars
 
 
 def _resolve_pipeline_dir(name_or_path: str | Path) -> Path:
@@ -52,6 +48,7 @@ class BenchCLI:
         pipelines    List available pipeline configurations
         compare      Compare two pipeline results
         serve        View reports in browser with PDF support
+        version      Print the installed parse-bench version
 
     Advanced subcommands:
         inference    Run inference only
@@ -69,6 +66,10 @@ class BenchCLI:
         self.data = DataCLI()
 
     # ── Top-level convenience commands ──────────────────────────────
+
+    def version(self) -> str:
+        """Print the installed parse-bench version."""
+        return __version__
 
     def run(
         self,

--- a/src/parse_bench/data/cli.py
+++ b/src/parse_bench/data/cli.py
@@ -54,9 +54,7 @@ class DataCLI:
         """
         import json
 
-        data_path = (
-            Path(data_dir) if data_dir else Path.cwd() / default_data_dir(test=test)
-        )
+        data_path = Path(data_dir) if data_dir else Path.cwd() / default_data_dir(test=test)
         ready = is_dataset_ready(data_path)
 
         if not ready:
@@ -94,9 +92,7 @@ class DataCLI:
         if docs_dir.exists():
             for cat_dir in sorted(docs_dir.iterdir()):
                 if cat_dir.is_dir():
-                    doc_counts[cat_dir.name] = sum(
-                        1 for _ in cat_dir.rglob("*") if _.is_file()
-                    )
+                    doc_counts[cat_dir.name] = sum(1 for _ in cat_dir.rglob("*") if _.is_file())
 
         # Print table
         hdr = f"{'Category':<20} {'Test Cases':>12} {'PDFs':>8}"

--- a/src/parse_bench/data/download.py
+++ b/src/parse_bench/data/download.py
@@ -121,10 +121,7 @@ def download_dataset(
     )
 
     if not is_dataset_ready(data_dir):
-        raise RuntimeError(
-            f"Dataset download completed but validation failed. "
-            f"Check {data_dir} for missing files."
-        )
+        raise RuntimeError(f"Dataset download completed but validation failed. Check {data_dir} for missing files.")
 
     print(f"Dataset ready at: {data_dir}")
     return data_dir

--- a/src/parse_bench/evaluation/metrics/parse/llm_normalization/__init__.py
+++ b/src/parse_bench/evaluation/metrics/parse/llm_normalization/__init__.py
@@ -45,6 +45,7 @@ def get_normalizer(
 
     if mode == NormalizationMode.JUDGE:
         from parse_bench.evaluation.metrics.parse.llm_normalization.strategy_judge import JudgeNormalizer
+
         return JudgeNormalizer()
 
     return None

--- a/src/parse_bench/evaluation/runner.py
+++ b/src/parse_bench/evaluation/runner.py
@@ -38,7 +38,7 @@ from parse_bench.evaluation.metric_aggregation import add_precision_recall_f1_ag
 from parse_bench.evaluation.stats import build_operational_stats
 from parse_bench.schemas.evaluation import EvaluationResult, EvaluationSummary
 from parse_bench.schemas.layout_detection_output import LayoutOutput
-from parse_bench.schemas.pipeline_io import InferenceResult, InferenceRequest
+from parse_bench.schemas.pipeline_io import InferenceRequest, InferenceResult
 from parse_bench.schemas.product import ProductType
 from parse_bench.test_cases import load_test_cases
 from parse_bench.test_cases.parse_rule_schemas import get_rule_type

--- a/src/parse_bench/inference/providers/parse/amazon_nova.py
+++ b/src/parse_bench/inference/providers/parse/amazon_nova.py
@@ -292,9 +292,7 @@ class AmazonNovaProvider(Provider):
         except Exception as e:
             raise ProviderPermanentError(f"Failed to convert PDF to images: {e}") from e
 
-    def _converse(
-        self, image: Image.Image, system_prompt: str, user_prompt: str
-    ) -> tuple[str, dict[str, int], str]:
+    def _converse(self, image: Image.Image, system_prompt: str, user_prompt: str) -> tuple[str, dict[str, int], str]:
         """Send one page image to Bedrock Converse and return (text, usage, stop_reason)."""
         image_bytes = self._image_to_jpeg_bytes(image)
 
@@ -345,9 +343,7 @@ class AmazonNovaProvider(Provider):
 
         return text, self._extract_usage(response), stop_reason
 
-    def _parse_image_with_layout(
-        self, image: Image.Image
-    ) -> tuple[list[dict[str, Any]], str, dict[str, int], str]:
+    def _parse_image_with_layout(self, image: Image.Image) -> tuple[list[dict[str, Any]], str, dict[str, int], str]:
         """Parse a page image to layout-annotated markdown blocks."""
         text, usage, stop_reason = self._converse(image, SYSTEM_PROMPT_LAYOUT, USER_PROMPT_LAYOUT)
         # Prefer the lenient reader (Nova uses <TABLE>/<p> wrappers and leaves

--- a/src/parse_bench/inference/providers/parse/infinity_parser2.py
+++ b/src/parse_bench/inference/providers/parse/infinity_parser2.py
@@ -1,11 +1,11 @@
 """Provider for Infinity-Parser2 PARSE via infinity_parser2 SDK with vLLM server."""
 
-from datetime import datetime
 import json
 import logging
-from pathlib import Path
 import re
 import traceback
+from datetime import datetime
+from pathlib import Path
 from typing import Any
 
 from pdf2image import convert_from_path
@@ -18,7 +18,7 @@ from parse_bench.inference.providers.base import (
     ProviderTransientError,
 )
 from parse_bench.inference.providers.registry import register_provider
-from parse_bench.schemas.parse_output import ParseLayoutPageIR, ParseOutput, PageIR
+from parse_bench.schemas.parse_output import PageIR, ParseLayoutPageIR, ParseOutput
 from parse_bench.schemas.pipeline import PipelineSpec
 from parse_bench.schemas.pipeline_io import (
     InferenceRequest,
@@ -257,10 +257,7 @@ class InfinityParser2Provider(Provider):
             if not isinstance(elements, list):
                 return result
 
-            figure_elements = [
-                elem for elem in elements
-                if elem.get("category", "").strip().lower() == "figure"
-            ]
+            figure_elements = [elem for elem in elements if elem.get("category", "").strip().lower() == "figure"]
             if not figure_elements:
                 return result
 
@@ -282,7 +279,7 @@ class InfinityParser2Provider(Provider):
                 "max_new_tokens": 2048,
             }
             deep_results = [self._parser.parse(img, **deep_parse_kwargs) for img in pil_figure_images]
-            for elem, deep_result in zip(figure_elements, deep_results):
+            for elem, deep_result in zip(figure_elements, deep_results, strict=False):
                 elem["text"] = deep_result
 
             return json.dumps(elements)
@@ -431,6 +428,7 @@ def load_image(file_path: str) -> tuple[PILImage.Image, float, float]:
 # Postprocess for chart2table
 # =============================================================================
 
+
 def _is_valid_md_table(table_text: str) -> bool:
     """Check if a markdown table is valid (non-empty)."""
     if not table_text or not table_text.strip():
@@ -544,6 +542,7 @@ def _convert_nonstandard_table(text: str) -> str:
 # Postprocess for HTML table header
 # =============================================================================
 
+
 def _is_year_cell(text: str) -> bool:
     """Return True if text looks like a date/year (yyyy, yyyymm, yyyymmdd, etc.)."""
     text = text.strip()
@@ -582,8 +581,7 @@ def _determine_header_row_count(rows: list) -> int:
         return 0
 
     def non_empty_cells(row):
-        return [td.get_text(strip=True) for td in row.find_all("td", recursive=False)
-                if td.get_text(strip=True)]
+        return [td.get_text(strip=True) for td in row.find_all("td", recursive=False) if td.get_text(strip=True)]
 
     def stats(row_list):
         """Return (pure_text_count, pure_number_count, total) for a list of rows."""
@@ -623,15 +621,15 @@ def _determine_header_row_count(rows: list) -> int:
     best_i = -1
     best_score = -1.0
     for i in range(3):
-        header_rows = rows[:i + 1]
-        data_rows = rows[i + 1:]
+        header_rows = rows[: i + 1]
+        data_rows = rows[i + 1 :]
         if not header_rows or not data_rows:
             continue
         header_text, header_num, header_total = stats(header_rows)
         data_text, data_num, data_total = stats(data_rows)
         if header_total == 0 or data_total == 0:
             continue
-        if (header_text / header_total >= 0.5 and data_num / data_total >= 0.5):
+        if header_text / header_total >= 0.5 and data_num / data_total >= 0.5:
             score = header_text / header_total + data_num / data_total
             if score > best_score:
                 best_score = score

--- a/src/parse_bench/inference/providers/parse/liteparse.py
+++ b/src/parse_bench/inference/providers/parse/liteparse.py
@@ -11,6 +11,15 @@ from parse_bench.inference.providers.base import (
     ProviderConfigError,
     ProviderPermanentError,
 )
+from parse_bench.inference.providers.registry import register_provider
+from parse_bench.schemas.parse_output import PageIR, ParseOutput
+from parse_bench.schemas.pipeline import PipelineSpec
+from parse_bench.schemas.pipeline_io import (
+    InferenceRequest,
+    InferenceResult,
+    RawInferenceResult,
+)
+from parse_bench.schemas.product import ProductType
 
 # Hardcoded path to the workspace `lit` release binary. ParseBench lives at
 # <workspace>/ParseBench/src/parse_bench/inference/providers/parse/liteparse.py,
@@ -26,15 +35,6 @@ _CLI_FLAG_MAP: dict[str, str] = {
     "num_workers": "--num-workers",
     "image_mode": "--image-mode",
 }
-from parse_bench.inference.providers.registry import register_provider
-from parse_bench.schemas.parse_output import PageIR, ParseOutput
-from parse_bench.schemas.pipeline import PipelineSpec
-from parse_bench.schemas.pipeline_io import (
-    InferenceRequest,
-    InferenceResult,
-    RawInferenceResult,
-)
-from parse_bench.schemas.product import ProductType
 
 
 @register_provider("liteparse")
@@ -61,9 +61,7 @@ class LiteParseProvider(Provider):
         self._output_format = self.base_config.get("output_format", "markdown")
         self._ocr_enabled = self.base_config.get("ocr_enabled", True)
         self._preserve_small_text = self.base_config.get("preserve_very_small_text", False)
-        self._flag_kwargs = {
-            k: v for k, v in self.base_config.items() if k in _CLI_FLAG_MAP and v is not None
-        }
+        self._flag_kwargs = {k: v for k, v in self.base_config.items() if k in _CLI_FLAG_MAP and v is not None}
 
     def _build_cli_args(self, pdf_path: str, fmt: str) -> list[str]:
         args: list[str] = [str(_LIT_BIN), "parse", pdf_path, "--format", fmt, "--quiet"]

--- a/src/parse_bench/inference/providers/parse/markitdown.py
+++ b/src/parse_bench/inference/providers/parse/markitdown.py
@@ -50,9 +50,7 @@ class MarkItDownProvider(Provider):
 
     def run_inference(self, pipeline: PipelineSpec, request: InferenceRequest) -> RawInferenceResult:
         if request.product_type != ProductType.PARSE:
-            raise ProviderPermanentError(
-                f"MarkItDownProvider only supports PARSE, got {request.product_type}"
-            )
+            raise ProviderPermanentError(f"MarkItDownProvider only supports PARSE, got {request.product_type}")
 
         pdf_path = Path(request.source_file_path)
         if not pdf_path.exists():

--- a/src/parse_bench/inference/providers/parse/nemotron_omni.py
+++ b/src/parse_bench/inference/providers/parse/nemotron_omni.py
@@ -116,8 +116,7 @@ class NemotronOmniProvider(Provider):
         server_url = self.base_config.get("server_url") or os.getenv("NEMOTRON_OMNI_SERVER_URL")
         if not server_url:
             raise ProviderConfigError(
-                "NemotronOmni provider requires 'server_url' in config or "
-                "NEMOTRON_OMNI_SERVER_URL in the environment."
+                "NemotronOmni provider requires 'server_url' in config or NEMOTRON_OMNI_SERVER_URL in the environment."
             )
         self._server_url: str = str(server_url)
 

--- a/src/parse_bench/inference/providers/parse/oi_parser.py
+++ b/src/parse_bench/inference/providers/parse/oi_parser.py
@@ -83,9 +83,7 @@ def _block_to_html(block: list[str]) -> str | None:
     if not data:
         return None
     th = "".join(f"<th>{_html.escape(c)}</th>" for c in header)
-    body = "".join(
-        "<tr>" + "".join(f"<td>{_html.escape(c)}</td>" for c in row) + "</tr>" for row in data
-    )
+    body = "".join("<tr>" + "".join(f"<td>{_html.escape(c)}</td>" for c in row) + "</tr>" for row in data)
     return f"<table><thead><tr>{th}</tr></thead><tbody>{body}</tbody></table>"
 
 
@@ -137,9 +135,7 @@ class OIParserProvider(Provider):
 
     def run_inference(self, pipeline: PipelineSpec, request: InferenceRequest) -> RawInferenceResult:
         if request.product_type != ProductType.PARSE:
-            raise ProviderPermanentError(
-                f"OIParserProvider only supports PARSE, got {request.product_type}"
-            )
+            raise ProviderPermanentError(f"OIParserProvider only supports PARSE, got {request.product_type}")
 
         path = Path(request.source_file_path)
         if not path.exists():
@@ -178,9 +174,7 @@ class OIParserProvider(Provider):
         except (ValueError, requests.exceptions.RequestException) as e:
             # Truncated/invalid body (e.g. ChunkedEncodingError surfacing at read
             # time, or non-JSON) — transient; let the runner retry.
-            raise ProviderTransientError(
-                f"oi-parser bad/truncated response body: {type(e).__name__}: {e}"
-            ) from e
+            raise ProviderTransientError(f"oi-parser bad/truncated response body: {type(e).__name__}: {e}") from e
         completed_at = datetime.now()
         latency_ms = int((completed_at - started_at).total_seconds() * 1000)
 
@@ -197,9 +191,7 @@ class OIParserProvider(Provider):
 
     def normalize(self, raw_result: RawInferenceResult) -> InferenceResult:
         if raw_result.product_type != ProductType.PARSE:
-            raise ProviderPermanentError(
-                f"OIParserProvider only supports PARSE, got {raw_result.product_type}"
-            )
+            raise ProviderPermanentError(f"OIParserProvider only supports PARSE, got {raw_result.product_type}")
 
         body_output = raw_result.raw_output.get("output")
         if not isinstance(body_output, dict):

--- a/src/parse_bench/inference/providers/parse/opendataloader.py
+++ b/src/parse_bench/inference/providers/parse/opendataloader.py
@@ -34,9 +34,7 @@ class OpenDataLoaderProvider(Provider):
         try:
             import opendataloader_pdf
         except ImportError as e:
-            raise ProviderConfigError(
-                "opendataloader-pdf not installed. Run: pip install opendataloader-pdf"
-            ) from e
+            raise ProviderConfigError("opendataloader-pdf not installed. Run: pip install opendataloader-pdf") from e
 
         ext = "md" if self._format == "markdown" else "txt"
 
@@ -62,9 +60,7 @@ class OpenDataLoaderProvider(Provider):
 
     def run_inference(self, pipeline: PipelineSpec, request: InferenceRequest) -> RawInferenceResult:
         if request.product_type != ProductType.PARSE:
-            raise ProviderPermanentError(
-                f"OpenDataLoaderProvider only supports PARSE, got {request.product_type}"
-            )
+            raise ProviderPermanentError(f"OpenDataLoaderProvider only supports PARSE, got {request.product_type}")
 
         pdf_path = Path(request.source_file_path)
         if not pdf_path.exists():

--- a/src/parse_bench/inference/providers/parse/pdf_inspector.py
+++ b/src/parse_bench/inference/providers/parse/pdf_inspector.py
@@ -34,9 +34,7 @@ class PdfInspectorProvider(Provider):
     def _extract(self, pdf_path: str) -> dict[str, Any]:
         pdf2md = shutil.which("pdf2md") or os.path.expanduser("~/.cargo/bin/pdf2md")
         if not os.path.exists(pdf2md):
-            raise ProviderConfigError(
-                "pdf2md not found. Install with: cargo install pdf-inspector"
-            )
+            raise ProviderConfigError("pdf2md not found. Install with: cargo install pdf-inspector")
 
         try:
             out = subprocess.run(
@@ -56,9 +54,7 @@ class PdfInspectorProvider(Provider):
 
     def run_inference(self, pipeline: PipelineSpec, request: InferenceRequest) -> RawInferenceResult:
         if request.product_type != ProductType.PARSE:
-            raise ProviderPermanentError(
-                f"PdfInspectorProvider only supports PARSE, got {request.product_type}"
-            )
+            raise ProviderPermanentError(f"PdfInspectorProvider only supports PARSE, got {request.product_type}")
 
         pdf_path = Path(request.source_file_path)
         if not pdf_path.exists():

--- a/tests/parse_bench/evaluation/test_runner_aggregation.py
+++ b/tests/parse_bench/evaluation/test_runner_aggregation.py
@@ -357,9 +357,7 @@ def test_no_failures_is_a_no_op() -> None:
 def _layout_case(test_id: str, with_annotations: bool):
     from parse_bench.test_cases.schema import LayoutDetectionTestCase, LayoutTestRule
 
-    rules = (
-        [LayoutTestRule(page=1, bbox=[0.1, 0.1, 0.2, 0.2], canonical_class="text")] if with_annotations else []
-    )
+    rules = [LayoutTestRule(page=1, bbox=[0.1, 0.1, 0.2, 0.2], canonical_class="text")] if with_annotations else []
     return LayoutDetectionTestCase(
         test_id=test_id,
         group="layout",
@@ -386,9 +384,7 @@ def test_missing_layout_output_is_synthesized_as_zero(tmp_path: Path, monkeypatc
     assert synthesized.error == "No usable inference output for this example"
 
 
-def test_layout_case_without_annotations_is_not_scored_as_zero(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_layout_case_without_annotations_is_not_scored_as_zero(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     tc = _layout_case("layout/doc2", with_annotations=False)
     monkeypatch.setattr("parse_bench.evaluation.runner.load_test_cases", lambda **kwargs: [tc])
 

--- a/tests/parse_bench/inference/providers/parse/test_infinity_parser2.py
+++ b/tests/parse_bench/inference/providers/parse/test_infinity_parser2.py
@@ -132,12 +132,7 @@ class TestConvertTableHeader(unittest.TestCase):
     """End-to-end: <td> in detected header rows is rewritten to <th>."""
 
     def test_td_to_th_in_header_row(self) -> None:
-        html = (
-            "<table>"
-            "<tr><td>2022</td><td>2023</td></tr>"
-            "<tr><td>10</td><td>20</td></tr>"
-            "</table>"
-        )
+        html = "<table><tr><td>2022</td><td>2023</td></tr><tr><td>10</td><td>20</td></tr></table>"
         out = _convert_table_header(html)
         soup = BeautifulSoup(out, "html.parser")
         rows = soup.find_all("tr")

--- a/tests/parse_bench/inference/providers/parse/test_pymupdf4llm.py
+++ b/tests/parse_bench/inference/providers/parse/test_pymupdf4llm.py
@@ -18,9 +18,7 @@ from parse_bench.schemas.product import ProductType
 
 
 def test_only_one_pymupdf4llm_pipeline_is_registered() -> None:
-    assert [name for name in list_pipelines() if name.startswith("pymupdf4llm")] == [
-        "pymupdf4llm_markdown"
-    ]
+    assert [name for name in list_pipelines() if name.startswith("pymupdf4llm")] == ["pymupdf4llm_markdown"]
 
 
 def test_pipeline_uses_rapidocr_and_native_html() -> None:
@@ -130,9 +128,7 @@ def test_normalize_preserves_native_html_and_layout_grounding() -> None:
                 "text": native_html,
                 "width": 100,
                 "height": 100,
-                "page_boxes": [
-                    {"class": "table", "bbox": [0, 0, 100, 100], "pos": [0, len(native_html)]}
-                ],
+                "page_boxes": [{"class": "table", "bbox": [0, 0, 100, 100], "pos": [0, len(native_html)]}],
             }
         ],
         "num_pages": 1,

--- a/uv.lock
+++ b/uv.lock
@@ -2,27 +2,15 @@ version = 1
 revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
-    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-11-parse-bench-pymupdf4llm' and extra == 'extra-11-parse-bench-runners'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-11-parse-bench-pymupdf4llm' and extra == 'extra-11-parse-bench-runners'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-11-parse-bench-pymupdf4llm' and extra == 'extra-11-parse-bench-runners'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-11-parse-bench-pymupdf4llm' and extra == 'extra-11-parse-bench-runners'",
-    "python_full_version < '3.13' and sys_platform == 'win32' and extra != 'extra-11-parse-bench-pymupdf4llm' and extra == 'extra-11-parse-bench-runners'",
-    "python_full_version == '3.13.*' and sys_platform == 'emscripten' and extra != 'extra-11-parse-bench-pymupdf4llm' and extra == 'extra-11-parse-bench-runners'",
-    "python_full_version < '3.13' and sys_platform == 'emscripten' and extra != 'extra-11-parse-bench-pymupdf4llm' and extra == 'extra-11-parse-bench-runners'",
-    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-11-parse-bench-pymupdf4llm' and extra == 'extra-11-parse-bench-runners'",
-    "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-11-parse-bench-pymupdf4llm' and extra == 'extra-11-parse-bench-runners'",
-    "python_full_version >= '3.14' and sys_platform == 'win32' and extra == 'extra-11-parse-bench-pymupdf4llm' and extra != 'extra-11-parse-bench-runners'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra == 'extra-11-parse-bench-pymupdf4llm' and extra != 'extra-11-parse-bench-runners'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-11-parse-bench-pymupdf4llm' and extra != 'extra-11-parse-bench-runners'",
-    "python_full_version < '3.14' and sys_platform == 'win32' and extra == 'extra-11-parse-bench-pymupdf4llm' and extra != 'extra-11-parse-bench-runners'",
-    "python_full_version < '3.14' and sys_platform == 'emscripten' and extra == 'extra-11-parse-bench-pymupdf4llm' and extra != 'extra-11-parse-bench-runners'",
-    "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-11-parse-bench-pymupdf4llm' and extra != 'extra-11-parse-bench-runners'",
-    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-11-parse-bench-pymupdf4llm' and extra != 'extra-11-parse-bench-runners'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-11-parse-bench-pymupdf4llm' and extra != 'extra-11-parse-bench-runners'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-11-parse-bench-pymupdf4llm' and extra != 'extra-11-parse-bench-runners'",
-    "python_full_version < '3.14' and sys_platform == 'win32' and extra != 'extra-11-parse-bench-pymupdf4llm' and extra != 'extra-11-parse-bench-runners'",
-    "python_full_version < '3.14' and sys_platform == 'emscripten' and extra != 'extra-11-parse-bench-pymupdf4llm' and extra != 'extra-11-parse-bench-runners'",
-    "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-11-parse-bench-pymupdf4llm' and extra != 'extra-11-parse-bench-runners'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version < '3.13' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 conflicts = [[
     { package = "parse-bench", extra = "pymupdf4llm" },
@@ -470,7 +458,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy' or (extra == 'extra-11-parse-bench-pymupdf4llm' and extra == 'extra-11-parse-bench-runners')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -642,7 +630,7 @@ name = "cryptography"
 version = "46.0.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy' or (extra == 'extra-11-parse-bench-pymupdf4llm' and extra == 'extra-11-parse-bench-runners')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/60/04/ee2a9e8542e4fa2773b81771ff8349ff19cdd56b7258a0cc442639052edb/cryptography-46.0.5.tar.gz", hash = "sha256:abace499247268e3757271b2f1e244b36b06f8515cf27c4d49468fc9eb16e93d", size = 750064, upload-time = "2026-02-10T19:18:38.255Z" }
 wheels = [
@@ -778,46 +766,12 @@ wheels = [
 ]
 
 [[package]]
-name = "datasets"
-version = "4.8.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "dill" },
-    { name = "filelock" },
-    { name = "fsspec", extra = ["http"] },
-    { name = "httpx" },
-    { name = "huggingface-hub" },
-    { name = "multiprocess" },
-    { name = "numpy" },
-    { name = "packaging" },
-    { name = "pandas" },
-    { name = "pyarrow" },
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "tqdm" },
-    { name = "xxhash" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/22/22/73e46ac7a8c25e7ef0b3bd6f10da3465021d90219a32eb0b4d2afea4c56e/datasets-4.8.4.tar.gz", hash = "sha256:a1429ed853275ce7943a01c6d2e25475b4501eb758934362106a280470df3a52", size = 604382, upload-time = "2026-03-23T14:21:17.987Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/e5/247d094108e42ac26363ab8dc57f168840cf7c05774b40ffeb0d78868fcc/datasets-4.8.4-py3-none-any.whl", hash = "sha256:cdc8bee4698e549d78bf1fed6aea2eebc760b22b084f07e6fc020c6577a6ce6d", size = 526991, upload-time = "2026-03-23T14:21:15.89Z" },
-]
-
-[[package]]
 name = "defusedxml"
 version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
-]
-
-[[package]]
-name = "dill"
-version = "0.4.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/81/e1/56027a71e31b02ddc53c7d65b01e68edf64dea2932122fe7746a516f75d5/dill-0.4.1.tar.gz", hash = "sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa", size = 187315, upload-time = "2026-01-19T02:36:56.85Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl", hash = "sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d", size = 120019, upload-time = "2026-01-19T02:36:55.663Z" },
 ]
 
 [[package]]
@@ -1046,11 +1000,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/ab/fb21f4c939bb440104cc2b396d3be1d9b7a9fd3c6c2a53d98c45b3d7c954/fsspec-2026.2.0-py3-none-any.whl", hash = "sha256:98de475b5cb3bd66bedd5c4679e87b4fdfe1a3bf4d707b151b3c07e58c9a2437", size = 202505, upload-time = "2026-02-05T21:50:51.819Z" },
 ]
 
-[package.optional-dependencies]
-http = [
-    { name = "aiohttp" },
-]
-
 [[package]]
 name = "fuzzysearch"
 version = "0.8.1"
@@ -1130,7 +1079,7 @@ name = "google-cloud-documentai"
 version = "3.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "google-api-core", extra = ["grpc"], marker = "extra == 'extra-11-parse-bench-runners'" },
+    { name = "google-api-core", extra = ["grpc"] },
     { name = "google-auth" },
     { name = "grpcio" },
     { name = "proto-plus" },
@@ -1148,7 +1097,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "distro" },
-    { name = "google-auth", extra = ["requests"], marker = "extra == 'extra-11-parse-bench-runners'" },
+    { name = "google-auth", extra = ["requests"] },
     { name = "httpx" },
     { name = "pydantic" },
     { name = "requests" },
@@ -1347,7 +1296,7 @@ dependencies = [
     { name = "pillow" },
     { name = "py-cpuinfo" },
     { name = "pybase64" },
-    { name = "pymupdf", version = "1.28.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "pymupdf" },
     { name = "pypdf" },
     { name = "qwen-vl-utils" },
     { name = "scikit-learn" },
@@ -2074,23 +2023,6 @@ wheels = [
 ]
 
 [[package]]
-name = "multiprocess"
-version = "0.70.19"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "dill" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a2/f2/e783ac7f2aeeed14e9e12801f22529cc7e6b7ab80928d6dcce4e9f00922d/multiprocess-0.70.19.tar.gz", hash = "sha256:952021e0e6c55a4a9fe4cd787895b86e239a40e76802a789d6305398d3975897", size = 2079989, upload-time = "2026-01-19T06:47:39.744Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/45/8004d1e6b9185c1a444d6b55ac5682acf9d98035e54386d967366035a03a/multiprocess-0.70.19-py310-none-any.whl", hash = "sha256:97404393419dcb2a8385910864eedf47a3cadf82c66345b44f036420eb0b5d87", size = 134948, upload-time = "2026-01-19T06:47:32.325Z" },
-    { url = "https://files.pythonhosted.org/packages/86/c2/dec9722dc3474c164a0b6bcd9a7ed7da542c98af8cabce05374abab35edd/multiprocess-0.70.19-py311-none-any.whl", hash = "sha256:928851ae7973aea4ce0eaf330bbdafb2e01398a91518d5c8818802845564f45c", size = 144457, upload-time = "2026-01-19T06:47:33.711Z" },
-    { url = "https://files.pythonhosted.org/packages/71/70/38998b950a97ea279e6bd657575d22d1a2047256caf707d9a10fbce4f065/multiprocess-0.70.19-py312-none-any.whl", hash = "sha256:3a56c0e85dd5025161bac5ce138dcac1e49174c7d8e74596537e729fd5c53c28", size = 150281, upload-time = "2026-01-19T06:47:35.037Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/74/d2c27e03cb84251dfe7249b8e82923643c6d48fa4883b9476b025e7dc7eb/multiprocess-0.70.19-py313-none-any.whl", hash = "sha256:8d5eb4ec5017ba2fab4e34a747c6d2c2b6fecfe9e7236e77988db91580ada952", size = 156414, upload-time = "2026-01-19T06:47:35.915Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/61/af9115673a5870fd885247e2f1b68c4f1197737da315b520a91c757a861a/multiprocess-0.70.19-py314-none-any.whl", hash = "sha256:e8cc7fbdff15c0613f0a1f1f8744bef961b0a164c0ca29bdff53e9d2d93c5e5f", size = 160318, upload-time = "2026-01-19T06:47:37.497Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/82/69e539c4c2027f1e1697e09aaa2449243085a0edf81ae2c6341e84d769b6/multiprocess-0.70.19-py39-none-any.whl", hash = "sha256:0d4b4397ed669d371c81dcd1ef33fd384a44d6c3de1bd0ca7ac06d837720d3c5", size = 133477, upload-time = "2026-01-19T06:47:38.619Z" },
-]
-
-[[package]]
 name = "munkres"
 version = "1.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2616,7 +2548,6 @@ wheels = [
 
 [[package]]
 name = "parse-bench"
-version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "anls-star" },
@@ -2624,7 +2555,6 @@ dependencies = [
     { name = "autoevals" },
     { name = "beautifulsoup4" },
     { name = "bleach" },
-    { name = "datasets" },
     { name = "fire" },
     { name = "fuzzysearch" },
     { name = "huggingface-hub" },
@@ -2641,23 +2571,78 @@ dependencies = [
     { name = "rich" },
     { name = "scikit-learn" },
     { name = "scipy" },
-    { name = "tqdm" },
     { name = "unidecode" },
 ]
 
 [package.optional-dependencies]
+anthropic = [
+    { name = "anthropic" },
+    { name = "pdf2image" },
+    { name = "pillow" },
+    { name = "pymupdf" },
+]
+aws = [
+    { name = "amazon-textract-textractor" },
+    { name = "boto3" },
+]
+azure = [
+    { name = "azure-ai-documentintelligence" },
+]
+chunkr = [
+    { name = "chunkr-ai" },
+]
+datalab = [
+    { name = "datalab-python-sdk" },
+]
 dev = [
     { name = "mypy" },
     { name = "numba" },
     { name = "pytest" },
     { name = "ruff" },
 ]
+docling = [
+    { name = "docling-core" },
+    { name = "httpx" },
+]
+extend = [
+    { name = "extend-ai" },
+]
 fast = [
     { name = "numba" },
+]
+google = [
+    { name = "google-cloud-documentai" },
+    { name = "google-genai" },
+    { name = "pdf2image" },
+    { name = "pillow" },
+    { name = "pymupdf" },
+]
+landingai = [
+    { name = "landingai-ade" },
+]
+llamaparse = [
+    { name = "httpx" },
+    { name = "llama-cloud" },
+]
+local = [
+    { name = "pdf2image" },
+    { name = "pillow" },
+    { name = "pymupdf" },
+    { name = "pypdf" },
+    { name = "pytesseract" },
+]
+openai = [
+    { name = "openai" },
+    { name = "pdf2image" },
+    { name = "pillow" },
+    { name = "pymupdf" },
 ]
 pymupdf4llm = [
     { name = "pymupdf4llm" },
     { name = "rapidocr" },
+]
+reducto = [
+    { name = "reductoai" },
 ]
 runners = [
     { name = "amazon-textract-textractor" },
@@ -2677,54 +2662,85 @@ runners = [
     { name = "openai" },
     { name = "pdf2image" },
     { name = "pillow" },
-    { name = "pymupdf", version = "1.28.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "pymupdf" },
     { name = "pypdf" },
     { name = "pytesseract" },
     { name = "reductoai" },
     { name = "unstructured-client" },
     { name = "warp-ingest", extra = ["ocr"], marker = "extra == 'extra-11-parse-bench-runners'" },
 ]
+unstructured = [
+    { name = "unstructured-client" },
+]
 
 [package.metadata]
 requires-dist = [
+    { name = "amazon-textract-textractor", marker = "extra == 'aws'", specifier = ">=1.7.0" },
     { name = "amazon-textract-textractor", marker = "extra == 'runners'", specifier = ">=1.7.0" },
     { name = "anls-star", specifier = ">=0.1.0" },
+    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.77.1" },
     { name = "anthropic", marker = "extra == 'runners'", specifier = ">=0.77.1" },
     { name = "apted", specifier = ">=1.0.3" },
     { name = "autoevals", specifier = ">=0.0.20" },
+    { name = "azure-ai-documentintelligence", marker = "extra == 'azure'", specifier = ">=1.0.0" },
     { name = "azure-ai-documentintelligence", marker = "extra == 'runners'", specifier = ">=1.0.0" },
     { name = "beautifulsoup4", specifier = ">=4.12.0" },
     { name = "bleach", specifier = ">=6.0.0" },
+    { name = "boto3", marker = "extra == 'aws'", specifier = ">=1.34.0" },
     { name = "boto3", marker = "extra == 'runners'", specifier = ">=1.34.0" },
+    { name = "chunkr-ai", marker = "extra == 'chunkr'", specifier = ">=0.0.43" },
     { name = "chunkr-ai", marker = "extra == 'runners'", specifier = ">=0.0.43" },
+    { name = "datalab-python-sdk", marker = "extra == 'datalab'" },
     { name = "datalab-python-sdk", marker = "extra == 'runners'" },
-    { name = "datasets", specifier = ">=4.8.4" },
+    { name = "docling-core", marker = "extra == 'docling'", specifier = ">=2.71.0" },
     { name = "docling-core", marker = "extra == 'runners'", specifier = ">=2.71.0" },
+    { name = "extend-ai", marker = "extra == 'extend'", specifier = ">=1.16.0" },
     { name = "extend-ai", marker = "extra == 'runners'", specifier = ">=1.16.0" },
     { name = "fire", specifier = ">=0.7.1" },
     { name = "fuzzysearch", specifier = ">=0.7.3" },
+    { name = "google-cloud-documentai", marker = "extra == 'google'", specifier = ">=2.20.0" },
     { name = "google-cloud-documentai", marker = "extra == 'runners'", specifier = ">=2.20.0" },
+    { name = "google-genai", marker = "extra == 'google'", specifier = ">=1.0.0" },
     { name = "google-genai", marker = "extra == 'runners'", specifier = ">=1.0.0" },
+    { name = "httpx", marker = "extra == 'docling'", specifier = ">=0.28.0" },
+    { name = "httpx", marker = "extra == 'llamaparse'", specifier = ">=0.28.0" },
     { name = "httpx", marker = "extra == 'runners'", specifier = ">=0.28.0" },
     { name = "huggingface-hub", specifier = ">=0.20.0" },
     { name = "infinity-parser2", marker = "extra == 'runners'", specifier = ">=0.3.0" },
+    { name = "landingai-ade", marker = "extra == 'landingai'", specifier = ">=1.4.0" },
     { name = "landingai-ade", marker = "extra == 'runners'", specifier = ">=1.4.0" },
+    { name = "llama-cloud", marker = "extra == 'llamaparse'", specifier = ">=1.4.1" },
     { name = "llama-cloud", marker = "extra == 'runners'", specifier = ">=1.4.1" },
     { name = "lxml", specifier = ">=5.0.0" },
     { name = "markdown", specifier = ">=3.0" },
-    { name = "markdown2", specifier = ">=2.4.0" },
+    { name = "markdown2", specifier = ">=2.5.5" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.18.2" },
     { name = "numba", marker = "extra == 'dev'", specifier = ">=0.59.0" },
     { name = "numba", marker = "extra == 'fast'", specifier = ">=0.59.0" },
     { name = "numpy", specifier = ">=1.24.0" },
+    { name = "openai", marker = "extra == 'openai'", specifier = ">=1.0.0" },
     { name = "openai", marker = "extra == 'runners'", specifier = ">=1.0.0" },
     { name = "pandas", specifier = ">=2.0.0" },
+    { name = "pdf2image", marker = "extra == 'anthropic'", specifier = ">=1.16.0" },
+    { name = "pdf2image", marker = "extra == 'google'", specifier = ">=1.16.0" },
+    { name = "pdf2image", marker = "extra == 'local'", specifier = ">=1.16.0" },
+    { name = "pdf2image", marker = "extra == 'openai'", specifier = ">=1.16.0" },
     { name = "pdf2image", marker = "extra == 'runners'", specifier = ">=1.16.0" },
+    { name = "pillow", marker = "extra == 'anthropic'", specifier = ">=10.0.0" },
+    { name = "pillow", marker = "extra == 'google'", specifier = ">=10.0.0" },
+    { name = "pillow", marker = "extra == 'local'", specifier = ">=10.0.0" },
+    { name = "pillow", marker = "extra == 'openai'", specifier = ">=10.0.0" },
     { name = "pillow", marker = "extra == 'runners'", specifier = ">=10.0.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
+    { name = "pymupdf", marker = "extra == 'anthropic'", specifier = ">=1.24.0" },
+    { name = "pymupdf", marker = "extra == 'google'", specifier = ">=1.24.0" },
+    { name = "pymupdf", marker = "extra == 'local'", specifier = ">=1.24.0" },
+    { name = "pymupdf", marker = "extra == 'openai'", specifier = ">=1.24.0" },
     { name = "pymupdf", marker = "extra == 'runners'", specifier = ">=1.24.0" },
     { name = "pymupdf4llm", marker = "extra == 'pymupdf4llm'", specifier = "==1.28.2" },
+    { name = "pypdf", marker = "extra == 'local'", specifier = ">=6.4.0" },
     { name = "pypdf", marker = "extra == 'runners'", specifier = ">=6.4.0" },
+    { name = "pytesseract", marker = "extra == 'local'", specifier = ">=0.3.10" },
     { name = "pytesseract", marker = "extra == 'runners'", specifier = ">=0.3.10" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "python-dateutil", specifier = ">=2.9.0" },
@@ -2732,17 +2748,18 @@ requires-dist = [
     { name = "python-levenshtein", specifier = ">=0.25.0" },
     { name = "rapidfuzz", specifier = ">=3.0.0" },
     { name = "rapidocr", marker = "extra == 'pymupdf4llm'", specifier = "==3.9.2" },
+    { name = "reductoai", marker = "extra == 'reducto'", specifier = ">=0.13.0" },
     { name = "reductoai", marker = "extra == 'runners'", specifier = ">=0.13.0" },
     { name = "rich", specifier = ">=13.7.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.14.5" },
     { name = "scikit-learn", specifier = ">=1.8.0" },
     { name = "scipy", specifier = ">=1.16.3" },
-    { name = "tqdm", specifier = ">=4.67.1" },
     { name = "unidecode", specifier = ">=1.3.0" },
     { name = "unstructured-client", marker = "extra == 'runners'", specifier = ">=0.26.0" },
+    { name = "unstructured-client", marker = "extra == 'unstructured'", specifier = ">=0.26.0" },
     { name = "warp-ingest", extras = ["ocr"], marker = "extra == 'runners'", specifier = ">=2.0.1" },
 ]
-provides-extras = ["runners", "pymupdf4llm", "fast", "dev"]
+provides-extras = ["anthropic", "aws", "azure", "chunkr", "datalab", "dev", "docling", "extend", "fast", "google", "landingai", "llamaparse", "local", "openai", "pymupdf4llm", "reducto", "runners", "unstructured"]
 
 [[package]]
 name = "partial-json-parser"
@@ -3041,49 +3058,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyarrow"
-version = "23.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/22/134986a4cc224d593c1afde5494d18ff629393d74cc2eddb176669f234a4/pyarrow-23.0.1.tar.gz", hash = "sha256:b8c5873e33440b2bc2f4a79d2b47017a89c5a24116c055625e6f2ee50523f019", size = 1167336, upload-time = "2026-02-16T10:14:12.39Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/4b/4166bb5abbfe6f750fc60ad337c43ecf61340fa52ab386da6e8dbf9e63c4/pyarrow-23.0.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:f4b0dbfa124c0bb161f8b5ebb40f1a680b70279aa0c9901d44a2b5a20806039f", size = 34214575, upload-time = "2026-02-16T10:09:56.225Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/da/3f941e3734ac8088ea588b53e860baeddac8323ea40ce22e3d0baa865cc9/pyarrow-23.0.1-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:7707d2b6673f7de054e2e83d59f9e805939038eebe1763fe811ee8fa5c0cd1a7", size = 35832540, upload-time = "2026-02-16T10:10:03.428Z" },
-    { url = "https://files.pythonhosted.org/packages/88/7c/3d841c366620e906d54430817531b877ba646310296df42ef697308c2705/pyarrow-23.0.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:86ff03fb9f1a320266e0de855dee4b17da6794c595d207f89bba40d16b5c78b9", size = 44470940, upload-time = "2026-02-16T10:10:10.704Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/a5/da83046273d990f256cb79796a190bbf7ec999269705ddc609403f8c6b06/pyarrow-23.0.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:813d99f31275919c383aab17f0f455a04f5a429c261cc411b1e9a8f5e4aaaa05", size = 47586063, upload-time = "2026-02-16T10:10:17.95Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/3c/b7d2ebcff47a514f47f9da1e74b7949138c58cfeb108cdd4ee62f43f0cf3/pyarrow-23.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bf5842f960cddd2ef757d486041d57c96483efc295a8c4a0e20e704cbbf39c67", size = 48173045, upload-time = "2026-02-16T10:10:25.363Z" },
-    { url = "https://files.pythonhosted.org/packages/43/b2/b40961262213beaba6acfc88698eb773dfce32ecdf34d19291db94c2bd73/pyarrow-23.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:564baf97c858ecc03ec01a41062e8f4698abc3e6e2acd79c01c2e97880a19730", size = 50621741, upload-time = "2026-02-16T10:10:33.477Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/70/1fdda42d65b28b078e93d75d371b2185a61da89dda4def8ba6ba41ebdeb4/pyarrow-23.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:07deae7783782ac7250989a7b2ecde9b3c343a643f82e8a4df03d93b633006f0", size = 27620678, upload-time = "2026-02-16T10:10:39.31Z" },
-    { url = "https://files.pythonhosted.org/packages/47/10/2cbe4c6f0fb83d2de37249567373d64327a5e4d8db72f486db42875b08f6/pyarrow-23.0.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6b8fda694640b00e8af3c824f99f789e836720aa8c9379fb435d4c4953a756b8", size = 34210066, upload-time = "2026-02-16T10:10:45.487Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/4f/679fa7e84dadbaca7a65f7cdba8d6c83febbd93ca12fa4adf40ba3b6362b/pyarrow-23.0.1-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:8ff51b1addc469b9444b7c6f3548e19dc931b172ab234e995a60aea9f6e6025f", size = 35825526, upload-time = "2026-02-16T10:10:52.266Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/63/d2747d930882c9d661e9398eefc54f15696547b8983aaaf11d4a2e8b5426/pyarrow-23.0.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:71c5be5cbf1e1cb6169d2a0980850bccb558ddc9b747b6206435313c47c37677", size = 44473279, upload-time = "2026-02-16T10:11:01.557Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/93/10a48b5e238de6d562a411af6467e71e7aedbc9b87f8d3a35f1560ae30fb/pyarrow-23.0.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:9b6f4f17b43bc39d56fec96e53fe89d94bac3eb134137964371b45352d40d0c2", size = 47585798, upload-time = "2026-02-16T10:11:09.401Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/20/476943001c54ef078dbf9542280e22741219a184a0632862bca4feccd666/pyarrow-23.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9fc13fc6c403d1337acab46a2c4346ca6c9dec5780c3c697cf8abfd5e19b6b37", size = 48179446, upload-time = "2026-02-16T10:11:17.781Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/b6/5dd0c47b335fcd8edba9bfab78ad961bd0fd55ebe53468cc393f45e0be60/pyarrow-23.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c16ed4f53247fa3ffb12a14d236de4213a4415d127fe9cebed33d51671113e2", size = 50623972, upload-time = "2026-02-16T10:11:26.185Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/09/a532297c9591a727d67760e2e756b83905dd89adb365a7f6e9c72578bcc1/pyarrow-23.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:cecfb12ef629cf6be0b1887f9f86463b0dd3dc3195ae6224e74006be4736035a", size = 27540749, upload-time = "2026-02-16T10:12:23.297Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/8e/38749c4b1303e6ae76b3c80618f84861ae0c55dd3c2273842ea6f8258233/pyarrow-23.0.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:29f7f7419a0e30264ea261fdc0e5fe63ce5a6095003db2945d7cd78df391a7e1", size = 34471544, upload-time = "2026-02-16T10:11:32.535Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/73/f237b2bc8c669212f842bcfd842b04fc8d936bfc9d471630569132dc920d/pyarrow-23.0.1-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:33d648dc25b51fd8055c19e4261e813dfc4d2427f068bcecc8b53d01b81b0500", size = 35949911, upload-time = "2026-02-16T10:11:39.813Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/86/b912195eee0903b5611bf596833def7d146ab2d301afeb4b722c57ffc966/pyarrow-23.0.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:cd395abf8f91c673dd3589cadc8cc1ee4e8674fa61b2e923c8dd215d9c7d1f41", size = 44520337, upload-time = "2026-02-16T10:11:47.764Z" },
-    { url = "https://files.pythonhosted.org/packages/69/c2/f2a717fb824f62d0be952ea724b4f6f9372a17eed6f704b5c9526f12f2f1/pyarrow-23.0.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:00be9576d970c31defb5c32eb72ef585bf600ef6d0a82d5eccaae96639cf9d07", size = 47548944, upload-time = "2026-02-16T10:11:56.607Z" },
-    { url = "https://files.pythonhosted.org/packages/84/a7/90007d476b9f0dc308e3bc57b832d004f848fd6c0da601375d20d92d1519/pyarrow-23.0.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c2139549494445609f35a5cda4eb94e2c9e4d704ce60a095b342f82460c73a83", size = 48236269, upload-time = "2026-02-16T10:12:04.47Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/3f/b16fab3e77709856eb6ac328ce35f57a6d4a18462c7ca5186ef31b45e0e0/pyarrow-23.0.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:7044b442f184d84e2351e5084600f0d7343d6117aabcbc1ac78eb1ae11eb4125", size = 50604794, upload-time = "2026-02-16T10:12:11.797Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/a1/22df0620a9fac31d68397a75465c344e83c3dfe521f7612aea33e27ab6c0/pyarrow-23.0.1-cp313-cp313t-win_amd64.whl", hash = "sha256:a35581e856a2fafa12f3f54fce4331862b1cfb0bef5758347a858a4aa9d6bae8", size = 27660642, upload-time = "2026-02-16T10:12:17.746Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/1b/6da9a89583ce7b23ac611f183ae4843cd3a6cf54f079549b0e8c14031e73/pyarrow-23.0.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:5df1161da23636a70838099d4aaa65142777185cc0cdba4037a18cee7d8db9ca", size = 34238755, upload-time = "2026-02-16T10:12:32.819Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/b5/d58a241fbe324dbaeb8df07be6af8752c846192d78d2272e551098f74e88/pyarrow-23.0.1-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:fa8e51cb04b9f8c9c5ace6bab63af9a1f88d35c0d6cbf53e8c17c098552285e1", size = 35847826, upload-time = "2026-02-16T10:12:38.949Z" },
-    { url = "https://files.pythonhosted.org/packages/54/a5/8cbc83f04aba433ca7b331b38f39e000efd9f0c7ce47128670e737542996/pyarrow-23.0.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:0b95a3994f015be13c63148fef8832e8a23938128c185ee951c98908a696e0eb", size = 44536859, upload-time = "2026-02-16T10:12:45.467Z" },
-    { url = "https://files.pythonhosted.org/packages/36/2e/c0f017c405fcdc252dbccafbe05e36b0d0eb1ea9a958f081e01c6972927f/pyarrow-23.0.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:4982d71350b1a6e5cfe1af742c53dfb759b11ce14141870d05d9e540d13bc5d1", size = 47614443, upload-time = "2026-02-16T10:12:55.525Z" },
-    { url = "https://files.pythonhosted.org/packages/af/6b/2314a78057912f5627afa13ba43809d9d653e6630859618b0fd81a4e0759/pyarrow-23.0.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c250248f1fe266db627921c89b47b7c06fee0489ad95b04d50353537d74d6886", size = 48232991, upload-time = "2026-02-16T10:13:04.729Z" },
-    { url = "https://files.pythonhosted.org/packages/40/f2/1bcb1d3be3460832ef3370d621142216e15a2c7c62602a4ea19ec240dd64/pyarrow-23.0.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5f4763b83c11c16e5f4c15601ba6dfa849e20723b46aa2617cb4bffe8768479f", size = 50645077, upload-time = "2026-02-16T10:13:14.147Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/3f/b1da7b61cd66566a4d4c8383d376c606d1c34a906c3f1cb35c479f59d1aa/pyarrow-23.0.1-cp314-cp314-win_amd64.whl", hash = "sha256:3a4c85ef66c134161987c17b147d6bffdca4566f9a4c1d81a0a01cdf08414ea5", size = 28234271, upload-time = "2026-02-16T10:14:09.397Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/78/07f67434e910a0f7323269be7bfbf58699bd0c1d080b18a1ab49ba943fe8/pyarrow-23.0.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:17cd28e906c18af486a499422740298c52d7c6795344ea5002a7720b4eadf16d", size = 34488692, upload-time = "2026-02-16T10:13:21.541Z" },
-    { url = "https://files.pythonhosted.org/packages/50/76/34cf7ae93ece1f740a04910d9f7e80ba166b9b4ab9596a953e9e62b90fe1/pyarrow-23.0.1-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:76e823d0e86b4fb5e1cf4a58d293036e678b5a4b03539be933d3b31f9406859f", size = 35964383, upload-time = "2026-02-16T10:13:28.63Z" },
-    { url = "https://files.pythonhosted.org/packages/46/90/459b827238936d4244214be7c684e1b366a63f8c78c380807ae25ed92199/pyarrow-23.0.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:a62e1899e3078bf65943078b3ad2a6ddcacf2373bc06379aac61b1e548a75814", size = 44538119, upload-time = "2026-02-16T10:13:35.506Z" },
-    { url = "https://files.pythonhosted.org/packages/28/a1/93a71ae5881e99d1f9de1d4554a87be37da11cd6b152239fb5bd924fdc64/pyarrow-23.0.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:df088e8f640c9fae3b1f495b3c64755c4e719091caf250f3a74d095ddf3c836d", size = 47571199, upload-time = "2026-02-16T10:13:42.504Z" },
-    { url = "https://files.pythonhosted.org/packages/88/a3/d2c462d4ef313521eaf2eff04d204ac60775263f1fb08c374b543f79f610/pyarrow-23.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:46718a220d64677c93bc243af1d44b55998255427588e400677d7192671845c7", size = 48259435, upload-time = "2026-02-16T10:13:49.226Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/f1/11a544b8c3d38a759eb3fbb022039117fd633e9a7b19e4841cc3da091915/pyarrow-23.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a09f3876e87f48bc2f13583ab551f0379e5dfb83210391e68ace404181a20690", size = 50629149, upload-time = "2026-02-16T10:13:57.238Z" },
-    { url = "https://files.pythonhosted.org/packages/50/f2/c0e76a0b451ffdf0cf788932e182758eb7558953f4f27f1aff8e2518b653/pyarrow-23.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:527e8d899f14bd15b740cd5a54ad56b7f98044955373a17179d5956ddb93d9ce", size = 28365807, upload-time = "2026-02-16T10:14:03.892Z" },
-]
-
-[[package]]
 name = "pyasn1"
 version = "0.6.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3372,44 +3346,8 @@ wheels = [
 
 [[package]]
 name = "pymupdf"
-version = "1.28.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version < '3.13' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version < '3.13' and sys_platform == 'emscripten'",
-    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/e9/6d6c5d6c0a3551bffd47681a6240caf941727f195b45593cf20ab36f018f/pymupdf-1.28.0.tar.gz", hash = "sha256:e53f3567403a92da15caa9e7ae0164327fff48817e9f40175367fb9de524258d", size = 87637751, upload-time = "2026-06-29T09:08:47.547Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/b7/88043e38cc7529de070f0c9bd267fa258035cca0b4ad5260536b994594a7/pymupdf-1.28.0-cp310-abi3-macosx_10_15_x86_64.whl", hash = "sha256:892b89ba88e8f98b53133b62877a9dc9b5e7dc6a4aeb837b612db56a8d2e03ac", size = 24597385, upload-time = "2026-06-29T09:03:30.608Z" },
-    { url = "https://files.pythonhosted.org/packages/33/f4/23775bbda0781b61fc398cc75079a2b0e64696d8fcf93271748883e9627e/pymupdf-1.28.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:4d692dcf44d3566ae96bc6f6346c6ad432274a29ba617bf7a9fe18009e24adb4", size = 23828292, upload-time = "2026-06-29T09:03:46.129Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/f5/bf75fc7a415722f8b33662054f82d88520c0cbfd4c36d0e08aeaec605e49/pymupdf-1.28.0-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:47a5c29ed4eb0744de9c4e37bb49b1259b18d4d75fcc8a7c130f7c9fa15956f6", size = 25045507, upload-time = "2026-06-29T09:04:03.86Z" },
-    { url = "https://files.pythonhosted.org/packages/58/69/5d12c9f1f2d76f28383d6110a069c79fbfced5a4f97bb1ee6e8354f52bb7/pymupdf-1.28.0-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:44f0973f5e5edbaec95bc34b64e71d1959d4ee90b1328de1b4f4f5b4fa78673f", size = 25716599, upload-time = "2026-06-29T09:04:19.367Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/b4/ec0e017bc42857cc86bd651441dbc41cc18be48d4698ecd27aac491e0c9a/pymupdf-1.28.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4d61ec323a706e153a12e262e51febfb43eeaa20977785ace135d18d48bcdc83", size = 25940489, upload-time = "2026-06-29T09:04:36.624Z" },
-    { url = "https://files.pythonhosted.org/packages/06/86/f831fef09013f33b3c9c09fb3923f2ff53e1e437f6ace14b8ae46392f558/pymupdf-1.28.0-cp310-abi3-win32.whl", hash = "sha256:caea2b3b67347fd79e5d15ed7929b0e886aac594ea228073b6d39de0078189da", size = 18489703, upload-time = "2026-06-29T20:50:30.599Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/5d/1a03f53eb0449900469335fcfc742ca28e3ba159b7d650e0921d50b8b308/pymupdf-1.28.0-cp310-abi3-win_amd64.whl", hash = "sha256:e01e90fd86abfeb37ceb921eddb951f988a11d45ff6ce6b7664f2039849068ec", size = 19773102, upload-time = "2026-06-29T09:04:49.773Z" },
-    { url = "https://files.pythonhosted.org/packages/72/f6/1e52ce243ca792254f6223b4017c5667194c146ce9b88baf37bc5eb3d1c9/pymupdf-1.28.0-cp313-abi3-pyemscripten_2025_0_wasm32.whl", hash = "sha256:74c6d00ba2a9aad3a635db73b07c15db462b480741d831a34a75a56535ebc22b", size = 18357011, upload-time = "2026-06-29T20:50:50.353Z" },
-    { url = "https://files.pythonhosted.org/packages/62/b1/46b5b3d8ef3cc71114667cf10c4d8b33f39af97253af32e9a0986775b638/pymupdf-1.28.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:b3e1399c7a64c6914239116a369efcdaac4cfb9e838bde2656d7accc4a85c72d", size = 25753599, upload-time = "2026-06-29T09:05:09.398Z" },
-]
-
-[[package]]
-name = "pymupdf"
 version = "1.28.2"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version < '3.14' and sys_platform == 'emscripten'",
-    "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/a3/fb/b6761fa2d5266f2cdb24c3b91f4023070ab7848381417678e7a289a1d52a/pymupdf-1.28.2.tar.gz", hash = "sha256:5e0be7908a715aa20333caddd73f1d6f01e4cd0c26e869fa2dd0b7f344da2249", size = 87903557, upload-time = "2026-08-06T21:43:23.321Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b4/51/550c9a75c4ff3245cb4ecb7bb95cbe2ab7374230b8e2b7a1f7259444150b/pymupdf-1.28.2-cp310-abi3-macosx_10_15_x86_64.whl", hash = "sha256:5fc315b425ff1f7afdd1ea2f348205cb19b806767daae7ce4d64115799c2bae1", size = 24645079, upload-time = "2026-08-06T21:37:25.001Z" },
@@ -3432,7 +3370,7 @@ dependencies = [
     { name = "networkx" },
     { name = "numpy" },
     { name = "onnxruntime" },
-    { name = "pymupdf", version = "1.28.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "pymupdf" },
     { name = "pyyaml" },
 ]
 wheels = [
@@ -3449,7 +3387,7 @@ version = "1.28.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "psutil" },
-    { name = "pymupdf", version = "1.28.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "pymupdf" },
     { name = "pymupdf-layout" },
     { name = "tabulate" },
 ]
@@ -4593,89 +4531,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/46/2c/c06ef49dc36e7954e55b802a8b231770d286a9758b3d936bd1e04ce5ba88/xlsxwriter-3.2.9.tar.gz", hash = "sha256:254b1c37a368c444eac6e2f867405cc9e461b0ed97a3233b2ac1e574efb4140c", size = 215940, upload-time = "2025-09-16T00:16:21.63Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/0c/3662f4a66880196a590b202f0db82d919dd2f89e99a27fadef91c4a33d41/xlsxwriter-3.2.9-py3-none-any.whl", hash = "sha256:9a5db42bc5dff014806c58a20b9eae7322a134abb6fce3c92c181bfb275ec5b3", size = 175315, upload-time = "2025-09-16T00:16:20.108Z" },
-]
-
-[[package]]
-name = "xxhash"
-version = "3.6.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/02/84/30869e01909fb37a6cc7e18688ee8bf1e42d57e7e0777636bd47524c43c7/xxhash-3.6.0.tar.gz", hash = "sha256:f0162a78b13a0d7617b2845b90c763339d1f1d82bb04a4b07f4ab535cc5e05d6", size = 85160, upload-time = "2025-10-02T14:37:08.097Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/07/d9412f3d7d462347e4511181dea65e47e0d0e16e26fbee2ea86a2aefb657/xxhash-3.6.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:01362c4331775398e7bb34e3ab403bc9ee9f7c497bc7dee6272114055277dd3c", size = 32744, upload-time = "2025-10-02T14:34:34.622Z" },
-    { url = "https://files.pythonhosted.org/packages/79/35/0429ee11d035fc33abe32dca1b2b69e8c18d236547b9a9b72c1929189b9a/xxhash-3.6.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b7b2df81a23f8cb99656378e72501b2cb41b1827c0f5a86f87d6b06b69f9f204", size = 30816, upload-time = "2025-10-02T14:34:36.043Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/f2/57eb99aa0f7d98624c0932c5b9a170e1806406cdbcdb510546634a1359e0/xxhash-3.6.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:dc94790144e66b14f67b10ac8ed75b39ca47536bf8800eb7c24b50271ea0c490", size = 194035, upload-time = "2025-10-02T14:34:37.354Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/ed/6224ba353690d73af7a3f1c7cdb1fc1b002e38f783cb991ae338e1eb3d79/xxhash-3.6.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:93f107c673bccf0d592cdba077dedaf52fe7f42dcd7676eba1f6d6f0c3efffd2", size = 212914, upload-time = "2025-10-02T14:34:38.6Z" },
-    { url = "https://files.pythonhosted.org/packages/38/86/fb6b6130d8dd6b8942cc17ab4d90e223653a89aa32ad2776f8af7064ed13/xxhash-3.6.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2aa5ee3444c25b69813663c9f8067dcfaa2e126dc55e8dddf40f4d1c25d7effa", size = 212163, upload-time = "2025-10-02T14:34:39.872Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/dc/e84875682b0593e884ad73b2d40767b5790d417bde603cceb6878901d647/xxhash-3.6.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f7f99123f0e1194fa59cc69ad46dbae2e07becec5df50a0509a808f90a0f03f0", size = 445411, upload-time = "2025-10-02T14:34:41.569Z" },
-    { url = "https://files.pythonhosted.org/packages/11/4f/426f91b96701ec2f37bb2b8cec664eff4f658a11f3fa9d94f0a887ea6d2b/xxhash-3.6.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:49e03e6fe2cac4a1bc64952dd250cf0dbc5ef4ebb7b8d96bce82e2de163c82a2", size = 193883, upload-time = "2025-10-02T14:34:43.249Z" },
-    { url = "https://files.pythonhosted.org/packages/53/5a/ddbb83eee8e28b778eacfc5a85c969673e4023cdeedcfcef61f36731610b/xxhash-3.6.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bd17fede52a17a4f9a7bc4472a5867cb0b160deeb431795c0e4abe158bc784e9", size = 210392, upload-time = "2025-10-02T14:34:45.042Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/c2/ff69efd07c8c074ccdf0a4f36fcdd3d27363665bcdf4ba399abebe643465/xxhash-3.6.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:6fb5f5476bef678f69db04f2bd1efbed3030d2aba305b0fc1773645f187d6a4e", size = 197898, upload-time = "2025-10-02T14:34:46.302Z" },
-    { url = "https://files.pythonhosted.org/packages/58/ca/faa05ac19b3b622c7c9317ac3e23954187516298a091eb02c976d0d3dd45/xxhash-3.6.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:843b52f6d88071f87eba1631b684fcb4b2068cd2180a0224122fe4ef011a9374", size = 210655, upload-time = "2025-10-02T14:34:47.571Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/7a/06aa7482345480cc0cb597f5c875b11a82c3953f534394f620b0be2f700c/xxhash-3.6.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:7d14a6cfaf03b1b6f5f9790f76880601ccc7896aff7ab9cd8978a939c1eb7e0d", size = 414001, upload-time = "2025-10-02T14:34:49.273Z" },
-    { url = "https://files.pythonhosted.org/packages/23/07/63ffb386cd47029aa2916b3d2f454e6cc5b9f5c5ada3790377d5430084e7/xxhash-3.6.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:418daf3db71e1413cfe211c2f9a528456936645c17f46b5204705581a45390ae", size = 191431, upload-time = "2025-10-02T14:34:50.798Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/93/14fde614cadb4ddf5e7cebf8918b7e8fac5ae7861c1875964f17e678205c/xxhash-3.6.0-cp312-cp312-win32.whl", hash = "sha256:50fc255f39428a27299c20e280d6193d8b63b8ef8028995323bf834a026b4fbb", size = 30617, upload-time = "2025-10-02T14:34:51.954Z" },
-    { url = "https://files.pythonhosted.org/packages/13/5d/0d125536cbe7565a83d06e43783389ecae0c0f2ed037b48ede185de477c0/xxhash-3.6.0-cp312-cp312-win_amd64.whl", hash = "sha256:c0f2ab8c715630565ab8991b536ecded9416d615538be8ecddce43ccf26cbc7c", size = 31534, upload-time = "2025-10-02T14:34:53.276Z" },
-    { url = "https://files.pythonhosted.org/packages/54/85/6ec269b0952ec7e36ba019125982cf11d91256a778c7c3f98a4c5043d283/xxhash-3.6.0-cp312-cp312-win_arm64.whl", hash = "sha256:eae5c13f3bc455a3bbb68bdc513912dc7356de7e2280363ea235f71f54064829", size = 27876, upload-time = "2025-10-02T14:34:54.371Z" },
-    { url = "https://files.pythonhosted.org/packages/33/76/35d05267ac82f53ae9b0e554da7c5e281ee61f3cad44c743f0fcd354f211/xxhash-3.6.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:599e64ba7f67472481ceb6ee80fa3bd828fd61ba59fb11475572cc5ee52b89ec", size = 32738, upload-time = "2025-10-02T14:34:55.839Z" },
-    { url = "https://files.pythonhosted.org/packages/31/a8/3fbce1cd96534a95e35d5120637bf29b0d7f5d8fa2f6374e31b4156dd419/xxhash-3.6.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7d8b8aaa30fca4f16f0c84a5c8d7ddee0e25250ec2796c973775373257dde8f1", size = 30821, upload-time = "2025-10-02T14:34:57.219Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/ea/d387530ca7ecfa183cb358027f1833297c6ac6098223fd14f9782cd0015c/xxhash-3.6.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d597acf8506d6e7101a4a44a5e428977a51c0fadbbfd3c39650cca9253f6e5a6", size = 194127, upload-time = "2025-10-02T14:34:59.21Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/0c/71435dcb99874b09a43b8d7c54071e600a7481e42b3e3ce1eb5226a5711a/xxhash-3.6.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:858dc935963a33bc33490128edc1c12b0c14d9c7ebaa4e387a7869ecc4f3e263", size = 212975, upload-time = "2025-10-02T14:35:00.816Z" },
-    { url = "https://files.pythonhosted.org/packages/84/7a/c2b3d071e4bb4a90b7057228a99b10d51744878f4a8a6dd643c8bd897620/xxhash-3.6.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ba284920194615cb8edf73bf52236ce2e1664ccd4a38fdb543506413529cc546", size = 212241, upload-time = "2025-10-02T14:35:02.207Z" },
-    { url = "https://files.pythonhosted.org/packages/81/5f/640b6eac0128e215f177df99eadcd0f1b7c42c274ab6a394a05059694c5a/xxhash-3.6.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4b54219177f6c6674d5378bd862c6aedf64725f70dd29c472eaae154df1a2e89", size = 445471, upload-time = "2025-10-02T14:35:03.61Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/1e/3c3d3ef071b051cc3abbe3721ffb8365033a172613c04af2da89d5548a87/xxhash-3.6.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:42c36dd7dbad2f5238950c377fcbf6811b1cdb1c444fab447960030cea60504d", size = 193936, upload-time = "2025-10-02T14:35:05.013Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/bd/4a5f68381939219abfe1c22a9e3a5854a4f6f6f3c4983a87d255f21f2e5d/xxhash-3.6.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f22927652cba98c44639ffdc7aaf35828dccf679b10b31c4ad72a5b530a18eb7", size = 210440, upload-time = "2025-10-02T14:35:06.239Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/37/b80fe3d5cfb9faff01a02121a0f4d565eb7237e9e5fc66e73017e74dcd36/xxhash-3.6.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:b45fad44d9c5c119e9c6fbf2e1c656a46dc68e280275007bbfd3d572b21426db", size = 197990, upload-time = "2025-10-02T14:35:07.735Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/fd/2c0a00c97b9e18f72e1f240ad4e8f8a90fd9d408289ba9c7c495ed7dc05c/xxhash-3.6.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:6f2580ffab1a8b68ef2b901cde7e55fa8da5e4be0977c68f78fc80f3c143de42", size = 210689, upload-time = "2025-10-02T14:35:09.438Z" },
-    { url = "https://files.pythonhosted.org/packages/93/86/5dd8076a926b9a95db3206aba20d89a7fc14dd5aac16e5c4de4b56033140/xxhash-3.6.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:40c391dd3cd041ebc3ffe6f2c862f402e306eb571422e0aa918d8070ba31da11", size = 414068, upload-time = "2025-10-02T14:35:11.162Z" },
-    { url = "https://files.pythonhosted.org/packages/af/3c/0bb129170ee8f3650f08e993baee550a09593462a5cddd8e44d0011102b1/xxhash-3.6.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f205badabde7aafd1a31e8ca2a3e5a763107a71c397c4481d6a804eb5063d8bd", size = 191495, upload-time = "2025-10-02T14:35:12.971Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/3a/6797e0114c21d1725e2577508e24006fd7ff1d8c0c502d3b52e45c1771d8/xxhash-3.6.0-cp313-cp313-win32.whl", hash = "sha256:2577b276e060b73b73a53042ea5bd5203d3e6347ce0d09f98500f418a9fcf799", size = 30620, upload-time = "2025-10-02T14:35:14.129Z" },
-    { url = "https://files.pythonhosted.org/packages/86/15/9bc32671e9a38b413a76d24722a2bf8784a132c043063a8f5152d390b0f9/xxhash-3.6.0-cp313-cp313-win_amd64.whl", hash = "sha256:757320d45d2fbcce8f30c42a6b2f47862967aea7bf458b9625b4bbe7ee390392", size = 31542, upload-time = "2025-10-02T14:35:15.21Z" },
-    { url = "https://files.pythonhosted.org/packages/39/c5/cc01e4f6188656e56112d6a8e0dfe298a16934b8c47a247236549a3f7695/xxhash-3.6.0-cp313-cp313-win_arm64.whl", hash = "sha256:457b8f85dec5825eed7b69c11ae86834a018b8e3df5e77783c999663da2f96d6", size = 27880, upload-time = "2025-10-02T14:35:16.315Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/30/25e5321c8732759e930c555176d37e24ab84365482d257c3b16362235212/xxhash-3.6.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:a42e633d75cdad6d625434e3468126c73f13f7584545a9cf34e883aa1710e702", size = 32956, upload-time = "2025-10-02T14:35:17.413Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/3c/0573299560d7d9f8ab1838f1efc021a280b5ae5ae2e849034ef3dee18810/xxhash-3.6.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:568a6d743219e717b07b4e03b0a828ce593833e498c3b64752e0f5df6bfe84db", size = 31072, upload-time = "2025-10-02T14:35:18.844Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/1c/52d83a06e417cd9d4137722693424885cc9878249beb3a7c829e74bf7ce9/xxhash-3.6.0-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:bec91b562d8012dae276af8025a55811b875baace6af510412a5e58e3121bc54", size = 196409, upload-time = "2025-10-02T14:35:20.31Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/8e/c6d158d12a79bbd0b878f8355432075fc82759e356ab5a111463422a239b/xxhash-3.6.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:78e7f2f4c521c30ad5e786fdd6bae89d47a32672a80195467b5de0480aa97b1f", size = 215736, upload-time = "2025-10-02T14:35:21.616Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/68/c4c80614716345d55071a396cf03d06e34b5f4917a467faf43083c995155/xxhash-3.6.0-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3ed0df1b11a79856df5ffcab572cbd6b9627034c1c748c5566fa79df9048a7c5", size = 214833, upload-time = "2025-10-02T14:35:23.32Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/e9/ae27c8ffec8b953efa84c7c4a6c6802c263d587b9fc0d6e7cea64e08c3af/xxhash-3.6.0-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0e4edbfc7d420925b0dd5e792478ed393d6e75ff8fc219a6546fb446b6a417b1", size = 448348, upload-time = "2025-10-02T14:35:25.111Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/6b/33e21afb1b5b3f46b74b6bd1913639066af218d704cc0941404ca717fc57/xxhash-3.6.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fba27a198363a7ef87f8c0f6b171ec36b674fe9053742c58dd7e3201c1ab30ee", size = 196070, upload-time = "2025-10-02T14:35:26.586Z" },
-    { url = "https://files.pythonhosted.org/packages/96/b6/fcabd337bc5fa624e7203aa0fa7d0c49eed22f72e93229431752bddc83d9/xxhash-3.6.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:794fe9145fe60191c6532fa95063765529770edcdd67b3d537793e8004cabbfd", size = 212907, upload-time = "2025-10-02T14:35:28.087Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/d3/9ee6160e644d660fcf176c5825e61411c7f62648728f69c79ba237250143/xxhash-3.6.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:6105ef7e62b5ac73a837778efc331a591d8442f8ef5c7e102376506cb4ae2729", size = 200839, upload-time = "2025-10-02T14:35:29.857Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/98/e8de5baa5109394baf5118f5e72ab21a86387c4f89b0e77ef3e2f6b0327b/xxhash-3.6.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:f01375c0e55395b814a679b3eea205db7919ac2af213f4a6682e01220e5fe292", size = 213304, upload-time = "2025-10-02T14:35:31.222Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/1d/71056535dec5c3177eeb53e38e3d367dd1d16e024e63b1cee208d572a033/xxhash-3.6.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:d706dca2d24d834a4661619dcacf51a75c16d65985718d6a7d73c1eeeb903ddf", size = 416930, upload-time = "2025-10-02T14:35:32.517Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/6c/5cbde9de2cd967c322e651c65c543700b19e7ae3e0aae8ece3469bf9683d/xxhash-3.6.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:5f059d9faeacd49c0215d66f4056e1326c80503f51a1532ca336a385edadd033", size = 193787, upload-time = "2025-10-02T14:35:33.827Z" },
-    { url = "https://files.pythonhosted.org/packages/19/fa/0172e350361d61febcea941b0cc541d6e6c8d65d153e85f850a7b256ff8a/xxhash-3.6.0-cp313-cp313t-win32.whl", hash = "sha256:1244460adc3a9be84731d72b8e80625788e5815b68da3da8b83f78115a40a7ec", size = 30916, upload-time = "2025-10-02T14:35:35.107Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/e6/e8cf858a2b19d6d45820f072eff1bea413910592ff17157cabc5f1227a16/xxhash-3.6.0-cp313-cp313t-win_amd64.whl", hash = "sha256:b1e420ef35c503869c4064f4a2f2b08ad6431ab7b229a05cce39d74268bca6b8", size = 31799, upload-time = "2025-10-02T14:35:36.165Z" },
-    { url = "https://files.pythonhosted.org/packages/56/15/064b197e855bfb7b343210e82490ae672f8bc7cdf3ddb02e92f64304ee8a/xxhash-3.6.0-cp313-cp313t-win_arm64.whl", hash = "sha256:ec44b73a4220623235f67a996c862049f375df3b1052d9899f40a6382c32d746", size = 28044, upload-time = "2025-10-02T14:35:37.195Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/5e/0138bc4484ea9b897864d59fce9be9086030825bc778b76cb5a33a906d37/xxhash-3.6.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:a40a3d35b204b7cc7643cbcf8c9976d818cb47befcfac8bbefec8038ac363f3e", size = 32754, upload-time = "2025-10-02T14:35:38.245Z" },
-    { url = "https://files.pythonhosted.org/packages/18/d7/5dac2eb2ec75fd771957a13e5dda560efb2176d5203f39502a5fc571f899/xxhash-3.6.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a54844be970d3fc22630b32d515e79a90d0a3ddb2644d8d7402e3c4c8da61405", size = 30846, upload-time = "2025-10-02T14:35:39.6Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/71/8bc5be2bb00deb5682e92e8da955ebe5fa982da13a69da5a40a4c8db12fb/xxhash-3.6.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:016e9190af8f0a4e3741343777710e3d5717427f175adfdc3e72508f59e2a7f3", size = 194343, upload-time = "2025-10-02T14:35:40.69Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/3b/52badfb2aecec2c377ddf1ae75f55db3ba2d321c5e164f14461c90837ef3/xxhash-3.6.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4f6f72232f849eb9d0141e2ebe2677ece15adfd0fa599bc058aad83c714bb2c6", size = 213074, upload-time = "2025-10-02T14:35:42.29Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/2b/ae46b4e9b92e537fa30d03dbc19cdae57ed407e9c26d163895e968e3de85/xxhash-3.6.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:63275a8aba7865e44b1813d2177e0f5ea7eadad3dd063a21f7cf9afdc7054063", size = 212388, upload-time = "2025-10-02T14:35:43.929Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/80/49f88d3afc724b4ac7fbd664c8452d6db51b49915be48c6982659e0e7942/xxhash-3.6.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3cd01fa2aa00d8b017c97eb46b9a794fbdca53fc14f845f5a328c71254b0abb7", size = 445614, upload-time = "2025-10-02T14:35:45.216Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/ba/603ce3961e339413543d8cd44f21f2c80e2a7c5cfe692a7b1f2cccf58f3c/xxhash-3.6.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0226aa89035b62b6a86d3c68df4d7c1f47a342b8683da2b60cedcddb46c4d95b", size = 194024, upload-time = "2025-10-02T14:35:46.959Z" },
-    { url = "https://files.pythonhosted.org/packages/78/d1/8e225ff7113bf81545cfdcd79eef124a7b7064a0bba53605ff39590b95c2/xxhash-3.6.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c6e193e9f56e4ca4923c61238cdaced324f0feac782544eb4c6d55ad5cc99ddd", size = 210541, upload-time = "2025-10-02T14:35:48.301Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/58/0f89d149f0bad89def1a8dd38feb50ccdeb643d9797ec84707091d4cb494/xxhash-3.6.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:9176dcaddf4ca963d4deb93866d739a343c01c969231dbe21680e13a5d1a5bf0", size = 198305, upload-time = "2025-10-02T14:35:49.584Z" },
-    { url = "https://files.pythonhosted.org/packages/11/38/5eab81580703c4df93feb5f32ff8fa7fe1e2c51c1f183ee4e48d4bb9d3d7/xxhash-3.6.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:c1ce4009c97a752e682b897aa99aef84191077a9433eb237774689f14f8ec152", size = 210848, upload-time = "2025-10-02T14:35:50.877Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/6b/953dc4b05c3ce678abca756416e4c130d2382f877a9c30a20d08ee6a77c0/xxhash-3.6.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:8cb2f4f679b01513b7adbb9b1b2f0f9cdc31b70007eaf9d59d0878809f385b11", size = 414142, upload-time = "2025-10-02T14:35:52.15Z" },
-    { url = "https://files.pythonhosted.org/packages/08/a9/238ec0d4e81a10eb5026d4a6972677cbc898ba6c8b9dbaec12ae001b1b35/xxhash-3.6.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:653a91d7c2ab54a92c19ccf43508b6a555440b9be1bc8be553376778be7f20b5", size = 191547, upload-time = "2025-10-02T14:35:53.547Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/ee/3cf8589e06c2164ac77c3bf0aa127012801128f1feebf2a079272da5737c/xxhash-3.6.0-cp314-cp314-win32.whl", hash = "sha256:a756fe893389483ee8c394d06b5ab765d96e68fbbfe6fde7aa17e11f5720559f", size = 31214, upload-time = "2025-10-02T14:35:54.746Z" },
-    { url = "https://files.pythonhosted.org/packages/02/5d/a19552fbc6ad4cb54ff953c3908bbc095f4a921bc569433d791f755186f1/xxhash-3.6.0-cp314-cp314-win_amd64.whl", hash = "sha256:39be8e4e142550ef69629c9cd71b88c90e9a5db703fecbcf265546d9536ca4ad", size = 32290, upload-time = "2025-10-02T14:35:55.791Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/11/dafa0643bc30442c887b55baf8e73353a344ee89c1901b5a5c54a6c17d39/xxhash-3.6.0-cp314-cp314-win_arm64.whl", hash = "sha256:25915e6000338999236f1eb68a02a32c3275ac338628a7eaa5a269c401995679", size = 28795, upload-time = "2025-10-02T14:35:57.162Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/db/0e99732ed7f64182aef4a6fb145e1a295558deec2a746265dcdec12d191e/xxhash-3.6.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:c5294f596a9017ca5a3e3f8884c00b91ab2ad2933cf288f4923c3fd4346cf3d4", size = 32955, upload-time = "2025-10-02T14:35:58.267Z" },
-    { url = "https://files.pythonhosted.org/packages/55/f4/2a7c3c68e564a099becfa44bb3d398810cc0ff6749b0d3cb8ccb93f23c14/xxhash-3.6.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1cf9dcc4ab9cff01dfbba78544297a3a01dafd60f3bde4e2bfd016cf7e4ddc67", size = 31072, upload-time = "2025-10-02T14:35:59.382Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/d9/72a29cddc7250e8a5819dad5d466facb5dc4c802ce120645630149127e73/xxhash-3.6.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:01262da8798422d0685f7cef03b2bd3f4f46511b02830861df548d7def4402ad", size = 196579, upload-time = "2025-10-02T14:36:00.838Z" },
-    { url = "https://files.pythonhosted.org/packages/63/93/b21590e1e381040e2ca305a884d89e1c345b347404f7780f07f2cdd47ef4/xxhash-3.6.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:51a73fb7cb3a3ead9f7a8b583ffd9b8038e277cdb8cb87cf890e88b3456afa0b", size = 215854, upload-time = "2025-10-02T14:36:02.207Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/b8/edab8a7d4fa14e924b29be877d54155dcbd8b80be85ea00d2be3413a9ed4/xxhash-3.6.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b9c6df83594f7df8f7f708ce5ebeacfc69f72c9fbaaababf6cf4758eaada0c9b", size = 214965, upload-time = "2025-10-02T14:36:03.507Z" },
-    { url = "https://files.pythonhosted.org/packages/27/67/dfa980ac7f0d509d54ea0d5a486d2bb4b80c3f1bb22b66e6a05d3efaf6c0/xxhash-3.6.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:627f0af069b0ea56f312fd5189001c24578868643203bca1abbc2c52d3a6f3ca", size = 448484, upload-time = "2025-10-02T14:36:04.828Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/63/8ffc2cc97e811c0ca5d00ab36604b3ea6f4254f20b7bc658ca825ce6c954/xxhash-3.6.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:aa912c62f842dfd013c5f21a642c9c10cd9f4c4e943e0af83618b4a404d9091a", size = 196162, upload-time = "2025-10-02T14:36:06.182Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/77/07f0e7a3edd11a6097e990f6e5b815b6592459cb16dae990d967693e6ea9/xxhash-3.6.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:b465afd7909db30168ab62afe40b2fcf79eedc0b89a6c0ab3123515dc0df8b99", size = 213007, upload-time = "2025-10-02T14:36:07.733Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/d8/bc5fa0d152837117eb0bef6f83f956c509332ce133c91c63ce07ee7c4873/xxhash-3.6.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:a881851cf38b0a70e7c4d3ce81fc7afd86fbc2a024f4cfb2a97cf49ce04b75d3", size = 200956, upload-time = "2025-10-02T14:36:09.106Z" },
-    { url = "https://files.pythonhosted.org/packages/26/a5/d749334130de9411783873e9b98ecc46688dad5db64ca6e04b02acc8b473/xxhash-3.6.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:9b3222c686a919a0f3253cfc12bb118b8b103506612253b5baeaac10d8027cf6", size = 213401, upload-time = "2025-10-02T14:36:10.585Z" },
-    { url = "https://files.pythonhosted.org/packages/89/72/abed959c956a4bfc72b58c0384bb7940663c678127538634d896b1195c10/xxhash-3.6.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:c5aa639bc113e9286137cec8fadc20e9cd732b2cc385c0b7fa673b84fc1f2a93", size = 417083, upload-time = "2025-10-02T14:36:12.276Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/b3/62fd2b586283b7d7d665fb98e266decadf31f058f1cf6c478741f68af0cb/xxhash-3.6.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5c1343d49ac102799905e115aee590183c3921d475356cb24b4de29a4bc56518", size = 193913, upload-time = "2025-10-02T14:36:14.025Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/9a/c19c42c5b3f5a4aad748a6d5b4f23df3bed7ee5445accc65a0fb3ff03953/xxhash-3.6.0-cp314-cp314t-win32.whl", hash = "sha256:5851f033c3030dd95c086b4a36a2683c2ff4a799b23af60977188b057e467119", size = 31586, upload-time = "2025-10-02T14:36:15.603Z" },
-    { url = "https://files.pythonhosted.org/packages/03/d6/4cc450345be9924fd5dc8c590ceda1db5b43a0a889587b0ae81a95511360/xxhash-3.6.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0444e7967dac37569052d2409b00a8860c2135cff05502df4da80267d384849f", size = 32526, upload-time = "2025-10-02T14:36:16.708Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/c9/7243eb3f9eaabd1a88a5a5acadf06df2d83b100c62684b7425c6a11bcaa8/xxhash-3.6.0-cp314-cp314t-win_arm64.whl", hash = "sha256:bb79b1e63f6fd84ec778a4b1916dfe0a7c3fdb986c06addd5db3a0d413819d95", size = 28898, upload-time = "2025-10-02T14:36:17.843Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- hatchling metadata, license, classifiers, URLs; version single-sourced from parse_bench.__version__ (bumped to 0.3.0)
- per-provider extras; runners stays the union; drop unused datasets/tqdm (removes the 123 MB pyarrow pull); raise markdown2 floor to 2.5.5
- CI (ruff, pytest on 3.12/3.13, wheel smoke test) and tag-driven PyPI publish via trusted publishing; docs/releasing.md
- parse-bench version command; .env discovery walks up from cwd
- exempt the three vendored VLM providers from ruff so CI is green