### PR TITLE
Fix layout element rules dropped when a doc also has parse rules

### DIFF
--- a/src/parse_bench/test_cases/loader.py
+++ b/src/parse_bench/test_cases/loader.py
@@ -159,16 +159,16 @@ def _load_jsonl_dataset(root_dir: Path) -> list[TestCase]:
         rule_meta = group_data.get("rule_meta", {})
         all_tags = [category] + [t for t in extra_tags if t != category]
 
-        if layout_rules and not parse_rules:
-            # Pure layout test case
+        if layout_rules:
+            # Keep parse_rules alongside layout_rules; test_rules type-routes each.
             tc = LayoutDetectionTestCase(
                 test_id=test_id,
                 group=category,
                 file_path=pdf_path,
                 tags=all_tags,
-                test_rules=layout_rules,
-                ontology=layout_rules[0].get("ontology") if layout_rules else None,
-                page_index=layout_rules[0].get("page_index", 0) if layout_rules else 0,
+                test_rules=layout_rules + parse_rules,
+                ontology=layout_rules[0].get("ontology"),
+                page_index=layout_rules[0].get("page_index", 0),
             )
         else:
             # Parse test case — only coerce parse rules (layout rules handled separately)

--- a/tests/parse_bench/test_cases/test_loader.py
+++ b/tests/parse_bench/test_cases/test_loader.py
@@ -1,0 +1,91 @@
+"""Regression tests for JSONL test-case loading in ``_load_jsonl_dataset``."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from parse_bench.test_cases.loader import _load_jsonl_dataset
+from parse_bench.test_cases.schema import LayoutDetectionTestCase, ParseTestCase
+
+
+def _write_jsonl(root: Path, rows: list[dict]) -> None:
+    (root / "layout.jsonl").write_text("\n".join(json.dumps(r) for r in rows), encoding="utf-8")
+
+
+def test_layout_doc_with_order_rule_keeps_layout_rules(tmp_path: Path) -> None:
+    (tmp_path / "pdfs").mkdir()
+    (tmp_path / "pdfs" / "doc1.pdf").write_bytes(b"%PDF-1.4 fake")
+    _write_jsonl(
+        tmp_path,
+        [
+            {
+                "pdf": "pdfs/doc1.pdf",
+                "category": "layout",
+                "type": "layout",
+                "id": "el-1",
+                "rule": {"id": "el-1", "page": 1, "bbox": [0, 0, 1, 1], "canonical_class": "title"},
+            },
+            {
+                "pdf": "pdfs/doc1.pdf",
+                "category": "layout",
+                "type": "order",
+                "id": "ord-1",
+                "rule": {"layout_bindings": {"before": "el-1", "after": "el-1"}},
+            },
+        ],
+    )
+
+    test_cases = _load_jsonl_dataset(tmp_path)
+
+    assert len(test_cases) == 1
+    tc = test_cases[0]
+    assert isinstance(tc, LayoutDetectionTestCase)
+    assert len(tc.get_layout_rules()) == 1
+    assert len(tc.test_rules) == 2
+
+
+def test_layout_only_doc_still_builds_layout_test_case(tmp_path: Path) -> None:
+    (tmp_path / "pdfs").mkdir()
+    (tmp_path / "pdfs" / "doc2.pdf").write_bytes(b"%PDF-1.4 fake")
+    _write_jsonl(
+        tmp_path,
+        [
+            {
+                "pdf": "pdfs/doc2.pdf",
+                "category": "layout",
+                "type": "layout",
+                "id": "el-1",
+                "rule": {"id": "el-1", "page": 1, "bbox": [0, 0, 1, 1], "canonical_class": "title"},
+            },
+        ],
+    )
+
+    test_cases = _load_jsonl_dataset(tmp_path)
+
+    assert len(test_cases) == 1
+    tc = test_cases[0]
+    assert isinstance(tc, LayoutDetectionTestCase)
+    assert len(tc.get_layout_rules()) == 1
+
+
+def test_doc_with_only_parse_rules_still_builds_parse_test_case(tmp_path: Path) -> None:
+    (tmp_path / "pdfs").mkdir()
+    (tmp_path / "pdfs" / "doc3.pdf").write_bytes(b"%PDF-1.4 fake")
+    _write_jsonl(
+        tmp_path,
+        [
+            {
+                "pdf": "pdfs/doc3.pdf",
+                "category": "text",
+                "type": "present",
+                "id": "p-1",
+                "rule": {"text": "hello"},
+            },
+        ],
+    )
+
+    test_cases = _load_jsonl_dataset(tmp_path)
+
+    assert len(test_cases) == 1
+    assert isinstance(test_cases[0], ParseTestCase)


### PR DESCRIPTION
`_load_jsonl_dataset` only built a `LayoutDetectionTestCase` when a group had layout rules and *no* parse rules (`if layout_rules and not parse_rules:`). A doc whose `layout.jsonl` rows mix `type: "layout"` element rules with a `type: "order"` rule (which lands in `parse_rules` since its type isn't `"layout"`) falls to the `else` branch instead, and `ParseTestCase.test_rules` is typed `list[ParseRule] | None`, so it can't hold `LayoutTestRule` entries. The layout element rules are dropped on the floor, and the run still reports `success: true`.

`load_test_case` a few lines below (the sidecar `.test.json` path) already does this right: `if has_layout_rules: return LayoutDetectionTestCase(..., test_rules=test_rules, ...)`, passing the full mixed rule list through. `LayoutDetectionTestCase.test_rules` type-routes each entry (`type == "layout"` vs everything else) and `EvaluationRunner._has_mixed_rules` + the multi-task path already exist to score both halves. This PR makes `_load_jsonl_dataset` match: route on `layout_rules` alone and pass `layout_rules + parse_rules` through together.

Added `tests/parse_bench/test_cases/test_loader.py` (there wasn't one for this function): a doc with both rule types now keeps both in `test_rules` and still resolves as `LayoutDetectionTestCase`, plus two cases confirming layout-only and parse-only docs are unaffected. The new test fails without the change (doc becomes a `ParseTestCase`, layout rule gone). `ruff check`/`ruff format --check` and the full suite (405 passed, 1 skipped) are clean on 3.12 and 3.13.

I didn't touch the CHANGELOG since no other bugfix PR in the history seems to add an entry there directly.
