### PR TITLE
Add FIRECRAWL_LAYOUT layout-detection model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to `parse-bench` are recorded here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project uses
 [Semantic Versioning](https://semver.org/).
 
+## [1.0.4] - 2026-09-04
+
+### Added
+- `LayoutDetectionModel.FIRECRAWL_LAYOUT` (with a `LAYOUT_MODEL_INFO` entry) so
+  Firecrawl parse output can be cross-evaluated on the layout-attribution
+  datasets, matching the other layout-capable parse providers.
+
 ## [Unreleased]
 
 ### Changed

--- a/src/parse_bench/__init__.py
+++ b/src/parse_bench/__init__.py
@@ -1,3 +1,3 @@
 """Document parsing evaluation system for competitive benchmarking."""
 
-__version__ = "1.0.3"
+__version__ = "1.0.4"

--- a/src/parse_bench/schemas/layout_detection_output.py
+++ b/src/parse_bench/schemas/layout_detection_output.py
@@ -323,6 +323,7 @@ class LayoutDetectionModel(StrEnum):
     COHERE_PARSE_LAYOUT = "cohere_parse_layout"
     PYMUPDF4LLM_LAYOUT = "pymupdf4llm_layout"
     LITEPARSE_LAYOUT = "liteparse_layout"
+    FIRECRAWL_LAYOUT = "firecrawl_layout"
 
 
 LAYOUT_MODEL_INFO: dict[LayoutDetectionModel, dict[str, str]] = {
@@ -461,6 +462,10 @@ LAYOUT_MODEL_INFO: dict[LayoutDetectionModel, dict[str, str]] = {
     LayoutDetectionModel.LITEPARSE_LAYOUT: {
         "name": "LiteParse Layout",
         "hf_url": "https://developers.llamaindex.ai/liteparse/guides/extraction/#layout-blocks",
+    },
+    LayoutDetectionModel.FIRECRAWL_LAYOUT: {
+        "name": "Firecrawl Layout",
+        "hf_url": "https://docs.firecrawl.dev/features/parse",
     },
 }
 


### PR DESCRIPTION
## What
Add `LayoutDetectionModel.FIRECRAWL_LAYOUT` (plus its `LAYOUT_MODEL_INFO` entry) and bump the package version to 1.0.4.

## Why
The internal harness (llamacloud-bench) now maps Firecrawl's `/v2/parse` layout blocks into `ParseOutput.layout_pages` and registers a `FirecrawlLayoutAdapter`, so a single Firecrawl parse run can be scored on the layout-attribution datasets. That adapter needs a model identity in the shared enum; without a `FIRECRAWL_LAYOUT` member it had to borrow another provider's tag. Every other layout-capable parse provider (Cohere, PyMuPDF4LLM, LiteParse, …) already has its own member here.

## How
- `LayoutDetectionModel.FIRECRAWL_LAYOUT = "firecrawl_layout"`.
- Matching `LAYOUT_MODEL_INFO` entry (name + docs URL).
- `__version__` 1.0.3 → 1.0.4, changelog entry.

## Changes
- `src/parse_bench/schemas/layout_detection_output.py`
- `src/parse_bench/__init__.py`
- `CHANGELOG.md`

## Testing
- Import check: `LayoutDetectionModel.FIRECRAWL_LAYOUT` resolves and is present in `LAYOUT_MODEL_INFO`.
- `ruff` and `mypy` clean on the changed schema file.

## Notes
- Additive and backward-compatible. Consumed by llamacloud-bench once 1.0.4 is released and the pin is bumped.